### PR TITLE
Use existing variable rather than create new variable

### DIFF
--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -860,7 +860,7 @@ void MapViewState::placeTubeEnd()
 	if (tubeStart.y() > tile->y())
 	{
 		incY = -incY;
-		int xEnd = tubeStart.x();
+		xEnd = tubeStart.x();
 	}
 
 	// 


### PR DESCRIPTION
This fixes an "unused variable" warning.

Looks like a small oversight that was added in #150.

Note: New AppVeyor config has not yet been merged to master, hence the AppVeyor failure.
