### PR TITLE
Disable AppVeyor Debug build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 image: Visual Studio 2019
 configuration:
   - Release
-  - Debug
 platform:
   - x64
   - x86


### PR DESCRIPTION
Builds are taking much too long to finish. By disabling the `Debug` build, it should halve the amount of time needed to complete.

One down side, is that changes which break only the Debug build may go unnoticed for quite some time.
