### PR TITLE
ListBox and ComboBox `size_t` correctness

### DIFF
--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -143,7 +143,7 @@ void ComboBox::lstItemsSelectionChanged()
 /**
  * Sets the maximum number of items to display before showing a scroll bar.
  */
-void ComboBox::maxDisplayItems(unsigned int count)
+void ComboBox::maxDisplayItems(std::size_t count)
 {
 	mMaxDisplayItems = count;
 	
@@ -186,7 +186,7 @@ int ComboBox::selectionTag() const
 }
 
 
-void ComboBox::currentSelection(unsigned int index) {
+void ComboBox::currentSelection(std::size_t index) {
 	lstItems.currentSelection(index);
 	text(lstItems.selectionText());
 	mSelectionChanged();

--- a/src/UI/Core/ComboBox.h
+++ b/src/UI/Core/ComboBox.h
@@ -21,8 +21,8 @@ public:
 
 	void addItem(const std::string& item, int tag = 0);
 
-	unsigned int maxDisplayItems() const { return mMaxDisplayItems; }
-	void maxDisplayItems(unsigned int count);
+	std::size_t maxDisplayItems() const { return mMaxDisplayItems; }
+	void maxDisplayItems(std::size_t count);
 
 	void clearSelection();
 
@@ -31,8 +31,8 @@ public:
 	const std::string& selectionText() const;
 	int selectionTag() const;
 
-	unsigned int currentSelection() { return lstItems.currentSelection(); }
-	void currentSelection(unsigned int index);
+	std::size_t currentSelection() { return lstItems.currentSelection(); }
+	void currentSelection(std::size_t index);
 
 	virtual void update();
 
@@ -58,5 +58,5 @@ private:
 
 	SelectionChanged        mSelectionChanged;
 
-	unsigned int            mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
+	std::size_t            mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
 };

--- a/src/UI/Core/ComboBox.h
+++ b/src/UI/Core/ComboBox.h
@@ -7,6 +7,9 @@
 #include "NAS2D/EventHandler.h"
 #include "NAS2D/Renderer/Rectangle.h"
 
+#include <cstddef>
+
+
 class ComboBox : public Control
 {
 public:

--- a/src/UI/Core/ListBox.cpp
+++ b/src/UI/Core/ListBox.cpp
@@ -79,7 +79,7 @@ void ListBox::_updateItemDisplay()
 {
 	mItemWidth = static_cast<unsigned int>(rect().width());
 
-	if ((mLineHeight * mItems.size()) > static_cast<size_t>(height()))
+	if ((mLineHeight * mItems.size()) > static_cast<std::size_t>(height()))
 	{
 		mLineCount = static_cast<unsigned int>(height() / mLineHeight);
 		if (mLineCount < mItems.size())
@@ -181,7 +181,7 @@ bool ListBox::itemExists(const std::string& item)
  */
 void ListBox::setSelectionByName(const std::string& item)
 {
-	for (size_t i = 0; i < mItems.size(); i++)
+	for (std::size_t i = 0; i < mItems.size(); i++)
 	{
 		if (toLowercase(mItems[i].Text) == toLowercase(item)) { mCurrentSelection = static_cast<int>(i); return; }
 	}
@@ -213,7 +213,7 @@ void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 		return;		// if the mouse is on the slider then the slider should handle that
 	}
 
-	if (static_cast<size_t>(mCurrentHighlight) >= mItems.size())
+	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{
 		return;
 	}
@@ -243,7 +243,7 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 	
 	mCurrentHighlight = (y - static_cast<int>(rect().y()) + mCurrentOffset) / (LST_FONT->height() + 2);
 
-	if (static_cast<size_t>(mCurrentHighlight) >= mItems.size())
+	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 	}

--- a/src/UI/Core/ListBox.cpp
+++ b/src/UI/Core/ListBox.cpp
@@ -85,7 +85,7 @@ void ListBox::_updateItemDisplay()
 		if (mLineCount < mItems.size())
 		{
 			mSlider.length((mLineHeight * mItems.size()) - height());
-			mCurrentOffset = static_cast<unsigned int>(mSlider.thumbPosition());
+			mCurrentOffset = static_cast<std::size_t>(mSlider.thumbPosition());
 			mItemWidth = static_cast<unsigned int>(width() - mSlider.width());
 			mSlider.visible(true);
 		}

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "UIContainer.h"
+#include "Slider.h"
+#include "../../Constants/UiConstants.h"
+
 #include "NAS2D/Signal.h"
 #include "NAS2D/EventHandler.h"
 #include "NAS2D/Renderer/Color.h"
@@ -8,10 +12,6 @@
 #include <string>
 #include <algorithm>
 
-#include "UIContainer.h"
-#include "Slider.h"
-
-#include "../../Constants/UiConstants.h"
 
 /**
  * Implements a ListBox control.

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -52,7 +52,7 @@ public:
 	bool itemExists(const std::string& item);
 	void dropAllItems();
 
-	size_t count() const { return mItems.size(); }
+	std::size_t count() const { return mItems.size(); }
 	unsigned int lineHeight() const { return mLineHeight; }
 
 	void setSelectionByName(const std::string& item);

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -57,11 +57,11 @@ public:
 
 	void setSelectionByName(const std::string& item);
 
-	unsigned int currentSelection() const { return mCurrentSelection; }
-	void currentSelection(int selection) { mCurrentSelection = selection; mSelectionChanged(); }
+	std::size_t currentSelection() const { return mCurrentSelection; }
+	void currentSelection(std::size_t selection) { mCurrentSelection = selection; mSelectionChanged(); }
 	void clearSelection() { mCurrentSelection = constants::NO_SELECTION; }
 
-	unsigned int currentHighlight() const { return mCurrentHighlight; }
+	std::size_t currentHighlight() const { return mCurrentHighlight; }
 
 	const std::string& selectionText() const;
 	int selectionTag() const;
@@ -87,9 +87,9 @@ private:
 	void _init();
 
 private:
-	unsigned int				mCurrentHighlight = constants::NO_SELECTION;	/**< Currently highlighted selection index. */
-	unsigned int				mCurrentSelection = 0;							/**< Current selection index. */
-	unsigned int				mCurrentOffset = 0;								/**< Current selection index. */
+	std::size_t				mCurrentHighlight = constants::NO_SELECTION;	/**< Currently highlighted selection index. */
+	std::size_t				mCurrentSelection = 0;							/**< Current selection index. */
+	std::size_t				mCurrentOffset = 0;								/**< Current selection index. */
 
 	unsigned int				mItemWidth = 0;									/**< Width of items. */
 	unsigned int				mLineHeight = 0;								/**< Height of an item line. */

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <string>
 #include <algorithm>
+#include <cstddef>
 
 
 /**

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -84,6 +84,7 @@ void MainMenuOptions::init()
 
 	cmbResolution.clearSelection();
 
+	std::size_t currentResolutionSelection = 0;
 	{
 		auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
 		auto resolutions = r.getDisplayModes();

--- a/src/UI/MainMenuOptions.h
+++ b/src/UI/MainMenuOptions.h
@@ -69,5 +69,4 @@ private:
 	bool optionsChanged = false;
 	bool videoOptionsChanged = false;
 	bool inInit = true;
-	int currentResolutionSelection = 0;
 };


### PR DESCRIPTION
Use `std::size_t` for array index type values in `ListBox` and `ComboBox`.

Fixes MSVC warning:
> warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data
