### PR TITLE
Refactor FactoryReport drawDetailPane

### DIFF
--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -574,23 +574,20 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 60, text_color.red(), text_color.green(), text_color.blue());
 
 	// MINERAL RESOURCES
-	r.drawText(*FONT_BOLD, "Common Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 80, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT_BOLD, "Common Minerals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 95, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT_BOLD, "Rare Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 110, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT_BOLD, "Rare Minerals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 125, text_color.red(), text_color.green(), text_color.blue());
-
 	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());
+	r.drawText(*FONT_BOLD, "Common Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 80, text_color.red(), text_color.green(), text_color.blue());
 	r.drawText(*FONT, std::to_string(_pc.commonMetals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.commonMetals())), DETAIL_PANEL.y() + 80, text_color.red(), text_color.green(), text_color.blue());
+	r.drawText(*FONT_BOLD, "Common Minerals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 95, text_color.red(), text_color.green(), text_color.blue());
 	r.drawText(*FONT, std::to_string(_pc.commonMinerals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.commonMinerals())), DETAIL_PANEL.y() + 95, text_color.red(), text_color.green(), text_color.blue());
+	r.drawText(*FONT_BOLD, "Rare Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 110, text_color.red(), text_color.green(), text_color.blue());
 	r.drawText(*FONT, std::to_string(_pc.rareMetals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.rareMetals())), DETAIL_PANEL.y() + 110, text_color.red(), text_color.green(), text_color.blue());
+	r.drawText(*FONT_BOLD, "Rare Minerals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 125, text_color.red(), text_color.green(), text_color.blue());
 	r.drawText(*FONT, std::to_string(_pc.rareMinerals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.rareMinerals())), DETAIL_PANEL.y() + 125, text_color.red(), text_color.green(), text_color.blue());
 
 	// POPULATION
 	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
-
-	r.drawText(*FONT_BOLD, "Workers", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 140, text_color.red(), text_color.green(), text_color.blue());
-
 	std::string _scratch = string_format("%i / %i", SELECTED_FACTORY->populationAvailable()[0], SELECTED_FACTORY->populationRequirements()[0]);
+	r.drawText(*FONT_BOLD, "Workers", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 140, text_color.red(), text_color.green(), text_color.blue());
 	r.drawText(*FONT, _scratch, DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(_scratch), DETAIL_PANEL.y() + 140, text_color.red(), text_color.green(), text_color.blue());
 }
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -554,7 +554,7 @@ void FactoryReport::cboFilterByProductSelectionChanged()
  */
 void FactoryReport::drawDetailPane(Renderer& r)
 {
-	Color textColor(0, 185, 0, 255);
+	NAS2D::Color textColor(0, 185, 0, 255);
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	r.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -582,19 +582,21 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	// MINERAL RESOURCES
 	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());
-	r.drawText(*FONT_BOLD, "Common Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 80, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT, std::to_string(_pc.commonMetals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.commonMetals())), DETAIL_PANEL.y() + 80, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT_BOLD, "Common Minerals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 95, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT, std::to_string(_pc.commonMinerals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.commonMinerals())), DETAIL_PANEL.y() + 95, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT_BOLD, "Rare Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 110, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT, std::to_string(_pc.rareMetals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.rareMetals())), DETAIL_PANEL.y() + 110, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT_BOLD, "Rare Minerals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 125, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT, std::to_string(_pc.rareMinerals()), DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(std::to_string(_pc.rareMinerals())), DETAIL_PANEL.y() + 125, text_color.red(), text_color.green(), text_color.blue());
+	const std::array requiredResources{
+		std::pair{"Common Metals", _pc.commonMetals()},
+		std::pair{"Common Minerals", _pc.commonMinerals()},
+		std::pair{"Rare Metals", _pc.rareMetals()},
+		std::pair{"Rare Minerals", _pc.rareMinerals()},
+	};
+	auto position = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 80};
+	for (auto [title, value] : requiredResources) {
+		drawTitleText(position, title, std::to_string(value), text_color);
+		position.y() += 15;
+	}
 
 	// POPULATION
 	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
 	std::string _scratch = string_format("%i / %i", SELECTED_FACTORY->populationAvailable()[0], SELECTED_FACTORY->populationRequirements()[0]);
-	const auto position = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 140};
 	drawTitleText(position, "Workers", _scratch, text_color);
 }
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -554,22 +554,22 @@ void FactoryReport::cboFilterByProductSelectionChanged()
  */
 void FactoryReport::drawDetailPane(Renderer& r)
 {
-	Color text_color(0, 185, 0, 255);
+	Color textColor(0, 185, 0, 255);
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	r.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
-	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, text_color);
+	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, textColor);
 
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
-	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, text_color);
+	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, textColor);
 
