### PR TITLE
Remove empty comments

### DIFF
--- a/src/Map/Tile.h
+++ b/src/Map/Tile.h
@@ -73,14 +73,14 @@ protected:
 	void thingIsStructure(bool value) { mThingIsStructure = value; }
 
 private:
-	int				mIndex = 0;					/**<  */
+	int				mIndex = 0;
 
 	int				mX = 0;						/**< Tile Position Information */
 	int				mY = 0;						/**< Tile Position Information */
 	int				mDepth = 0;					/**< Tile Position Information */
 
-	Thing*			mThing = nullptr;			/**<  */
-	Mine*			mMine = nullptr;			/**<  */
+	Thing*			mThing = nullptr;
+	Mine*			mMine = nullptr;
 
 	NAS2D::Color	mColor = NAS2D::Color::Normal;
 

--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -119,26 +119,26 @@ private:
 	MouseMapRegion getMouseMapRegion(int x, int y);
 
 private:
-	int					mEdgeLength = 0;			/**<  */
-	int					mWidth = 0;					/**<  */
-	int					mHeight = 0;				/**<  */
+	int					mEdgeLength = 0;
+	int					mWidth = 0;
+	int					mHeight = 0;
 
 	int					mMaxDepth = 0;				/**< Maximum digging depth. */
 	int					mCurrentDepth = 0;			/**< Current depth level to view. */
 
-	std::string			mMapPath;					/**<  */
-	std::string			mTsetPath;					/**<  */
+	std::string			mMapPath;
+	std::string			mTsetPath;
 
-	TileArray			mTileMap;					/**<  */
+	TileArray			mTileMap;
 
-	NAS2D::Image		mTileset;					/**<  */
-	NAS2D::Image		mMineBeacon;				/**<  */
+	NAS2D::Image		mTileset;
+	NAS2D::Image		mMineBeacon;
 
-	NAS2D::Timer		mTimer;						/**<  */
+	NAS2D::Timer		mTimer;
 
 	NAS2D::Point_2d		mMousePosition;				/**< Current mouse position. */
 	NAS2D::Point_2d		mMapHighlight;				/**< Tile the mouse is pointing to. */
-	NAS2D::Point_2d		mMapViewLocation;			/**<  */
+	NAS2D::Point_2d		mMapViewLocation;
 
 	NAS2D::Point_2df	mMapPosition;				/** Where to start drawing the TileMap on the screen. */
 

--- a/src/Mine.h
+++ b/src/Mine.h
@@ -22,7 +22,7 @@ public:
 	};
 
 	typedef std::array<int, 4> MineVein;
-	typedef std::vector<MineVein> MineVeins;	/**<  */
+	typedef std::vector<MineVein> MineVeins;
 
 public:
 	Mine();

--- a/src/States/MainMenuState.h
+++ b/src/States/MainMenuState.h
@@ -45,19 +45,19 @@ private:
 	void fileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
 private:
-	NAS2D::Image		mBgImage;						/**<  */
+	NAS2D::Image		mBgImage;
 
 	FileIo				mFileIoDialog;					/**< File IO window. */
 
-	Button				btnNewGame;						/**<  */
-	Button				btnContinueGame;				/**<  */
-	Button				btnOptions;						/**<  */
-	Button				btnHelp;						/**<  */
-	Button				btnQuit;						/**<  */
+	Button				btnNewGame;
+	Button				btnContinueGame;
+	Button				btnOptions;
+	Button				btnHelp;
+	Button				btnQuit;
 
 	MainMenuOptions		dlgOptions;
 	DifficultySelect	dlgNewGame;
 
-	Label				lblVersion;						/**<  */
-	NAS2D::State*		mReturnState = this;			/**<  */
+	Label				lblVersion;
+	NAS2D::State*		mReturnState = this;
 };

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -200,7 +200,7 @@ private:
 private:
 	FpsCounter			mFps;							/**< Main FPS Counter. */
 
-	TileMap*			mTileMap = nullptr;				/**<  */
+	TileMap*			mTileMap = nullptr;
 
 	Image				mBackground;					/**< Background image drawn behind the tile map. */
 	Image				mMapDisplay;					/**< Satellite view of the Site Map. */
@@ -214,7 +214,7 @@ private:
 	// POOL'S
 	ResourcePool		mPlayerResources;				/**< Player's current resources. */
 	RobotPool			mRobotPool;						/**< Robots that are currently available for use. */
-	PopulationPool		mPopulationPool;				/**<  */
+	PopulationPool		mPopulationPool;
 
 	RobotTileTable		mRobotList;						/**< List of active robots and their positions on the map. */
 
