### PR TITLE
Convert `isPointInRect` to `contains` UI

### DIFF
--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -72,8 +72,8 @@ void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	if (!visible()) { return; }	// ignore key presses when hidden.
 
-	const Rectangle_2d& _rect = mListBox.rect();
-	if (_rect.contains(NAS2D::Point{x, y}))
+	const Rectangle_2d& listBoxRect = mListBox.rect();
+	if (listBoxRect.contains(NAS2D::Point{x, y}))
 	{
 		if (mListBox.currentHighlight() != constants::NO_SELECTION && !txtFileName.empty())
 		{

--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -72,8 +72,7 @@ void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	if (!visible()) { return; }	// ignore key presses when hidden.
 
-	const Rectangle_2d& listBoxRect = mListBox.rect();
-	if (listBoxRect.contains(NAS2D::Point{x, y}))
+	if (mListBox.rect().to<int>().contains(NAS2D::Point{x, y}))
 	{
 		if (mListBox.currentHighlight() != constants::NO_SELECTION && !txtFileName.empty())
 		{

--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -73,7 +73,7 @@ void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
 	if (!visible()) { return; }	// ignore key presses when hidden.
 
 	const Rectangle_2d& _rect = mListBox.rect();
-	if (isPointInRect(x, y, _rect.x(), _rect.y(), _rect.width(), _rect.height()))
+	if (_rect.contains(NAS2D::Point{x, y}))
 	{
 		if (mListBox.currentHighlight() != constants::NO_SELECTION && !txtFileName.empty())
 		{

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -104,7 +104,8 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		return;
 	}
 
-	if (mIconItemList.empty() || !NAS2D::Rectangle{static_cast<int>(rect().x()), static_cast<int>(rect().y()), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
+	auto startPoint = mRect.startPoint().to<int>();
+	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
 	{
 		return;
 	}
@@ -133,14 +134,15 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!visible() || !hasFocus()) { return; }
 
-	if (mIconItemList.empty() || !NAS2D::Rectangle{static_cast<int>(rect().x()), static_cast<int>(rect().y()), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
+	auto startPoint = mRect.startPoint().to<int>();
+	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
 	{
 		mHighlightIndex = constants::NO_SELECTION;
 		return;
 	}
 
 	// Assumes all coordinates are not negative.
-	mHighlightIndex = translateCoordsToIndex(x - static_cast<int>(rect().x()), y - static_cast<int>(rect().y()));
+	mHighlightIndex = translateCoordsToIndex(x - startPoint.x(), y - startPoint.y());
 
 	if (static_cast<size_t>(mHighlightIndex) >= mIconItemList.size())
 	{

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -105,12 +105,13 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	}
 
 	auto startPoint = mRect.startPoint().to<int>();
-	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(NAS2D::Point{x, y}))
+	auto mousePoint = NAS2D::Point{x, y};
+	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(mousePoint))
 	{
 		return;
 	}
 
-	mCurrentSelection = translateCoordsToIndex(x - static_cast<int>(rect().x()), y - static_cast<int>(rect().y()));
+	mCurrentSelection = translateCoordsToIndex(mousePoint - startPoint);
 
 	if (static_cast<size_t>(mCurrentSelection) >= mIconItemList.size())
 	{
@@ -135,14 +136,15 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 	if (!visible() || !hasFocus()) { return; }
 
 	auto startPoint = mRect.startPoint().to<int>();
-	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(NAS2D::Point{x, y}))
+	auto mousePoint = NAS2D::Point{x, y};
+	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(mousePoint))
 	{
 		mHighlightIndex = constants::NO_SELECTION;
 		return;
 	}
 
 	// Assumes all coordinates are not negative.
-	mHighlightIndex = translateCoordsToIndex(x - startPoint.x(), y - startPoint.y());
+	mHighlightIndex = translateCoordsToIndex(mousePoint - startPoint);
 
 	if (static_cast<size_t>(mHighlightIndex) >= mIconItemList.size())
 	{
@@ -155,9 +157,9 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
  * Utility function that translates mouse coordinates into
  * an index value.
  */
-int IconGrid::translateCoordsToIndex(int x, int y)
+int IconGrid::translateCoordsToIndex(NAS2D::Vector<int> relativeOffset)
 {
-	return (x / (mIconSize + mIconMargin)) + (mGridSize.x * (y / (mIconSize + mIconMargin)));
+	return (relativeOffset.x / (mIconSize + mIconMargin)) + (mGridSize.x * (relativeOffset.y / (mIconSize + mIconMargin)));
 }
 
 

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -105,7 +105,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	}
 
 	auto startPoint = mRect.startPoint().to<int>();
-	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x * (mIconSize + mIconMargin), mGridSize.y * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
+	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(NAS2D::Point{x, y}))
 	{
 		return;
 	}
@@ -135,7 +135,7 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 	if (!visible() || !hasFocus()) { return; }
 
 	auto startPoint = mRect.startPoint().to<int>();
-	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x * (mIconSize + mIconMargin), mGridSize.y * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
+	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(NAS2D::Point{x, y}))
 	{
 		mHighlightIndex = constants::NO_SELECTION;
 		return;

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -104,7 +104,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		return;
 	}
 
-	if (mIconItemList.empty() || !isPointInRect(x, y, static_cast<int>(rect().x()), static_cast<int>(rect().y()), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{static_cast<int>(rect().x()), static_cast<int>(rect().y()), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
 	{
 		return;
 	}
@@ -133,7 +133,7 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!visible() || !hasFocus()) { return; }
 
-	if (mIconItemList.empty() || !isPointInRect(x, y, static_cast<int>(rect().x()), static_cast<int>(rect().y()), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{static_cast<int>(rect().x()), static_cast<int>(rect().y()), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
 	{
 		mHighlightIndex = constants::NO_SELECTION;
 		return;

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -105,7 +105,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	}
 
 	auto startPoint = mRect.startPoint().to<int>();
-	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x * (mIconSize + mIconMargin), mGridSize.y * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
 	{
 		return;
 	}
@@ -135,7 +135,7 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 	if (!visible() || !hasFocus()) { return; }
 
 	auto startPoint = mRect.startPoint().to<int>();
-	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x() * (mIconSize + mIconMargin), mGridSize.y() * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint.x(), startPoint.y(), mGridSize.x * (mIconSize + mIconMargin), mGridSize.y * (mIconSize + mIconMargin)}.contains(NAS2D::Point{x, y}))
 	{
 		mHighlightIndex = constants::NO_SELECTION;
 		return;
@@ -157,7 +157,7 @@ void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
  */
 int IconGrid::translateCoordsToIndex(int x, int y)
 {
-	return (x / (mIconSize + mIconMargin)) + (mGridSize.x() * (y / (mIconSize + mIconMargin)));
+	return (x / (mIconSize + mIconMargin)) + (mGridSize.x * (y / (mIconSize + mIconMargin)));
 }
 
 
@@ -419,8 +419,8 @@ void IconGrid::update()
 
 	for (size_t i = 0; i < mIconItemList.size(); ++i)
 	{
-		int x_pos = static_cast<int>(i) % mGridSize.x();
-		int y_pos = static_cast<int>(i) / mGridSize.x(); //-V537
+		int x_pos = static_cast<int>(i) % mGridSize.x;
+		int y_pos = static_cast<int>(i) / mGridSize.x; //-V537
 
 		float x = static_cast<float>((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos));
 		float y = static_cast<float>((rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos));
@@ -433,8 +433,8 @@ void IconGrid::update()
 
 	if (mCurrentSelection != constants::NO_SELECTION)
 	{
-		int x_pos = (static_cast<int>(mCurrentSelection) % mGridSize.x());
-		int y_pos = (static_cast<int>(mCurrentSelection) / mGridSize.x()); //-V537
+		int x_pos = (static_cast<int>(mCurrentSelection) % mGridSize.x);
+		int y_pos = (static_cast<int>(mCurrentSelection) / mGridSize.x); //-V537
 		r.drawBox((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos),
 			(rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos),
 			static_cast<float>(mIconSize),
@@ -443,8 +443,8 @@ void IconGrid::update()
 
 	if (mHighlightIndex != constants::NO_SELECTION)
 	{
-		int x_pos = (static_cast<int>(mHighlightIndex) % mGridSize.x());
-		int y_pos = (static_cast<int>(mHighlightIndex) / mGridSize.x()); //-V537
+		int x_pos = (static_cast<int>(mHighlightIndex) % mGridSize.x);
+		int y_pos = (static_cast<int>(mHighlightIndex) / mGridSize.x); //-V537
 
 		int x = static_cast<int>((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos));
 		int y = static_cast<int>((rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos));

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -5,6 +5,7 @@
 #include "NAS2D/Signal.h"
 #include "NAS2D/EventHandler.h"
 #include "NAS2D/Renderer/Point.h"
+#include "NAS2D/Renderer/Vector.h"
 #include "NAS2D/Resources/Image.h"
 
 
@@ -119,7 +120,7 @@ private:
 
 	NAS2D::ImageList	mSkin;
 
-	NAS2D::Point_2d		mGridSize;					/**< Dimensions of the grid that can be contained in the IconGrid with the current Icon Size and Icon Margin. */
+	NAS2D::Vector<int>	mGridSize;					/**< Dimensions of the grid that can be contained in the IconGrid with the current Icon Size and Icon Margin. */
 
 	IconItemList		mIconItemList;				/**< List of items. */
 

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -102,7 +102,7 @@ private:
 
 private:
 	void updateGrid();
-	int translateCoordsToIndex(int x, int y);
+	int translateCoordsToIndex(NAS2D::Vector<int> relativeOffset);
 
 	void raiseChangedEvent();
 

--- a/src/UI/Reports/WarehouseReport.cpp
+++ b/src/UI/Reports/WarehouseReport.cpp
@@ -296,7 +296,7 @@ void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int
 	if (!visible()) { return; }
 	if (button != EventHandler::MouseButton::BUTTON_LEFT) { return; }
 
-	if (SELECTED_WAREHOUSE && isPointInRect(Point_2d(x, y), lstStructures.rect()))
+	if (SELECTED_WAREHOUSE && lstStructures.rect().contains(NAS2D::Point{x, y}))
 	{
 		takeMeThereCallback()(SELECTED_WAREHOUSE);
 	}


### PR DESCRIPTION
This is an update for #206. It addresses only the changes that apply to UI that were not part of UI Core (#209).

The code being modified here had a number of related easy opportunities for improvement using some of the new updates to NAS2D. I made a few such improvements. There are likely more things that can be improved, though I didn't want to stray too far from the `isPointInRect` to `Rectangle::contains` conversion. Further updates can be delayed to another PR.
