### PR TITLE
Update for Filesystem auto mount removal

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main(int /*argc*/, char *argv[])
 	{
 		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
 		f.mount("data");
-
+		f.mountReadWrite(f.prefPath());
 
 		if (!f.exists(constants::SAVE_GAME_PATH))
 		{


### PR DESCRIPTION
This is to prepare for upstream change: https://github.com/lairworks/nas2d-core/pull/445

----

Add explicit mounting for the user preferences folder.

Currently the user preferences folder is already auto mounted during `Filesystem` construction. However, the upstream change is about to remove auto mounting, so this prepares OPHD for that change.

Technically this means the user's preferences folder is currently being set to mount twice. It is not an error to mount the same folder twice. The second duplicate mount will simply be ignored. Once the upstream change is merged in and the submodule updated, it will be back down to a single mount.

Ideally this branch should be merged first, before the upstream change. That way there are no breaks to the downstream project, nor versions of the dependency that need to be avoided or updated together. Things will just work when the update is brought in.
