### PR TITLE
Makefile warning support

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
-CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas $(WARN_EXTRA)
+CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas -Wnull-dereference -Wcast-qual -Wcast-align -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
-CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas
+CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW

--- a/makefile
+++ b/makefile
@@ -10,7 +10,8 @@ NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
 


### PR DESCRIPTION
Improves `makefile` warning support, and enables a bunch of warnings flags used by NAS2D.

A few warnings from NAS2D were omitted here. They are:
- `-Wextra`
- `-Wpedantic`
- `-Wzero-as-null-pointer-constant`
- `-Wold-style-cast`
- `-Wdouble-promotion`
- `-Wmissing-declarations`
- `-Wswitch-enum`
- `-Wswitch-default`
- `-Wredundant-decls`

Some work will need to be done to cleanup these warnings before we enable these flags.

----

Linux only change.
