### PR TITLE
Fix pather warning about `memset` with non-trivial type

### DIFF
--- a/src/MicroPather/micropather.h
+++ b/src/MicroPather/micropather.h
@@ -306,15 +306,15 @@ namespace micropather
 		struct Item
 		{
 			// The key:
-			void* start = nullptr;
-			void* end = nullptr;
+			void* start;
+			void* end;
 
 			bool KeyEqual(const Item& item) const { return start == item.start && end == item.end; }
 			bool Empty() const { return start == 0 && end == 0; }
 
 			// Data:
-			void* next = nullptr;
-			float	cost = 0.0f; // from 'start' to 'next'. FLT_MAX if unsolveable.
+			void* next;
+			float	cost; // from 'start' to 'next'. FLT_MAX if unsolveable.
 
 			unsigned Hash() const
 			{


### PR DESCRIPTION
Closes #239

Remove default initialization, making the type trivial. All instances of the type are fully initialized when created, so there is no need for the default initialization.

References:
https://en.cppreference.com/w/cpp/named_req/TrivialType
https://en.cppreference.com/w/cpp/language/default_constructor#Trivial_default_constructor
