### PR TITLE
Enum class Button::Type

### DIFF
--- a/src/States/MapViewStateUi.cpp
+++ b/src/States/MapViewStateUi.cpp
@@ -131,11 +131,11 @@ void MapViewState::initUi()
 
 	mBtnToggleHeightmap.image("ui/icons/height.png");
 	mBtnToggleHeightmap.size(static_cast<float>(constants::MAIN_BUTTON_SIZE));
-	mBtnToggleHeightmap.type(Button::BUTTON_TOGGLE);
+	mBtnToggleHeightmap.type(Button::Type::BUTTON_TOGGLE);
 
 	mBtnToggleConnectedness.image("ui/icons/connection.png");
 	mBtnToggleConnectedness.size(static_cast<float>(constants::MAIN_BUTTON_SIZE));
-	mBtnToggleConnectedness.type(Button::BUTTON_TOGGLE);
+	mBtnToggleConnectedness.type(Button::Type::BUTTON_TOGGLE);
 	mBtnToggleConnectedness.click().connect(this, &MapViewState::btnToggleConnectednessClicked);
 
 	// Menus

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -69,7 +69,7 @@ Button::~Button()
 
 void Button::type(Type type)
 {
-	mType = type ? Type::BUTTON_TOGGLE : Type::BUTTON_NORMAL;
+	mType = type;
 }
 
 

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -69,7 +69,7 @@ Button::~Button()
 
 void Button::type(Type type)
 {
-	mType = type ? BUTTON_TOGGLE : BUTTON_NORMAL;
+	mType = type ? Type::BUTTON_TOGGLE : Type::BUTTON_NORMAL;
 }
 
 
