### PR TITLE
Rename `onMouseMotion` to `onMouseMove`

### DIFF
--- a/src/States/GameState.cpp
+++ b/src/States/GameState.cpp
@@ -35,7 +35,7 @@ GameState::~GameState()
 	Utility<StructureManager>::get().dropAllStructures();
 
 	EventHandler& e = Utility<EventHandler>::get();
-	e.mouseMotion().disconnect(this, &GameState::onMouseMotion);
+	e.mouseMotion().disconnect(this, &GameState::onMouseMove);
 
 	Utility<Renderer>::get().fadeComplete().disconnect(this, &GameState::fadeComplete);
 
@@ -63,7 +63,7 @@ GameState::~GameState()
 void GameState::initialize()
 {
 	EventHandler& e = Utility<EventHandler>::get();
-	e.mouseMotion().connect(this, &GameState::onMouseMotion);
+	e.mouseMotion().connect(this, &GameState::onMouseMove);
 
 	MAIN_REPORTS_UI = new MainReportsUiState();
 	MAIN_REPORTS_UI->_initialize();
@@ -104,7 +104,7 @@ void GameState::mapviewstate(MapViewState* state)
 /**
  * Mouse motion event handler.
  */
-void GameState::onMouseMotion(int x, int y, int /*relX*/, int /*relY*/)
+void GameState::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
 	MOUSE_COORDS = {x, y};
 }

--- a/src/States/GameState.h
+++ b/src/States/GameState.h
@@ -17,7 +17,7 @@ public:
 	virtual State* update() final;
 
 private:
-	void onMouseMotion(int x, int y, int relX, int relY);
+	void onMouseMove(int x, int y, int relX, int relY);
 
 	void fadeComplete();
 	void musicComplete();

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -18,7 +18,7 @@ Button::Button()
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Button::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Button::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Button::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().connect(this, &Button::onMouseMove);
 	hasFocus(true);
 
 	mSkinNormal.push_back(Image("ui/skin/button_top_left.png"));
@@ -59,7 +59,7 @@ Button::~Button()
 {
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Button::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Button::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Button::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Button::onMouseMove);
 
 	delete mImage;
 }
@@ -146,7 +146,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void Button::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
+void Button::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
 	mMouseHover = mRect.to<int>().contains(NAS2D::Point{x, y});
 }

--- a/src/UI/Core/Button.h
+++ b/src/UI/Core/Button.h
@@ -42,7 +42,7 @@ public:
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
-	virtual void onMouseMotion(int x, int y, int dX, int dY);
+	virtual void onMouseMove(int x, int y, int dX, int dY);
 
 private:
 	enum State

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -29,7 +29,7 @@ Slider::Slider() :	Control()
 	SLD_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Slider::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Slider::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Slider::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().connect(this, &Slider::onMouseMove);
 	hasFocus(true);
 }
 
@@ -41,7 +41,7 @@ Slider::~Slider()
 {
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Slider::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Slider::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Slider::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Slider::onMouseMove);
 }
 
 
@@ -258,7 +258,7 @@ void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 /**
  *
  */
-void Slider::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
+void Slider::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 

--- a/src/UI/Core/Slider.h
+++ b/src/UI/Core/Slider.h
@@ -62,7 +62,7 @@ public:
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y); 	/*!< Event raised on mouse button down. */
 	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y); 	/*!< Event raised on mouse button up. */
-	virtual void onMouseMotion(int x, int y, int dX, int dY); 	/*!< Event raised on mouse move. */
+	virtual void onMouseMove(int x, int y, int dX, int dY); 	/*!< Event raised on mouse move. */
 	
 private:
 	float positionInternal();

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -23,14 +23,14 @@ Window::Window()
 Window::~Window()
 {
 	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Window::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Window::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Window::onMouseMove);
 }
 
 
 void Window::_init()
 {
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Window::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMove);
 
 	WINDOW_TITLE_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
@@ -68,7 +68,7 @@ void Window::onMouseUp(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*
 }
 
 
-void Window::onMouseMotion(int /*x*/, int /*y*/, int dX, int dY)
+void Window::onMouseMove(int /*x*/, int /*y*/, int dX, int dY)
 {
 	if (!visible() || !hasFocus()) { return; }
 

--- a/src/UI/Core/Window.h
+++ b/src/UI/Core/Window.h
@@ -18,7 +18,7 @@ public:
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
-	void onMouseMotion(int x, int y, int dX, int dY);
+	void onMouseMove(int x, int y, int dX, int dY);
 
 	static inline constexpr float sWindowTitleBarHeight = 20.0f;
 

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -20,7 +20,7 @@ static Font* FONT = nullptr;
 IconGrid::IconGrid()
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &IconGrid::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMove);
 	hasFocus(true);
 
 	mSkin.push_back(Image("ui/skin/textbox_top_left.png"));
@@ -43,7 +43,7 @@ IconGrid::IconGrid()
 IconGrid::~IconGrid()
 {
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &IconGrid::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &IconGrid::onMouseMotion);
+	Utility<EventHandler>::get().mouseMotion().disconnect(this, &IconGrid::onMouseMove);
 }
 
 
@@ -131,7 +131,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 /**
  * MouseMotion event handler.
  */
-void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
+void IconGrid::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!visible() || !hasFocus()) { return; }
 

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -92,7 +92,7 @@ public:
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
-	virtual void onMouseMotion(int x, int y, int dX, int dY);
+	virtual void onMouseMove(int x, int y, int dX, int dY);
 
 	virtual void sizeChanged();
 


### PR DESCRIPTION
This makes the event handler name consistent across the code base. Previously it was a toss up between either `onMouseMove` or `onMouseMotion`.