-	if (SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed()) { text_color(255, 0, 0, 255); }
+	if (SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed()) { textColor(255, 0, 0, 255); }
 	statusPosition.x() += FONT_MED_BOLD->width("Status") + 20;
-	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, text_color);
+	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, textColor);
 
-	text_color(0, 185, 0, 255);
+	textColor(0, 185, 0, 255);
 
-	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, text_color);
+	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, textColor);
 
 	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
 	const auto drawTitleText = [&renderer = r, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {
@@ -588,14 +588,14 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	};
 	auto position = startPoint + NAS2D::Vector{138, 80};
 	for (auto [title, value] : requiredResources) {
-		drawTitleText(position, title, std::to_string(value), text_color);
+		drawTitleText(position, title, std::to_string(value), textColor);
 		position.y() += 15;
 	}
 
 	// POPULATION
-	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
+	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? textColor(0, 185, 0, 255) : textColor(255, 0, 0, 255);
 	auto text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
-	drawTitleText(position, "Workers", text, text_color);
+	drawTitleText(position, "Workers", text, textColor);
 }
 
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -563,7 +563,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
 	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, textColor);
 
-	if (SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed()) { textColor(255, 0, 0, 255); }
+	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
+	if (isStatusHighlighted) { textColor(255, 0, 0, 255); }
 	statusPosition.x() += FONT_MED_BOLD->width("Status") + 20;
 	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, textColor);
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -554,20 +554,20 @@ void FactoryReport::cboFilterByProductSelectionChanged()
  */
 void FactoryReport::drawDetailPane(Renderer& renderer)
 {
-	NAS2D::Color textColor(0, 185, 0);
+	NAS2D::Color defaultTextColor(0, 185, 0);
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	renderer.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
-	renderer.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, textColor);
+	renderer.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
 
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
-	renderer.drawText(*FONT_MED_BOLD, "Status", statusPosition, textColor);
+	renderer.drawText(*FONT_MED_BOLD, "Status", statusPosition, defaultTextColor);
 
 	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
 	statusPosition.x() += FONT_MED_BOLD->width("Status") + 20;
-	renderer.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : textColor));
+	renderer.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
 
-	renderer.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, textColor);
+	renderer.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
 
 	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
 	const auto drawTitleText = [&renderer, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {
@@ -586,14 +586,14 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 	};
 	auto position = startPoint + NAS2D::Vector{138, 80};
 	for (auto [title, value] : requiredResources) {
-		drawTitleText(position, title, std::to_string(value), textColor);
+		drawTitleText(position, title, std::to_string(value), defaultTextColor);
 		position.y() += 15;
 	}
 
 	// POPULATION
 	bool isPopulationRequirementHighlighted = SELECTED_FACTORY->populationAvailable()[0] != SELECTED_FACTORY->populationRequirements()[0];
 	auto text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
-	drawTitleText(position, "Workers", text, (isPopulationRequirementHighlighted ? NAS2D::Color::Red : textColor));
+	drawTitleText(position, "Workers", text, (isPopulationRequirementHighlighted ? NAS2D::Color::Red : defaultTextColor));
 }
 
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -16,8 +16,6 @@
 using namespace NAS2D;
 
 static float SORT_BY_PRODUCT_POSITION = 0;
-static float STATUS_LABEL_POSITION = 0;
-static float WIDTH_RESOURCES_REQUIRED_LABEL = 0;
 
 static Rectangle_2df FACTORY_LISTBOX;
 static Rectangle_2df DETAIL_PANEL;
@@ -188,7 +186,6 @@ void FactoryReport::init()
 	txtProductDescription.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
 
 	SORT_BY_PRODUCT_POSITION = cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() - FONT->width("Filter by Product");
-	WIDTH_RESOURCES_REQUIRED_LABEL = static_cast<float>(FONT_MED_BOLD->width(RESOURCES_REQUIRED));
 
 	Control::resized().connect(this, &FactoryReport::resized);
 	fillLists();
@@ -337,8 +334,6 @@ void FactoryReport::resized(Control* /*c*/)
 		rect().y() + rect().height() - 69
 	};
 
