### PR TITLE
Refactor TileInspector

### DIFF
--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -64,18 +64,10 @@ void TileInspector::update()
 	auto position = rect().startPoint() + NAS2D::Vector{5, 25};
 	drawTitleText(position, "Has Mine: ", (mine ? "Yes" : "No"));
 
-	if(mTile->mine())
+	if(mine)
 	{
-		r.drawText(*FONT_BOLD, "Active:", rect().x() + 5, rect().y() + 35, 255, 255, 255);
-
-		if (mTile->mine()->active())
-		{
-			r.drawText(*FONT, "Yes", rect().x() + 5 + FONT_BOLD->width("Active: "), rect().y() + 35, 255, 255, 255);
-		}
-		else
-		{
-			r.drawText(*FONT, "No", rect().x() + 5 + FONT_BOLD->width("Active: "), rect().y() + 35, 255, 255, 255);
-		}
+		position.y() += 10;
+		drawTitleText(position, "Active: ", (mine->active() ? "Yes" : "No"));
 
 		r.drawText(*FONT_BOLD, "Production Rate:", rect().x() + 5, rect().y() + 45, 255, 255, 255);
 		r.drawText(*FONT, MINE_YIELD_TRANSLATION[mTile->mine()->productionRate()], rect().x() + 5 + FONT_BOLD->width("Production Rate: "), rect().y() + 45, 255, 255, 255);

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -69,8 +69,8 @@ void TileInspector::update()
 		position.y() += 10;
 		drawTitleText(position, "Active: ", (mine->active() ? "Yes" : "No"));
 
-		r.drawText(*FONT_BOLD, "Production Rate:", rect().x() + 5, rect().y() + 45, 255, 255, 255);
-		r.drawText(*FONT, MINE_YIELD_TRANSLATION[mTile->mine()->productionRate()], rect().x() + 5 + FONT_BOLD->width("Production Rate: "), rect().y() + 45, 255, 255, 255);
+		position.y() += 10;
+		drawTitleText(position, "Production Rate: ", MINE_YIELD_TRANSLATION[mTile->mine()->productionRate()]);
 	}
 
 	r.drawText(*FONT_BOLD, "Location:", rect().x() + 5, rect().y() + 62, 255, 255, 255);

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -53,12 +53,19 @@ void TileInspector::update()
 
 	Renderer& r = Utility<Renderer>::get();
 
-	r.drawText(*FONT_BOLD, "Has Mine:", rect().x() + 5, rect().y() + 25, 255, 255, 255);
+	const auto drawTitleText = [&renderer = r](NAS2D::Point<int> position, std::string title, std::string text) {
+		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
+		position.x() += FONT_BOLD->width(title);
+		renderer.drawText(*FONT, text, position, NAS2D::Color::White);
+	};
+
+	const auto* mine = mTile->mine();
+
+	auto position = rect().startPoint() + NAS2D::Vector{5, 25};
+	drawTitleText(position, "Has Mine: ", (mine ? "Yes" : "No"));
 
 	if(mTile->mine())
 	{
-		r.drawText(*FONT, "Yes", rect().x() + 5 + FONT_BOLD->width("Has Mine: "), rect().y() + 25, 255, 255, 255);
-
 		r.drawText(*FONT_BOLD, "Active:", rect().x() + 5, rect().y() + 35, 255, 255, 255);
 
 		if (mTile->mine()->active())
@@ -72,10 +79,6 @@ void TileInspector::update()
 
 		r.drawText(*FONT_BOLD, "Production Rate:", rect().x() + 5, rect().y() + 45, 255, 255, 255);
 		r.drawText(*FONT, MINE_YIELD_TRANSLATION[mTile->mine()->productionRate()], rect().x() + 5 + FONT_BOLD->width("Production Rate: "), rect().y() + 45, 255, 255, 255);
-	}
-	else
-	{
-		r.drawText(*FONT, "No", rect().x() + 5 + FONT_BOLD->width("Has Mine: "), rect().y() + 25, 255, 255, 255);
 	}
 
 	r.drawText(*FONT_BOLD, "Location:", rect().x() + 5, rect().y() + 62, 255, 255, 255);

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -51,9 +51,9 @@ void TileInspector::update()
 
 	Window::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	const auto drawTitleText = [&renderer = r](NAS2D::Point<int> position, std::string title, std::string text) {
+	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, std::string title, std::string text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
 		position.x() += FONT_BOLD->width(title);
 		renderer.drawText(*FONT, text, position, NAS2D::Color::White);

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -53,7 +53,7 @@ void TileInspector::update()
 
 	Renderer& renderer = Utility<Renderer>::get();
 
-	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, std::string title, std::string text) {
+	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
 		position.x() += FONT_BOLD->width(title);
 		renderer.drawText(*FONT, text, position, NAS2D::Color::White);

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -76,8 +76,8 @@ void TileInspector::update()
 	position = rect().startPoint() + NAS2D::Vector{5, 62};
 	drawTitleText(position, "Location: ", string_format("%i, %i", mTile->x(), mTile->y()));
 
-	r.drawText(*FONT_BOLD, "Terrain:", rect().x() + 5, rect().y() + 72, 255, 255, 255);
-	r.drawText(*FONT, TILE_INDEX_TRANSLATION[mTile->index()], rect().x() + 5 + FONT_BOLD->width("Terrain: "), rect().y() + 72, 255, 255, 255);
+	position.y() += 10;
+	drawTitleText(position, "Terrain: ", TILE_INDEX_TRANSLATION[mTile->index()]);
 }
 
 

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -73,8 +73,8 @@ void TileInspector::update()
 		drawTitleText(position, "Production Rate: ", MINE_YIELD_TRANSLATION[mTile->mine()->productionRate()]);
 	}
 
-	r.drawText(*FONT_BOLD, "Location:", rect().x() + 5, rect().y() + 62, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i, %i", mTile->x(), mTile->y()), rect().x() + 5 + FONT_BOLD->width("Location: "), rect().y() + 62, 255, 255, 255);
+	position = rect().startPoint() + NAS2D::Vector{5, 62};
+	drawTitleText(position, "Location: ", string_format("%i, %i", mTile->x(), mTile->y()));
 
 	r.drawText(*FONT_BOLD, "Terrain:", rect().x() + 5, rect().y() + 72, 255, 255, 255);
 	r.drawText(*FONT, TILE_INDEX_TRANSLATION[mTile->index()], rect().x() + 5 + FONT_BOLD->width("Terrain: "), rect().y() + 72, 255, 255, 255);

--- a/src/UI/TileInspector.cpp
+++ b/src/UI/TileInspector.cpp
@@ -74,7 +74,7 @@ void TileInspector::update()
 	}
 
 	position = rect().startPoint() + NAS2D::Vector{5, 62};
-	drawTitleText(position, "Location: ", string_format("%i, %i", mTile->x(), mTile->y()));
+	drawTitleText(position, "Location: ", std::to_string(mTile->x()) + ", " + std::to_string(mTile->y()));
 
 	position.y() += 10;
 	drawTitleText(position, "Terrain: ", TILE_INDEX_TRANSLATION[mTile->index()]);


### PR DESCRIPTION
Reference: #266

A bit of refactoring for the `TileInspector` class. Allows for higher level text output. Removes use of `string_format`.