@@ -222,9 +222,9 @@ private:
 	StructureID			mCurrentStructure = SID_NONE;	/**< Structure being placed. */
 	RobotType			mCurrentRobot = ROBOT_NONE;		/**< Robot being placed. */
 
-	Population			mPopulation;					/**<  */
+	Population			mPopulation;
 
-	//Music				mBgMusic;						/**<  */
+	//Music				mBgMusic;
 
 	// USER INTERFACE
 	Button				mBtnTurns;						/**< Turns Button. */
@@ -256,20 +256,20 @@ private:
 	MapChangedCallback	mMapChangedCallback;			/**< Signal indicating that the map changed. */
 
 	// MISCELLANEOUS
-	int					mTurnCount = 0;					/**<  */
+	int					mTurnCount = 0;
 
 	int					mCurrentMorale = constants::DEFAULT_STARTING_MORALE;
 	int					mPreviousMorale = constants::DEFAULT_STARTING_MORALE;
 
-	int					mLandersColonist = 0;			/**<  */
-	int					mLandersCargo = 0;				/**<  */
+	int					mLandersColonist = 0;
+	int					mLandersCargo = 0;
 
-	int					mResidentialCapacity = 0;		/**<  */
+	int					mResidentialCapacity = 0;
 
 	bool				mLeftButtonDown = false;		/**< Used for mouse drags on the mini map. */
 	bool				mLoadingExisting = false;		/**< Flag used for loading an existing game. */
-	bool				mPinResourcePanel = false;		/**<  */
-	bool				mPinPopulationPanel = false;	/**<  */
+	bool				mPinResourcePanel = false;
+	bool				mPinPopulationPanel = false;
 
 	std::string			mExistingToLoad;				/**< Filename of the existing game to load. */
 };

--- a/src/States/MapViewStateHelper.h
+++ b/src/States/MapViewStateHelper.h
@@ -15,7 +15,7 @@
 #include "../Map/TileMap.h"
 
 
-typedef std::map<Robot*, Tile*> RobotTileTable; /**<  */
+typedef std::map<Robot*, Tile*> RobotTileTable;
 
 class Warehouse;	/**< Forward declaration for getAvailableWarehouse() function. */
 class RobotCommand;	/**< Forward declaration for getAvailableRobotCommand() function. */

--- a/src/Things/Thing.h
+++ b/src/Things/Thing.h
@@ -63,5 +63,5 @@ private:
 
 	bool			mIsDead = false;/**< Thing is dead and should be cleaned up. */
 
-	DieCallback		mDieCallback;	/**<  */
+	DieCallback		mDieCallback;
 };

--- a/src/UI/Core/CheckBox.h
+++ b/src/UI/Core/CheckBox.h
@@ -31,9 +31,9 @@ protected:
 	virtual void onTextChanged() final;
 	
 private:
-	NAS2D::Image	mSkin;				/**<  */
+	NAS2D::Image	mSkin;
 
 	ClickCallback	mCallback;			/**< Object to notify when the Button is activated. */
 
-	bool			mChecked = false;	/**<  */
+	bool			mChecked = false;
 };

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -101,7 +101,7 @@ private:
 	NAS2D::Color				mHighlightText = NAS2D::Color::White;			/**< Text Color for an item that is currently highlighted. */
 
 	SelectionChangedCallback	mSelectionChanged;								/**< Callback for selection changed callback. */
-	Slider						mSlider;										/**<  */
+	Slider						mSlider;
 	
 	bool						mSorted = false;								/**< Flag indicating that all Items should be sorted. */
 };

--- a/src/UI/Core/RadioButton.h
+++ b/src/UI/Core/RadioButton.h
@@ -39,11 +39,11 @@ protected:
 	void parentContainer(UIContainer* parent);
 
 private:
-	NAS2D::Image	mSkin;				/**<  */
+	NAS2D::Image	mSkin;
 	Label			mLabel;
 	ClickCallback	mCallback;			/**< Object to notify when the Button is activated. */
 	UIContainer*	mParentContainer{nullptr};
-	bool			mChecked{false};	/**<  */
+	bool			mChecked{false};
 
 	friend class UIContainer;
 };

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -34,7 +34,7 @@ public:
 		std::string name;			/**< Name of the Item. Can be empty. */
 
 		int meta = 0;				/**< User defined integer value. Optional. */
-		bool available = true;		/**<  */
+		bool available = true;
 
 	protected:
 		friend class IconGrid;


### PR DESCRIPTION
Remove empty Doxygen style comments. I don't believe these add any particular value, but did add to the noise when checking for whitespace errors. Probably best to remove comments that don't add value.

We may want to do similar for non-empty comments that just repeat the variable name, or otherwise don't tell us anything new. I'll leave that for the future though.
