### PR TITLE
Fixes various bugs in MainMenuOptions

### DIFF
--- a/src/States/MainMenuState.cpp
+++ b/src/States/MainMenuState.cpp
@@ -128,6 +128,9 @@ void MainMenuState::positionButtons()
 	mFileIoDialog.position(static_cast<int>(r.center_x() - mFileIoDialog.width() / 2), static_cast<int>(r.center_y() - mFileIoDialog.height() / 2));
 	dlgOptions.position(static_cast<int>(r.center_x() - dlgOptions.width() / 2), static_cast<int>(r.center_y() - dlgOptions.height() / 2));
 	dlgNewGame.position(static_cast<int>(r.center_x() - dlgNewGame.width() / 2), static_cast<int>(r.center_y() - dlgNewGame.height() / 2));
+
+	Font* tiny_font = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	lblVersion.position(r.width() - tiny_font->width(constants::VERSION) - 5, r.height() - tiny_font->height() - 5);
 }
 
 

--- a/src/States/MainMenuState.cpp
+++ b/src/States/MainMenuState.cpp
@@ -63,7 +63,7 @@ void MainMenuState::initialize()
 	btnOptions.text(constants::MAIN_MENU_OPTIONS);
 	btnOptions.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnOptions.size(200, 30);
-	btnOptions.enabled(false);
+	btnOptions.enabled(true);
 	btnOptions.click().connect(this, &MainMenuState::btnOptionsClicked);
 
 	btnHelp.text(constants::MAIN_MENU_HELP);
@@ -151,7 +151,7 @@ void MainMenuState::enableButtons()
 {
 	btnNewGame.enabled(true);
 	btnContinueGame.enabled(true);
-	btnOptions.enabled(false);
+	btnOptions.enabled(true);
 	btnHelp.enabled(true);
 	btnQuit.enabled(true);
 }

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -101,7 +101,7 @@ void MainMenuOptions::init()
 			desired_mode.h = resolution.height;
 			if(SDL_GetClosestDisplayMode(display_index, &desired_mode, &closest_mode))
 			{
-                NAS2D::DisplayDesc closest{closest_mode.w, closest_mode.h, closest_mode.refresh_rate};
+				NAS2D::DisplayDesc closest{closest_mode.w, closest_mode.h, closest_mode.refresh_rate};
 				if(current_dimensions == closest)
 				{
 					//Set combobox to current dimensions of window, not desktop
@@ -110,7 +110,7 @@ void MainMenuOptions::init()
 			}
 			std::string resolution_str = std::to_string(resolution.width) + "x" + std::to_string(resolution.height) + "x" + std::to_string(resolution.refreshHz);
 			cmbResolution.addItem(resolution_str, resolution_index);
-            ++resolution_index;
+			++resolution_index;
 		}
 		cmbResolution.currentSelection(currentResolutionSelection);
 	}

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -73,16 +73,17 @@ void MainMenuOptions::init()
 
     auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
     auto resolutions = r.getDisplayModes();
-    resolutions.erase(std::remove_if(std::begin(resolutions), std::end(resolutions),
-        [](const NAS2D::DisplayDesc& desc) {
-            const auto w = desc.width;
-            const auto h = desc.height;
-            const auto min_w = constants::MINIMUM_WINDOW_WIDTH;
-            const auto min_h = constants::MINIMUM_WINDOW_HEIGHT;
-            const auto is_invalid = w < min_w || h < min_h;
-            return is_invalid;
-        }),
-    std::end(resolutions));
+    resolutions.erase(
+        std::remove_if(
+            std::begin(resolutions),
+            std::end(resolutions),
+            [](const NAS2D::DisplayDesc& desc) {
+                const auto is_invalid = desc.width < constants::MINIMUM_WINDOW_WIDTH || desc.height < constants::MINIMUM_WINDOW_HEIGHT;
+                return is_invalid;
+            }
+        ),
+        std::end(resolutions)
+    );
 
 
 	{

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -120,12 +120,6 @@ void MainMenuOptions::init()
     cbxSkipSplash.size(200, 0);
     cbxSkipSplash.click().connect(this, &MainMenuOptions::onOptionsChanged);
 
-    lblStartMaximized.text("Start Maximized");
-    lblStartMaximized.size(0, 0);
-
-    cbxStartMaximized.size(200, 0);
-    cbxStartMaximized.click().connect(this, &MainMenuOptions::onOptionsChanged);
-
     lblVSync.text("VSync");
     lblVSync.size(0, 0);
 
@@ -179,8 +173,6 @@ void MainMenuOptions::init()
     pnlControls.add(&sldrMusicVolume, right_edge - sldrMusicVolume.width() - border_right_width, lblMusicVolume.rect().startPoint().y() - sldrMusicVolume.height());
     pnlControls.add(&lblSkipSplash, left_edge, lblMusicVolume.rect().startPoint().y() + element_spacing);
     pnlControls.add(&cbxSkipSplash, right_edge - cbxSkipSplash.width(), sldrMusicVolume.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&lblStartMaximized, left_edge, lblSkipSplash.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&cbxStartMaximized, right_edge - cbxStartMaximized.width(), cbxSkipSplash.rect().startPoint().y() + element_spacing);
     add(&pnlControls, 0, 0);
 
     pnlButtons.add(&btnOk, 0, 0);
@@ -344,7 +336,6 @@ void MainMenuOptions::setConfigFromControls()
     cf.vsync(cbxVSync.checked());
     cf.fullscreen(cbxFullscreen.checked());
     cf.option("skip-splash", (cbxSkipSplash.checked() ? "true" : "false"));
-    cf.option("maximized", (cbxStartMaximized.checked() ? "true" : "false"));
 
     auto& mixer = NAS2D::Utility<NAS2D::Mixer>::get();
     mixer.musicVolume(cf.audioMusicVolume());
@@ -366,7 +357,5 @@ void MainMenuOptions::setControlsFromConfig()
     cbxFullscreen.checked(cf.vsync());
 
     const auto skipsplash_str = NAS2D::toLowercase(cf.option("skip-splash"));
-    const auto maximized_str = NAS2D::toLowercase(cf.option("maximized"));
     cbxSkipSplash.checked(skipsplash_str == "true" ? true : (skipsplash_str == "false" ? false : false));
-    cbxStartMaximized.checked(maximized_str == "true" ? true : (maximized_str == "false" ? false : false));
 }

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -92,16 +92,19 @@ void MainMenuOptions::init()
 		const auto gfx_width = cf.graphicsWidth();
 		const auto gfx_height = cf.graphicsHeight();
         int resolution_index = 0;
