### PR TITLE
Refactor StructureInspector::drawPopulationRequirements

### DIFF
--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -107,9 +107,9 @@ void StructureInspector::drawPopulationRequirements()
 		const auto& populationAvailable = mStructure->populationAvailable();
 		if (populationRequirements[populationType] > 0)
 		{
-			std::string format = populationTypes[populationType] + ": " + std::to_string(populationAvailable[populationType]) + "/" + std::to_string(populationRequirements[populationType]);
+			std::string text = populationTypes[populationType] + ": " + std::to_string(populationAvailable[populationType]) + "/" + std::to_string(populationRequirements[populationType]);
 			Color color = populationAvailable[populationType] >= populationRequirements[populationType] ? Color::White : Color::Red;
-			renderer.drawText(*FONT, format, position, color);
+			renderer.drawText(*FONT, text, position, color);
 			position.y() += 10;
 		}
 	}

--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -96,20 +96,20 @@ void StructureInspector::drawPopulationRequirements()
 	auto position = rect().startPoint() + NAS2D::Vector{10, 85};
 	r.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
 
-	position.y() += 20;
-	if (mStructure->populationRequirements()[0] > 0)
-	{
-		std::string format = string_format("Workers: %i/%i", mStructure->populationAvailable()[0], mStructure->populationRequirements()[0]);
-		Color color = mStructure->populationAvailable()[0] >= mStructure->populationRequirements()[0] ? Color::White : Color::Red;
-		r.drawText(*FONT, format, position, color);
-		position.y() += 10;
-	}
+	const std::array<std::string, 2> populationTypes = {{
+		"Workers",
+		"Scientists"
+	}};
 
-	if (mStructure->populationRequirements()[1] > 0)
-	{
-		std::string format = string_format("Scientists: %i/%i", mStructure->populationAvailable()[1], mStructure->populationRequirements()[1]);
-		Color color = mStructure->populationAvailable()[1] >= mStructure->populationRequirements()[1] ? Color::White : Color::Red;
-		r.drawText(*FONT, format, position, color);
+	position.y() += 20;
+	for (std::size_t populationType = 0; populationType < populationTypes.size(); ++populationType) {
+		if (mStructure->populationRequirements()[populationType] > 0)
+		{
+			std::string format = string_format(populationTypes[populationType] + ": %i/%i", mStructure->populationAvailable()[populationType], mStructure->populationRequirements()[populationType]);
+			Color color = mStructure->populationAvailable()[populationType] >= mStructure->populationRequirements()[populationType] ? Color::White : Color::Red;
+			r.drawText(*FONT, format, position, color);
+			position.y() += 10;
+		}
 	}
 }
 

--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -107,7 +107,7 @@ void StructureInspector::drawPopulationRequirements()
 		const auto& populationAvailable = mStructure->populationAvailable();
 		if (populationRequirements[populationType] > 0)
 		{
-			std::string format = string_format(populationTypes[populationType] + ": %i/%i", populationAvailable[populationType], populationRequirements[populationType]);
+			std::string format = populationTypes[populationType] + ": " + std::to_string(populationAvailable[populationType]) + "/" + std::to_string(populationRequirements[populationType]);
 			Color color = populationAvailable[populationType] >= populationRequirements[populationType] ? Color::White : Color::Red;
 			renderer.drawText(*FONT, format, position, color);
 			position.y() += 10;

--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -92,26 +92,24 @@ void StructureInspector::btnCloseClicked()
 void StructureInspector::drawPopulationRequirements()
 {
 	Renderer& r = Utility<Renderer>::get();
-	float posX = rect().x() + 10.0f;
-	float posY = rect().y() + 85.0f;
 
-	r.drawText(*FONT_BOLD, "Population Required", rect().x() + 10, posY, 255, 255, 255);
+	auto position = rect().startPoint() + NAS2D::Vector{10, 85};
+	r.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
 
-	posY += 20;
-
+	position.y() += 20;
 	if (mStructure->populationRequirements()[0] > 0)
 	{
 		std::string format = string_format("Workers: %i/%i", mStructure->populationAvailable()[0], mStructure->populationRequirements()[0]);
 		Color color = mStructure->populationAvailable()[0] >= mStructure->populationRequirements()[0] ? Color::White : Color::Red;
-		r.drawText(*FONT, format, posX, posY, color.red(), color.green(), color.blue());
-		posY += 10;
+		r.drawText(*FONT, format, position, color);
+		position.y() += 10;
 	}
 
 	if (mStructure->populationRequirements()[1] > 0)
 	{
 		std::string format = string_format("Scientists: %i/%i", mStructure->populationAvailable()[1], mStructure->populationRequirements()[1]);
 		Color color = mStructure->populationAvailable()[1] >= mStructure->populationRequirements()[1] ? Color::White : Color::Red;
-		r.drawText(*FONT, format, posX, posY, color.red(), color.green(), color.blue());
+		r.drawText(*FONT, format, position, color);
 	}
 }
 

--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -103,10 +103,12 @@ void StructureInspector::drawPopulationRequirements()
 
 	position.y() += 20;
 	for (std::size_t populationType = 0; populationType < populationTypes.size(); ++populationType) {
-		if (mStructure->populationRequirements()[populationType] > 0)
+		const auto& populationRequirements = mStructure->populationRequirements();
+		const auto& populationAvailable = mStructure->populationAvailable();
+		if (populationRequirements[populationType] > 0)
 		{
-			std::string format = string_format(populationTypes[populationType] + ": %i/%i", mStructure->populationAvailable()[populationType], mStructure->populationRequirements()[populationType]);
-			Color color = mStructure->populationAvailable()[populationType] >= mStructure->populationRequirements()[populationType] ? Color::White : Color::Red;
+			std::string format = string_format(populationTypes[populationType] + ": %i/%i", populationAvailable[populationType], populationRequirements[populationType]);
+			Color color = populationAvailable[populationType] >= populationRequirements[populationType] ? Color::White : Color::Red;
 			r.drawText(*FONT, format, position, color);
 			position.y() += 10;
 		}

--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -91,10 +91,10 @@ void StructureInspector::btnCloseClicked()
 
 void StructureInspector::drawPopulationRequirements()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	auto position = rect().startPoint() + NAS2D::Vector{10, 85};
-	r.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
+	renderer.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
 
 	const std::array<std::string, 2> populationTypes = {{
 		"Workers",
@@ -109,7 +109,7 @@ void StructureInspector::drawPopulationRequirements()
 		{
 			std::string format = string_format(populationTypes[populationType] + ": %i/%i", populationAvailable[populationType], populationRequirements[populationType]);
 			Color color = populationAvailable[populationType] >= populationRequirements[populationType] ? Color::White : Color::Red;
-			r.drawText(*FONT, format, position, color);
+			renderer.drawText(*FONT, format, position, color);
 			position.y() += 10;
 		}
 	}

--- a/src/UI/StructureInspector.cpp
+++ b/src/UI/StructureInspector.cpp
@@ -96,10 +96,10 @@ void StructureInspector::drawPopulationRequirements()
 	auto position = rect().startPoint() + NAS2D::Vector{10, 85};
 	renderer.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
 
-	const std::array<std::string, 2> populationTypes = {{
+	const std::array<std::string, 2> populationTypes{
 		"Workers",
 		"Scientists"
-	}};
+	};
 
 	position.y() += 20;
 	for (std::size_t populationType = 0; populationType < populationTypes.size(); ++populationType) {


### PR DESCRIPTION
Reference: #266

A bit of refactoring for `StructureInspector::drawPopulationRequirements`. Reduced redundancy in text output code. Removes use of string_format.
