### PR TITLE
Fix bug to allow game to run with no audio

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,7 @@ int main(int /*argc*/, char *argv[])
 		}
 		catch (...)
 		{
-			Utility<MixerNull>::init();
+			Utility<Mixer>::init<MixerNull>();
 		}
 
 		WindowEventWrapper _wew;


### PR DESCRIPTION
Fix bug to allow game to run with no audio.

Previously, if `MixerSDL` construction threw an error, a `MixerNull` global was initialized using that specific interface, rather than the more generic `Mixer` interface. This meant any future references to the `Mixer` interface would try to initialize a new object, rather than try to use the existing `MixerNull` object.

Since the `Mixer` object is not default constructible, trying to create one in a delayed manner causes an error that terminates the game.
