### PR TITLE
Refactor MapViewState::drawResourceInfo

### DIFF
--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -162,11 +162,9 @@ void MapViewState::drawResourceInfo()
 		std::tuple{NAS2D::Rectangle{112, 16, iconSize, iconSize}, mPlayerResources.rareMinerals(), 0},
 	};
 
-	NAS2D::Color color;
-
 	for (const auto& [imageRect, amount, spacing] : resources) {
 		renderer.drawSubImage(mUiIcons, position, imageRect);
-		color = (amount <= 10) ? glowColor : NAS2D::Color::White;
+		const auto color = (amount <= 10) ? glowColor : NAS2D::Color::White;
 		renderer.drawText(*MAIN_FONT, std::to_string(amount), position + textOffset, color);
 		position.x() += spacing;
 	}
@@ -181,7 +179,7 @@ void MapViewState::drawResourceInfo()
 	position.x() += x + offsetX;
 	for (const auto& [imageRect, parts, total, isHighlighted] : storageCapacities) {
 		renderer.drawSubImage(mUiIcons, position, imageRect);
-		color = isHighlighted ? glowColor : NAS2D::Color::White;
+		const auto color = isHighlighted ? glowColor : NAS2D::Color::White;
 		renderer.drawText(*MAIN_FONT, NAS2D::string_format("%i/%i", parts, total), position + textOffset, color);
 		position.x() += (x + offsetX) * 2;
 	}

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -180,7 +180,8 @@ void MapViewState::drawResourceInfo()
 	for (const auto& [imageRect, parts, total, isHighlighted] : storageCapacities) {
 		renderer.drawSubImage(mUiIcons, position, imageRect);
 		const auto color = isHighlighted ? glowColor : NAS2D::Color::White;
-		renderer.drawText(*MAIN_FONT, NAS2D::string_format("%i/%i", parts, total), position + textOffset, color);
+		const auto text = std::to_string(parts) + "/" + std::to_string(total);
+		renderer.drawText(*MAIN_FONT, text, position + textOffset, color);
 		position.x() += (x + offsetX) * 2;
 	}
 

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -185,32 +185,24 @@ void MapViewState::drawResourceInfo()
 	color = shouldRareMineralsGlow ? glowColor : NAS2D::Color::White;
 	renderer.drawText(*MAIN_FONT, std::to_string(mPlayerResources.rareMinerals()), position + textOffset, color);
 
-	// Storage Capacity
+	// Capacity (Storage, Food, Energy)
+	constexpr auto iconSize = constants::RESOURCE_ICON_SIZE;
+	const std::array storageCapacities{
+		std::tuple{NAS2D::Rectangle{96, 32, iconSize, iconSize}, mPlayerResources.currentLevel(), mPlayerResources.capacity(), mPlayerResources.capacity() - mPlayerResources.currentLevel() <= 100},
+		std::tuple{NAS2D::Rectangle{64, 32, iconSize, iconSize}, foodInStorage(), foodTotalStorage(), foodInStorage() <= 10},
+		std::tuple{NAS2D::Rectangle{80, 32, iconSize, iconSize}, mPlayerResources.energy(), NAS2D::Utility<StructureManager>::get().totalEnergyProduction(), mPlayerResources.energy() <= 5}
+	};
+
 	position.x() += x + offsetX;
-	const auto storageCapacityImageRect = NAS2D::Rectangle<int>{96, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, storageCapacityImageRect);
-	bool shouldStorageCapacityGlow = mPlayerResources.capacity() - mPlayerResources.currentLevel() <= 100;
-	color = shouldStorageCapacityGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, NAS2D::string_format("%i/%i", mPlayerResources.currentLevel(), mPlayerResources.capacity()), position + textOffset, color);
-
-	// Food
-	position.x() += (x + offsetX) * 2;
-	const auto foodImageRect = NAS2D::Rectangle<int>{64, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, foodImageRect);
-	bool shouldFoodStorageGlow = foodInStorage() <= 10;
-	color = shouldFoodStorageGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, NAS2D::string_format("%i/%i", foodInStorage(), foodTotalStorage()), position + textOffset, color);
-
-	// Energy
-	position.x() += (x + offsetX) * 2;
-	const auto energyImageRect = NAS2D::Rectangle<int>{80, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, energyImageRect);
-	bool shouldEnergyGlow = mPlayerResources.energy() <= 5;
-	color = shouldEnergyGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, NAS2D::string_format("%i/%i", mPlayerResources.energy(), NAS2D::Utility<StructureManager>::get().totalEnergyProduction()), position + textOffset, color);
+	for (const auto& [imageRect, parts, total, isHighlighted] : storageCapacities) {
+		renderer.drawSubImage(mUiIcons, position, imageRect);
+		color = isHighlighted ? glowColor : NAS2D::Color::White;
+		renderer.drawText(*MAIN_FONT, NAS2D::string_format("%i/%i", parts, total), position + textOffset, color);
+		position.x() += (x + offsetX) * 2;
+	}
 
 	// Population / Morale
