### PR TITLE
Refactor TileMap::draw

### DIFF
--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -356,18 +356,18 @@ void TileMap::draw()
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{71, 224, 146, 255});
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{71, 224, 146});
 					}
 					else
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{125, 200, 255, 255});
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{125, 200, 255});
 					}
 				}
 				else
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{0, 255, 0, 255});
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{0, 255, 0});
 					}
 					else
 					{

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -329,7 +329,7 @@ bool TileMap::tileHighlightVisible() const
 
 void TileMap::draw()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	Tile* tile = nullptr;
 
@@ -354,7 +354,7 @@ void TileMap::draw()
 					isTileHighlighted ?
 						isConnectionHighlighted ? NAS2D::Color{71, 224, 146} : NAS2D::Color{125, 200, 255} :
 						isConnectionHighlighted ? NAS2D::Color::Green : NAS2D::Color::Normal;
-				r.drawSubImage(mTileset, position, subImageRect, highlightColor);
+				renderer.drawSubImage(mTileset, position, subImageRect, highlightColor);
 
 				// Draw a beacon on an unoccupied tile with a mine
 				if (tile->mine() != nullptr && !tile->thing())
@@ -362,8 +362,8 @@ void TileMap::draw()
 					uint8_t glow = 120 + sin(mTimer.tick() / THROB_SPEED) * 57;
 					const auto mineBeaconPosition = position + NAS2D::Vector{TILE_HALF_WIDTH - 6, 15};
 
-					r.drawImage(mMineBeacon, mineBeaconPosition);
-					r.drawSubImage(mMineBeacon, mineBeaconPosition, NAS2D::Rectangle{0, 0, 10, 5}, NAS2D::Color{glow, glow, glow});
+					renderer.drawImage(mMineBeacon, mineBeaconPosition);
+					renderer.drawSubImage(mMineBeacon, mineBeaconPosition, NAS2D::Rectangle{0, 0, 10, 5}, NAS2D::Color{glow, glow, glow});
 				}
 
 				// Tell an occupying thing to update itself.

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -352,9 +352,10 @@ void TileMap::draw()
 			{
 				auto position = NAS2D::Point{x, y};
 				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
+				const bool isTileHighlighted = row == mMapHighlight.y() && col == mMapHighlight.x();
 				const bool isConnectionHighlighted = mShowConnections && tile->connected();
 				NAS2D::Color highlightColor;
-				if (row == mMapHighlight.y() && col == mMapHighlight.x())
+				if (isTileHighlighted)
 				{
 					if (isConnectionHighlighted)
 					{

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -331,7 +331,6 @@ void TileMap::draw()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	int x = 0, y = 0;
 	Tile* tile = nullptr;
 
 	int tsetOffset = mCurrentDepth > 0 ? TILE_HEIGHT : 0;
@@ -340,9 +339,6 @@ void TileMap::draw()
 	{
 		for(int col = 0; col < mEdgeLength; col++)
 		{
-			x = mMapPosition.x() + ((col - row) * TILE_HALF_WIDTH);
-			y = mMapPosition.y() + ((col + row) * TILE_HEIGHT_HALF_ABSOLUTE);
-
 			tile = &mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
 
 			/// fixme: this is ... well, it's ugly. Find a better way to do this as pretty soon I'm going to need
@@ -350,7 +346,7 @@ void TileMap::draw()
 			/// ranges, etc.
 			if(tile->excavated())
 			{
-				auto position = NAS2D::Point{x, y};
+				auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = row == mMapHighlight.y() && col == mMapHighlight.x();
 				const bool isConnectionHighlighted = mShowConnections && tile->connected();

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -367,7 +367,7 @@ void TileMap::draw()
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{0, 255, 0});
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color::Green);
 					}
 					else
 					{

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -333,13 +333,13 @@ void TileMap::draw()
 
 	int tsetOffset = mCurrentDepth > 0 ? TILE_HEIGHT : 0;
 
-	for(int row = 0; row < mEdgeLength; row++)
+	for (int row = 0; row < mEdgeLength; row++)
 	{
-		for(int col = 0; col < mEdgeLength; col++)
+		for (int col = 0; col < mEdgeLength; col++)
 		{
 			Tile& tile = mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
 
-			if(tile.excavated())
+			if (tile.excavated())
 			{
 				auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -341,7 +341,7 @@ void TileMap::draw()
 
 			if (tile.excavated())
 			{
-				auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
+				const auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = row == mMapHighlight.y() && col == mMapHighlight.x();
 				const bool isConnectionHighlighted = mShowConnections && tile.connected();

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -339,9 +339,6 @@ void TileMap::draw()
 		{
 			Tile& tile = mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
 
-			/// fixme: this is ... well, it's ugly. Find a better way to do this as pretty soon I'm going to need
-			/// an easier way to change tile render color when it comes time to highlight truck routes, comm
-			/// ranges, etc.
 			if(tile.excavated())
 			{
 				auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -350,26 +350,28 @@ void TileMap::draw()
 			/// ranges, etc.
 			if(tile->excavated())
 			{
+				auto position = NAS2D::Point{x, y};
+				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				if (row == mMapHighlight.y() && col == mMapHighlight.x())
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, x, y, tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT, 71, 224, 146, 255);
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{71, 224, 146, 255});
 					}
 					else
 					{
-						r.drawSubImage(mTileset, x, y, tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT, 125, 200, 255, 255);
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{125, 200, 255, 255});
 					}
 				}
 				else
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, x, y, tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT, 0, 255, 0, 255);
+						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{0, 255, 0, 255});
 					}
 					else
 					{
-						r.drawSubImage(mTileset, x, y, tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT);
+						r.drawSubImage(mTileset, position, subImageRect);
 					}
 				}
 
@@ -377,14 +379,14 @@ void TileMap::draw()
 				if (tile->mine() != nullptr && !tile->thing())
 				{
 					uint8_t glow = 120 + sin(mTimer.tick() / THROB_SPEED) * 57;
-					const auto mineBeaconPosition = NAS2D::Point{x, y} + NAS2D::Vector{TILE_HALF_WIDTH - 6, 15};
+					const auto mineBeaconPosition = position + NAS2D::Vector{TILE_HALF_WIDTH - 6, 15};
 
 					r.drawImage(mMineBeacon, mineBeaconPosition);
 					r.drawSubImage(mMineBeacon, mineBeaconPosition, NAS2D::Rectangle{0, 0, 10, 5}, NAS2D::Color{glow, glow, glow});
 				}
 
 				// Tell an occupying thing to update itself.
-				if (tile->thing()) { tile->thing()->sprite().update(x, y); }
+				if (tile->thing()) { tile->thing()->sprite().update(position); }
 			}
 		}
 	}

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -354,29 +354,10 @@ void TileMap::draw()
 				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = row == mMapHighlight.y() && col == mMapHighlight.x();
 				const bool isConnectionHighlighted = mShowConnections && tile->connected();
