### PR TITLE
Refactor PopulationPanel::update

### DIFF
--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -52,7 +52,7 @@ void PopulationPanel::update()
 	};
 
 	auto position = NAS2D::Point{positionX() + 5, positionY() + 45};
-	const auto fontOffset = NAS2D::Vector{37, 20};
+	const auto fontOffset = NAS2D::Vector{37, 32 - FONT->height()};
 	for (const auto& [imageRect, personCount] : populationData) {
 		r.drawSubImage(mIcons, position, imageRect);
 		r.drawText(*FONT, std::to_string(personCount), position + fontOffset, NAS2D::Color::White);

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -36,12 +36,15 @@ void PopulationPanel::update()
 	Renderer& r = Utility<Renderer>::get();
 	r.drawImageRect(rect(), mSkin);
 
-	r.drawText(*FONT, string_format("Morale: %i", *mMorale), positionX() + 5, positionY() + 5, 255, 255, 255);
-	r.drawText(*FONT, string_format("Previous: %i", *mPreviousMorale), positionX() + 5, positionY() + 15, 255, 255, 255);
+	auto position = NAS2D::Point{positionX() + 5, positionY() + 5};
+	r.drawText(*FONT, string_format("Morale: %i", *mMorale), position, NAS2D::Color::White);
+	position.y() += 10;
+	r.drawText(*FONT, string_format("Previous: %i", *mPreviousMorale), position, NAS2D::Color::White);
 
 	mCapacity = (mResidentialCapacity > 0) ? (static_cast<float>(mPopulation->size()) / static_cast<float>(mResidentialCapacity)) * 100.0f : 0.0f;
 	
-	r.drawText(*FONT, string_format("Housing: %i / %i  (%i%%)", mPopulation->size(), mResidentialCapacity, static_cast<int>(mCapacity)), positionX() + 5, positionY() + 30, 255, 255, 255);
+	position.y() += 15;
+	r.drawText(*FONT, string_format("Housing: %i / %i  (%i%%)", mPopulation->size(), mResidentialCapacity, static_cast<int>(mCapacity)), position, NAS2D::Color::White);
 
 	const std::array populationData{
 		std::pair{NAS2D::Rectangle{0, 96, 32, 32}, mPopulation->size(Population::ROLE_CHILD)},
@@ -51,7 +54,7 @@ void PopulationPanel::update()
 		std::pair{NAS2D::Rectangle{128, 96, 32, 32}, mPopulation->size(Population::ROLE_RETIRED)},
 	};
 
-	auto position = NAS2D::Point{positionX() + 5, positionY() + 45};
+	position.y() += 15;
 	const auto fontOffset = NAS2D::Vector{37, 32 - FONT->height()};
 	for (const auto& [imageRect, personCount] : populationData) {
 		r.drawSubImage(mIcons, position, imageRect);

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -34,7 +34,7 @@ PopulationPanel::PopulationPanel() : mIcons("ui/icons.png")
 void PopulationPanel::update()
 {
 	Renderer& r = Utility<Renderer>::get();
-	r.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkin);
+	r.drawImageRect(rect(), mSkin);
 
 	r.drawText(*FONT, string_format("Morale: %i", *mMorale), positionX() + 5, positionY() + 5, 255, 255, 255);
 	r.drawText(*FONT, string_format("Previous: %i", *mPreviousMorale), positionX() + 5, positionY() + 15, 255, 255, 255);

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -33,19 +33,19 @@ PopulationPanel::PopulationPanel() : mIcons("ui/icons.png")
 
 void PopulationPanel::update()
 {
-	Renderer& r = Utility<Renderer>::get();
-	r.drawImageRect(rect(), mSkin);
+	Renderer& renderer = Utility<Renderer>::get();
+	renderer.drawImageRect(rect(), mSkin);
 
 	auto position = NAS2D::Point{positionX() + 5, positionY() + 5};
-	r.drawText(*FONT, "Morale: " + std::to_string(*mMorale), position, NAS2D::Color::White);
+	renderer.drawText(*FONT, "Morale: " + std::to_string(*mMorale), position, NAS2D::Color::White);
 	position.y() += 10;
-	r.drawText(*FONT, "Previous: " + std::to_string(*mPreviousMorale), position, NAS2D::Color::White);
+	renderer.drawText(*FONT, "Previous: " + std::to_string(*mPreviousMorale), position, NAS2D::Color::White);
 
 	mCapacity = (mResidentialCapacity > 0) ? (static_cast<float>(mPopulation->size()) / static_cast<float>(mResidentialCapacity)) * 100.0f : 0.0f;
 	
 	position.y() += 15;
 	const auto text = "Housing: " + std::to_string(mPopulation->size()) + " / " + std::to_string(mResidentialCapacity) + "  (" + std::to_string(static_cast<int>(mCapacity)) + "%)";
-	r.drawText(*FONT, text, position, NAS2D::Color::White);
+	renderer.drawText(*FONT, text, position, NAS2D::Color::White);
 
 	const std::array populationData{
 		std::pair{NAS2D::Rectangle{0, 96, 32, 32}, mPopulation->size(Population::ROLE_CHILD)},
@@ -58,8 +58,8 @@ void PopulationPanel::update()
 	position.y() += 15;
 	const auto fontOffset = NAS2D::Vector{37, 32 - FONT->height()};
 	for (const auto& [imageRect, personCount] : populationData) {
-		r.drawSubImage(mIcons, position, imageRect);
-		r.drawText(*FONT, std::to_string(personCount), position + fontOffset, NAS2D::Color::White);
+		renderer.drawSubImage(mIcons, position, imageRect);
+		renderer.drawText(*FONT, std::to_string(personCount), position + fontOffset, NAS2D::Color::White);
 		position.y() += 34;
 	}
 }

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -52,6 +52,6 @@ void PopulationPanel::update()
 	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_CHILD)), positionX() + 42, positionY() + 65, 255, 255, 255);
 	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_STUDENT)), positionX() + 42, positionY() + 97, 255, 255, 255);
 	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_WORKER)), positionX() + 42, positionY() + 129, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 160, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 161, 255, 255, 255);
 	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_RETIRED)), positionX() + 42, positionY() + 193, 255, 255, 255);
 }

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -42,7 +42,7 @@ void PopulationPanel::update()
 	renderer.drawText(*FONT, "Previous: " + std::to_string(*mPreviousMorale), position, NAS2D::Color::White);
 
 	mCapacity = (mResidentialCapacity > 0) ? (static_cast<float>(mPopulation->size()) / static_cast<float>(mResidentialCapacity)) * 100.0f : 0.0f;
