### PR TITLE
Remove pointInRect_f functions

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -229,24 +229,6 @@ HWND WIN32_getWindowHandle()
 #endif
 
 
-/**
- * Convenience function to pass a Rectangle_2df to \c isPointInRect()
- */
-bool pointInRect_f(int x, int y, const Rectangle_2df& rect)
-{
-	return rect.to<int>().contains(Point{x, y});
-}
-
-
-/**
- * Convenience function to pass \c float's to \c isPointInRect()
- */
-bool pointInRect_f(int x, int y, float rectX, float rectY, float rectW, float rectH)
-{
-	return NAS2D::Rectangle{rectX, rectY, rectW, rectH}.to<int>().contains(Point{x, y});
-}
-
-
 const std::string& productDescription(ProductType type)
 {
 	if (type == PRODUCT_NONE) { return constants::NONE; }

--- a/src/Common.h
+++ b/src/Common.h
@@ -296,17 +296,6 @@ extern std::map<int, std::string> TILE_INDEX_TRANSLATION;
 extern std::map<MineProductionRate, std::string> MINE_YIELD_TRANSLATION;
 
 
-/**
- * Convenience function to pass a Rectangle_2df to \c isPointInRect()
- */
-bool pointInRect_f(int x, int y, const NAS2D::Rectangle_2df& rect);
-
-
-/**
- * Convenience function to pass \c float's to \c isPointInRect()
- */
-bool pointInRect_f(int x, int y, float rectX, float rectY, float rectW, float rectH);
-
 void doNonFatalErrorMessage(const std::string& title, const std::string& msg);
 void doAlertMessage(const std::string& title, const std::string& msg);
 bool doYesNoMessage(const std::string& title, const std::string msg);

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -148,7 +148,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 void Button::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 {
-	mMouseHover = pointInRect_f(x, y, rect());
+	mMouseHover = mRect.to<int>().contains(NAS2D::Point{x, y});
 }
 
 

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -266,14 +266,7 @@ void Slider::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 
 	if (mDisplayPosition)
 	{
-		if (mSliderType == SLIDER_VERTICAL)
-		{
-			mMouseHoverSlide = mSlideBar.to<int>().contains(NAS2D::Point{x, y});
-		}
-		else
-		{ /// \fixme V523 https://www.viva64.com/en/w/v523/ These two conditionals do the same thing.
-			mMouseHoverSlide = mSlideBar.to<int>().contains(NAS2D::Point{x, y});
-		}
+		mMouseHoverSlide = mSlideBar.to<int>().contains(NAS2D::Point{x, y});
 	}
 
 	if (!mThumbPressed) { return; }

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -179,7 +179,7 @@ void Slider::positionInternal(float newPosition)
 
 void Slider::_buttonCheck(bool& buttonFlag, Rectangle_2df& rect, float value)
 {
-	if (pointInRect_f(mMousePosition.x(), mMousePosition.y(), rect))
+	if (rect.to<int>().contains(mMousePosition))
 	{
 		changeThumbPosition(value);
 		buttonFlag = true;
@@ -200,7 +200,7 @@ void Slider::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		if (pointInRect_f(x, y, mSlider))
+		if (mSlider.to<int>().contains(NAS2D::Point{x, y}))
 		{
 			mThumbPressed = true;
 			return;
@@ -225,7 +225,7 @@ void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 
-	if (pointInRect_f(x, y, mSlider))
+	if (mSlider.to<int>().contains(NAS2D::Point{x, y}))
 	{
 		// nothing
 	}
@@ -239,7 +239,7 @@ void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 		changeThumbPosition(-1.0);
 	}
 	*/
-	else if (pointInRect_f(x, y, mSlideBar))
+	else if (mSlideBar.to<int>().contains(NAS2D::Point{x, y}))
 	{
 		if (mSliderType == SLIDER_VERTICAL)
 		{
@@ -268,11 +268,11 @@ void Slider::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 	{
 		if (mSliderType == SLIDER_VERTICAL)
 		{
-			mMouseHoverSlide = pointInRect_f(x, y, mSlideBar);
+			mMouseHoverSlide = mSlideBar.to<int>().contains(NAS2D::Point{x, y});
 		}
 		else
 		{ /// \fixme V523 https://www.viva64.com/en/w/v523/ These two conditionals do the same thing.
-			mMouseHoverSlide = pointInRect_f(x, y, mSlideBar);
+			mMouseHoverSlide = mSlideBar.to<int>().contains(NAS2D::Point{x, y});
 		}
 	}
 

--- a/src/UI/Core/UIContainer.cpp
+++ b/src/UI/Core/UIContainer.cpp
@@ -127,7 +127,7 @@ void UIContainer::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y
 	for (auto it = mControls.rbegin(); it != mControls.rend(); ++it)
 	{
 		control = (*it);
-		if (control->visible() && pointInRect_f(x, y, control->rect()))
+		if (control->visible() && control->rect().to<int>().contains(NAS2D::Point{x, y}))
 		{
 			if (control == mControls.back()) { return; }
 			bringToFront(control);

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -57,8 +57,8 @@ void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	UIContainer::onMouseDown(button, x, y);
 
-	const auto titleBarRect = NAS2D::Rectangle{mRect.x(), mRect.y(), mRect.width(), sWindowTitleBarHeight};
-	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && titleBarRect.to<int>().contains(NAS2D::Point{x, y}));
+	const auto titleBarBounds = NAS2D::Rectangle{mRect.x(), mRect.y(), mRect.width(), sWindowTitleBarHeight};
+	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && titleBarBounds.to<int>().contains(NAS2D::Point{x, y}));
 }
 
 

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -57,7 +57,8 @@ void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	UIContainer::onMouseDown(button, x, y);
 
-	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), sWindowTitleBarHeight));
+	const auto titleBarRect = NAS2D::Rectangle{mRect.x(), mRect.y(), mRect.width(), sWindowTitleBarHeight};
+	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && titleBarRect.to<int>().contains(NAS2D::Point{x, y}));
 }
 
 

--- a/src/UI/Core/WindowStack.cpp
+++ b/src/UI/Core/WindowStack.cpp
@@ -48,7 +48,7 @@ bool WindowStack::pointInWindow(int x, int y) const
 	for (auto it = mWindowList.begin(); it != mWindowList.end(); ++it)
 	{
 		Window* w = *(it);
-		if (w->visible() && pointInRect_f(x, y, w->rect()))
+		if (w->visible() && w->rect().to<int>().contains(NAS2D::Point{x, y}))
 		{
 			return true;
 		}
@@ -66,7 +66,7 @@ void WindowStack::updateStack(int x, int y)
 	for (auto it = mWindowList.begin(); it != mWindowList.end(); ++it)
 	{
 		Window* w = (*it);
-		if (w->visible() && pointInRect_f(x, y, w->rect()))
+		if (w->visible() && w->rect().to<int>().contains(NAS2D::Point{x, y}))
 		{
 			if (it == mWindowList.begin()) { return; }
 			bringToFront(w);


### PR DESCRIPTION
Remove `pointInRect_f` functions. Instead consider using the `Rectangle::contains` method. The `Rectangle` methods are more explicit about type conversions, making the code easy to reason about, and generally quite compact when working with already packed values of the correct type.

Edit: In the spirit up https://github.com/lairworks/nas2d-core/pull/457, I thought I'd continue that line of thought in OPHD.