-	STATUS_LABEL_POSITION = DETAIL_PANEL.x() + FONT_MED_BOLD->width("Status") + 158.0f;
-	
 	float position_x = rect().width() - 150.0f;
 	btnIdle.position(position_x, btnIdle.positionY());
 	btnClearProduction.position(position_x, btnClearProduction.positionY());

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -559,10 +559,11 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	r.drawImage(*FACTORY_IMAGE, DETAIL_PANEL.x(), DETAIL_PANEL.y() + 25);
 	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), DETAIL_PANEL.x(), DETAIL_PANEL.y() - 8, text_color.red(), text_color.green(), text_color.blue());
 
-	r.drawText(*FONT_MED_BOLD, "Status", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 20, text_color.red(), text_color.green(), text_color.blue());
+	auto statusPosition = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 20};
+	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, text_color);
 
 	if (SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed()) { text_color(255, 0, 0, 255); }
-	const auto statusPosition = DETAIL_PANEL.startPoint() + NAS2D::Vector{FONT_MED_BOLD->width("Status") + 158, 20};
+	statusPosition.x() += FONT_MED_BOLD->width("Status") + 20;
 	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, text_color);
 
 	text_color(0, 185, 0, 255);

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -571,7 +571,7 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	text_color(0, 185, 0, 255);
 
-	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 60, text_color.red(), text_color.green(), text_color.blue());
+	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 60}, text_color);
 
 	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
 	const auto drawTitleText = [&renderer = r, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -564,11 +564,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, textColor);
 
 	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
-	if (isStatusHighlighted) { textColor(255, 0, 0, 255); }
 	statusPosition.x() += FONT_MED_BOLD->width("Status") + 20;
-	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, textColor);
-
-	textColor(0, 185, 0, 255);
+	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : textColor));
 
 	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, textColor);
 
@@ -595,9 +592,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	// POPULATION
 	bool isPopulationRequirementHighlighted = SELECTED_FACTORY->populationAvailable()[0] != SELECTED_FACTORY->populationRequirements()[0];
-	!isPopulationRequirementHighlighted ? textColor(0, 185, 0, 255) : textColor(255, 0, 0, 255);
 	auto text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
-	drawTitleText(position, "Workers", text, textColor);
+	drawTitleText(position, "Workers", text, (isPopulationRequirementHighlighted ? NAS2D::Color::Red : textColor));
 }
 
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -552,25 +552,25 @@ void FactoryReport::cboFilterByProductSelectionChanged()
 /**
  * 
  */
-void FactoryReport::drawDetailPane(Renderer& r)
+void FactoryReport::drawDetailPane(Renderer& renderer)
 {
 	NAS2D::Color textColor(0, 185, 0);
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
-	r.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
-	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, textColor);
+	renderer.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
+	renderer.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, textColor);
 
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
-	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, textColor);
+	renderer.drawText(*FONT_MED_BOLD, "Status", statusPosition, textColor);
 
 	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
 	statusPosition.x() += FONT_MED_BOLD->width("Status") + 20;
-	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : textColor));
+	renderer.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : textColor));
 
-	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, textColor);
+	renderer.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, textColor);
 
 	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
-	const auto drawTitleText = [&renderer = r, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {
+	const auto drawTitleText = [&renderer, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {
 		renderer.drawText(*FONT_BOLD, title, position, textColor);
 		position.x() += labelWidth - FONT->width(text);
 		renderer.drawText(*FONT, text, position, textColor);

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -556,8 +556,9 @@ void FactoryReport::drawDetailPane(Renderer& r)
 {
 	Color text_color(0, 185, 0, 255);
 
-	r.drawImage(*FACTORY_IMAGE, DETAIL_PANEL.x(), DETAIL_PANEL.y() + 25);
-	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), DETAIL_PANEL.x(), DETAIL_PANEL.y() - 8, text_color.red(), text_color.green(), text_color.blue());
+	const auto startPoint = DETAIL_PANEL.startPoint();
+	r.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
+	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, text_color);
 
 	auto statusPosition = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 20};
 	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, text_color);

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -567,7 +567,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	r.drawText(*FONT_MED_BOLD, "Status", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 20, text_color.red(), text_color.green(), text_color.blue());
 
 	if (SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed()) { text_color(255, 0, 0, 255); }
-	r.drawText(*FONT_MED, FACTORY_STATUS, STATUS_LABEL_POSITION, DETAIL_PANEL.y() + 20, text_color.red(), text_color.green(), text_color.blue());
+	const auto statusPosition = DETAIL_PANEL.startPoint() + NAS2D::Vector{FONT_MED_BOLD->width("Status") + 158, 20};
+	r.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, text_color);
 
 	text_color(0, 185, 0, 255);
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -554,7 +554,7 @@ void FactoryReport::cboFilterByProductSelectionChanged()
  */
 void FactoryReport::drawDetailPane(Renderer& r)
 {
-	NAS2D::Color textColor(0, 185, 0, 255);
+	NAS2D::Color textColor(0, 185, 0);
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	r.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -560,7 +560,7 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	r.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
 	r.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, text_color);
 