-	
+
 	position.y() += 15;
 	const auto text = "Housing: " + std::to_string(mPopulation->size()) + " / " + std::to_string(mResidentialCapacity) + "  (" + std::to_string(static_cast<int>(mCapacity)) + "%)";
 	renderer.drawText(*FONT, text, position, NAS2D::Color::White);

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -44,7 +44,8 @@ void PopulationPanel::update()
 	mCapacity = (mResidentialCapacity > 0) ? (static_cast<float>(mPopulation->size()) / static_cast<float>(mResidentialCapacity)) * 100.0f : 0.0f;
 	
 	position.y() += 15;
-	r.drawText(*FONT, string_format("Housing: %i / %i  (%i%%)", mPopulation->size(), mResidentialCapacity, static_cast<int>(mCapacity)), position, NAS2D::Color::White);
+	const auto text = string_format("Housing: %i / %i  (%i%%)", mPopulation->size(), mResidentialCapacity, static_cast<int>(mCapacity));
+	r.drawText(*FONT, text, position, NAS2D::Color::White);
 
 	const std::array populationData{
 		std::pair{NAS2D::Rectangle{0, 96, 32, 32}, mPopulation->size(Population::ROLE_CHILD)},

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -43,15 +43,18 @@ void PopulationPanel::update()
 	
 	r.drawText(*FONT, string_format("Housing: %i / %i  (%i%%)", mPopulation->size(), mResidentialCapacity, static_cast<int>(mCapacity)), positionX() + 5, positionY() + 30, 255, 255, 255);
 
-	r.drawSubImage(mIcons, positionX() + 5, positionY() + 45, 0, 96, 32, 32);		// Infant
-	r.drawSubImage(mIcons, positionX() + 5, positionY() + 79, 32, 96, 32, 32);		// Student
-	r.drawSubImage(mIcons, positionX() + 5, positionY() + 113, 64, 96, 32, 32);		// Worker
-	r.drawSubImage(mIcons, positionX() + 5, positionY() + 147, 96, 96, 32, 32);		// Scientist
-	r.drawSubImage(mIcons, positionX() + 5, positionY() + 181, 128, 96, 32, 32);	// Retired
+	const std::array populationData{
+		std::pair{NAS2D::Rectangle{0, 96, 32, 32}, mPopulation->size(Population::ROLE_CHILD)},
+		std::pair{NAS2D::Rectangle{32, 96, 32, 32}, mPopulation->size(Population::ROLE_STUDENT)},
+		std::pair{NAS2D::Rectangle{64, 96, 32, 32}, mPopulation->size(Population::ROLE_WORKER)},
+		std::pair{NAS2D::Rectangle{96, 96, 32, 32}, mPopulation->size(Population::ROLE_SCIENTIST)},
+		std::pair{NAS2D::Rectangle{128, 96, 32, 32}, mPopulation->size(Population::ROLE_RETIRED)},
+	};
 
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_CHILD)), positionX() + 42, positionY() + 65, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_STUDENT)), positionX() + 42, positionY() + 99, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_WORKER)), positionX() + 42, positionY() + 133, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 167, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_RETIRED)), positionX() + 42, positionY() + 201, 255, 255, 255);
+	auto position = NAS2D::Point{positionX() + 5, positionY() + 45};
+	for (const auto& [imageRect, personCount] : populationData) {
+		r.drawSubImage(mIcons, position, imageRect);
+		r.drawText(*FONT, std::to_string(personCount), position + NAS2D::Vector{37, 20}, NAS2D::Color::White);
+		position.y() += 34;
+	}
 }

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -37,14 +37,14 @@ void PopulationPanel::update()
 	r.drawImageRect(rect(), mSkin);
 
 	auto position = NAS2D::Point{positionX() + 5, positionY() + 5};
