### PR TITLE
Add Vector direction constants

### DIFF
--- a/src/DirectionOffset.h
+++ b/src/DirectionOffset.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "NAS2D/Renderer/Vector.h"
+
+#include <array>
+
+
+constexpr auto DirectionNorthWest = NAS2D::Vector<int>{-1, -1};
+constexpr auto DirectionNorth     = NAS2D::Vector<int>{ 0, -1};
+constexpr auto DirectionNorthEast = NAS2D::Vector<int>{ 1, -1};
+constexpr auto DirectionWest      = NAS2D::Vector<int>{-1,  0};
+constexpr auto DirectionCenter    = NAS2D::Vector<int>{ 0,  0};
+constexpr auto DirectionEast      = NAS2D::Vector<int>{ 1,  0};
+constexpr auto DirectionSouthWest = NAS2D::Vector<int>{-1,  1};
+constexpr auto DirectionSouth     = NAS2D::Vector<int>{ 0,  1};
+constexpr auto DirectionSouthEast = NAS2D::Vector<int>{ 1,  1};
+
+
+constexpr auto DirectionScan3x3 = std::array<NAS2D::Vector<int>, 9>{
+	DirectionNorthWest,
+	DirectionNorth,
+	DirectionNorthEast,
+	DirectionWest,
+	DirectionCenter,
+	DirectionEast,
+	DirectionSouthWest,
+	DirectionSouth,
+	DirectionSouthEast
+};
+
+constexpr auto DirectionClockwise8 = std::array<NAS2D::Vector<int>, 8>{
+	DirectionNorth,
+	DirectionNorthEast,
+	DirectionEast,
+	DirectionSouthEast,
+	DirectionSouth,
+	DirectionSouthWest,
+	DirectionWest,
+	DirectionNorthWest
+};
+
+constexpr auto DirectionClockwise4 = std::array<NAS2D::Vector<int>, 4>{
+	DirectionNorth,
+	DirectionEast,
+	DirectionSouth,
+	DirectionWest,
+};

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -4,6 +4,7 @@
 #include "TileMap.h"
 
 #include "../Constants.h"
+#include "../DirectionOffset.h"
 
 #include <functional>
 #include <random>
@@ -635,13 +636,11 @@ float TileMap::LeastCostEstimate(void* stateStart, void* stateEnd)
 using namespace micropather;
 void TileMap::AdjacentCost(void* state, std::vector<StateCost>* adjacent)
 {
-	const auto offsets = std::array<NAS2D::Vector<int>, 4>{{{0, -1}, {1, 0}, {0, 1}, {-1, 0}}};
-
 	Tile* tile = static_cast<Tile*>(state);
 
 	const auto tilePosition = tile->position();
 
-	for (const auto& offset : offsets)
+	for (const auto& offset : DirectionClockwise4)
 	{
 		Tile* adjacent_tile = getTile(tilePosition + offset, 0);
 		float cost = 0.5f;

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -14,6 +14,7 @@
 
 #include "../Constants.h"
 #include "../StructureCatalogue.h"
+#include "../DirectionOffset.h"
 
 
 #include "../Things/Structures/RobotCommand.h"
@@ -152,10 +153,11 @@ bool checkStructurePlacement(Tile* tile, Direction dir)
  */
 bool validTubeConnection(TileMap* tilemap, int x, int y, ConnectorDir dir)
 {
-	return checkTubeConnection(tilemap->getTile(x + 1, y, tilemap->currentDepth()), DIR_EAST, dir) ||
-		checkTubeConnection(tilemap->getTile(x - 1, y, tilemap->currentDepth()), DIR_WEST, dir) ||
-		checkTubeConnection(tilemap->getTile(x, y + 1, tilemap->currentDepth()), DIR_SOUTH, dir) ||
-		checkTubeConnection(tilemap->getTile(x, y - 1, tilemap->currentDepth()), DIR_NORTH, dir);
+	const auto point = NAS2D::Point<int>{x, y};
+	return checkTubeConnection(tilemap->getTile(point + DirectionEast, tilemap->currentDepth()), DIR_EAST, dir) ||
+		checkTubeConnection(tilemap->getTile(point + DirectionWest, tilemap->currentDepth()), DIR_WEST, dir) ||
+		checkTubeConnection(tilemap->getTile(point + DirectionSouth, tilemap->currentDepth()), DIR_SOUTH, dir) ||
+		checkTubeConnection(tilemap->getTile(point + DirectionNorth, tilemap->currentDepth()), DIR_NORTH, dir);
 }
 
 
@@ -166,10 +168,11 @@ bool validTubeConnection(TileMap* tilemap, int x, int y, ConnectorDir dir)
  */
 bool validStructurePlacement(TileMap* tilemap, int x, int y)
 {
-	return checkStructurePlacement(tilemap->getTile(x, y - 1, tilemap->currentDepth()), DIR_NORTH) ||
-		checkStructurePlacement(tilemap->getTile(x + 1, y, tilemap->currentDepth()), DIR_EAST) ||
-		checkStructurePlacement(tilemap->getTile(x, y + 1, tilemap->currentDepth()), DIR_SOUTH) ||
-		checkStructurePlacement(tilemap->getTile(x - 1, y, tilemap->currentDepth()), DIR_WEST);
+	const auto point = NAS2D::Point<int>{x, y};
+	return checkStructurePlacement(tilemap->getTile(point + DirectionNorth, tilemap->currentDepth()), DIR_NORTH) ||
+		checkStructurePlacement(tilemap->getTile(point + DirectionEast, tilemap->currentDepth()), DIR_EAST) ||
+		checkStructurePlacement(tilemap->getTile(point + DirectionSouth, tilemap->currentDepth()), DIR_SOUTH) ||
+		checkStructurePlacement(tilemap->getTile(point + DirectionWest, tilemap->currentDepth()), DIR_WEST);
 }
 
 


### PR DESCRIPTION
Add `Vector<int>` direction constants, and iteration offset array constants.

----

The named direction constants allows a `Point` to be easily offset in any named direction:
```cpp
const auto point = NAS2D::Point<int>{x, y};
const auto offsetPoint = point + DirectionNorth;
```

----

The iteration arrays allows easy iteration over surrounding points.

This can be done as a 3x3 scan, top to bottom, left to right (NW, N, NE, W, Center, E, SW, S, SE):
```cpp
const auto point = NAS2D::Point<int>{x, y};
for (const auto offset : DirectionScan3x3) {
    doSomeProcessing(point + offset);
}
```

This can be done as an 8 direction clockwise scan (N, NE, E, SE, S, SW, W, NW):
```cpp
const auto point = NAS2D::Point<int>{x, y};
for (const auto offset : DirectionClockwise8) {
    doSomeProcessing(point + offset);
}
```

This can be done as a 4 direction clockwise scan (N, E, S, W):
```cpp
const auto point = NAS2D::Point<int>{x, y};
for (const auto offset : DirectionClockwise4) {
    doSomeProcessing(point + offset);
}
```