-				NAS2D::Color highlightColor;
-				if (isTileHighlighted)
-				{
-					if (isConnectionHighlighted)
-					{
-						highlightColor = NAS2D::Color{71, 224, 146};
-					}
-					else
-					{
-						highlightColor = NAS2D::Color{125, 200, 255};
-					}
-				}
-				else
-				{
-					if (isConnectionHighlighted)
-					{
-						highlightColor = NAS2D::Color::Green;
-					}
-					else
-					{
-						highlightColor = NAS2D::Color::Normal;
-					}
-				}
+				const NAS2D::Color highlightColor =
+					isTileHighlighted ?
+						isConnectionHighlighted ? NAS2D::Color{71, 224, 146} : NAS2D::Color{125, 200, 255} :
+						isConnectionHighlighted ? NAS2D::Color::Green : NAS2D::Color::Normal;
 				r.drawSubImage(mTileset, position, subImageRect, highlightColor);
 
 				// Draw a beacon on an unoccupied tile with a mine

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -331,15 +331,13 @@ void TileMap::draw()
 {
 	Renderer& renderer = Utility<Renderer>::get();
 
-	Tile* tile = nullptr;
-
 	int tsetOffset = mCurrentDepth > 0 ? TILE_HEIGHT : 0;
 
 	for(int row = 0; row < mEdgeLength; row++)
 	{
 		for(int col = 0; col < mEdgeLength; col++)
 		{
-			tile = &mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
+			Tile* tile = &mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
 
 			/// fixme: this is ... well, it's ugly. Find a better way to do this as pretty soon I'm going to need
 			/// an easier way to change tile render color when it comes time to highlight truck routes, comm

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -337,17 +337,17 @@ void TileMap::draw()
 	{
 		for(int col = 0; col < mEdgeLength; col++)
 		{
-			Tile* tile = &mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
+			Tile& tile = mTileMap[mCurrentDepth][row + mMapViewLocation.y()][col + mMapViewLocation.x()];
 
 			/// fixme: this is ... well, it's ugly. Find a better way to do this as pretty soon I'm going to need
 			/// an easier way to change tile render color when it comes time to highlight truck routes, comm
 			/// ranges, etc.
-			if(tile->excavated())
+			if(tile.excavated())
 			{
 				auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
-				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
+				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = row == mMapHighlight.y() && col == mMapHighlight.x();
-				const bool isConnectionHighlighted = mShowConnections && tile->connected();
+				const bool isConnectionHighlighted = mShowConnections && tile.connected();
 				const NAS2D::Color highlightColor =
 					isTileHighlighted ?
 						isConnectionHighlighted ? NAS2D::Color{71, 224, 146} : NAS2D::Color{125, 200, 255} :
@@ -355,7 +355,7 @@ void TileMap::draw()
 				renderer.drawSubImage(mTileset, position, subImageRect, highlightColor);
 
 				// Draw a beacon on an unoccupied tile with a mine
-				if (tile->mine() != nullptr && !tile->thing())
+				if (tile.mine() != nullptr && !tile.thing())
 				{
 					uint8_t glow = 120 + sin(mTimer.tick() / THROB_SPEED) * 57;
 					const auto mineBeaconPosition = position + NAS2D::Vector{TILE_HALF_WIDTH - 6, 15};
@@ -365,7 +365,7 @@ void TileMap::draw()
 				}
 
 				// Tell an occupying thing to update itself.
-				if (tile->thing()) { tile->thing()->sprite().update(position); }
+				if (tile.thing()) { tile.thing()->sprite().update(position); }
 			}
 		}
 	}

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -352,28 +352,30 @@ void TileMap::draw()
 			{
 				auto position = NAS2D::Point{x, y};
 				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
+				NAS2D::Color highlightColor;
 				if (row == mMapHighlight.y() && col == mMapHighlight.x())
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{71, 224, 146});
+						highlightColor = NAS2D::Color{71, 224, 146};
 					}
 					else
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color{125, 200, 255});
+						highlightColor = NAS2D::Color{125, 200, 255};
 					}
 				}
 				else
 				{
 					if (mShowConnections && tile->connected())
 					{
-						r.drawSubImage(mTileset, position, subImageRect, NAS2D::Color::Green);
+						highlightColor = NAS2D::Color::Green;
 					}
 					else
 					{
-						r.drawSubImage(mTileset, position, subImageRect);
+						highlightColor = NAS2D::Color::Normal;
 					}
 				}