-	r.drawText(*FONT, string_format("Morale: %i", *mMorale), position, NAS2D::Color::White);
+	r.drawText(*FONT, "Morale: " + std::to_string(*mMorale), position, NAS2D::Color::White);
 	position.y() += 10;
-	r.drawText(*FONT, string_format("Previous: %i", *mPreviousMorale), position, NAS2D::Color::White);
+	r.drawText(*FONT, "Previous: " + std::to_string(*mPreviousMorale), position, NAS2D::Color::White);
 
 	mCapacity = (mResidentialCapacity > 0) ? (static_cast<float>(mPopulation->size()) / static_cast<float>(mResidentialCapacity)) * 100.0f : 0.0f;
 	
 	position.y() += 15;
-	const auto text = string_format("Housing: %i / %i  (%i%%)", mPopulation->size(), mResidentialCapacity, static_cast<int>(mCapacity));
+	const auto text = "Housing: " + std::to_string(mPopulation->size()) + " / " + std::to_string(mResidentialCapacity) + "  (" + std::to_string(static_cast<int>(mCapacity)) + "%)";
 	r.drawText(*FONT, text, position, NAS2D::Color::White);
 
 	const std::array populationData{

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -52,9 +52,10 @@ void PopulationPanel::update()
 	};
 
 	auto position = NAS2D::Point{positionX() + 5, positionY() + 45};
+	const auto fontOffset = NAS2D::Vector{37, 20};
 	for (const auto& [imageRect, personCount] : populationData) {
 		r.drawSubImage(mIcons, position, imageRect);
-		r.drawText(*FONT, std::to_string(personCount), position + NAS2D::Vector{37, 20}, NAS2D::Color::White);
+		r.drawText(*FONT, std::to_string(personCount), position + fontOffset, NAS2D::Color::White);
 		position.y() += 34;
 	}
 }

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -50,8 +50,8 @@ void PopulationPanel::update()
 	r.drawSubImage(mIcons, positionX() + 5, positionY() + 181, 128, 96, 32, 32);	// Retired
 
 	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_CHILD)), positionX() + 42, positionY() + 65, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_STUDENT)), positionX() + 42, positionY() + 97, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_WORKER)), positionX() + 42, positionY() + 129, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 161, 255, 255, 255);
-	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_RETIRED)), positionX() + 42, positionY() + 193, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_STUDENT)), positionX() + 42, positionY() + 99, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_WORKER)), positionX() + 42, positionY() + 133, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_SCIENTIST)), positionX() + 42, positionY() + 167, 255, 255, 255);
+	r.drawText(*FONT, std::to_string(mPopulation->size(Population::ROLE_RETIRED)), positionX() + 42, positionY() + 201, 255, 255, 255);
 }


### PR DESCRIPTION
Reference: #266

Refactor `PopulationPanel::update`. Use packed parameter draw calls. Replace use of `string_format` with `std::to_string`.

Edit:
Technically this is not quite a refactor since it makes some minor adjustments to the output. It makes changes to the text position, so it has more regular spacing, and lines up with the icons better. You could say it fixes some barely noticeable display bugs. Of course, making this more regular was a precursor to some of the cleanup, as loops imply a high degree of regularity.

----

I would like to make some updates to the definition and use of `mCapacity` as well, but that affects things in other classes, so I'd like to defer on that part until a separate PR.
