### PR TITLE
Refactor FactoryProduction

### DIFF
--- a/src/UI/FactoryProduction.cpp
+++ b/src/UI/FactoryProduction.cpp
@@ -220,7 +220,7 @@ void FactoryProduction::update()
 
 	Renderer& renderer = Utility<Renderer>::get();
 
-	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, std::string title, std::string text) {
+	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
 		position.x() += 120;
 		renderer.drawText(*FONT, text, position, NAS2D::Color::White);

--- a/src/UI/FactoryProduction.cpp
+++ b/src/UI/FactoryProduction.cpp
@@ -218,9 +218,9 @@ void FactoryProduction::update()
 
 	Window::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	const auto drawTitleText = [&renderer = r](NAS2D::Point<int> position, std::string title, std::string text) {
+	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, std::string title, std::string text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
 		position.x() += 120;
 		renderer.drawText(*FONT, text, position, NAS2D::Color::White);

--- a/src/UI/FactoryProduction.cpp
+++ b/src/UI/FactoryProduction.cpp
@@ -220,18 +220,24 @@ void FactoryProduction::update()
 
 	Renderer& r = Utility<Renderer>::get();
 
-	r.drawText(*FONT_BOLD, "Turns Completed:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 25.0f, 255, 255, 255);
-	r.drawText(*FONT, string_format("%i of %i", mFactory->productionTurnsCompleted(), mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 25.0f, 255, 255, 255);
+	const auto drawTitleText = [&renderer = r](NAS2D::Point<int> position, std::string title, std::string text) {
+		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
+		position.x() += 120;
+		renderer.drawText(*FONT, text, position, NAS2D::Color::White);
+	};
 
-	r.drawText(*FONT_BOLD, "Common Metals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 45.0f, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 45.0f, 255, 255, 255);
+	auto position = rect().startPoint() + NAS2D::Vector{constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), 25};
+	drawTitleText(position, "Turns Completed:", string_format("%i of %i", mFactory->productionTurnsCompleted(), mProductCost.turnsToBuild()));
 
-	r.drawText(*FONT_BOLD, "Common Minerals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 55.0f, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 55.0f, 255, 255, 255);
+	position.y() += 20;
+	drawTitleText(position, "Common Metals:", std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()));
 
-	r.drawText(*FONT_BOLD, "Rare Metals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 65.0f, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 65.0f, 255, 255, 255);
+	position.y() += 10;
+	drawTitleText(position, "Common Minerals:", std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild()));
 
-	r.drawText(*FONT_BOLD, "Rare Minerals:", rect().x() + constants::MARGIN * 2 + mProductGrid.width(), rect().y() + 75.0f, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild()), rect().x() + constants::MARGIN * 2 + mProductGrid.width() + 120, rect().y() + 75.0f, 255, 255, 255);
+	position.y() += 10;
+	drawTitleText(position, "Rare Metals:", std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild()));
+
+	position.y() += 10;
+	drawTitleText(position, "Rare Minerals:", std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild()));
 }

--- a/src/UI/FactoryProduction.cpp
+++ b/src/UI/FactoryProduction.cpp
@@ -227,7 +227,7 @@ void FactoryProduction::update()
 	};
 
 	auto position = rect().startPoint() + NAS2D::Vector{constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), 25};
-	drawTitleText(position, "Turns Completed:", string_format("%i of %i", mFactory->productionTurnsCompleted(), mProductCost.turnsToBuild()));
+	drawTitleText(position, "Turns Completed:", std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild()));
 
 	position.y() += 20;
 	drawTitleText(position, "Common Metals:", std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()));


### PR DESCRIPTION
Reference: #266

A bit of refactoring for the `FactoryProduction` class. Allows for higher level text output. Removes use of `string_format`.