+        SDL_DisplayMode cur_mode{};
+        SDL_GetWindowDisplayMode(underlyingWindow, &cur_mode);
+        NAS2D::DisplayDesc current_dimensions{cur_mode.w, cur_mode.h, cur_mode.refresh_rate};
         for(const auto& resolution : resolutions)
 		{
 			SDL_DisplayMode closest_mode{};
 			SDL_DisplayMode desired_mode{};
-			desired_mode.w = gfx_width;
-			desired_mode.h = gfx_height;
+			desired_mode.w = resolution.width;
+			desired_mode.h = resolution.height;
 			if(SDL_GetClosestDisplayMode(display_index, &desired_mode, &closest_mode))
 			{
                 NAS2D::DisplayDesc closest{closest_mode.w, closest_mode.h, closest_mode.refresh_rate};
-				if(resolution == closest)
+				if(current_dimensions == closest)
 				{
 					//Set combobox to current dimensions of window, not desktop
 					currentResolutionSelection = resolution_index;
@@ -109,6 +112,7 @@ void MainMenuOptions::init()
 			}
 			std::string resolution_str = std::to_string(resolution.width) + "x" + std::to_string(resolution.height) + "x" + std::to_string(resolution.refreshHz);
 			cmbResolution.addItem(resolution_str, resolution_index);
+            ++resolution_index;
 		}
 		cmbResolution.currentSelection(currentResolutionSelection);
 	}

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -20,90 +20,90 @@
 
 MainMenuOptions::MainMenuOptions() : Window()
 {
-    text(constants::WINDOW_SYSTEM_TITLE);
-    init();
+	text(constants::WINDOW_SYSTEM_TITLE);
+	init();
 }
 
 
 MainMenuOptions::~MainMenuOptions()
 {
-    auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-    e.keyDown().disconnect(this, &MainMenuOptions::onKeyDown);
-    btnOk.click().disconnect(this, &MainMenuOptions::btnOkClicked);
-    btnCancel.click().disconnect(this, &MainMenuOptions::btnCancelClicked);
-    btnApply.click().disconnect(this, &MainMenuOptions::btnApplyClicked);
+	auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
+	e.keyDown().disconnect(this, &MainMenuOptions::onKeyDown);
+	btnOk.click().disconnect(this, &MainMenuOptions::btnOkClicked);
+	btnCancel.click().disconnect(this, &MainMenuOptions::btnCancelClicked);
+	btnApply.click().disconnect(this, &MainMenuOptions::btnApplyClicked);
 }
 
 
 void MainMenuOptions::init()
 {
 
-    auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-    e.keyDown().connect(this, &MainMenuOptions::onKeyDown);
+	auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
+	e.keyDown().connect(this, &MainMenuOptions::onKeyDown);
 
-    size(500, 350);
+	size(500, 350);
 
-    const auto border_left_width = 5;
-    const auto border_right_width = 5;
-    constexpr auto border_top_height = sWindowTitleBarHeight + 5;
-    const auto border_bottom_height = 5;
-    const auto element_spacing = 5;
-    const auto left_edge = positionX() + border_left_width;
-    const auto right_edge = left_edge + width() - border_right_width * 2.0f;
-    const auto top_edge = positionY() + border_top_height;
-    const auto bottom_edge = top_edge + height() - border_top_height - border_bottom_height * 2.0f;
-    const auto width = right_edge - left_edge;
-    const auto height = bottom_edge - top_edge;
+	const auto border_left_width = 5;
+	const auto border_right_width = 5;
+	constexpr auto border_top_height = sWindowTitleBarHeight + 5;
+	const auto border_bottom_height = 5;
+	const auto element_spacing = 5;
+	const auto left_edge = positionX() + border_left_width;
+	const auto right_edge = left_edge + width() - border_right_width * 2.0f;
+	const auto top_edge = positionY() + border_top_height;
+	const auto bottom_edge = top_edge + height() - border_top_height - border_bottom_height * 2.0f;
+	const auto width = right_edge - left_edge;
+	const auto height = bottom_edge - top_edge;
 
-    pnlControls.position(left_edge, top_edge);
-    pnlControls.size(width, height);
+	pnlControls.position(left_edge, top_edge);
+	pnlControls.size(width, height);
 
-    pnlButtons.position(pnlControls.positionX(), bottom_edge - element_spacing);
-    pnlButtons.size(pnlControls.width(), 120);
+	pnlButtons.position(pnlControls.positionX(), bottom_edge - element_spacing);
+	pnlButtons.size(pnlControls.width(), 120);
 
-    lblResolution.text("Resolution");
-    lblResolution.size(0, 0);
+	lblResolution.text("Resolution");
+	lblResolution.size(0, 0);
 
-    cmbResolution.visible(true);
-    cmbResolution.enabled(true);
-    cmbResolution.size(200, 0);
-    cmbResolution.maxDisplayItems(1);
+	cmbResolution.visible(true);
+	cmbResolution.enabled(true);
+	cmbResolution.size(200, 0);
+	cmbResolution.maxDisplayItems(1);
 
 	cmbResolution.clearSelection();
 
-    auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
-    auto resolutions = r.getDisplayModes();
-    resolutions.erase(
-        std::remove_if(
-            std::begin(resolutions),
-            std::end(resolutions),
-            [](const NAS2D::DisplayDesc& desc) {
-                const auto is_invalid = desc.width < constants::MINIMUM_WINDOW_WIDTH || desc.height < constants::MINIMUM_WINDOW_HEIGHT;
-                return is_invalid;
-            }
-        ),
-        std::end(resolutions)
-    );
+	auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto resolutions = r.getDisplayModes();
+	resolutions.erase(
+		std::remove_if(
+			std::begin(resolutions),
+			std::end(resolutions),
+			[](const NAS2D::DisplayDesc& desc) {
+				const auto is_invalid = desc.width < constants::MINIMUM_WINDOW_WIDTH || desc.height < constants::MINIMUM_WINDOW_HEIGHT;
+				return is_invalid;
+			}
+		),
+		std::end(resolutions)
+	);
 
 
 	{
 		extern SDL_Window* underlyingWindow;
 		const auto display_index = SDL_GetWindowDisplayIndex(underlyingWindow);
 		auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-        int resolution_index = 0;
-        SDL_DisplayMode cur_mode{};
-        SDL_GetWindowDisplayMode(underlyingWindow, &cur_mode);
-        NAS2D::DisplayDesc current_dimensions{cur_mode.w, cur_mode.h, cur_mode.refresh_rate};
-        for(const auto& resolution : resolutions)
+		int resolution_index = 0;
+		SDL_DisplayMode cur_mode{};
+		SDL_GetWindowDisplayMode(underlyingWindow, &cur_mode);
+		NAS2D::DisplayDesc current_dimensions{cur_mode.w, cur_mode.h, cur_mode.refresh_rate};
+		for (const auto& resolution : resolutions)
 		{
 			SDL_DisplayMode closest_mode{};
 			SDL_DisplayMode desired_mode{};
 			desired_mode.w = resolution.width;
 			desired_mode.h = resolution.height;
-			if(SDL_GetClosestDisplayMode(display_index, &desired_mode, &closest_mode))
+			if (SDL_GetClosestDisplayMode(display_index, &desired_mode, &closest_mode))
 			{
 				NAS2D::DisplayDesc closest{closest_mode.w, closest_mode.h, closest_mode.refresh_rate};
-				if(current_dimensions == closest)
+				if (current_dimensions == closest)
 				{
 					//Set combobox to current dimensions of window, not desktop
 					currentResolutionSelection = resolution_index;
@@ -117,81 +117,81 @@ void MainMenuOptions::init()
 	}
 	cmbResolution.selectionChanged().connect(this, &MainMenuOptions::onVideoOptionsChanged);
 
-    lblFullscreen.text("Fullscreen");
-    lblFullscreen.size(0, 0);
+	lblFullscreen.text("Fullscreen");
+	lblFullscreen.size(0, 0);
 
-    cbxFullscreen.size(200, 0);
-    cbxFullscreen.click().connect(this, &MainMenuOptions::onVideoOptionsChanged);
+	cbxFullscreen.size(200, 0);
+	cbxFullscreen.click().connect(this, &MainMenuOptions::onVideoOptionsChanged);
 
-    lblSkipSplash.text("Quickstart");
-    lblSkipSplash.size(0, 0);
+	lblSkipSplash.text("Quickstart");
+	lblSkipSplash.size(0, 0);
 
-    cbxSkipSplash.size(200, 0);
-    cbxSkipSplash.click().connect(this, &MainMenuOptions::onOptionsChanged);
+	cbxSkipSplash.size(200, 0);
+	cbxSkipSplash.click().connect(this, &MainMenuOptions::onOptionsChanged);
 
-    lblVSync.text("VSync");
-    lblVSync.size(0, 0);
+	lblVSync.text("VSync");
+	lblVSync.size(0, 0);
 
-    cbxVSync.size(200,0);
-    cbxVSync.click().connect(this, &MainMenuOptions::onVideoOptionsChanged);
+	cbxVSync.size(200, 0);
+	cbxVSync.click().connect(this, &MainMenuOptions::onVideoOptionsChanged);
 
-    lblSoundVolume.text("Sound Volume");
-    lblSoundVolume.size(0, 0);
+	lblSoundVolume.text("Sound Volume");
+	lblSoundVolume.size(0, 0);
 
-    sldrSoundVolume.size(250, 10);
-    sldrSoundVolume.displayPosition(true);
-    sldrSoundVolume.length(100.0f);
-    sldrSoundVolume.changeThumbPosition(sldrSoundVolume.length());
-    sldrSoundVolume.enabled(true);
-    sldrSoundVolume.visible(true);
-    sldrSoundVolume.change().connect(this, &MainMenuOptions::onSoundVolumeChanged);
+	sldrSoundVolume.size(250, 10);
+	sldrSoundVolume.displayPosition(true);
+	sldrSoundVolume.length(100.0f);
+	sldrSoundVolume.changeThumbPosition(sldrSoundVolume.length());
+	sldrSoundVolume.enabled(true);
+	sldrSoundVolume.visible(true);
+	sldrSoundVolume.change().connect(this, &MainMenuOptions::onSoundVolumeChanged);
 
-    lblMusicVolume.text("Music Volume");
-    lblMusicVolume.size(0, 0);
+	lblMusicVolume.text("Music Volume");
+	lblMusicVolume.size(0, 0);
 
-    sldrMusicVolume.size(250, 10);
-    sldrMusicVolume.displayPosition(true);
-    sldrMusicVolume.length(100.0f);
-    sldrMusicVolume.changeThumbPosition(sldrMusicVolume.length());
-    sldrMusicVolume.enabled(true);
-    sldrMusicVolume.visible(true);
-    sldrMusicVolume.change().connect(this, &MainMenuOptions::onMusicVolumeChanged);
+	sldrMusicVolume.size(250, 10);
+	sldrMusicVolume.displayPosition(true);
+	sldrMusicVolume.length(100.0f);
+	sldrMusicVolume.changeThumbPosition(sldrMusicVolume.length());
+	sldrMusicVolume.enabled(true);
+	sldrMusicVolume.visible(true);
+	sldrMusicVolume.change().connect(this, &MainMenuOptions::onMusicVolumeChanged);
 
-    btnApply.text("Apply");
-    btnApply.size(100, 25);
-    btnApply.click().connect(this, &MainMenuOptions::btnApplyClicked);
-    btnApply.enabled(false);
+	btnApply.text("Apply");
+	btnApply.size(100, 25);
+	btnApply.click().connect(this, &MainMenuOptions::btnApplyClicked);
+	btnApply.enabled(false);
 
-    btnCancel.text("Cancel");
-    btnCancel.size(100, 25);
-    btnCancel.click().connect(this, &MainMenuOptions::btnCancelClicked);
+	btnCancel.text("Cancel");
+	btnCancel.size(100, 25);
+	btnCancel.click().connect(this, &MainMenuOptions::btnCancelClicked);
 
-    btnOk.text("Ok");
-    btnOk.size(100, 25);
-    btnOk.click().connect(this, &MainMenuOptions::btnOkClicked);
+	btnOk.text("Ok");
+	btnOk.size(100, 25);
+	btnOk.click().connect(this, &MainMenuOptions::btnOkClicked);
 
-    pnlControls.add(&lblResolution, left_edge, top_edge);
-    pnlControls.add(&cmbResolution, right_edge - cmbResolution.width() - element_spacing, top_edge);
-    pnlControls.add(&lblFullscreen, left_edge, lblResolution.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&cbxFullscreen, right_edge - cbxFullscreen.width(), cmbResolution.rect().endPoint().y() + element_spacing);
-    pnlControls.add(&lblVSync, left_edge, lblFullscreen.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&cbxVSync, right_edge - cbxVSync.width(), lblVSync.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&lblSoundVolume, left_edge, lblVSync.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&sldrSoundVolume, right_edge - sldrSoundVolume.width() - border_right_width, lblSoundVolume.rect().startPoint().y() - sldrSoundVolume.height() * 0.5f);
-    pnlControls.add(&lblMusicVolume, left_edge, lblSoundVolume.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&sldrMusicVolume, right_edge - sldrMusicVolume.width() - border_right_width, lblMusicVolume.rect().startPoint().y() - sldrMusicVolume.height());
-    pnlControls.add(&lblSkipSplash, left_edge, lblMusicVolume.rect().startPoint().y() + element_spacing);
-    pnlControls.add(&cbxSkipSplash, right_edge - cbxSkipSplash.width(), sldrMusicVolume.rect().startPoint().y() + element_spacing);
-    add(&pnlControls, 0, 0);
+	pnlControls.add(&lblResolution, left_edge, top_edge);
+	pnlControls.add(&cmbResolution, right_edge - cmbResolution.width() - element_spacing, top_edge);
+	pnlControls.add(&lblFullscreen, left_edge, lblResolution.rect().startPoint().y() + element_spacing);
+	pnlControls.add(&cbxFullscreen, right_edge - cbxFullscreen.width(), cmbResolution.rect().endPoint().y() + element_spacing);
+	pnlControls.add(&lblVSync, left_edge, lblFullscreen.rect().startPoint().y() + element_spacing);
+	pnlControls.add(&cbxVSync, right_edge - cbxVSync.width(), lblVSync.rect().startPoint().y() + element_spacing);
+	pnlControls.add(&lblSoundVolume, left_edge, lblVSync.rect().startPoint().y() + element_spacing);
+	pnlControls.add(&sldrSoundVolume, right_edge - sldrSoundVolume.width() - border_right_width, lblSoundVolume.rect().startPoint().y() - sldrSoundVolume.height() * 0.5f);
+	pnlControls.add(&lblMusicVolume, left_edge, lblSoundVolume.rect().startPoint().y() + element_spacing);
+	pnlControls.add(&sldrMusicVolume, right_edge - sldrMusicVolume.width() - border_right_width, lblMusicVolume.rect().startPoint().y() - sldrMusicVolume.height());
+	pnlControls.add(&lblSkipSplash, left_edge, lblMusicVolume.rect().startPoint().y() + element_spacing);
+	pnlControls.add(&cbxSkipSplash, right_edge - cbxSkipSplash.width(), sldrMusicVolume.rect().startPoint().y() + element_spacing);
+	add(&pnlControls, 0, 0);
 
-    pnlButtons.add(&btnOk, 0, 0);
-    pnlButtons.add(&btnCancel, btnOk.rect().endPoint().x() + element_spacing, 0);
-    pnlButtons.add(&btnApply, btnCancel.rect().endPoint().x() + element_spacing, 0);
-    add(&pnlButtons, left_edge + pnlButtons.width() * 0.25f, pnlControls.height() + element_spacing);//right_edge - pnlButtons.width(), pnlControls.rect().endPoint().y() + element_spacing);
+	pnlButtons.add(&btnOk, 0, 0);
+	pnlButtons.add(&btnCancel, btnOk.rect().endPoint().x() + element_spacing, 0);
+	pnlButtons.add(&btnApply, btnCancel.rect().endPoint().x() + element_spacing, 0);
+	add(&pnlButtons, left_edge + pnlButtons.width() * 0.25f, pnlControls.height() + element_spacing);//right_edge - pnlButtons.width(), pnlControls.rect().endPoint().y() + element_spacing);
 
-    anchored(true);
+	anchored(true);
 
-    setControlsFromConfig();
+	setControlsFromConfig();
 	// setControlsFromConfig calls the various event handler functions
 	// which in turn enable the apply button.
 	// Need to force it to disabled when it should be.
@@ -202,16 +202,16 @@ void MainMenuOptions::init()
 
 
 void MainMenuOptions::visibilityChanged(bool visible) {
-    if (visible)
-    {
-        enableControls();
-        setControlsFromConfig();
-        btnApply.enabled(false);
-    }
-    else
-    {
-        disableControls();
-    }
+	if (visible)
+	{
+		enableControls();
+		setControlsFromConfig();
+		btnApply.enabled(false);
+	}
+	else
+	{
+		disableControls();
+	}
 }
 
 void MainMenuOptions::btnOkClicked() {
@@ -243,58 +243,59 @@ void MainMenuOptions::btnApplyClicked() {
 }
 
 void MainMenuOptions::saveOptions() {
-    auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-    cf.save();
+	auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
+	cf.save();
 }
 
 void MainMenuOptions::loadOptions() {
-    auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-    cf.load("config.xml");
+	auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
+	cf.load("config.xml");
 }
 
 void MainMenuOptions::applyVideoChanges() {
-    if (videoOptionsChanged) {
-        auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-        const auto& txt = cmbResolution.selectionText();
-        const auto whd = NAS2D::split(txt, 'x');
-        const auto width = std::stoi(whd[0]);
-        const auto height = std::stoi(whd[1]);
-        const auto depth = std::stoi(whd[2]);
-        cf.graphicsWidth(width);
-        cf.graphicsHeight(height);
-        cf.graphicsColorDepth(depth);
-        cf.fullscreen(cbxFullscreen.checked());
-        cf.vsync(cbxVSync.checked());
-        saveOptions();
+	if (videoOptionsChanged) {
+		auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
+		const auto& txt = cmbResolution.selectionText();
+		const auto whd = NAS2D::split(txt, 'x');
+		const auto width = std::stoi(whd[0]);
+		const auto height = std::stoi(whd[1]);
+		const auto depth = std::stoi(whd[2]);
+		cf.graphicsWidth(width);
+		cf.graphicsHeight(height);
+		cf.graphicsColorDepth(depth);
+		cf.fullscreen(cbxFullscreen.checked());
+		cf.vsync(cbxVSync.checked());
+		saveOptions();
 
-        auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
-        r.size(cf.graphicsWidth(), cf.graphicsHeight());
-        r.fullscreen(cf.fullscreen());
+		auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
+		r.size(cf.graphicsWidth(), cf.graphicsHeight());
+		r.fullscreen(cf.fullscreen());
 
-        auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-        e.windowResized().emit(cf.graphicsWidth(), cf.graphicsHeight());
+		auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
+		e.windowResized().emit(cf.graphicsWidth(), cf.graphicsHeight());
 
-        videoOptionsChanged = false;
-    }
+		videoOptionsChanged = false;
+	}
 }
 
 void MainMenuOptions::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat) {
-    if (key == NAS2D::EventHandler::KeyCode::KEY_ESCAPE) {
-        btnCancelClicked();
-    }
+	if (key == NAS2D::EventHandler::KeyCode::KEY_ESCAPE)
+	{
+		btnCancelClicked();
+	}
 }
 
 void MainMenuOptions::onSoundVolumeChanged(float /*newValue*/) {
-    onOptionsChanged();
+	onOptionsChanged();
 }
 
 void MainMenuOptions::onMusicVolumeChanged(float /*newValue*/) {
-    onOptionsChanged();
+	onOptionsChanged();
 }
 
 void MainMenuOptions::onOptionsChanged() {
-    optionsChanged = true;
-    btnApply.enabled(true);
+	optionsChanged = true;
+	btnApply.enabled(true);
 }
 
 void MainMenuOptions::onVideoOptionsChanged() {
@@ -303,65 +304,65 @@ void MainMenuOptions::onVideoOptionsChanged() {
 }
 
 void MainMenuOptions::enableControls() {
-    pnlControls.enabled(true);
+	pnlControls.enabled(true);
 }
 
 void MainMenuOptions::disableControls() {
-    pnlControls.enabled(false);
+	pnlControls.enabled(false);
 }
 
 void MainMenuOptions::enableButtons() {
-    pnlButtons.enabled(true);
+	pnlButtons.enabled(true);
 }
 
 void MainMenuOptions::disableButtons() {
-    pnlButtons.enabled(false);
+	pnlButtons.enabled(false);
 }
 
 void MainMenuOptions::update()
 {
-    if (!visible()) { return; }
+	if (!visible()) { return; }
 
-    //Calls update on the panel controls, which call update on their children.
-    Window::update();
+	//Calls update on the panel controls, which call update on their children.
+	Window::update();
 
-    if (optionsChanged)
-    {
-        setConfigFromControls();
-        optionsChanged = false;
-    }
+	if (optionsChanged)
+	{
+		setConfigFromControls();
+		optionsChanged = false;
+	}
 
 }
 
 void MainMenuOptions::setConfigFromControls()
 {
-    auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-    cf.audioSfxVolume(static_cast<int>(std::floor((sldrSoundVolume.thumbPosition() / sldrSoundVolume.length()) * 128.0f)));
-    cf.audioMusicVolume(static_cast<int>(std::floor((sldrMusicVolume.thumbPosition() / sldrMusicVolume.length()) * 128.0f)));
+	auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
+	cf.audioSfxVolume(static_cast<int>(std::floor((sldrSoundVolume.thumbPosition() / sldrSoundVolume.length()) * 128.0f)));
+	cf.audioMusicVolume(static_cast<int>(std::floor((sldrMusicVolume.thumbPosition() / sldrMusicVolume.length()) * 128.0f)));
 
-    auto& mixer = NAS2D::Utility<NAS2D::Mixer>::get();
-    mixer.musicVolume(cf.audioMusicVolume());
-    mixer.soundVolume(cf.audioSfxVolume());
+	auto& mixer = NAS2D::Utility<NAS2D::Mixer>::get();
+	mixer.musicVolume(cf.audioMusicVolume());
+	mixer.soundVolume(cf.audioSfxVolume());
 
-    cf.vsync(cbxVSync.checked());
-    cf.fullscreen(cbxFullscreen.checked());
-    cf.option("skip-splash", (cbxSkipSplash.checked() ? "true" : "false"));
+	cf.vsync(cbxVSync.checked());
+	cf.fullscreen(cbxFullscreen.checked());
+	cf.option("skip-splash", (cbxSkipSplash.checked() ? "true" : "false"));
 
 }
 
 void MainMenuOptions::setControlsFromConfig()
 {
-    auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-    sldrSoundVolume.thumbPosition(std::floor((cf.audioSfxVolume() / 128.0f) * sldrSoundVolume.length()));
-    sldrMusicVolume.thumbPosition(std::floor((cf.audioMusicVolume() / 128.0f) * sldrMusicVolume.length()));
+	auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
+	sldrSoundVolume.thumbPosition(std::floor((cf.audioSfxVolume() / 128.0f) * sldrSoundVolume.length()));
+	sldrMusicVolume.thumbPosition(std::floor((cf.audioMusicVolume() / 128.0f) * sldrMusicVolume.length()));
 
-    auto& mixer = NAS2D::Utility<NAS2D::Mixer>::get();
-    mixer.musicVolume(cf.audioMusicVolume());
-    mixer.soundVolume(cf.audioSfxVolume());
+	auto& mixer = NAS2D::Utility<NAS2D::Mixer>::get();
+	mixer.musicVolume(cf.audioMusicVolume());
+	mixer.soundVolume(cf.audioSfxVolume());
 
-    cbxVSync.checked(cf.vsync());
-    cbxFullscreen.checked(cf.fullscreen());
+	cbxVSync.checked(cf.vsync());
+	cbxFullscreen.checked(cf.fullscreen());
 
-    const auto skipsplash_str = NAS2D::toLowercase(cf.option("skip-splash"));
-    cbxSkipSplash.checked(skipsplash_str == "true" ? true : (skipsplash_str == "false" ? false : false));
+	const auto skipsplash_str = NAS2D::toLowercase(cf.option("skip-splash"));
+	cbxSkipSplash.checked(skipsplash_str == "true" ? true : (skipsplash_str == "false" ? false : false));
 }

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -70,10 +70,6 @@ void MainMenuOptions::init()
     cmbResolution.maxDisplayItems(1);
 
 	cmbResolution.clearSelection();
-	{
-		const auto default_resolution = std::to_string(constants::MINIMUM_WINDOW_WIDTH) + 'x' + std::to_string(constants::MINIMUM_WINDOW_HEIGHT) + 'x' + std::to_string(60);
-		cmbResolution.text(default_resolution);
-	}
 
     auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
     auto resolutions = r.getDisplayModes();

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -89,8 +89,6 @@ void MainMenuOptions::init()
 		extern SDL_Window* underlyingWindow;
 		const auto display_index = SDL_GetWindowDisplayIndex(underlyingWindow);
 		auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-		const auto gfx_width = cf.graphicsWidth();
-		const auto gfx_height = cf.graphicsHeight();
         int resolution_index = 0;
         SDL_DisplayMode cur_mode{};
         SDL_GetWindowDisplayMode(underlyingWindow, &cur_mode);

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -182,19 +182,6 @@ void MainMenuOptions::init()
 
     anchored(true);
 
-    lblResolutionChanged.text("You must restart the game for video options to take effect.");
-    lblResolutionChanged.size(250, 15);
-    btnResolutionChangedOk.text("Ok");
-    btnResolutionChangedOk.size(100, 25);
-    btnResolutionChangedOk.click().connect(this, &MainMenuOptions::btnResolutionOkClicked);
-
-    dlgResolutionChanged.text("Notice");
-    dlgResolutionChanged.anchored(true);
-    dlgResolutionChanged.size(500, 85);
-    dlgResolutionChanged.add(&lblResolutionChanged, dlgResolutionChanged.width() * 0.5f - lblResolutionChanged.width() * 0.5f, 10 + dlgResolutionChanged.height() * 0.25f - lblResolutionChanged.height() * 0.5f);
-    dlgResolutionChanged.add(&btnResolutionChangedOk, dlgResolutionChanged.width() * 0.5f - btnResolutionChangedOk.width() * 0.5f, dlgResolutionChanged.height() - 5 - btnResolutionChangedOk.height());
-    add(&dlgResolutionChanged, positionX() + (width * 0.5f) - (dlgResolutionChanged.width() * 0.5f), positionY() + (height * 0.5f) - (dlgResolutionChanged.height() * 0.5f));
-
     setControlsFromConfig();
     inInit = false;
 }
@@ -222,11 +209,16 @@ void MainMenuOptions::btnOkClicked() {
 }
 
 void MainMenuOptions::btnResolutionOkClicked() {
-    dlgResolutionChanged.hide();
 }
 
 void MainMenuOptions::btnCancelClicked() {
     hide();
+	loadOptions();
+	setControlsFromConfig();
+	cmbResolution.currentSelection(previousResolutionSelection);
+	optionsChanged = false;
+	videoOptionsChanged = false;
+	hide();
 }
 
 void MainMenuOptions::btnApplyClicked() {

--- a/src/UI/MainMenuOptions.h
+++ b/src/UI/MainMenuOptions.h
@@ -5,65 +5,65 @@
 class MainMenuOptions : public Window
 {
 public:
-    MainMenuOptions();
-    virtual ~MainMenuOptions();
+	MainMenuOptions();
+	virtual ~MainMenuOptions();
 
-    virtual void update() override;
+	virtual void update() override;
 
 protected:
-    virtual void init();
-    virtual void visibilityChanged(bool visible) override;
+	virtual void init();
+	virtual void visibilityChanged(bool visible) override;
 
 private:
-    void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
-    void onSoundVolumeChanged(float newValue);
-    void onMusicVolumeChanged(float newValue);
-    void onOptionsChanged();
-    void onVideoOptionsChanged();
+	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
+	void onSoundVolumeChanged(float newValue);
+	void onMusicVolumeChanged(float newValue);
+	void onOptionsChanged();
+	void onVideoOptionsChanged();
 
-    void setConfigFromControls();
-    void setControlsFromConfig();
+	void setConfigFromControls();
+	void setControlsFromConfig();
 
-    void enableControls();
-    void disableControls();
+	void enableControls();
+	void disableControls();
 
-    void enableButtons();
-    void disableButtons();
+	void enableButtons();
+	void disableButtons();
 
-    void btnOkClicked();
+	void btnOkClicked();
 
-    void applyChanges();
+	void applyChanges();
 
-    void btnCancelClicked();
-    void btnApplyClicked();
+	void btnCancelClicked();
+	void btnApplyClicked();
 
-    void saveOptions();
-    void loadOptions();
-    void applyVideoChanges();
+	void saveOptions();
+	void loadOptions();
+	void applyVideoChanges();
 
-    UIContainer pnlControls;
+	UIContainer pnlControls;
 
-    Label lblResolution;
-    Label lblFullscreen;
-    Label lblVSync;
-    Label lblMusicVolume;
-    Label lblSoundVolume;
-    Label lblSkipSplash;
+	Label lblResolution;
+	Label lblFullscreen;
+	Label lblVSync;
+	Label lblMusicVolume;
+	Label lblSoundVolume;
+	Label lblSkipSplash;
 
-    ComboBox cmbResolution;
-    CheckBox cbxFullscreen;
-    CheckBox cbxVSync;
-    CheckBox cbxSkipSplash;
-    Slider sldrMusicVolume;
-    Slider sldrSoundVolume;
+	ComboBox cmbResolution;
+	CheckBox cbxFullscreen;
+	CheckBox cbxVSync;
+	CheckBox cbxSkipSplash;
+	Slider sldrMusicVolume;
+	Slider sldrSoundVolume;
 
-    UIContainer pnlButtons;
-    Button btnOk;
-    Button btnCancel;
-    Button btnApply;
+	UIContainer pnlButtons;
+	Button btnOk;
+	Button btnCancel;
+	Button btnApply;
 
-    bool optionsChanged = false;
-    bool videoOptionsChanged = false;
-    int currentResolutionSelection = 0;
-    int previousResolutionSelection = 0;
+	bool optionsChanged = false;
+	bool videoOptionsChanged = false;
+	int currentResolutionSelection = 0;
+	int previousResolutionSelection = 0;
 };

--- a/src/UI/MainMenuOptions.h
+++ b/src/UI/MainMenuOptions.h
@@ -53,7 +53,6 @@ private:
     CheckBox cbxFullscreen;
     CheckBox cbxVSync;
     CheckBox cbxSkipSplash;
-    CheckBox cbxStartMaximized;
     Slider sldrMusicVolume;
     Slider sldrSoundVolume;
 

--- a/src/UI/MainMenuOptions.h
+++ b/src/UI/MainMenuOptions.h
@@ -31,7 +31,9 @@ private:
     void disableButtons();
 
     void btnOkClicked();
-    void btnResolutionOkClicked();
+
+    void applyChanges();
+
     void btnCancelClicked();
     void btnApplyClicked();
 
@@ -47,7 +49,6 @@ private:
     Label lblMusicVolume;
     Label lblSoundVolume;
     Label lblSkipSplash;
-    Label lblStartMaximized;
 
     ComboBox cmbResolution;
     CheckBox cbxFullscreen;
@@ -61,12 +62,8 @@ private:
     Button btnCancel;
     Button btnApply;
 
-    Window dlgResolutionChanged;
-    Button btnResolutionChangedOk;
-    Label lblResolutionChanged;
-
     bool optionsChanged = false;
     bool videoOptionsChanged = false;
-    bool inInit = true;
     int currentResolutionSelection = 0;
+    int previousResolutionSelection = 0;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,10 +94,6 @@ int main(int /*argc*/, char *argv[])
 		{
 			cf.option("skip-splash", "false");
 		}
-		if (cf.option("maximized").empty())
-		{
-			cf.option("maximized", "true");
-		}
 
 		validateVideoResolution();
 
@@ -123,13 +119,6 @@ int main(int /*argc*/, char *argv[])
 		r.addCursor(constants::MOUSE_POINTER_INSPECT, POINTER_INSPECT, 8, 8);
 		r.setCursor(POINTER_NORMAL);
 		r.fadeOut(0.0f);
-
-		if (cf.option("maximized") == "true")
-		{
-			/** \fixme Evil hack exposing an internal NAS2D variable. */
-			extern SDL_Window* underlyingWindow;
-			SDL_MaximizeWindow(underlyingWindow);
-		}
 
 		std::cout << "Loading packed assets... ";
 


### PR DESCRIPTION
Fixes various bugs in the options menu:
- Disables start in maximized windowed mode.
- Renables the options button due to master merge disabling it.
- Resolution combobox does not have a default value
- Fullscreen checkbox is tied to vsync checkbox
- isInit is removed
- Uses `std::to_string` instead of `std::ostringstream`
- Resolution popup appears when it shouldn't.
- Removes resolution popup
- Resolution combobox is changed when re-entering the menu even if Cancel is clicked.
- Apply button does not properly disable itself when no changes have been made.
- Occasionally fullscreen is applied even though the setting is unchecked.
