### PR TITLE
Add missing header includes

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -6,6 +6,9 @@
 
 #include "Things/Structures/Structure.h"
 
+#include "NAS2D/Xml/XmlDocument.h"
+#include "NAS2D/Xml/XmlElement.h"
+
 #include <iostream>
 
 #if defined(WINDOWS) || defined(WIN32)

--- a/src/States/GameState.cpp
+++ b/src/States/GameState.cpp
@@ -9,6 +9,9 @@
 
 #include "Wrapper.h"
 
+#include "NAS2D/Mixer/Mixer.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 Point_2d MOUSE_COORDS;									/**< Mouse Coordinates. Used by other states/wrapers. */
 
 MainReportsUiState* MAIN_REPORTS_UI = nullptr;			/**< Pointer to a MainReportsUiState. Memory is handled by GameState. */

--- a/src/States/MainMenuState.cpp
+++ b/src/States/MainMenuState.cpp
@@ -10,6 +10,10 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Mixer/Mixer.h"
+#include "NAS2D/Renderer/Renderer.h"
+
+
 using namespace NAS2D;
 
 

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "NAS2D/Signal.h"
+#include "NAS2D/FpsCounter.h"
 
 #include "MapViewStateHelper.h"
 #include "MainReportsUiState.h"

--- a/src/States/MapViewStateIO.cpp
+++ b/src/States/MapViewStateIO.cpp
@@ -20,6 +20,8 @@
 #include <stdexcept>
 #include <iostream>
 
+#include "NAS2D/Xml/XmlDocument.h"
+#include "NAS2D/Xml/XmlMemoryBuffer.h"
 
 using namespace NAS2D;
 using namespace NAS2D::Xml;

--- a/src/States/PlanetSelectState.cpp
+++ b/src/States/PlanetSelectState.cpp
@@ -10,6 +10,9 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Mixer/Mixer.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 using namespace NAS2D;
 
 Planet::PlanetType PLANET_TYPE_SELECTION = Planet::PLANET_TYPE_NONE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "NAS2D/Mixer/MixerSDL.h"
 #include "NAS2D/Mixer/MixerNull.h"
 #include "NAS2D/Renderer/RendererOpenGL.h"
+#include "NAS2D/StateManager.h"
 
 #include "Common.h"
 #include "Constants.h"


### PR DESCRIPTION
Add missing header includes for classes that are being used but were never directly imported.

These were caught by an upstream change that is due to be merged soon.
Reference: https://github.com/lairworks/nas2d-core/pull/447