### PR TITLE
Vectorize planet

### DIFF
--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -56,8 +56,6 @@ Planet::~Planet()
 
 bool Planet::pointInCircle(NAS2D::Point<int> point)
 {
-	// Standard point in circle equation. Magic numbers for a circle diameter of 128.
-	// Note: assumes all values are always positive.
 	const auto offset = point - mPosition - PlanetSize / 2;
 	constexpr auto radiusSquared = PlanetRadius * PlanetRadius;
 	return ((offset.x * offset.x) + (offset.y * offset.y) <= radiusSquared);

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -80,5 +80,6 @@ void Planet::update()
 	//			In the limited scope that this class is used it's not really worth it to go through a full implementation
 	//			as only a few of these objects will ever be on screen ever and as of 11/1/2015 are only ever used once
 	//			during planetary selection at the beginning of the game.
-	NAS2D::Utility<NAS2D::Renderer>::get().drawSubImage(mImage, (float)mPosition.x(), (float)mPosition.y(), (float)(mTick % 8 * 128), (float)(((mTick % 64) / 8) * 128), 128.0f, 128.0f);
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	renderer.drawSubImage(mImage, (float)mPosition.x(), (float)mPosition.y(), (float)(mTick % 8 * 128), (float)(((mTick % 64) / 8) * 128), 128.0f, 128.0f);
 }

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -54,7 +54,7 @@ Planet::~Planet()
 }
 
 
-bool Planet::pointInArea(NAS2D::Point<int> point)
+bool Planet::pointInCircle(NAS2D::Point<int> point)
 {
 	// Standard point in circle equation. Magic numbers for a circle diameter of 128.
 	// Note: assumes all values are always positive.
@@ -66,7 +66,7 @@ bool Planet::pointInArea(NAS2D::Point<int> point)
 
 void Planet::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
 {
-	bool inArea = pointInArea({x, y});
+	bool inArea = pointInCircle({x, y});
 	if (inArea != mMouseInArea)
 	{
 		mMouseInArea = inArea;

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -81,5 +81,7 @@ void Planet::update()
 	//			as only a few of these objects will ever be on screen ever and as of 11/1/2015 are only ever used once
 	//			during planetary selection at the beginning of the game.
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	renderer.drawSubImage(mImage, (float)mPosition.x(), (float)mPosition.y(), (float)(mTick % 8 * 128), (float)(((mTick % 64) / 8) * 128), 128.0f, 128.0f);
+	const auto spriteFrameOffset = NAS2D::Point<int>{mTick % 8 * 128, ((mTick % 64) / 8) * 128};
+	const auto size = NAS2D::Vector<float>{128.0f, 128.0f};
+	renderer.drawSubImage(mImage, mPosition.to<float>(), spriteFrameOffset.to<float>(), size);
 }

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -58,7 +58,7 @@ bool Planet::pointInArea(NAS2D::Point<int> point)
 	// Standard point in circle equation. Magic numbers for a circle diameter of 128.
 	// Note: assumes all values are always positive.
 	const auto offset = point - mPosition - PlanetSize / 2;
-	return (pow(offset.x, 2) + pow(offset.y, 2) <= 4096);
+	return ((offset.x * offset.x) + (offset.y * offset.y) <= 4096);
 }
 
 

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -11,7 +11,8 @@
 
 
 namespace {
-	constexpr auto PlanetSize = NAS2D::Vector<int>{128, 128};
+	constexpr auto PlanetRadius = 64;
+	constexpr auto PlanetSize = NAS2D::Vector<int>{PlanetRadius * 2, PlanetRadius * 2};
 }
 
 
@@ -58,7 +59,8 @@ bool Planet::pointInArea(NAS2D::Point<int> point)
 	// Standard point in circle equation. Magic numbers for a circle diameter of 128.
 	// Note: assumes all values are always positive.
 	const auto offset = point - mPosition - PlanetSize / 2;
-	return ((offset.x * offset.x) + (offset.y * offset.y) <= 4096);
+	constexpr auto radiusSquared = PlanetRadius * PlanetRadius;
+	return ((offset.x * offset.x) + (offset.y * offset.y) <= radiusSquared);
 }
 
 

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -82,10 +82,6 @@ void Planet::update()
 		++mTick;
 	}
 
