### PR TITLE
Remove redundant check of `start` value

### DIFF
--- a/src/MicroPather/micropather.cpp
+++ b/src/MicroPather/micropather.cpp
@@ -253,7 +253,7 @@ bool PathNodePool::PushCache(const NodeCost* nodes, std::size_t nNodes, std::siz
 
 void PathNodePool::GetCache(std::size_t start, std::size_t nNodes, NodeCost* nodes)
 {
-	MPASSERT(start >= 0 && start < cacheCap);
+	MPASSERT(start < cacheCap);
 	MPASSERT(nNodes > 0);
 	MPASSERT(start + nNodes <= cacheCap);
 	memcpy(nodes, &cache[start], sizeof(NodeCost) * nNodes);


### PR DESCRIPTION
Fix MSVC error seen locally (but not on CI):
> warning C4296: '>=': expression is always true


Now that it is an unsigned `std::size_t` type, it is impossible for that check to be false.
