### PR TITLE
Use `int` for residence capacity (percentage)

### DIFF
--- a/src/States/MapViewStateTurn.cpp
+++ b/src/States/MapViewStateTurn.cpp
@@ -151,10 +151,10 @@ void MapViewState::updateMorale()
 	mCurrentMorale -= sm.disabled();
 	mCurrentMorale -= sm.destroyed();
 
-	int residentialMoraleHit = static_cast<int>(mPopulationPanel.capacity() / 100.0f);
+	int residentialMoraleHit = mPopulationPanel.capacity() / 100;
 
 	// Ensure that there is always a morale hit if residential capacity is more than 100%.
-	if (mPopulationPanel.capacity() > 100.0f && residentialMoraleHit < constants::MINIMUM_RESIDENCE_OVERCAPACITY_HIT) { residentialMoraleHit = constants::MINIMUM_RESIDENCE_OVERCAPACITY_HIT; }
+	if (mPopulationPanel.capacity() > 100 && residentialMoraleHit < constants::MINIMUM_RESIDENCE_OVERCAPACITY_HIT) { residentialMoraleHit = constants::MINIMUM_RESIDENCE_OVERCAPACITY_HIT; }
 
 	mCurrentMorale -= residentialMoraleHit;
 

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -41,10 +41,10 @@ void PopulationPanel::update()
 	position.y() += 10;
 	renderer.drawText(*FONT, "Previous: " + std::to_string(*mPreviousMorale), position, NAS2D::Color::White);
 
-	mCapacity = (mResidentialCapacity > 0) ? (static_cast<float>(mPopulation->size()) / static_cast<float>(mResidentialCapacity)) * 100.0f : 0.0f;
+	mCapacity = (mResidentialCapacity > 0) ? (mPopulation->size() * 100 / mResidentialCapacity) : 0;
 
 	position.y() += 15;
-	const auto text = "Housing: " + std::to_string(mPopulation->size()) + " / " + std::to_string(mResidentialCapacity) + "  (" + std::to_string(static_cast<int>(mCapacity)) + "%)";
+	const auto text = "Housing: " + std::to_string(mPopulation->size()) + " / " + std::to_string(mResidentialCapacity) + "  (" + std::to_string(mCapacity) + "%)";
 	renderer.drawText(*FONT, text, position, NAS2D::Color::White);
 
 	const std::array populationData{

--- a/src/UI/PopulationPanel.h
+++ b/src/UI/PopulationPanel.h
@@ -21,7 +21,7 @@ public:
 	 * \fixme	This class/function is use to store residence capacity
 	 *			by the MapViewState. Probably not be an appropriate place.
 	 */
-	float capacity() const { return mCapacity; }
+	int capacity() const { return mCapacity; }
 
 	virtual void update() final;
 
@@ -38,5 +38,5 @@ private:
 	int*				mMorale = nullptr;
 	int*				mPreviousMorale = nullptr;
 
-	float				mCapacity = 0.0f;
+	int				mCapacity = 0;
 };

--- a/src/UI/PopulationPanel.h
+++ b/src/UI/PopulationPanel.h
@@ -28,15 +28,15 @@ public:
 protected:
 
 private:
-	NAS2D::Image		mIcons;
-	NAS2D::ImageList	mSkin;
+	NAS2D::Image mIcons;
+	NAS2D::ImageList mSkin;
 
-	Population*			mPopulation = nullptr;
+	Population* mPopulation = nullptr;
 
-	int					mResidentialCapacity = 0;
+	int mResidentialCapacity = 0;
 
-	int*				mMorale = nullptr;
-	int*				mPreviousMorale = nullptr;
+	int* mMorale = nullptr;
+	int* mPreviousMorale = nullptr;
 
-	int				mCapacity = 0;
+	int mCapacity = 0;
 };


### PR DESCRIPTION
Reference: #325

Change residence capacity to use integers. (Percentage 0-100+).

The code was designed to expect whole numbers, and to round when they weren't. Might as well just use integers.

Values over 100 (%) are expected. There are likely no negatives, so unsigned may be a reasonable consideration here. Other related expressions appear to use `int` though, so I thought I'd try being consistent.
