### PR TITLE
Fix warning about class/desctructor `final` inconsistency

### DIFF
--- a/src/UI/MineOperationsWindow.h
+++ b/src/UI/MineOperationsWindow.h
@@ -9,7 +9,7 @@
 /**
  * \brief Implements the Mine Facility Operations Window
  */
-class MineOperationsWindow : public Window
+class MineOperationsWindow final : public Window
 {
 public:
 	MineOperationsWindow();


### PR DESCRIPTION
Closes #267.

The smallest change was to add `final` to the class. Perhaps more long term we should consider removing `final` specifiers. I don't believe they are serving any useful purpose here. There are a lot of similar uses in other classes, so we may want to consider a blanket update.
