### PR TITLE
Enable Warnings as Errors on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
       - checkout
       - run: git submodule update --init
       - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: export MAKEFLAGS="--keep-going"
+      - run: export MAKEFLAGS="--keep-going --jobs 2"
       - run: make nas2d
       - run: make
 
@@ -33,7 +33,7 @@ jobs:
       - checkout
       - run: git submodule update --init
       - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: export MAKEFLAGS="--keep-going"
+      - run: export MAKEFLAGS="--keep-going --jobs 2"
       - run: make intermediate
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,9 @@ commands:
       - checkout
       - run: git submodule update --init
       - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: make --keep-going nas2d
-      - run: make --keep-going
+      - run: export MAKEFLAGS="--keep-going"
+      - run: make nas2d
+      - run: make
 
 jobs:
   build-linux:
@@ -32,7 +33,8 @@ jobs:
       - checkout
       - run: git submodule update --init
       - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: make --keep-going intermediate
+      - run: export MAKEFLAGS="--keep-going"
+      - run: make intermediate
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,8 @@ commands:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: export MAKEFLAGS="--keep-going --jobs 2"
-      - run: make nas2d
-      - run: make
+      - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" nas2d
+      - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror"
 
 jobs:
   build-linux:
@@ -32,9 +30,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: export MAKEFLAGS="--keep-going --jobs 2"
-      - run: make intermediate
+      - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" intermediate
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - build
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.3
+      - image: outpostuniverse/nas2d-mingw:1.4
     steps:
       - checkout
       - run: git submodule update --init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ commands:
     steps:
       - checkout
       - run: git submodule update --init
+      - run: export CXXFLAGS_EXTRA="-Werror"
       - run: make --keep-going nas2d
       - run: make --keep-going
 
@@ -30,6 +31,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
+      - run: export CXXFLAGS_EXTRA="-Werror"
       - run: make --keep-going intermediate
 
 workflows:

--- a/makefile
+++ b/makefile
@@ -9,10 +9,10 @@ NAS2DINCLUDEDIR := $(NAS2DDIR)include/
 NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
-CPPFLAGS := $(CPPFLAGS.EXTRA)
-CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
-LDFLAGS := $(LDFLAGS.EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
-LDLIBS := $(LDLIBS.EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
+CPPFLAGS := $(CPPFLAGS_EXTRA)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
+LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)$*.Td
 


### PR DESCRIPTION
Enable warnings as errors.

Increases build parallelism.

Linux only change.
