### PR TITLE
Use `auto` to deduce correct type

### DIFF
--- a/src/UI/Core/TextField.cpp
+++ b/src/UI/Core/TextField.cpp
@@ -139,7 +139,7 @@ void TextField::onTextInput(const std::string& _s)
 
 	if (mMaxCharacters > 0 && text().length() == mMaxCharacters) { return; }
 
-	int prvLen = text().length();
+	auto prvLen = text().length();
 
 	if (mNumbersOnly && !std::isdigit(_s[0], LOC)) { return; }
 


### PR DESCRIPTION
Fixes MSVC warning:
> warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