-	// FIXME:	Table approach would be a lot faster for this instead of using multiplications and modulus operations.
-	//			In the limited scope that this class is used it's not really worth it to go through a full implementation
-	//			as only a few of these objects will ever be on screen ever and as of 11/1/2015 are only ever used once
-	//			during planetary selection at the beginning of the game.
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto spriteFrameOffset = NAS2D::Point<int>{mTick % 8 * PlanetSize.x, ((mTick % 64) / 8) * PlanetSize.y};
 	renderer.drawSubImage(mImage, mPosition.to<float>(), spriteFrameOffset.to<float>(), PlanetSize.to<float>());

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -10,6 +10,11 @@
 #include <array>
 
 
+namespace {
+	constexpr auto PlanetSize = NAS2D::Vector<int>{128, 128};
+}
+
+
 Planet::Planet(PlanetType type) : mType(type)
 {
 	// Fixme: This should be in a table vs. a giant switch statement.
@@ -81,7 +86,6 @@ void Planet::update()
 	//			as only a few of these objects will ever be on screen ever and as of 11/1/2015 are only ever used once
 	//			during planetary selection at the beginning of the game.
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto spriteFrameOffset = NAS2D::Point<int>{mTick % 8 * 128, ((mTick % 64) / 8) * 128};
-	const auto size = NAS2D::Vector<float>{128.0f, 128.0f};
-	renderer.drawSubImage(mImage, mPosition.to<float>(), spriteFrameOffset.to<float>(), size);
+	const auto spriteFrameOffset = NAS2D::Point<int>{mTick % 8 * PlanetSize.x, ((mTick % 64) / 8) * PlanetSize.y};
+	renderer.drawSubImage(mImage, mPosition.to<float>(), spriteFrameOffset.to<float>(), PlanetSize.to<float>());
 }

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -53,17 +53,18 @@ Planet::~Planet()
 }
 
 
-bool Planet::pointInArea(int x, int y)
+bool Planet::pointInArea(NAS2D::Point<int> point)
 {
 	// Standard point in circle equation. Magic numbers for a circle diameter of 128.
 	// Note: assumes all values are always positive.
-	return (pow(x - mPosition.x() - 64, 2) + pow(y - mPosition.y() - 64, 2) <= 4096);
+	const auto offset = point - mPosition - PlanetSize / 2;
+	return (pow(offset.x, 2) + pow(offset.y, 2) <= 4096);
 }
 
 
 void Planet::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
 {
-	bool inArea = pointInArea(x, y);
+	bool inArea = pointInArea({x, y});
 	if (inArea != mMouseInArea)
 	{
 		mMouseInArea = inArea;

--- a/src/States/Planet.h
+++ b/src/States/Planet.h
@@ -52,7 +52,7 @@ public:
 	void update();
 
 protected:
-	bool pointInArea(NAS2D::Point<int> point);
+	bool pointInCircle(NAS2D::Point<int> point);
 	void onMouseMove(int x, int y, int rX, int rY);
 
 private:

--- a/src/States/Planet.h
+++ b/src/States/Planet.h
@@ -52,7 +52,7 @@ public:
 	void update();
 
 protected:
-	bool pointInArea(int x, int y);
+	bool pointInArea(NAS2D::Point<int> point);
 	void onMouseMove(int x, int y, int rX, int rY);
 
 private:


### PR DESCRIPTION
Reference: #272 (`-Wold-style-cast`)
Reference: #217

Refactor `Planet` class. Vectorizes some of the code, and removes old C-style casts.

There's probably more that can be done, but I'm stopping for the moment, and this seemed like a good stopping point.