-	auto statusPosition = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 20};
+	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
 	r.drawText(*FONT_MED_BOLD, "Status", statusPosition, text_color);
 
 	if (SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed()) { text_color(255, 0, 0, 255); }
@@ -569,7 +569,7 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	text_color(0, 185, 0, 255);
 
-	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 60}, text_color);
+	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, text_color);
 
 	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
 	const auto drawTitleText = [&renderer = r, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {
@@ -586,7 +586,7 @@ void FactoryReport::drawDetailPane(Renderer& r)
 		std::pair{"Rare Metals", _pc.rareMetals()},
 		std::pair{"Rare Minerals", _pc.rareMinerals()},
 	};
-	auto position = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 80};
+	auto position = startPoint + NAS2D::Vector{138, 80};
 	for (auto [title, value] : requiredResources) {
 		drawTitleText(position, title, std::to_string(value), text_color);
 		position.y() += 15;

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -594,7 +594,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	}
 
 	// POPULATION
-	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? textColor(0, 185, 0, 255) : textColor(255, 0, 0, 255);
+	bool isPopulationRequirementHighlighted = SELECTED_FACTORY->populationAvailable()[0] != SELECTED_FACTORY->populationRequirements()[0];
+	!isPopulationRequirementHighlighted ? textColor(0, 185, 0, 255) : textColor(255, 0, 0, 255);
 	auto text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
 	drawTitleText(position, "Workers", text, textColor);
 }

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -573,6 +573,13 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	r.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 60, text_color.red(), text_color.green(), text_color.blue());
 
+	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
+	const auto drawTitleText = [&renderer = r, labelWidth](NAS2D::Point<int> position, const std::string& title, const std::string& text, Color textColor) {
+		renderer.drawText(*FONT_BOLD, title, position, textColor);
+		position.x() += labelWidth - FONT->width(text);
+		renderer.drawText(*FONT, text, position, textColor);
+	};
+
 	// MINERAL RESOURCES
 	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());
 	r.drawText(*FONT_BOLD, "Common Metals", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 80, text_color.red(), text_color.green(), text_color.blue());
@@ -587,8 +594,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 	// POPULATION
 	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
 	std::string _scratch = string_format("%i / %i", SELECTED_FACTORY->populationAvailable()[0], SELECTED_FACTORY->populationRequirements()[0]);
-	r.drawText(*FONT_BOLD, "Workers", DETAIL_PANEL.x() + 138, DETAIL_PANEL.y() + 140, text_color.red(), text_color.green(), text_color.blue());
-	r.drawText(*FONT, _scratch, DETAIL_PANEL.x() + 138 + WIDTH_RESOURCES_REQUIRED_LABEL - FONT->width(_scratch), DETAIL_PANEL.y() + 140, text_color.red(), text_color.green(), text_color.blue());
+	const auto position = DETAIL_PANEL.startPoint() + NAS2D::Vector{138, 140};
+	drawTitleText(position, "Workers", _scratch, text_color);
 }
 
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -596,7 +596,7 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	// POPULATION
 	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
-	std::string text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
+	auto text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
 	drawTitleText(position, "Workers", text, text_color);
 }
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -596,7 +596,7 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	// POPULATION
 	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
-	std::string _scratch = string_format("%i / %i", SELECTED_FACTORY->populationAvailable()[0], SELECTED_FACTORY->populationRequirements()[0]);
+	std::string _scratch = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
 	drawTitleText(position, "Workers", _scratch, text_color);
 }
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -596,8 +596,8 @@ void FactoryReport::drawDetailPane(Renderer& r)
 
 	// POPULATION
 	SELECTED_FACTORY->populationAvailable()[0] == SELECTED_FACTORY->populationRequirements()[0] ? text_color(0, 185, 0, 255) : text_color(255, 0, 0, 255);
-	std::string _scratch = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
-	drawTitleText(position, "Workers", _scratch, text_color);
+	std::string text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
+	drawTitleText(position, "Workers", text, text_color);
 }
 
 


### PR DESCRIPTION
Reference: #266

Refactor `FactoryReport::drawDetailPane`. Use vectorized draw calls. Replace use of `string_format` with `std::to_string`.
