### PR TITLE
Replace all simple uses of `string_format` with `std::to_string`

### DIFF
--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -147,25 +147,25 @@ void MapViewState::drawResourceInfo()
 	r.drawSubImage(mUiIcons, x, y, 64, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 	bool shouldCommonMetalsGlow = mPlayerResources.commonMetals() <= 10;
 	int glowColor = shouldCommonMetalsGlow ? GLOW_STEP : 255;
-	r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMetals()), x + margin, textY, 255, glowColor, glowColor);
+	r.drawText(*MAIN_FONT, std::to_string(mPlayerResources.commonMetals()), x + margin, textY, 255, glowColor, glowColor);
 
 	// Rare Metals
 	r.drawSubImage(mUiIcons, x + offsetX, y, 80, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 	bool shouldRareMetalsGlow = mPlayerResources.rareMetals() <= 10;
 	glowColor = shouldRareMetalsGlow ? GLOW_STEP : 255;
-	r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMetals()), (x + offsetX) + margin, textY, 255, glowColor, glowColor);
+	r.drawText(*MAIN_FONT, std::to_string(mPlayerResources.rareMetals()), (x + offsetX) + margin, textY, 255, glowColor, glowColor);
 
 	// Common Minerals
 	r.drawSubImage(mUiIcons, (x + offsetX) * 2, y, 96, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 	bool shouldCommonMineralsGlow = mPlayerResources.commonMinerals() <= 10;
 	glowColor = shouldCommonMineralsGlow ? GLOW_STEP : 255;
-	r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMinerals()), (x + offsetX) * 2 + margin, textY, 255, glowColor, glowColor);
+	r.drawText(*MAIN_FONT, std::to_string(mPlayerResources.commonMinerals()), (x + offsetX) * 2 + margin, textY, 255, glowColor, glowColor);
 
 	// Rare Minerals
 	r.drawSubImage(mUiIcons, (x + offsetX) * 3, y, 112, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 	bool shouldRareMineralsGlow = mPlayerResources.rareMinerals() <= 10;
 	glowColor = shouldRareMineralsGlow ? GLOW_STEP : 255;
-	r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMinerals()), (x + offsetX) * 3 + margin, textY, 255, glowColor, glowColor);
+	r.drawText(*MAIN_FONT, std::to_string(mPlayerResources.rareMinerals()), (x + offsetX) * 3 + margin, textY, 255, glowColor, glowColor);
 
 	// Storage Capacity
 	r.drawSubImage(mUiIcons, (x + offsetX) * 4, y, 96, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
@@ -190,7 +190,7 @@ void MapViewState::drawResourceInfo()
 	r.drawSubImage(mUiIcons, (x + offsetX) * 10 - 17, y, popMoraleDeltaImageOffsetX, 48, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 
 	r.drawSubImage(mUiIcons, (x + offsetX) * 10, y, 176 + (std::clamp(mCurrentMorale, 1, 999) / 200) * constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	r.drawText(*MAIN_FONT, string_format("%i", mPopulation.size()), (x + offsetX) * 10 + margin, textY, 255, 255, 255);
+	r.drawText(*MAIN_FONT, std::to_string(mPopulation.size()), (x + offsetX) * 10 + margin, textY, 255, 255, 255);
 
 	bool isMouseInPopPanel = NAS2D::Rectangle{675, 1, 75, 19}.contains(MOUSE_COORDS);
 	bool shouldShowPopPanel = mPinPopulationPanel || isMouseInPopPanel;
@@ -202,7 +202,7 @@ void MapViewState::drawResourceInfo()
 
 	// Turns
 	r.drawSubImage(mUiIcons, r.width() - 80, y, 128, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	r.drawText(*MAIN_FONT, string_format("%i", mTurnCount), r.width() - 80 + margin, textY, 255, 255, 255);
+	r.drawText(*MAIN_FONT, std::to_string(mTurnCount), r.width() - 80 + margin, textY, 255, 255, 255);
 
 	bool isMouseInMenu = MENU_ICON.contains(MOUSE_COORDS);
 	int menuGearHighlightOffsetX = isMouseInMenu ? 144 : 128;
@@ -273,7 +273,7 @@ void MapViewState::drawNavInfo()
 	
 	for (int i = mTileMap->maxDepth(); i >= 0; i--)
 	{
-		S_LEVEL = string_format("%i", i);	// Set string for current level
+		S_LEVEL = std::to_string(i);	// Set string for current level
 		if (i == 0) { S_LEVEL = "S"; }		// surface level
 		bool isCurrentDepth = i == mTileMap->currentDepth();
 		NAS2D::Color color = isCurrentDepth ? NAS2D::Color{255, 0, 0, 255} : NAS2D::Color{200, 200, 200, 255}; // red for current depth : white for others

--- a/src/UI/FactoryProduction.cpp
+++ b/src/UI/FactoryProduction.cpp
@@ -224,14 +224,14 @@ void FactoryProduction::update()
 	r.drawText(*FONT, string_format("%i of %i", mFactory->productionTurnsCompleted(), mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 25.0f, 255, 255, 255);
 
 	r.drawText(*FONT_BOLD, "Common Metals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 45.0f, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mProductCost.commonMetals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 45.0f, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 45.0f, 255, 255, 255);
 
 	r.drawText(*FONT_BOLD, "Common Minerals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 55.0f, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mProductCost.commonMinerals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 55.0f, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 55.0f, 255, 255, 255);
 
 	r.drawText(*FONT_BOLD, "Rare Metals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 65.0f, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mProductCost.rareMetals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 65.0f, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 65.0f, 255, 255, 255);
 
 	r.drawText(*FONT_BOLD, "Rare Minerals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 75.0f, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mProductCost.rareMinerals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 75.0f, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 75.0f, 255, 255, 255);
 }

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -49,9 +49,9 @@ void PopulationPanel::update()
 	r.drawSubImage(mIcons, positionX() + 5, positionY() + 147, 96, 96, 32, 32);		// Scientist
 	r.drawSubImage(mIcons, positionX() + 5, positionY() + 181, 128, 96, 32, 32);	// Retired
 
-	r.drawText(*FONT, string_format("%i", mPopulation->size(Population::ROLE_CHILD)), positionX() + 42, positionY() + 65, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mPopulation->size(Population::ROLE_STUDENT)), positionX() + 42, positionY() + 97, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mPopulation->size(Population::ROLE_WORKER)), positionX() + 42, positionY() + 129, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 160, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i", mPopulation->size(Population::ROLE_RETIRED)), positionX() + 42, positionY() + 193, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_CHILD)), positionX() + 42, positionY() + 65, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_STUDENT)), positionX() + 42, positionY() + 97, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_WORKER)), positionX() + 42, positionY() + 129, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 160, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_RETIRED)), positionX() + 42, positionY() + 193, 255, 255, 255);
 }

--- a/src/UI/ResourceBreakdownPanel.cpp
+++ b/src/UI/ResourceBreakdownPanel.cpp
@@ -112,16 +112,16 @@ void ResourceBreakdownPanel::update()
 	r.drawText(*FONT, "Common Minerals", 28.0f, rect().y() + 41.0f, 255, 255, 255);
 	r.drawText(*FONT, "Rare Minerals", 28.0f, rect().y() + 59.0f, 255, 255, 255);
 
-	std::string fmt = string_format("%i", mPlayerResources->commonMetals());
+	std::string fmt = std::to_string(mPlayerResources->commonMetals());
 	r.drawText(*FONT, fmt, 200.0f - FONT->width(fmt) , rect().y() + 5.0f, 255, 255, 255);
 	
-	fmt = string_format("%i", mPlayerResources->rareMetals());
+	fmt = std::to_string(mPlayerResources->rareMetals());
 	r.drawText(*FONT, fmt, 200.0f - FONT->width(fmt), rect().y() + 23.0f, 255, 255, 255);
 
-	fmt = string_format("%i", mPlayerResources->commonMinerals());
+	fmt = std::to_string(mPlayerResources->commonMinerals());
 	r.drawText(*FONT, fmt, 200.0f - FONT->width(fmt), rect().y() + 41.0f, 255, 255, 255);
 
-	fmt = string_format("%i", mPlayerResources->rareMinerals());
+	fmt = std::to_string(mPlayerResources->rareMinerals());
 	r.drawText(*FONT, fmt, 200.0f - FONT->width(fmt), rect().y() + 59.0f, 255, 255, 255);
 
 	r.drawSubImage(mIcons, 220.0f, rect().y() + 8.0f,  ICON_SLICE[COMMON_METALS].x(),   ICON_SLICE[COMMON_METALS].y(),   8.0f, 8.0f);


### PR DESCRIPTION
Reference: #266

Text replace of `string_format("%i", ` with `std::to_string(`.