### PR TITLE
Add CcNotPlaced constant with invalid tile coordinates

### DIFF
--- a/src/Map/Tile.cpp
+++ b/src/Map/Tile.cpp
@@ -125,9 +125,9 @@ Robot* Tile::robot()
 /**
  * 
  */
-float Tile::distanceTo(Tile* t)
+float Tile::distanceTo(Tile* tile)
 {
-	return distanceTo(t->position());
+	return distanceTo(tile->position());
 }
 
 

--- a/src/Map/Tile.cpp
+++ b/src/Map/Tile.cpp
@@ -127,9 +127,7 @@ Robot* Tile::robot()
  */
 float Tile::distanceTo(Tile* t)
 {
-	int x = t->x() - Tile::x();
-	int y = t->y() - Tile::y();
-	return static_cast<float>(sqrt((x * x) + (y * y)));
+	return distanceTo(t->position());
 }
 
 

--- a/src/Map/Tile.cpp
+++ b/src/Map/Tile.cpp
@@ -131,3 +131,10 @@ float Tile::distanceTo(Tile* t)
 	int y = t->y() - Tile::y();
 	return static_cast<float>(sqrt((x * x) + (y * y)));
 }
+
+
+float Tile::distanceTo(NAS2D::Point<int> point)
+{
+	const auto direction = point - position();
+	return static_cast<float>(std::sqrt((direction.x * direction.x) + (direction.y * direction.y)));
+}

--- a/src/Map/Tile.h
+++ b/src/Map/Tile.h
@@ -61,7 +61,7 @@ public:
 	Mine* mine() { return mMine; }
 	void pushMine(Mine*);
 
-	float distanceTo(Tile*);
+	float distanceTo(Tile* tile);
 	float distanceTo(NAS2D::Point<int> point);
 
 	void color(const NAS2D::Color& c) { mColor = c; }

--- a/src/Map/Tile.h
+++ b/src/Map/Tile.h
@@ -62,6 +62,7 @@ public:
 	void pushMine(Mine*);
 
 	float distanceTo(Tile*);
+	float distanceTo(NAS2D::Point<int> point);
 
 	void color(const NAS2D::Color& c) { mColor = c; }
 	const NAS2D::Color& color() const { return mColor; }

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -79,7 +79,7 @@ MapViewState::MapViewState(const std::string& savegame) :
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
 {
-	ccLocation() = {0, 0};
+	ccLocation() = CcNotPlaced;
 	Utility<EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);
 }
 