+				r.drawSubImage(mTileset, position, subImageRect, highlightColor);
 
 				// Draw a beacon on an unoccupied tile with a mine
 				if (tile->mine() != nullptr && !tile->thing())

--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -352,10 +352,11 @@ void TileMap::draw()
 			{
 				auto position = NAS2D::Point{x, y};
 				const auto subImageRect = NAS2D::Rectangle{tile->index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
+				const bool isConnectionHighlighted = mShowConnections && tile->connected();
 				NAS2D::Color highlightColor;
 				if (row == mMapHighlight.y() && col == mMapHighlight.x())
 				{
-					if (mShowConnections && tile->connected())
+					if (isConnectionHighlighted)
 					{
 						highlightColor = NAS2D::Color{71, 224, 146};
 					}
@@ -366,7 +367,7 @@ void TileMap::draw()
 				}
 				else
 				{
-					if (mShowConnections && tile->connected())
+					if (isConnectionHighlighted)
 					{
 						highlightColor = NAS2D::Color::Green;
 					}


### PR DESCRIPTION
A bit of refactoring for `TileMap::draw`. This method had a warning fixed yesterday, though I didn't have time to refactor the rest of the method until today.

There's probably more that can be done, but this seems like a good stopping point. In particular, the `loopVar++` syntax can probably be changed to `++loopVar`, which is slightly more common in other files. However, this may require an update involving more than just the one function being refactored here, so I thought I'd leave it for a blanket update.

I made use of nested ternary operators to select the `highlightColor`. Normally I would consider nested ternary to be a bad idea, and something to avoid. It's usually not very readable. I thought I'd try it out here though, since it results in quite significantly more compact code, and the ability to declare a variable `const`. Hopefully the formatting helps keep it readable.