-	position.x() += (x + offsetX) * 2 - 17;
+	position.x() -= 17;
 	int popMoraleDeltaImageOffsetX = mCurrentMorale < mPreviousMorale ? 0 : (mCurrentMorale > mPreviousMorale ? 16 : 32);
 	const auto popMoraleDirectionImageRect = NAS2D::Rectangle<int>{popMoraleDeltaImageOffsetX, 48, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, popMoraleDirectionImageRect);

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -162,7 +162,8 @@ void MapViewState::drawResourceInfo()
 		std::tuple{NAS2D::Rectangle{112, 16, iconSize, iconSize}, mPlayerResources.rareMinerals(), 0},
 	};
 
-	for (const auto& [imageRect, amount, spacing] : resources) {
+	for (const auto& [imageRect, amount, spacing] : resources)
+	{
 		renderer.drawSubImage(mUiIcons, position, imageRect);
 		const auto color = (amount <= 10) ? glowColor : NAS2D::Color::White;
 		renderer.drawText(*MAIN_FONT, std::to_string(amount), position + textOffset, color);
@@ -177,7 +178,8 @@ void MapViewState::drawResourceInfo()
 	};
 
 	position.x() += x + offsetX;
-	for (const auto& [imageRect, parts, total, isHighlighted] : storageCapacities) {
+	for (const auto& [imageRect, parts, total, isHighlighted] : storageCapacities)
+	{
 		renderer.drawSubImage(mUiIcons, position, imageRect);
 		const auto color = isHighlighted ? glowColor : NAS2D::Color::White;
 		const auto text = std::to_string(parts) + "/" + std::to_string(total);

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -154,39 +154,24 @@ void MapViewState::drawResourceInfo()
 	const auto glowIntensity = calcGlowIntensity();
 	const auto glowColor = NAS2D::Color{255, glowIntensity, glowIntensity};
 
-	// Common Metals
-	const auto commonMetalsImageRect = NAS2D::Rectangle<int>{64, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, commonMetalsImageRect);
-	bool shouldCommonMetalsGlow = mPlayerResources.commonMetals() <= 10;
-	auto color = shouldCommonMetalsGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, std::to_string(mPlayerResources.commonMetals()), position + textOffset, color);
+	constexpr auto iconSize = constants::RESOURCE_ICON_SIZE;
+	const std::array resources{
+		std::tuple{NAS2D::Rectangle{64, 16, iconSize, iconSize}, mPlayerResources.commonMetals(), offsetX},
+		std::tuple{NAS2D::Rectangle{80, 16, iconSize, iconSize}, mPlayerResources.rareMetals(), x + offsetX},
+		std::tuple{NAS2D::Rectangle{96, 16, iconSize, iconSize}, mPlayerResources.commonMinerals(), x + offsetX},
+		std::tuple{NAS2D::Rectangle{112, 16, iconSize, iconSize}, mPlayerResources.rareMinerals(), 0},
+	};
 
-	// Rare Metals
-	position.x() += offsetX;
-	const auto rareMetalsImageRect = NAS2D::Rectangle<int>{80, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, rareMetalsImageRect);
-	bool shouldRareMetalsGlow = mPlayerResources.rareMetals() <= 10;
-	color = shouldRareMetalsGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, std::to_string(mPlayerResources.rareMetals()), position + textOffset, color);
+	NAS2D::Color color;
 
-	// Common Minerals
-	position.x() += x + offsetX;
-	const auto commonMineralsImageRect = NAS2D::Rectangle<int>{96, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, commonMineralsImageRect);
-	bool shouldCommonMineralsGlow = mPlayerResources.commonMinerals() <= 10;
-	color = shouldCommonMineralsGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, std::to_string(mPlayerResources.commonMinerals()), position + textOffset, color);
-
-	// Rare Minerals
-	position.x() += x + offsetX;
-	const auto rareMineralsImageRect = NAS2D::Rectangle<int>{112, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
-	renderer.drawSubImage(mUiIcons, position, rareMineralsImageRect);
-	bool shouldRareMineralsGlow = mPlayerResources.rareMinerals() <= 10;
-	color = shouldRareMineralsGlow ? glowColor : NAS2D::Color::White;
-	renderer.drawText(*MAIN_FONT, std::to_string(mPlayerResources.rareMinerals()), position + textOffset, color);
+	for (const auto& [imageRect, amount, spacing] : resources) {
+		renderer.drawSubImage(mUiIcons, position, imageRect);
+		color = (amount <= 10) ? glowColor : NAS2D::Color::White;
+		renderer.drawText(*MAIN_FONT, std::to_string(amount), position + textOffset, color);
+		position.x() += spacing;
+	}
 
 	// Capacity (Storage, Food, Energy)
-	constexpr auto iconSize = constants::RESOURCE_ICON_SIZE;
 	const std::array storageCapacities{
 		std::tuple{NAS2D::Rectangle{96, 32, iconSize, iconSize}, mPlayerResources.currentLevel(), mPlayerResources.capacity(), mPlayerResources.capacity() - mPlayerResources.currentLevel() <= 100},
 		std::tuple{NAS2D::Rectangle{64, 32, iconSize, iconSize}, foodInStorage(), foodTotalStorage(), foodInStorage() <= 10},


### PR DESCRIPTION
Reference: #266

Refactor similar code into data driven loops. Replace use of `string_format` with `std::to_string`.
