### PR TITLE
Rename short parameter names UI Core

### DIFF
--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -57,7 +57,7 @@ void ComboBox::init()
 /**
  * Resized event handler.
  */
-void ComboBox::resizedHandler(Control* /*c*/)
+void ComboBox::resizedHandler(Control* /*control*/)
 {
 	if (height() < 20) { height(20); } // enforce minimum height;
 	if (width() < 50) { width(50); } // enforce mininum width;

--- a/src/UI/Core/ComboBox.h
+++ b/src/UI/Core/ComboBox.h
@@ -39,7 +39,7 @@ public:
 private:
 	void init();
 
-	void resizedHandler(Control*);
+	void resizedHandler(Control* control);
 	void repositioned(float, float);
 	void lstItemsSelectionChanged();
 

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -48,9 +48,9 @@ Slider::~Slider()
 /**
  *
  */
-void Slider::size(float w, float h)
+void Slider::size(float width, float height)
 {
-	Control::size(w, h);
+	Control::size(width, height);
 
 	// deduce the type of slider from the ratio.
 	if (rect().height() > rect().width())

--- a/src/UI/Core/Slider.h
+++ b/src/UI/Core/Slider.h
@@ -55,7 +55,7 @@ public:
 	void backward(bool isBackward) { mBackward = isBackward; } 	/*!< Set the backward flag. */
 
 	void update(); 							/*!< Called to display the slider. */
-	virtual void size(float w, float h); 	/*!< Set the slider size. */
+	virtual void size(float width, float height); 	/*!< Set the slider size. */
 
 	ValueChangedCallback& change() { return mCallback; } 	/*!< Give the callback to enable another control or a window to dis/connect to this event call. */
 

--- a/src/UI/Core/UIContainer.cpp
+++ b/src/UI/Core/UIContainer.cpp
@@ -35,27 +35,27 @@ UIContainer::~UIContainer()
 /**
  * Adds a Control to the UIContainer.
  */
-void UIContainer::add(Control* c, float x, float y)
+void UIContainer::add(Control* control, float x, float y)
 {
-	if(c == nullptr)
+	if(control == nullptr)
 	{
 		std::cout << "UIContainer::addControl(): Attempting to add a NULL Control." << std::endl;
 		return;
 	}
 
-	if (std::find(mControls.begin(), mControls.end(), c) != mControls.end())
+	if (std::find(mControls.begin(), mControls.end(), control) != mControls.end())
 	{
 		std::cout << "UIContainer::addControl(): Duplicate control." << std::endl;
 		return;
 	}
 
 	if (mControls.size() > 0) { mControls.back()->hasFocus(false); }
-	mControls.push_back(c);
+	mControls.push_back(control);
 
-	c->position(rect().x() + x, rect().y() + y);
-	c->visible(visible());
-	c->hasFocus(true);
-	if (auto* asRadioButton = dynamic_cast<RadioButton*>(c))
+	control->position(rect().x() + x, rect().y() + y);
+	control->visible(visible());
+	control->hasFocus(true);
+	if (auto* asRadioButton = dynamic_cast<RadioButton*>(control))
 	{
 		asRadioButton->parentContainer(this);
 	}

--- a/src/UI/Core/UIContainer.h
+++ b/src/UI/Core/UIContainer.h
@@ -17,7 +17,7 @@ public:
 	UIContainer();
 	virtual ~UIContainer();
 
-	void add(Control* c, float x, float y);
+	void add(Control* control, float x, float y);
 	void clear();
 
 	void bringToFront(Control* control);


### PR DESCRIPTION
More explicit longer parameter names are easier to understand than highly abbreviated ones.

Additionally, single letter variable names do not allow highlighting of matching names in the Atom editor.