@@ -99,7 +99,7 @@ MapViewState::MapViewState(const std::string& siteMap, const std::string& tileSe
 	mHeightMap(siteMap + MAP_TERRAIN_EXTENSION),
 	mUiIcons("ui/icons.png")
 {
-	ccLocation() = {0, 0};
+	ccLocation() = CcNotPlaced;
 	Utility<EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);
 }
 

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -1345,7 +1345,7 @@ void MapViewState::setStructureID(StructureID type, InsertMode mode)
  */
 void MapViewState::checkConnectedness()
 {
-	if (ccLocationX() == 0 && ccLocationY() == 0)
+	if (ccLocation() == NAS2D::Point{0, 0})
 	{
 		return;
 	}

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -280,7 +280,7 @@ int MapViewState::foodTotalStorage()
 	int food_storage = 0;
 
 	// Command Center has a limited amount of food storage for when colonists first land.
-	if (ccLocation() != NAS2D::Point{0, 0})
+	if (ccLocation() != CcNotPlaced)
 	{
 		food_storage += constants::BASE_STORAGE_CAPACITY;
 	}
@@ -1345,7 +1345,7 @@ void MapViewState::setStructureID(StructureID type, InsertMode mode)
  */
 void MapViewState::checkConnectedness()
 {
-	if (ccLocation() == NAS2D::Point{0, 0})
+	if (ccLocation() == CcNotPlaced)
 	{
 		return;
 	}

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -280,7 +280,7 @@ int MapViewState::foodTotalStorage()
 	int food_storage = 0;
 
 	// Command Center has a limited amount of food storage for when colonists first land.
-	if (ccLocationX() != 0)
+	if (ccLocation() != NAS2D::Point{0, 0})
 	{
 		food_storage += constants::BASE_STORAGE_CAPACITY;
 	}

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -71,7 +71,7 @@ void MapViewState::drawMiniMap()
 
 	const auto miniMapOffset = mMiniMapBoundingBox.startPoint() - NAS2D::Point<int>{0, 0};
 	const auto ccPosition = ccLocation();
-	if (ccPosition != NAS2D::Point<int>{0, 0})
+	if (ccPosition != CcNotPlaced)
 	{
 		const auto ccOffsetPosition = ccPosition + miniMapOffset;
 		const auto ccCommRangeImageRect = NAS2D::Rectangle<int>{166, 226, 30, 30};
@@ -227,7 +227,7 @@ void MapViewState::drawResourceInfo()
 void MapViewState::drawRobotInfo()
 {
 	// CC hasn't been placed yet.
-	if (ccLocation() == NAS2D::Point{0, 0}) { return; }
+	if (ccLocation() == CcNotPlaced) { return; }
 
 	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -226,7 +226,6 @@ void MapViewState::drawResourceInfo()
  */
 void MapViewState::drawRobotInfo()
 {
-	// CC hasn't been placed yet.
 	if (ccLocation() == CcNotPlaced) { return; }
 
 	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -29,13 +29,13 @@ using namespace NAS2D::Xml;
 extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 
 
-static Point_2d COMMAND_CENTER_LOCATION;
+static Point<int> COMMAND_CENTER_LOCATION;
 
 
 /**
  * 
  */
-Point_2d& ccLocation()
+Point<int>& ccLocation()
 {
 	return COMMAND_CENTER_LOCATION;
 }

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -29,6 +29,7 @@ using namespace NAS2D::Xml;
 extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 
 
+const NAS2D::Point<int> CcNotPlaced{0, 0};
 static Point<int> COMMAND_CENTER_LOCATION;
 
 

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -30,7 +30,7 @@ extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 
 
 const NAS2D::Point<int> CcNotPlaced{0, 0};
-static Point<int> COMMAND_CENTER_LOCATION = CcNotPlaced;
+static Point<int> commandCenterLocation = CcNotPlaced;
 
 
 /**
@@ -38,7 +38,7 @@ static Point<int> COMMAND_CENTER_LOCATION = CcNotPlaced;
  */
 Point<int>& ccLocation()
 {
-	return COMMAND_CENTER_LOCATION;
+	return commandCenterLocation;
 }
 
 

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -30,7 +30,7 @@ extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 
 
 const NAS2D::Point<int> CcNotPlaced{0, 0};
-static Point<int> COMMAND_CENTER_LOCATION;
+static Point<int> COMMAND_CENTER_LOCATION = CcNotPlaced;
 
 
 /**

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -189,10 +189,7 @@ bool validLanderSite(Tile* tile)
 		return false;
 	}
 
-	// bleh, direct copy from Tile::distanceTo()
-	int _x = tile->x() - ccLocationX();
-	int _y = tile->y() - ccLocationY();
-	float _dist = std::sqrt(static_cast<float>(_x * _x) + _y * _y);
+	auto _dist = tile->distanceTo(ccLocation());
 	if (_dist > constants::LANDER_COM_RANGE)
 	{
 		doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_LANDER_COMM_RANGE);

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -29,7 +29,7 @@ using namespace NAS2D::Xml;
 extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 
 
-const NAS2D::Point<int> CcNotPlaced{0, 0};
+const NAS2D::Point<int> CcNotPlaced{-1, -1};
 static Point<int> commandCenterLocation = CcNotPlaced;
 
 

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -189,8 +189,7 @@ bool validLanderSite(Tile* tile)
 		return false;
 	}
 
-	auto _dist = tile->distanceTo(ccLocation());
-	if (_dist > constants::LANDER_COM_RANGE)
+	if (tile->distanceTo(ccLocation()) > constants::LANDER_COM_RANGE)
 	{
 		doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_LANDER_COMM_RANGE);
 		return false;

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -42,24 +42,6 @@ Point_2d& ccLocation()
 
 
 /**
- * 
- */
-int ccLocationX()
-{
-	return COMMAND_CENTER_LOCATION.x();
-}
-
-
-/**
- * 
- */
-int ccLocationY()
-{
-	return COMMAND_CENTER_LOCATION.y();
-}
-
-
-/**
  * Checks to see if a given tube connection is valid.
  * 
  * \warning		Assumes \c tile is never nullptr.

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -181,17 +181,17 @@ bool validStructurePlacement(TileMap* tilemap, int x, int y)
  *
  * \warning		Assumes \c tile is never nullptr.
  */
-bool validLanderSite(Tile* t)
+bool validLanderSite(Tile* tile)
 {
-	if (!t->empty())
+	if (!tile->empty())
 	{
 		doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_LANDER_TILE_OBSTRUCTED);
 		return false;
 	}
 
 	// bleh, direct copy from Tile::distanceTo()
-	int _x = t->x() - ccLocationX();
-	int _y = t->y() - ccLocationY();
+	int _x = tile->x() - ccLocationX();
+	int _y = tile->y() - ccLocationY();
 	float _dist = std::sqrt(static_cast<float>(_x * _x) + _y * _y);
 	if (_dist > constants::LANDER_COM_RANGE)
 	{
@@ -199,7 +199,7 @@ bool validLanderSite(Tile* t)
 		return false;
 	}
 
-	if (t->index() == TERRAIN_IMPASSABLE)
+	if (tile->index() == TERRAIN_IMPASSABLE)
 	{
 		doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_LANDER_TERRAIN);
 		return false;

--- a/src/States/MapViewStateHelper.h
+++ b/src/States/MapViewStateHelper.h
@@ -20,7 +20,7 @@ typedef std::map<Robot*, Tile*> RobotTileTable;
 class Warehouse;	/**< Forward declaration for getAvailableWarehouse() function. */
 class RobotCommand;	/**< Forward declaration for getAvailableRobotCommand() function. */
 
-NAS2D::Point_2d& ccLocation();
+NAS2D::Point<int>& ccLocation();
 
 bool checkTubeConnection(Tile* tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile* tile, Direction dir);

--- a/src/States/MapViewStateHelper.h
+++ b/src/States/MapViewStateHelper.h
@@ -20,6 +20,7 @@ typedef std::map<Robot*, Tile*> RobotTileTable;
 class Warehouse;	/**< Forward declaration for getAvailableWarehouse() function. */
 class RobotCommand;	/**< Forward declaration for getAvailableRobotCommand() function. */
 
+extern const NAS2D::Point<int> CcNotPlaced;
 NAS2D::Point<int>& ccLocation();
 
 bool checkTubeConnection(Tile* tile, Direction dir, ConnectorDir sourceConnectorDir);

--- a/src/States/MapViewStateHelper.h
+++ b/src/States/MapViewStateHelper.h
@@ -21,8 +21,6 @@ class Warehouse;	/**< Forward declaration for getAvailableWarehouse() function. 
 class RobotCommand;	/**< Forward declaration for getAvailableRobotCommand() function. */
 
 NAS2D::Point_2d& ccLocation();
-int ccLocationX();
-int ccLocationY();
 
 bool checkTubeConnection(Tile* tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile* tile, Direction dir);

--- a/src/States/MapViewStateIO.cpp
+++ b/src/States/MapViewStateIO.cpp
@@ -139,7 +139,7 @@ void MapViewState::load(const std::string& filePath)
 	scrubRobotList();
 	mPlayerResources.clear();
 	Utility<StructureManager>::get().dropAllStructures();
-	ccLocation() = CcNotPlaced;	// Reset CC location
+	ccLocation() = CcNotPlaced;
 
 	delete mTileMap;
 	mTileMap = nullptr;

--- a/src/States/MapViewStateIO.cpp
+++ b/src/States/MapViewStateIO.cpp
@@ -139,7 +139,7 @@ void MapViewState::load(const std::string& filePath)
 	scrubRobotList();
 	mPlayerResources.clear();
 	Utility<StructureManager>::get().dropAllStructures();
-	ccLocation() = {0, 0};	// Reset CC location
+	ccLocation() = CcNotPlaced;	// Reset CC location
 
 	delete mTileMap;
 	mTileMap = nullptr;


### PR DESCRIPTION
Closes #292

Refactor uses of `ccLocation`, and introduces a `CcNotPlaced` constant, with invalid tile coordinates.

----

At some point we should add `size`/`length` support to `NAS2D::Vector`.
