### PR TITLE
Replace string_format for robot location

### DIFF
--- a/src/Constants/Strings.h
+++ b/src/Constants/Strings.h
@@ -34,7 +34,7 @@ namespace constants
 	const std::string MINE_YIELD_HIGH = "High";
 
 	const std::string ROBOT_BREAKDOWN_TITLE = "Robot Breakdown";
-	const std::string ROBOT_BREAKDOWN_MESSAGE = "Your %s at location %i, %i has broken down. It will not be able to complete its task and will be removed from your inventory.";
+	const std::string ROBOT_BREAKDOWN_MESSAGE = "Your %s at location %s has broken down. It will not be able to complete its task and will be removed from your inventory.";
 
 	const std::string PRODUCT_TRANSFER_TITLE = "Remaining Product";
 	const std::string PRODUCT_TRANSFER_MESSAGE = "Bulldozing this Warehouse will result in some products being discarded due to insufficient storage space at other warehouses.\n\nDo you want to discard these products?";

--- a/src/Constants/Strings.h
+++ b/src/Constants/Strings.h
@@ -33,9 +33,6 @@ namespace constants
 	const std::string MINE_YIELD_MEDIUM = "Medium";
 	const std::string MINE_YIELD_HIGH = "High";
 
-	const std::string ROBOT_BREAKDOWN_TITLE = "Robot Breakdown";
-	const std::string ROBOT_BREAKDOWN_MESSAGE = "Your %s at location %s has broken down. It will not be able to complete its task and will be removed from your inventory.";
-
 	const std::string PRODUCT_TRANSFER_TITLE = "Remaining Product";
 	const std::string PRODUCT_TRANSFER_MESSAGE = "Bulldozing this Warehouse will result in some products being discarded due to insufficient storage space at other warehouses.\n\nDo you want to discard these products?";
 

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -1279,7 +1279,8 @@ void MapViewState::updateRobots()
 			if (robot_it->first->name() != constants::ROBOMINER)
 			{
 				const auto robotLocationText = std::to_string(robot_it->second->x()) + ", " + std::to_string(robot_it->second->y());
-				doAlertMessage(constants::ROBOT_BREAKDOWN_TITLE, string_format(constants::ROBOT_BREAKDOWN_MESSAGE, robot_it->first->name().c_str(), robotLocationText.c_str()));
+				const auto text = string_format(constants::ROBOT_BREAKDOWN_MESSAGE, robot_it->first->name().c_str(), robotLocationText.c_str());
+				doAlertMessage(constants::ROBOT_BREAKDOWN_TITLE, text);
 				Robodozer* _d = dynamic_cast<Robodozer*>(robot_it->first);
 				if (_d) { robot_it->second->index(static_cast<int>(_d->tileIndex())); }
 			}

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -1278,7 +1278,8 @@ void MapViewState::updateRobots()
 			// \fixme	This is an awful way of doing this.
 			if (robot_it->first->name() != constants::ROBOMINER)
 			{
-				doAlertMessage(constants::ROBOT_BREAKDOWN_TITLE, string_format(constants::ROBOT_BREAKDOWN_MESSAGE, robot_it->first->name().c_str(), robot_it->second->x(), robot_it->second->y()));
+				const auto robotLocationText = std::to_string(robot_it->second->x()) + ", " + std::to_string(robot_it->second->y());
+				doAlertMessage(constants::ROBOT_BREAKDOWN_TITLE, string_format(constants::ROBOT_BREAKDOWN_MESSAGE, robot_it->first->name().c_str(), robotLocationText.c_str()));
 				Robodozer* _d = dynamic_cast<Robodozer*>(robot_it->first);
 				if (_d) { robot_it->second->index(static_cast<int>(_d->tileIndex())); }
 			}

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -1279,7 +1279,7 @@ void MapViewState::updateRobots()
 			if (robot_it->first->name() != constants::ROBOMINER)
 			{
 				const auto robotLocationText = std::to_string(robot_it->second->x()) + ", " + std::to_string(robot_it->second->y());
-				const auto text = string_format("Your %s at location %s has broken down. It will not be able to complete its task and will be removed from your inventory.", robot_it->first->name().c_str(), robotLocationText.c_str());
+				const auto text = "Your " + robot_it->first->name() + " at location " + robotLocationText + " has broken down. It will not be able to complete its task and will be removed from your inventory.";
 				doAlertMessage("Robot Breakdown", text);
 				Robodozer* _d = dynamic_cast<Robodozer*>(robot_it->first);
 				if (_d) { robot_it->second->index(static_cast<int>(_d->tileIndex())); }

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -1279,8 +1279,8 @@ void MapViewState::updateRobots()
 			if (robot_it->first->name() != constants::ROBOMINER)
 			{
 				const auto robotLocationText = std::to_string(robot_it->second->x()) + ", " + std::to_string(robot_it->second->y());
-				const auto text = string_format(constants::ROBOT_BREAKDOWN_MESSAGE, robot_it->first->name().c_str(), robotLocationText.c_str());
-				doAlertMessage(constants::ROBOT_BREAKDOWN_TITLE, text);
+				const auto text = string_format("Your %s at location %s has broken down. It will not be able to complete its task and will be removed from your inventory.", robot_it->first->name().c_str(), robotLocationText.c_str());
+				doAlertMessage("Robot Breakdown", text);
 				Robodozer* _d = dynamic_cast<Robodozer*>(robot_it->first);
 				if (_d) { robot_it->second->index(static_cast<int>(_d->tileIndex())); }
 			}


### PR DESCRIPTION
Reference: #266

This should be the last use of `string_format`.

I wanted to keep this change set small. There are other improvements to be made to the function, but those can wait until later.
