### PR TITLE
Add missing `<cmath>` header

### DIFF
--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -13,6 +13,7 @@
 #include "../Constants.h"
 
 #include <sstream>
+#include <cmath>
 
 #include "SDL2/SDL.h"
 #include "SDL2/SDL_video.h"


### PR DESCRIPTION
Mingw-w64 complains about `std::floor` if the header is missing.
