### PR TITLE
Simplify check for restricted filename characters

### DIFF
--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -153,25 +153,11 @@ void FileIo::fileNameModified(Control* control)
 {
 	std::string sFile = control->text();
 
+	const std::string RestrictedFilenameChars = "\\/:*?\"<>|";
+
 	if (sFile.empty())	// no blank filename
 		btnFileOp.enabled(false);
-	else if ((int)sFile.find('\\')>-1)	// no \ in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('/')>-1)	// no / in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find(':')>-1)	// no : in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('*')>-1)	// no * in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('?')>-1)	// no ? in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('"')>-1)	// no " in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('<')>-1)	// no < in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('>')>-1)	// no > in the filename
-		btnFileOp.enabled(false);
-	else if ((int)sFile.find('|')>-1)	// no | in the filename
+	else if (sFile.find_first_of(RestrictedFilenameChars) != std::string::npos)
 		btnFileOp.enabled(false);
 	else
 		btnFileOp.enabled(true);


### PR DESCRIPTION
Reference: #272 (`-Wold-style-cast`)

Simplify check for restricted filename characters, and eliminate use of C-style cast.
