### PR TITLE
Adds Jason Turner's recommended MSVC warnings

### DIFF
--- a/proj/vs2019/ophd.vcxproj
+++ b/proj/vs2019/ophd.vcxproj
@@ -92,6 +92,7 @@
       <EnablePREfast>false</EnablePREfast>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/w44242 /w44254 /w44263 /w44265 /w44287 /w44289 /w44296 /w44311 /w44545 /w44546 /w44547 /w44549 /w44555 /w44619 /w44640 /w44826 /w44905 /w44906 /w44928 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>NAS2D.lib;opengl32.lib;sdl2maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -115,6 +116,7 @@
       <EnablePREfast>false</EnablePREfast>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/w44242 /w44254 /w44263 /w44265 /w44287 /w44289 /w44296 /w44311 /w44545 /w44546 /w44547 /w44549 /w44555 /w44619 /w44640 /w44826 /w44905 /w44906 /w44928 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>NAS2D.lib;opengl32.lib;sdl2maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -136,6 +138,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/w44242 /w44254 /w44263 /w44265 /w44287 /w44289 /w44296 /w44311 /w44545 /w44546 /w44547 /w44549 /w44555 /w44619 /w44640 /w44826 /w44905 /w44906 /w44928 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>NAS2D.lib;opengl32.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -161,6 +164,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/w44242 /w44254 /w44263 /w44265 /w44287 /w44289 /w44296 /w44311 /w44545 /w44546 /w44547 /w44549 /w44555 /w44619 /w44640 /w44826 /w44905 /w44906 /w44928 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>NAS2D.lib;opengl32.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Adds the warnings [recommended by Jason Turner for MSVC](https://github.com/lairworks/nas2d-core/issues/528#issuecomment-600663952) as `Level 4` warnings. When `Treat Warnings As Errors` can be turned on, these will have to change to `\weXXXX`to take advantage of that.

The prior `Add lint rules to MSVC` PR is superseded by this as the default setting is the correct `Native Recommended Ruleset`, albeit analysis is turned off. Although, adding to NAS2D will have to occur separately.

MSVC-only change.