### PR TITLE
Don't override empty destructors

### DIFF
--- a/src/MicroPather/micropather.h
+++ b/src/MicroPather/micropather.h
@@ -108,7 +108,7 @@ namespace micropather
 	class Graph
 	{
 	public:
-		virtual ~Graph() {}
+		virtual ~Graph() = default;
 
 		/**
 			Return the least possible cost between 2 states. For example, if your pathfinding

--- a/src/States/Wrapper.h
+++ b/src/States/Wrapper.h
@@ -24,7 +24,6 @@ class Wrapper : public NAS2D::State
 {
 public:
 	Wrapper() : _active(false) {}
-	virtual ~Wrapper() {}
 
 	State* _update() { return update(); }
 

--- a/src/Things/Robots/Robodigger.h
+++ b/src/Things/Robots/Robodigger.h
@@ -15,9 +15,6 @@ public:
 		sprite().play("running");
 	}
 
-	virtual ~Robodigger() {}
-
-
 	void direction(Direction dir) { mDirection = dir; }
 	Direction direction() const { return mDirection; }
 

--- a/src/Things/Robots/Robodozer.h
+++ b/src/Things/Robots/Robodozer.h
@@ -12,8 +12,6 @@ public:
 		sprite().play("running");
 	}
 
-	virtual ~Robodozer() {}
-
 	void tileIndex(size_t index) { mTileIndex = index; }
 	size_t tileIndex() const { return mTileIndex; }
 

--- a/src/Things/Robots/Robominer.h
+++ b/src/Things/Robots/Robominer.h
@@ -12,7 +12,5 @@ public:
 		sprite().play("running");
 	}
 
-	virtual ~Robominer() {}
-
 	void update() { updateTask(); }
 };

--- a/src/Things/Structures/MineFacility.h
+++ b/src/Things/Structures/MineFacility.h
@@ -13,7 +13,7 @@ public:
 	typedef NAS2D::Signals::Signal<MineFacility*> ExtensionCompleteCallback;
 public:
 	MineFacility(Mine* mine);
-	
+
 	void mine(Mine* mine) { mMine = mine; }
 	void maxDepth(int depth) { mMaxDepth = depth; }
 

--- a/src/Things/Structures/SeedSmelter.h
+++ b/src/Things/Structures/SeedSmelter.h
@@ -17,8 +17,6 @@ public:
 		storage().capacity(250);
 	}
 
-	virtual ~SeedSmelter() {}
-
 	virtual void input(ResourcePool& _resourcePool)
 	{
 		if (!operational()) { return; }

--- a/src/Things/Structures/Smelter.h
+++ b/src/Things/Structures/Smelter.h
@@ -17,8 +17,6 @@ public:
 		storage().capacity(750);
 	}
 
-	virtual ~Smelter() {}
-
 	virtual void input(ResourcePool& _resourcePool)
 	{
 		if (!operational()) { return; }

--- a/src/Things/Structures/Warehouse.h
+++ b/src/Things/Structures/Warehouse.h
@@ -16,8 +16,6 @@ public:
 		requiresCHAP(false);
 	}
 
-	virtual ~Warehouse() {}
-
 	ProductPool& products() { return mProducts; }
 
 protected:

--- a/src/UI/FactoryListBox.h
+++ b/src/UI/FactoryListBox.h
@@ -28,7 +28,6 @@ public:
 	{
 	public:
 		FactoryListBoxItem(Factory* newFactory) : factory(newFactory) {}
-		virtual ~FactoryListBoxItem() {}
 
 	public:
 		Factory* factory = nullptr;

--- a/src/UI/Reports/ReportInterface.h
+++ b/src/UI/Reports/ReportInterface.h
@@ -20,7 +20,6 @@ public:
 
 public:
 	ReportInterface() {}
-	virtual ~ReportInterface() {}
 
 public:
 	/**


### PR DESCRIPTION
I noticed this while doing some related investigation for #307, with warning flag `-Winconsistent-missing-destructor-override`. This doesn't address that issue, but was some related cleanup to reduce the work that directly affects those warnings.

Basically, if we're not actually overriding the destructor, then don't override it.