@@ -113,7 +113,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 		if(rect().contains(click))
 		{
-			if(mType == BUTTON_NORMAL)
+			if(mType == Type::BUTTON_NORMAL)
 			{
 				mState = STATE_PRESSED;
 			}
@@ -135,7 +135,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 	{
 		Point_2d click(x, y);
 		
-		if(mType == BUTTON_NORMAL)
+		if(mType == Type::BUTTON_NORMAL)
 		{
 			mState = STATE_NORMAL;
 

--- a/src/UI/Core/Button.h
+++ b/src/UI/Core/Button.h
@@ -12,7 +12,7 @@
 class Button: public Control
 {
 public:
-	enum Type
+	enum class Type
 	{
 		BUTTON_NORMAL,
 		BUTTON_TOGGLE

--- a/src/UI/Core/Button.h
+++ b/src/UI/Core/Button.h
@@ -56,7 +56,7 @@ private:
 
 private:
 	State				mState = STATE_NORMAL;		/**< Current state of the Button. */
-	Type				mType = BUTTON_NORMAL;		/**< Modifies Button behavior. */
+	Type				mType = Type::BUTTON_NORMAL;		/**< Modifies Button behavior. */
 
 	NAS2D::Image*		mImage = nullptr;			/**< Image to draw centered on the Button. */
 

--- a/src/UI/MineOperationsWindow.cpp
+++ b/src/UI/MineOperationsWindow.cpp
@@ -86,7 +86,7 @@ void MineOperationsWindow::init()
 
 	// Set up GUI Layout
 	add(&btnIdle, 10, 230);
-	btnIdle.type(Button::BUTTON_TOGGLE);
+	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size(60, 30);
 	btnIdle.click().connect(this, &MineOperationsWindow::btnIdleClicked);
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -117,38 +117,38 @@ void FactoryReport::init()
 
 	add(&btnShowAll, 10, 10);
 	btnShowAll.size(75, 20);
-	btnShowAll.type(Button::BUTTON_TOGGLE);
+	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
 	btnShowAll.click().connect(this, &FactoryReport::btnShowAllClicked);
 
 	add(&btnShowSurface, 87, 10);
 	btnShowSurface.size(75, 20);
-	btnShowSurface.type(Button::BUTTON_TOGGLE);
+	btnShowSurface.type(Button::Type::BUTTON_TOGGLE);
 	btnShowSurface.click().connect(this, &FactoryReport::btnShowSurfaceClicked);
 
 	add(&btnShowUnderground, 164, 10);
 	btnShowUnderground.size(75, 20);
-	btnShowUnderground.type(Button::BUTTON_TOGGLE);
+	btnShowUnderground.type(Button::Type::BUTTON_TOGGLE);
 	btnShowUnderground.click().connect(this, &FactoryReport::btnShowUndergroundClicked);
 
 	add(&btnShowActive, 10, 33);
 	btnShowActive.size(75, 20);
-	btnShowActive.type(Button::BUTTON_TOGGLE);
+	btnShowActive.type(Button::Type::BUTTON_TOGGLE);
 	btnShowActive.click().connect(this, &FactoryReport::btnShowActiveClicked);
 
 	add(&btnShowIdle, 87, 33);
 	btnShowIdle.size(75, 20);
-	btnShowIdle.type(Button::BUTTON_TOGGLE);
+	btnShowIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnShowIdle.click().connect(this, &FactoryReport::btnShowIdleClicked);
 
 	add(&btnShowDisabled, 164, 33);
 	btnShowDisabled.size(75, 20);
-	btnShowDisabled.type(Button::BUTTON_TOGGLE);
+	btnShowDisabled.type(Button::Type::BUTTON_TOGGLE);
 	btnShowDisabled.click().connect(this, &FactoryReport::btnShowDisabledClicked);
 
 	float position_x = Utility<Renderer>::get().width() - 110;
 	add(&btnIdle, position_x, 35);
-	btnIdle.type(Button::BUTTON_TOGGLE);
+	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size(140, 30);
 	btnIdle.click().connect(this, &FactoryReport::btnIdleClicked);
 

--- a/src/UI/Reports/WarehouseReport.cpp
+++ b/src/UI/Reports/WarehouseReport.cpp
@@ -113,31 +113,31 @@ void WarehouseReport::init()
 
 	add(&btnShowAll, 10, 10);
 	btnShowAll.size(75, 20);
-	btnShowAll.type(Button::BUTTON_TOGGLE);
+	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
 	btnShowAll.click().connect(this, &WarehouseReport::btnShowAllClicked);
 
 	add(&btnSpaceAvailable, 90, 10);
 	btnSpaceAvailable.size(100, 20);
-	btnSpaceAvailable.type(Button::BUTTON_TOGGLE);
+	btnSpaceAvailable.type(Button::Type::BUTTON_TOGGLE);
 	btnSpaceAvailable.toggle(false);
 	btnSpaceAvailable.click().connect(this, &WarehouseReport::btnSpaceAvailableClicked);
 
 	add(&btnFull, 195, 10);
 	btnFull.size(75, 20);
-	btnFull.type(Button::BUTTON_TOGGLE);
+	btnFull.type(Button::Type::BUTTON_TOGGLE);
 	btnFull.toggle(false);
 	btnFull.click().connect(this, &WarehouseReport::btnFullClicked);
 
 	add(&btnEmpty, 275, 10);
 	btnEmpty.size(75, 20);
-	btnEmpty.type(Button::BUTTON_TOGGLE);
+	btnEmpty.type(Button::Type::BUTTON_TOGGLE);
 	btnEmpty.toggle(false);
 	btnEmpty.click().connect(this, &WarehouseReport::btnEmptyClicked);
 
 	add(&btnDisabled, 355, 10);
 	btnDisabled.size(75, 20);
-	btnDisabled.type(Button::BUTTON_TOGGLE);
+	btnDisabled.type(Button::Type::BUTTON_TOGGLE);
 	btnDisabled.toggle(false);
 	btnDisabled.click().connect(this, &WarehouseReport::btnDisabledClicked);
 


### PR DESCRIPTION
Convert `Button::Type` from `enum` to `enum class`.

There are many other similar enums, which will eventually be converted. I'm starting with this one as a template. The bulk of the changes are simply adding the enum name prefix when accessing enum values. That can be done safely before switching to an `enum class`. Any code that relies on implicit conversion of `enum` to `int` or other data types will also need to be updated.
