### PR TITLE
Use vectorized TileMap

### DIFF
--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -74,7 +74,7 @@ static bool validConnection(Structure* src, Structure* dst, Direction _d)
 
 GraphWalker::GraphWalker(const Point_2d& _p, int _d, TileMap* _t) :
 	mTileMap(_t),
-	mThisTile(_t->getTile(_p.x(), _p.y(), _d)),
+	mThisTile(_t->getTile(_p, _d)),
 	mGridPosition(_p),
 	mDepth(_d)
 {

--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -38,7 +38,6 @@ public:
 	Tile* getVisibleTile(NAS2D::Point<int> position, int level);
 	Tile* getVisibleTile() { return getVisibleTile(tileMouseHover(), mCurrentDepth); }
 
-	bool isVisibleTile(int x, int y, int z) const { return isVisibleTile(NAS2D::Point<int>{x, y}, z); }
 	bool isVisibleTile(NAS2D::Point<int> position, int z) const;
 	bool isVisibleTile(NAS2D::Point<int> position) const { return isVisibleTile(position, mCurrentDepth); }
 	bool isVisibleTile(const Tile& t) { return isVisibleTile(t.position(), t.depth()); }

--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -34,12 +34,10 @@ public:
 	Tile* getTile(int x, int y, int level);
 	Tile* getTile(int x, int y) { return getTile(x, y, mCurrentDepth); }
 	Tile* getTile(NAS2D::Point<int> position, int level) { return getTile(position.x(), position.y(), level); }
-	
-	Tile* getVisibleTile(int x, int y, int level) { return getVisibleTile(NAS2D::Point<int>{x, y}, level); }
-	Tile* getVisibleTile(int x, int y) { return getVisibleTile(x, y, mCurrentDepth); }
+
 	Tile* getVisibleTile(NAS2D::Point<int> position, int level);
 	Tile* getVisibleTile() { return getVisibleTile(tileMouseHover(), mCurrentDepth); }
-	
+
 	bool isVisibleTile(int x, int y, int z) const { return isVisibleTile(NAS2D::Point<int>{x, y}, z); }
 	bool isVisibleTile(NAS2D::Point<int> position, int z) const;
 	bool isVisibleTile(NAS2D::Point<int> position) const { return isVisibleTile(position, mCurrentDepth); }

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -752,7 +752,7 @@ void MapViewState::placeTubes()
 	int x = mTileMapMouseHover.x();
 	int y = mTileMapMouseHover.y();
 
-	Tile* tile = mTileMap->getVisibleTile(x, y, mTileMap->currentDepth());
+	Tile* tile = mTileMap->getVisibleTile(mTileMapMouseHover, mTileMap->currentDepth());
 	if (!tile) { return; }
 
 	// Check the basics.
@@ -786,7 +786,7 @@ void MapViewState::placeTubeStart()
 	int x = mTileMapMouseHover.x();
 	int y = mTileMapMouseHover.y();
 
-	Tile* tile = mTileMap->getVisibleTile(x, y, mTileMap->currentDepth());
+	Tile* tile = mTileMap->getVisibleTile(mTileMapMouseHover, mTileMap->currentDepth());
 	if (!tile) { return; }
 
 	// Check the basics.
@@ -819,7 +819,7 @@ void MapViewState::placeTubeEnd()
 	bool endReach = false;
 	if (tubeStart.height() != 1) return;
 	tubeStart.height(0);	// the height is used as a boolean to indicate that we are
-	Tile* tile = mTileMap->getVisibleTile(x, y, mTileMap->currentDepth());
+	Tile* tile = mTileMap->getVisibleTile(mTileMapMouseHover, mTileMap->currentDepth());
 	if (!tile) { return; }
 
 	/** \fixme	This is a kludge that only works because all of the tube structures are listed alphabetically.
@@ -865,7 +865,7 @@ void MapViewState::placeTubeEnd()
 	// 
 	do {
 		std::cout << "Tube " << x << "/" << y << std::endl;
-		tile = mTileMap->getVisibleTile(x, y, mTileMap->currentDepth());
+		tile = mTileMap->getVisibleTile(tubeStart.startPoint(), mTileMap->currentDepth());
 		if (!tile) {
 			endReach = true;
 		}else if (tile->thing() || tile->mine() || !tile->bulldozed() || !tile->excavated()){

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -925,7 +925,7 @@ void MapViewState::placeRobot()
 			tile->pushMine(nullptr);
 			for (size_t i = 0; i <= static_cast<size_t>(mTileMap->maxDepth()); ++i)
 			{
-				Tile* _t = mTileMap->getTile(mTileMap->tileMouseHoverX(), mTileMap->tileMouseHoverY(), static_cast<int>(i));
+				Tile* _t = mTileMap->getTile(mTileMap->tileMouseHover(), static_cast<int>(i));
 
 				// Probably overkill here but if this is ever true there is a serious logic error somewhere.
 				if (!_t->thing() || !_t->thingIsStructure())
@@ -1008,7 +1008,7 @@ void MapViewState::placeRobot()
 		if (!tile->excavated()) { return; }
 
 		// Check for obstructions underneath the the digger location.
-		if (tile->depth() != mTileMap->maxDepth() && !mTileMap->getTile(tile->x(), tile->y(), tile->depth() + 1)->empty())
+		if (tile->depth() != mTileMap->maxDepth() && !mTileMap->getTile(tile->position(), tile->depth() + 1)->empty())
 		{
 			doAlertMessage(constants::ALERT_INVALID_ROBOT_PLACEMENT, constants::ALERT_DIGGER_BLOCKED_BELOW);
 			return;
@@ -1121,7 +1121,7 @@ void MapViewState::placeStructure()
 	// NOTE:	This function will never be called until the seed lander is deployed so there
 	//			is no need to check that the CC Location is anything other than { 0, 0 }.
 	if (!structureIsLander(mCurrentStructure) && !selfSustained(mCurrentStructure) &&
-		(tile->distanceTo(mTileMap->getTile(ccLocationX(), ccLocationY(), 0)) > constants::ROBOT_COM_RANGE))
+		(tile->distanceTo(mTileMap->getTile(ccLocation(), 0)) > constants::ROBOT_COM_RANGE))
 	{
 		doAlertMessage(constants::ALERT_INVALID_STRUCTURE_ACTION, constants::ALERT_STRUCTURE_OUT_OF_RANGE);
 		return;
@@ -1349,7 +1349,7 @@ void MapViewState::checkConnectedness()
 	}
 
 	// Assumes that the 'thing' at mCCLocation is in fact a Structure.
-	Tile *t = mTileMap->getTile(ccLocationX(), ccLocationY(), 0);
+	Tile *t = mTileMap->getTile(ccLocation(), 0);
 	Structure *cc = t->structure();
 
 	if (!cc)

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -89,7 +89,7 @@ void MapViewState::drawMiniMap()
 
 	for (auto _mine : mTileMap->mineLocations())
 	{
-		Mine* mine = mTileMap->getTile(_mine.x(), _mine.y(), 0)->mine();
+		Mine* mine = mTileMap->getTile(_mine, 0)->mine();
 		if (!mine) { break; } // avoids potential race condition where a mine is destroyed during an updated cycle.
 
 		float mineBeaconStatusOffsetX = 0.0f;		

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -214,14 +214,14 @@ void MapViewState::diggerTaskFinished(Robot* r)
 
 		AirShaft* as2 = new AirShaft();
 		as2->ug();
-		Utility<StructureManager>::get().addStructure(as2, mTileMap->getTile(t->x(), t->y(), t->depth() + 1));
+		Utility<StructureManager>::get().addStructure(as2, mTileMap->getTile(t->position(), t->depth() + 1));
 
 		originX = t->x();
 		originY = t->y();
 		depthAdjust = 1;
 
-		mTileMap->getTile(originX, originY, t->depth())->index(TERRAIN_DOZED);
-		mTileMap->getTile(originX, originY, t->depth() + depthAdjust)->index(TERRAIN_DOZED);
+		mTileMap->getTile(t->position(), t->depth())->index(TERRAIN_DOZED);
+		mTileMap->getTile(t->position(), t->depth() + depthAdjust)->index(TERRAIN_DOZED);
 
 		/// \fixme Naive approach; will be slow with large colonies.
 		Utility<StructureManager>::get().disconnectAll();
@@ -281,7 +281,7 @@ void MapViewState::minerTaskFinished(Robot* r)
 	_mf->extensionComplete().connect(this, &MapViewState::mineFacilityExtended);
 
 	// Tile immediately underneath facility.
-	Tile* t2 = mTileMap->getTile(t->x(), t->y(), t->depth() + 1);
+	Tile* t2 = mTileMap->getTile(t->position(), t->depth() + 1);
 	Utility<StructureManager>::get().addStructure(new MineShaft(), t2);
 
 	t->index(0);
@@ -297,7 +297,7 @@ void MapViewState::mineFacilityExtended(MineFacility* mf)
 	if (mMineOperationsWindow.mineFacility() == mf) { mMineOperationsWindow.mineFacility(mf); }
 	
 	Tile* mf_tile = Utility<StructureManager>::get().tileFromStructure(mf);
-	Tile* t = mTileMap->getTile(mf_tile->x(), mf_tile->y(), mf->mine()->depth());
+	Tile* t = mTileMap->getTile(mf_tile->position(), mf->mine()->depth());
 	Utility<StructureManager>::get().addStructure(new MineShaft(), t);
 	t->index(0);
 	t->excavated(true);

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -340,7 +340,7 @@ bool outOfCommRange(Point_2d& cc_location, TileMap* tile_map, Tile* current_tile
 {
 	Tile* tile = tile_map->getVisibleTile();
 
-	if (tile->distanceTo(tile_map->getTile(cc_location.x(), cc_location.y(), 0)) <= constants::ROBOT_COM_RANGE)
+	if (tile->distanceTo(tile_map->getTile(cc_location, 0)) <= constants::ROBOT_COM_RANGE)
 		return false;
 
 	Tile* _comm_t = nullptr;


### PR DESCRIPTION
This converts code to use vectorized methods on `TileMap`, but only for the easy cases where packed parameters are already available.
