### PR TITLE
Fix signed/unsigned comparison warnings

### DIFF
--- a/src/MicroPather/micropather.h
+++ b/src/MicroPather/micropather.h
@@ -349,8 +349,8 @@ namespace micropather
 		const Item* Find(void* start, void* end);
 
 		Item* mem = nullptr;
-		int allocated = 0;
-		int nItems = 0;
+		unsigned allocated = 0;
+		unsigned nItems = 0;
 	};
 
 	struct CacheData


### PR DESCRIPTION
Cherry-picked from #225.

Closes #128. (Which is only concerned with the signed/unsigned warnings, not with the `memset` warnings).
