### PR TITLE
Use explicit conversion to uint8_t

### DIFF
--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -52,7 +52,7 @@ namespace {
 				glowStepDelta = -glowStepDelta;
 			}
 		}
-		return glowStep;
+		return static_cast<uint8_t>(glowStep);
 	}
 }
 


### PR DESCRIPTION
The `glowStep` value is already clamped to 0..255, so it is guaranteed to fit.

Fixes MSVC conversion warning:
> warning C4244: 'return': conversion from 'int' to 'uint8_t', possible loss of data
