### PR TITLE
Fix MSVC warnings in Pather

### DIFF
--- a/src/MicroPather/micropather.cpp
+++ b/src/MicroPather/micropather.cpp
@@ -44,6 +44,9 @@ distribution.
 
 using namespace micropather;
 
+constexpr auto Unset = int(-1);
+
+
 class OpenQueue
 {
 public:
@@ -233,7 +236,7 @@ PathNodePool::~PathNodePool()
 
 bool PathNodePool::PushCache(const NodeCost* nodes, int nNodes, int* start)
 {
-	*start = -1;
+	*start = Unset;
 	if (nNodes + cacheSize <= cacheCap)
 	{
 		for (int i = 0; i < nNodes; ++i)
@@ -468,8 +471,8 @@ void PathNode::Init(unsigned _frame,
 void PathNode::Clear()
 {
 	memset(this, 0, sizeof(PathNode));
-	numAdjacent = -1;
-	cacheIndex = -1;
+	numAdjacent = Unset;
+	cacheIndex = Unset;
 }
 
 

--- a/src/MicroPather/micropather.cpp
+++ b/src/MicroPather/micropather.cpp
@@ -604,7 +604,7 @@ void MicroPather::GetNodeNeighbors(PathNode* node, std::vector< NodeCost >* pNod
 		// it has no neighbors.
 		pNodeCost->resize(0);
 	}
-	else if (node->cacheIndex < 0)
+	else if (node->cacheIndex == Unset)
 	{
 		// Not in the cache. Either the first time or just didn't fit. We don't know
 		// the number of neighbors and need to call back to the client.

--- a/src/MicroPather/micropather.cpp
+++ b/src/MicroPather/micropather.cpp
@@ -44,7 +44,7 @@ distribution.
 
 using namespace micropather;
 
-constexpr auto Unset = int(-1);
+constexpr auto Unset = std::size_t(-1);
 
 
 class OpenQueue
@@ -192,7 +192,7 @@ private:
 };
 
 
-PathNodePool::PathNodePool(unsigned _allocate, unsigned _typicalAdjacent)
+PathNodePool::PathNodePool(std::size_t _allocate, std::size_t _typicalAdjacent)
 	: firstBlock(nullptr),
 	blocks(nullptr),
 #if defined( MICROPATHER_STRESS )
@@ -234,12 +234,12 @@ PathNodePool::~PathNodePool()
 }
 
 
-bool PathNodePool::PushCache(const NodeCost* nodes, int nNodes, int* start)
+bool PathNodePool::PushCache(const NodeCost* nodes, std::size_t nNodes, std::size_t* start)
 {
 	*start = Unset;
 	if (nNodes + cacheSize <= cacheCap)
 	{
-		for (int i = 0; i < nNodes; ++i)
+		for (std::size_t i = 0; i < nNodes; ++i)
 		{
 			cache[i + cacheSize] = nodes[i];
 		}
@@ -251,7 +251,7 @@ bool PathNodePool::PushCache(const NodeCost* nodes, int nNodes, int* start)
 }
 
 
-void PathNodePool::GetCache(int start, int nNodes, NodeCost* nodes)
+void PathNodePool::GetCache(std::size_t start, std::size_t nNodes, NodeCost* nodes)
 {
 	MPASSERT(start >= 0 && start < cacheCap);
 	MPASSERT(nNodes > 0);
@@ -281,7 +281,7 @@ void PathNodePool::Clear()
 		freeMemSentinel.prev = &freeMemSentinel;
 
 		memset(hashTable, 0, sizeof(PathNode*) * HashSize());
-		for (unsigned i = 0; i < allocate; ++i)
+		for (std::size_t i = 0; i < allocate; ++i)
 		{
 			freeMemSentinel.AddBefore(&firstBlock->pathNode[i]);
 		}
@@ -298,7 +298,7 @@ PathNodePool::Block* PathNodePool::NewBlock()
 	block->nextBlock = nullptr;
 
 	nAvailable += allocate;
-	for (unsigned i = 0; i < allocate; ++i)
+	for (std::size_t i = 0; i < allocate; ++i)
 	{
 		freeMemSentinel.AddBefore(&block->pathNode[i]);
 	}
@@ -385,7 +385,7 @@ void PathNodePool::AddPathNode(unsigned key, PathNode* root)
 		PathNode* p = hashTable[key];
 		while (true)
 		{
-			int dir = (root->state < p->state) ? 0 : 1;
+			std::size_t dir = (root->state < p->state) ? 0 : 1;
 			if (p->child[dir])
 			{
 				p = p->child[dir];
@@ -476,7 +476,7 @@ void PathNode::Clear()
 }
 
 
-MicroPather::MicroPather(Graph* _graph, unsigned allocate, unsigned typicalAdjacent, bool cache)
+MicroPather::MicroPather(Graph* _graph, std::size_t allocate, std::size_t typicalAdjacent, bool cache)
 	: pathNodePool(allocate, typicalAdjacent),
 	graph(_graph),
 	frame(0)
@@ -515,7 +515,7 @@ void MicroPather::GoalReached( PathNode* node, void* start, void* end, std::vect
 
 	// We have reached the goal.
 	// How long is the path? Used to allocate the vector which is returned.
-	int count = 1;
+	std::size_t count = 1;
 	PathNode* it = node;
 	while( it->parent )
 	{
@@ -555,12 +555,12 @@ void MicroPather::GoalReached( PathNode* node, void* start, void* end, std::vect
 
 		PathNode* pn0 = pathNodePool.FetchPathNode(path[0]);
 		PathNode* pn1 = nullptr;
-		for (unsigned i = 0; i < path.size() - 1; ++i)
+		for (std::size_t i = 0; i < path.size() - 1; ++i)
 		{
 			pn1 = pathNodePool.FetchPathNode(path[i + 1]);
 			nodeCostVec.clear();
 			GetNodeNeighbors(pn0, &nodeCostVec);
-			for (unsigned j = 0; j < nodeCostVec.size(); ++j)
+			for (std::size_t j = 0; j < nodeCostVec.size(); ++j)
 			{
 				if (nodeCostVec[j].node == pn1)
 				{
@@ -576,9 +576,9 @@ void MicroPather::GoalReached( PathNode* node, void* start, void* end, std::vect
 
 #ifdef DEBUG_PATH
 	printf("Path: ");
-	int counter = 0;
+	std::size_t counter = 0;
 #endif
-	for (unsigned k = 0; k < path.size(); ++k)
+	for (std::size_t k = 0; k < path.size(); ++k)
 	{
 #ifdef DEBUG_PATH
 		graph->PrintStateInfo(path[k]);
@@ -616,7 +616,7 @@ void MicroPather::GetNodeNeighbors(PathNode* node, std::vector< NodeCost >* pNod
 			// If this assert fires, you have passed a state
 			// as its own neighbor state. This is impossible --
 			// bad things will happen.
-			for (unsigned i = 0; i < stateCostVec.size(); ++i)
+			for (std::size_t i = 0; i < stateCostVec.size(); ++i)
 				MPASSERT(stateCostVec[i].state != node->state);
 		}
 #endif
@@ -629,11 +629,11 @@ void MicroPather::GetNodeNeighbors(PathNode* node, std::vector< NodeCost >* pNod
 			// Now convert to pathNodes.
 			// Note that the microsoft std library is actually pretty slow.
 			// Move things to temp vars to help.
-			const unsigned stateCostVecSize = stateCostVec.size();
+			const std::size_t stateCostVecSize = stateCostVec.size();
 			const StateCost* stateCostVecPtr = &stateCostVec[0];
 			NodeCost* pNodeCostPtr = &(*pNodeCost)[0];
 
-			for (unsigned i = 0; i < stateCostVecSize; ++i)
+			for (std::size_t i = 0; i < stateCostVecSize; ++i)
 			{
 				void* state = stateCostVecPtr[i].state;
 				pNodeCostPtr[i].cost = stateCostVecPtr[i].cost;
@@ -641,7 +641,7 @@ void MicroPather::GetNodeNeighbors(PathNode* node, std::vector< NodeCost >* pNod
 			}
 
 			// Can this be cached?
-			int start = 0;
+			std::size_t start = 0;
 			if (pNodeCost->size() > 0 && pathNodePool.PushCache(pNodeCostPtr, pNodeCost->size(), &start))
 			{
 				node->cacheIndex = start;
@@ -656,7 +656,7 @@ void MicroPather::GetNodeNeighbors(PathNode* node, std::vector< NodeCost >* pNod
 
 		// A node is uninitialized (even if memory is allocated) if it is from a previous frame.
 		// Check for that, and Init() as necessary.
-		for (int i = 0; i < node->numAdjacent; ++i)
+		for (std::size_t i = 0; i < node->numAdjacent; ++i)
 		{
 			PathNode* pNode = pNodeCostPtr[i].node;
 			if (pNode->frame != frame)
@@ -679,7 +679,7 @@ void PathNodePool::AllStates(unsigned frame, std::vector<void*>* stateVec)
 {
 	for (Block* b = blocks; b; b = b->nextBlock)
 	{
-		for (unsigned i = 0; i < allocate; ++i)
+		for (std::size_t i = 0; i < allocate; ++i)
 		{
 			if (b->pathNode[i].frame == frame)
 				stateVec->push_back(b->pathNode[i].state);
@@ -688,7 +688,7 @@ void PathNodePool::AllStates(unsigned frame, std::vector<void*>* stateVec)
 }
 
 
-PathCache::PathCache(int _allocated)
+PathCache::PathCache(std::size_t _allocated)
 {
 	mem = new Item[_allocated]{};
 	allocated = _allocated;
@@ -723,7 +723,7 @@ void PathCache::Add(const std::vector< void* >& path, const std::vector< float >
 		return;
 	}
 
-	for (unsigned i = 0; i < path.size() - 1; ++i)
+	for (std::size_t i = 0; i < path.size() - 1; ++i)
 	{
 		// example: a->b->c->d
 		// Huge memory saving to only store 3 paths to 'd'
@@ -737,14 +737,14 @@ void PathCache::Add(const std::vector< void* >& path, const std::vector< float >
 	}
 }
 
-void PathCache::AddNoSolution(void* end, void* states[], int count)
+void PathCache::AddNoSolution(void* end, void* states[], std::size_t count)
 {
 	if (count + nItems > allocated * 3 / 4)\
 	{
 		return;
 	}
 
-	for (int i = 0; i < count; ++i)
+	for (std::size_t i = 0; i < count; ++i)
 	{
 		Item item = { states[i], end, nullptr, FLT_MAX };
 		AddItem(item);
@@ -924,7 +924,7 @@ int MicroPather::Solve(void* startNode, void* endNode, std::vector< void* >* pat
 			// We have not reached the goal - add the neighbors.
 			GetNodeNeighbors(node, &nodeCostVec);
 
-			for (int i = 0; i < node->numAdjacent; ++i)
+			for (std::size_t i = 0; i < node->numAdjacent; ++i)
 			{
 				// Not actually a neighbor, but useful. Filter out infinite cost.
 				if (nodeCostVec[i].cost == FLT_MAX)
@@ -1030,7 +1030,7 @@ int MicroPather::SolveForNearStates(void* startState, std::vector< StateCost >* 
 
 		GetNodeNeighbors(node, &nodeCostVec);
 
-		for (int i = 0; i < node->numAdjacent; ++i)
+		for (std::size_t i = 0; i < node->numAdjacent; ++i)
 		{
 			MPASSERT(node->costFromStart < FLT_MAX);
 			float newCost = node->costFromStart + nodeCostVec[i].cost;
@@ -1078,9 +1078,9 @@ int MicroPather::SolveForNearStates(void* startState, std::vector< StateCost >* 
 		}
 	}
 #ifdef DEBUG
-	for (unsigned i = 0; i < near->size(); ++i)
+	for (std::size_t i = 0; i < near->size(); ++i)
 	{
-		for (unsigned k = i + 1; k < near->size(); ++k)
+		for (std::size_t k = i + 1; k < near->size(); ++k)
 		{
 			MPASSERT((*near)[i].state != (*near)[k].state);
 		}

--- a/src/MicroPather/micropather.h
+++ b/src/MicroPather/micropather.h
@@ -73,7 +73,7 @@ distribution.
 	typedef uintptr_t		MP_UPTR;
 #else
 	// Assume not 64 bit pointers. Get a new compiler.
-	typedef unsigned MP_UPTR;
+	typedef std::size_t MP_UPTR;
 #endif
 
 namespace micropather
@@ -173,8 +173,8 @@ namespace micropather
 		unsigned frame = 0;			// unique id for this path, so the solver can distinguish
 									// correct from stale values
 
-		int numAdjacent = 0;		// -1  is unknown & needs to be queried
-		int cacheIndex = 0;			// position in cache
+		std::size_t numAdjacent = 0;		// -1  is unknown & needs to be queried
+		std::size_t cacheIndex = 0;			// position in cache
 
 		PathNode* child[2];			// Binary search in the hash table. [left, right]
 		PathNode* next = nullptr, * prev = nullptr;	// used by open queue
@@ -226,7 +226,7 @@ namespace micropather
 	class PathNodePool
 	{
 	public:
-		PathNodePool(unsigned allocate, unsigned typicalAdjacent);
+		PathNodePool(std::size_t allocate, std::size_t typicalAdjacent);
 		~PathNodePool();
 
 		// Free all the memory except the first block. Resets all memory.
@@ -254,11 +254,11 @@ namespace micropather
 		PathNode* FetchPathNode(void* state);
 
 		// Store stuff in cache
-		bool PushCache(const NodeCost* nodes, int nNodes, int* start);
+		bool PushCache(const NodeCost* nodes, std::size_t nNodes, std::size_t* start);
 
 		// Get neighbors from the cache
 		// Note - always access this with an offset. Can get re-allocated.
-		void GetCache(int start, int nNodes, NodeCost* nodes);
+		void GetCache(std::size_t start, std::size_t nNodes, NodeCost* nodes);
 
 		// Return all the allocated states. Useful for visuallizing what
 		// the pather is doing.
@@ -283,13 +283,13 @@ namespace micropather
 		Block* blocks = nullptr;
 
 		NodeCost* cache = nullptr;
-		int			cacheCap = 0;
-		int			cacheSize = 0;
+		std::size_t cacheCap = 0;
+		std::size_t cacheSize = 0;
 
 		PathNode	freeMemSentinel;
-		unsigned	allocate = 0;				// how big a block of pathnodes to allocate at once
-		unsigned	nAllocated = 0;				// number of pathnodes allocated (from Alloc())
-		unsigned	nAvailable = 0;				// number available for allocation
+		std::size_t	allocate = 0;				// how big a block of pathnodes to allocate at once
+		std::size_t	nAllocated = 0;				// number of pathnodes allocated (from Alloc())
+		std::size_t	nAvailable = 0;				// number available for allocation
 
 		unsigned	hashShift = 0;
 		unsigned	totalCollide = 0;
@@ -321,7 +321,7 @@ namespace micropather
 				const unsigned char* p = reinterpret_cast<const unsigned char*>(&start);
 				unsigned int h = 2166136261U;
 
-				for (unsigned i = 0; i < sizeof(void*) * 2; ++i, ++p)
+				for (std::size_t i = 0; i < sizeof(void*) * 2; ++i, ++p)
 				{
 					h ^= *p;
 					h *= 16777619;
@@ -330,16 +330,16 @@ namespace micropather
 			}
 		};
 
-		PathCache(int itemsToAllocate);
+		PathCache(std::size_t itemsToAllocate);
 		~PathCache();
 
 		void Reset();
 		void Add(const std::vector< void* >& path, const std::vector<float>& cost);
-		void AddNoSolution(void* end, void* states[], int count);
+		void AddNoSolution(void* end, void* states[], std::size_t count);
 		int Solve(void* startState, void* endState, std::vector<void*>* path, float* totalCost);
 
-		int AllocatedBytes() const { return allocated * sizeof(Item); }
-		int UsedBytes() const { return nItems * sizeof(Item); }
+		std::size_t AllocatedBytes() const { return allocated * sizeof(Item); }
+		std::size_t UsedBytes() const { return nItems * sizeof(Item); }
 
 		int hit = 0;
 		int miss = 0;
@@ -349,14 +349,14 @@ namespace micropather
 		const Item* Find(void* start, void* end);
 
 		Item* mem = nullptr;
-		unsigned allocated = 0;
-		unsigned nItems = 0;
+		std::size_t allocated = 0;
+		std::size_t nItems = 0;
 	};
 
 	struct CacheData
 	{
-		int nBytesAllocated = 0;
-		int nBytesUsed = 0;
+		std::size_t nBytesAllocated = 0;
+		std::size_t nBytesUsed = 0;
 		float memoryFraction = 0;
 
 		int hit = 0;
@@ -406,7 +406,7 @@ namespace micropather
 								advantage if you may call the pather with the same path or sub-path, which
 								is common for pathing over maps in games.
 		*/
-		MicroPather(Graph* graph, unsigned allocate = 250, unsigned typicalAdjacent = 6, bool cache = true);
+		MicroPather(Graph* graph, std::size_t allocate = 250, std::size_t typicalAdjacent = 6, bool cache = true);
 		~MicroPather();
 
 		/**


### PR DESCRIPTION
Use `std::size_t` for array indexes and allocation counts. Set a named constant for `Unset` (`-1`) values, of type `std::size_t`.

Fix MSVC warnings:
> C:\projects\ophd\src\MicroPather\micropather.cpp(622,42): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data [C:\projects\ophd\proj\vs2019\ophd.vcxproj]
>   C:\projects\ophd\src\MicroPather\micropather.cpp(629,57): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\projects\ophd\proj\vs2019\ophd.vcxproj]
>   C:\projects\ophd\src\MicroPather\micropather.cpp(629,57): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\projects\ophd\proj\vs2019\ophd.vcxproj]
>   C:\projects\ophd\src\MicroPather\micropather.cpp(642,7): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\ophd\proj\vs2019\ophd.vcxproj]
> 