### PR TITLE
Fix MSVC warning in TileMap

### DIFF
--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -377,11 +377,10 @@ void TileMap::draw()
 				if (tile->mine() != nullptr && !tile->thing())
 				{
 					uint8_t glow = 120 + sin(mTimer.tick() / THROB_SPEED) * 57;
-					int loc_x = x + TILE_HALF_WIDTH - 6;
-					int loc_y = y + 15;
+					const auto mineBeaconPosition = NAS2D::Point{x, y} + NAS2D::Vector{TILE_HALF_WIDTH - 6, 15};
 
-					r.drawImage(mMineBeacon, loc_x, loc_y);
-					r.drawSubImage(mMineBeacon, loc_x, loc_y, 0, 0, 10, 5, glow, glow, glow, 255);
+					r.drawImage(mMineBeacon, mineBeaconPosition);
+					r.drawSubImage(mMineBeacon, mineBeaconPosition, NAS2D::Rectangle{0, 0, 10, 5}, NAS2D::Color{glow, glow, glow, 255});
 				}
 
 				// Tell an occupying thing to update itself.

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -376,7 +376,7 @@ void TileMap::draw()
 				// Draw a beacon on an unoccupied tile with a mine
 				if (tile->mine() != nullptr && !tile->thing())
 				{
-					int glow = 120 + sin(mTimer.tick() / THROB_SPEED) * 57;
+					uint8_t glow = 120 + sin(mTimer.tick() / THROB_SPEED) * 57;
 					int loc_x = x + TILE_HALF_WIDTH - 6;
 					int loc_y = y + 15;
 

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -380,7 +380,7 @@ void TileMap::draw()
 					const auto mineBeaconPosition = NAS2D::Point{x, y} + NAS2D::Vector{TILE_HALF_WIDTH - 6, 15};
 
 					r.drawImage(mMineBeacon, mineBeaconPosition);
-					r.drawSubImage(mMineBeacon, mineBeaconPosition, NAS2D::Rectangle{0, 0, 10, 5}, NAS2D::Color{glow, glow, glow, 255});
+					r.drawSubImage(mMineBeacon, mineBeaconPosition, NAS2D::Rectangle{0, 0, 10, 5}, NAS2D::Color{glow, glow, glow});
 				}
 
 				// Tell an occupying thing to update itself.


### PR DESCRIPTION
Use `uint8_t` type for glow intensity of mine beacon.

Fix MSVC warning:
> warning C4242: 'argument': conversion from 'int' to 'uint8_t', possible loss of data

This one is intentionally minimal. There's more than can be done to update the function. I just don't have the energy to tackle the rest right at the moment. That's a tomorrow problem.
