### PR TITLE
Remove extra semicolons

### DIFF
--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -84,7 +84,7 @@ public:
 	/** MicroPather public interface implementation. */
 	virtual float LeastCostEstimate(void* stateStart, void* stateEnd);
 	virtual void AdjacentCost(void* state, std::vector<micropather::StateCost>* adjacent);
-	virtual void PrintStateInfo(void* /*state*/) {};
+	virtual void PrintStateInfo(void* /*state*/) {}
 
 protected:
 	/**

--- a/src/Mine.h
+++ b/src/Mine.h
@@ -27,7 +27,6 @@ public:
 public:
 	Mine();
 	Mine(MineProductionRate rate);
-	~Mine() {};
 
 	bool active() const;
 	void active(bool newActive);

--- a/src/Things/Structures/MineFacility.h
+++ b/src/Things/Structures/MineFacility.h
@@ -13,7 +13,6 @@ public:
 	typedef NAS2D::Signals::Signal<MineFacility*> ExtensionCompleteCallback;
 public:
 	MineFacility(Mine* mine);
-	virtual ~MineFacility() {};
 	
 	void mine(Mine* mine) { mMine = mine; }
 	void maxDepth(int depth) { mMaxDepth = depth; }

--- a/src/Things/Structures/Structure.h
+++ b/src/Things/Structures/Structure.h
@@ -148,7 +148,7 @@ protected:
 
 	void activate();
 
-	virtual void disabledStateSet() {};
+	virtual void disabledStateSet() {}
 
 	void state(StructureState newState) { mStructureState = newState; }
 
@@ -167,7 +167,7 @@ private:
 	 * Provided so that structures that need to do something upon
 	 * activation can do so without overriding void activate();
 	 */
-	virtual void activated() {};
+	virtual void activated() {}
 
 private:
 	int						mTurnsToBuild = 0;			/**< Number of turns it takes to build the Structure. */

--- a/src/UI/Core/Control.h
+++ b/src/UI/Core/Control.h
@@ -65,7 +65,7 @@ public:
 
 	ResizeCallback& resized();
 
-	virtual void update() {};
+	virtual void update() {}
 
 protected:
 	/**
@@ -78,12 +78,12 @@ protected:
 
 	virtual void visibilityChanged(bool /*visible*/) {}
 
-	virtual void enabledChanged() {};
+	virtual void enabledChanged() {}
 
-	virtual void onFocusChanged() {};
+	virtual void onFocusChanged() {}
 
 	virtual void onSizeChanged() { mResized(this); }
-	virtual void onTextChanged() { mTextChanged(this); };
+	virtual void onTextChanged() { mTextChanged(this); }
 
 	std::string& _text();
 
@@ -95,7 +95,7 @@ protected:
 	NAS2D::Rectangle_2df	mRect;				/**< Area of the Control. */
 
 private:
-	virtual void draw() {};
+	virtual void draw() {}
 
 private:
 	std::string				mText;				/**< Internal text string. */


### PR DESCRIPTION
Reference: #307 (`-Wextra-semi`)

Remove extra trailing semicolons. Found using:
```
make WARN_EXTRA=-Wextra-semi
```
