### PR TITLE
Add makefile lint rules

### DIFF
--- a/makefile
+++ b/makefile
@@ -58,3 +58,15 @@ clean:
 clean-all:
 	-rm -rf $(BUILDDIR)
 	-rm -f $(EXE)
+
+
+.PHONY: lint
+lint: cppcheck cppclean
+
+.PHONY: cppcheck
+cppcheck:
+	cppcheck --quiet "$(SRCDIR)"
+
+.PHONY: cppclean
+cppclean:
+	cppclean --quiet --include-path "$(NAS2DINCLUDEDIR)" --include-path "/usr/include/SDL2" --exclude "MicroPather" "$(SRCDIR)"


### PR DESCRIPTION
Closes #246

Add lint rules to the `makefile` using `cppcheck` and `cppclean`.

This rules are largely copied from the NAS2D submodule, with some updates for include directories, and exclude directories for problem code that would crash `cppclean`.

Updated includes an excludes from #138.

----

Linux only change.
