### PR TITLE
Add more CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,7 @@ jobs:
       - image: outpostuniverse/nas2d-circleci:1.1
     steps:
       - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule init
-            git submodule update
+      - run: git submodule update --init
       - run:
           name: "Build"
           command: make --keep-going

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,39 @@
-version: 2.0
-jobs:
+version: 2.1
+
+commands:
   build:
-    docker:
-      - image: outpostuniverse/nas2d-circleci:1.1
     steps:
       - checkout
       - run: git submodule update --init
       - run: make --keep-going nas2d
       - run: make --keep-going
+
+jobs:
+  build-linux:
+    docker:
+      - image: outpostuniverse/nas2d:1.4
+    steps:
+      - build
+  build-linux-gcc8:
+    docker:
+      - image: outpostuniverse/nas2d-gcc8:1.0
+    steps:
+      - build
+  build-linux-clang:
+    docker:
+      - image: outpostuniverse/nas2d-clang:1.0
+    steps:
+      - build
+  build-linux-mingw:
+    docker:
+      - image: outpostuniverse/nas2d-mingw:1.3
+    steps:
+      - build
+
+workflows:
+  build:
+    jobs:
+      - build-linux
+      - build-linux-gcc8
+      - build-linux-clang
+      - build-linux-mingw

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ jobs:
     docker:
       - image: outpostuniverse/nas2d-mingw:1.3
     steps:
-      - build
+      - checkout
+      - run: git submodule update --init
+      - run: make --keep-going intermediate
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,5 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run:
-          name: "Build"
-          command: make --keep-going
+      - run: make --keep-going nas2d
+      - run: make --keep-going

--- a/makefile
+++ b/makefile
@@ -30,6 +30,9 @@ $(EXE): $(NAS2DLIB) $(OBJS)
 	@mkdir -p ${@D}
 	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
+.PHONY: intermediate
+intermediate: $(OBJS)
+
 $(NAS2DLIB): nas2d
 
 .PHONY: nas2d


### PR DESCRIPTION
Add more CircleCI builds:
- gcc
- gcc-8
- clang
- mingw-w64 (partial support, compile without linking)

Previously, there was only a `gcc` build.
