### PR TITLE
Simplify signal declarations

### DIFF
--- a/src/ResourcePool.h
+++ b/src/ResourcePool.h
@@ -12,7 +12,7 @@
 class ResourcePool
 {
 public:
-	using Callback = NAS2D::Signals::Signal0<void>;
+	using Callback = NAS2D::Signals::Signal<>;
 
 	enum ResourceType
 	{

--- a/src/States/MainReportsUiState.h
+++ b/src/States/MainReportsUiState.h
@@ -10,7 +10,7 @@ class Structure;
 class MainReportsUiState : public Wrapper
 {
 public:
-	using ReportsUiCallback = NAS2D::Signals::Signal0<void>;
+	using ReportsUiCallback = NAS2D::Signals::Signal<>;
 	using TakeMeThere = NAS2D::Signals::Signal1<Structure*>;
 	using TakeMeThereList = std::vector<TakeMeThere*>;
 

--- a/src/States/MainReportsUiState.h
+++ b/src/States/MainReportsUiState.h
@@ -11,7 +11,7 @@ class MainReportsUiState : public Wrapper
 {
 public:
 	using ReportsUiCallback = NAS2D::Signals::Signal<>;
-	using TakeMeThere = NAS2D::Signals::Signal1<Structure*>;
+	using TakeMeThere = NAS2D::Signals::Signal<Structure*>;
 	using TakeMeThereList = std::vector<TakeMeThere*>;
 
 public:

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -59,9 +59,9 @@ public:
 	};
 
 public:
-	using QuitCallback = NAS2D::Signals::Signal0<void>;
-	using ReportsUiCallback = NAS2D::Signals::Signal0<void>;
-	using MapChangedCallback = NAS2D::Signals::Signal0<void>;
+	using QuitCallback = NAS2D::Signals::Signal<>;
+	using ReportsUiCallback = NAS2D::Signals::Signal<>;
+	using MapChangedCallback = NAS2D::Signals::Signal<>;
 
 public:
 	MapViewState(const std::string& savegame);

--- a/src/States/Planet.h
+++ b/src/States/Planet.h
@@ -27,7 +27,7 @@ public:
 	};
 
 public:
-	using MouseCallback = NAS2D::Signals::Signal0<void>;
+	using MouseCallback = NAS2D::Signals::Signal<>;
 
 public:
 	Planet(PlanetType type);

--- a/src/Things/Robots/Robot.h
+++ b/src/Things/Robots/Robot.h
@@ -6,7 +6,7 @@
 class Robot: public Thing
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> Callback;
+	typedef NAS2D::Signals::Signal<> Callback;
 	typedef NAS2D::Signals::Signal1<Robot*> TaskCallback;
 
 public:

--- a/src/Things/Robots/Robot.h
+++ b/src/Things/Robots/Robot.h
@@ -7,7 +7,7 @@ class Robot: public Thing
 {
 public:
 	typedef NAS2D::Signals::Signal<> Callback;
-	typedef NAS2D::Signals::Signal1<Robot*> TaskCallback;
+	typedef NAS2D::Signals::Signal<Robot*> TaskCallback;
 
 public:
 	Robot(const std::string& name, const std::string& sprite_path);

--- a/src/Things/Structures/CargoLander.h
+++ b/src/Things/Structures/CargoLander.h
@@ -9,7 +9,7 @@ class CargoLander : public Structure
 {
 public:
 
-	typedef NAS2D::Signals::Signal0<void> Callback;
+	typedef NAS2D::Signals::Signal<> Callback;
 
 	CargoLander(Tile* t) : Structure(constants::CARGO_LANDER, "structures/lander_0.sprite", CLASS_LANDER), mTile(t)
 	{

--- a/src/Things/Structures/ColonistLander.h
+++ b/src/Things/Structures/ColonistLander.h
@@ -8,7 +8,7 @@
 class ColonistLander : public Structure
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> Callback;
+	typedef NAS2D::Signals::Signal<> Callback;
 
 public:
 

--- a/src/Things/Structures/Factory.h
+++ b/src/Things/Structures/Factory.h
@@ -22,7 +22,7 @@ class Factory : public Structure
 {
 public:
 	// Callback providing what was complete and a reference to the Factory.
-	typedef NAS2D::Signals::Signal1<Factory&> ProductionCallback;
+	typedef NAS2D::Signals::Signal<Factory&> ProductionCallback;
 
 	typedef std::vector<ProductType> ProductionTypeList;
 

--- a/src/Things/Structures/MineFacility.h
+++ b/src/Things/Structures/MineFacility.h
@@ -10,7 +10,7 @@
 class MineFacility: public Structure
 {
 public:
-	typedef NAS2D::Signals::Signal1<MineFacility*> ExtensionCompleteCallback;
+	typedef NAS2D::Signals::Signal<MineFacility*> ExtensionCompleteCallback;
 public:
 	MineFacility(Mine* mine);
 	virtual ~MineFacility() {};

--- a/src/Things/Structures/SeedLander.h
+++ b/src/Things/Structures/SeedLander.h
@@ -6,7 +6,7 @@
 class SeedLander: public Structure
 {
 public:
-	typedef NAS2D::Signals::Signal2<int, int> Callback;
+	typedef NAS2D::Signals::Signal<int, int> Callback;
 
 public:
 	SeedLander() = delete;

--- a/src/Things/Thing.h
+++ b/src/Things/Thing.h
@@ -14,7 +14,7 @@ class Tile;
 class Thing
 {
 public:
-	typedef NAS2D::Signals::Signal1<Thing*> DieCallback;
+	typedef NAS2D::Signals::Signal<Thing*> DieCallback;
 
 public:
 	Thing(const std::string& name, const std::string& spritePath):	mName(name),

--- a/src/UI/Core/Button.h
+++ b/src/UI/Core/Button.h
@@ -19,7 +19,7 @@ public:
 	};
 
 public:
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 
 public:
 	Button();

--- a/src/UI/Core/CheckBox.h
+++ b/src/UI/Core/CheckBox.h
@@ -11,7 +11,7 @@
 class CheckBox : public Control
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 
 public:
 	CheckBox();

--- a/src/UI/Core/ComboBox.h
+++ b/src/UI/Core/ComboBox.h
@@ -10,7 +10,7 @@
 class ComboBox : public Control
 {
 public:
-	using SelectionChanged = NAS2D::Signals::Signal0<void>;
+	using SelectionChanged = NAS2D::Signals::Signal<>;
 
 public:
 	ComboBox();

--- a/src/UI/Core/Control.h
+++ b/src/UI/Core/Control.h
@@ -16,9 +16,9 @@
 class Control
 {
 public:
-	typedef NAS2D::Signals::Signal1<Control*> ResizeCallback;
-	typedef NAS2D::Signals::Signal1<Control*> TextChangedCallback;
-	typedef NAS2D::Signals::Signal2<float, float> PositionChangedCallback;
+	typedef NAS2D::Signals::Signal<Control*> ResizeCallback;
+	typedef NAS2D::Signals::Signal<Control*> TextChangedCallback;
+	typedef NAS2D::Signals::Signal<float, float> PositionChangedCallback;
 
 public:
 	Control() = default;

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -19,7 +19,7 @@
 class ListBox: public UIContainer
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> SelectionChangedCallback;
+	typedef NAS2D::Signals::Signal<> SelectionChangedCallback;
 
 	struct ListBoxItem
 	{

--- a/src/UI/Core/ListBoxBase.h
+++ b/src/UI/Core/ListBoxBase.h
@@ -28,7 +28,7 @@ public:
 	/**
 	 * Callback signal fired whenever the list selection changes.
 	 */
-	using SelectionChangedCallback = NAS2D::Signals::Signal0<void>;
+	using SelectionChangedCallback = NAS2D::Signals::Signal<>;
 
 public:
 	/**

--- a/src/UI/Core/RadioButton.h
+++ b/src/UI/Core/RadioButton.h
@@ -14,7 +14,7 @@ class UIContainer;
 class RadioButton : public Control
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 
 public:
 	RadioButton();

--- a/src/UI/Core/Slider.h
+++ b/src/UI/Core/Slider.h
@@ -32,7 +32,7 @@ public:
 		SLIDER_HORIZONTAL	/*!< Horizontal slider. */
 	};
 
-	typedef NAS2D::Signals::Signal1<float> ValueChangedCallback; /*!< type for Callback on value changed. */
+	typedef NAS2D::Signals::Signal<float> ValueChangedCallback; /*!< type for Callback on value changed. */
 
 public:
 	Slider();

--- a/src/UI/DifficultySelect.h
+++ b/src/UI/DifficultySelect.h
@@ -5,8 +5,8 @@
 class DifficultySelect : public Window
 {
 public:
-	using OkClickCallback = NAS2D::Signals::Signal0<void>;
-	using CancelCallback = NAS2D::Signals::Signal0<void>;
+	using OkClickCallback = NAS2D::Signals::Signal<>;
+	using CancelCallback = NAS2D::Signals::Signal<>;
 
 	DifficultySelect();
 	virtual ~DifficultySelect();

--- a/src/UI/DiggerDirection.h
+++ b/src/UI/DiggerDirection.h
@@ -19,7 +19,7 @@ public:
 		SEL_WEST
 	};
 
-	typedef NAS2D::Signals::Signal2<DiggerSelection, Tile*> Callback;
+	typedef NAS2D::Signals::Signal<DiggerSelection, Tile*> Callback;
 
 public:
 	DiggerDirection();

--- a/src/UI/FactoryListBox.h
+++ b/src/UI/FactoryListBox.h
@@ -21,7 +21,7 @@
 class FactoryListBox : public ListBoxBase
 {
 public:
-	using SelectionChangedCallback = NAS2D::Signals::Signal1<Factory*>;
+	using SelectionChangedCallback = NAS2D::Signals::Signal<Factory*>;
 
 public:
 	class FactoryListBoxItem : public ListBoxItem

--- a/src/UI/FileIo.h
+++ b/src/UI/FileIo.h
@@ -15,7 +15,7 @@ public:
 		FILE_SAVE
 	};
 
-	typedef NAS2D::Signals::Signal2<const std::string&, FileOperation> FileOperationCallback;
+	typedef NAS2D::Signals::Signal<const std::string&, FileOperation> FileOperationCallback;
 
 public:
 	FileIo();

--- a/src/UI/GameOptionsDialog.h
+++ b/src/UI/GameOptionsDialog.h
@@ -5,7 +5,7 @@
 class GameOptionsDialog : public Window
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 
 public:
 	GameOptionsDialog();

--- a/src/UI/GameOverDialog.h
+++ b/src/UI/GameOverDialog.h
@@ -5,7 +5,7 @@
 class GameOverDialog : public Window
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 
 public:
 	GameOverDialog();

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -42,7 +42,7 @@ public:
 		NAS2D::Point_2df pos;
 	};
 
-	typedef NAS2D::Signals::Signal1<const IconGridItem*> Callback;
+	typedef NAS2D::Signals::Signal<const IconGridItem*> Callback;
 
 public:
 	IconGrid();

--- a/src/UI/Reports/ReportInterface.h
+++ b/src/UI/Reports/ReportInterface.h
@@ -16,7 +16,7 @@ public:
 	 * Callback signal used to handle clicks of a "Take Me There" button to center
 	 * the map view on a given structure.
 	 */
-	using TakeMeThere = NAS2D::Signals::Signal1<Structure*>;
+	using TakeMeThere = NAS2D::Signals::Signal<Structure*>;
 
 public:
 	ReportInterface() {}

--- a/src/UI/StructureListBox.h
+++ b/src/UI/StructureListBox.h
@@ -12,7 +12,7 @@ class Structure;
 class StructureListBox : public ListBoxBase
 {
 public:
-	using SelectionChangedCallback = NAS2D::Signals::Signal1<Structure*>;
+	using SelectionChangedCallback = NAS2D::Signals::Signal<Structure*>;
 
 public:
 	class StructureListBoxItem : public ListBoxItem


### PR DESCRIPTION
Simplifies `Signal` declarations by removing explicit `void` for no parameters, and removing the explicit count of the number of parameters. Parameter count is automatically detected by the updated template `Signal` code.
