### PR TITLE
Refactor GraphWalker

### DIFF
--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -105,7 +105,7 @@ void GraphWalker::walkGraph()
  */
 void GraphWalker::check(int x, int y, int depth, Direction direction)
 {
-	if (x < 0 || x > mTileMap->width() - 1 || y < 0 || y > mTileMap->height() - 1) { return; }
+	if (x < 0 || x >= mTileMap->width() || y < 0 || y >= mTileMap->height()) { return; }
 	if (depth < 0 || depth > mTileMap->maxDepth()) { return; }
 
 	Tile* tile = mTileMap->getTile(x, y, depth);

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -72,11 +72,11 @@ static bool validConnection(Structure* src, Structure* dst, Direction _d)
 }
 
 
-GraphWalker::GraphWalker(const Point_2d& _p, int _d, TileMap* _t) :
-	mTileMap(_t),
-	mThisTile(_t->getTile(_p, _d)),
-	mGridPosition(_p),
-	mDepth(_d)
+GraphWalker::GraphWalker(const NAS2D::Point_2d& point, int depth, TileMap* tileMap) :
+	mTileMap(tileMap),
+	mThisTile(tileMap->getTile(point, depth)),
+	mGridPosition(point),
+	mDepth(depth)
 {
 	walkGraph();
 }

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -114,6 +114,6 @@ void GraphWalker::check(int x, int y, int depth, Direction direction)
 
 	if (validConnection(mThisTile->structure(), tile->structure(), direction))
 	{
-		GraphWalker walker(Point_2d(x, y), depth, mTileMap);
+		GraphWalker walker({x, y}, depth, mTileMap);
 	}
 }

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -108,11 +108,11 @@ void GraphWalker::check(int x, int y, int depth, Direction _d)
 	if (x < 0 || x > mTileMap->width() - 1 || y < 0 || y > mTileMap->height() - 1) { return; }
 	if (depth < 0 || depth > mTileMap->maxDepth()) { return; }
 
-	Tile* t = mTileMap->getTile(x, y, depth);
+	Tile* tile = mTileMap->getTile(x, y, depth);
 
-	if (t->connected() || t->mine() || !t->excavated() || !t->thingIsStructure()) { return; }
+	if (tile->connected() || tile->mine() || !tile->excavated() || !tile->thingIsStructure()) { return; }
 
-	if (validConnection(mThisTile->structure(), t->structure(), _d))
+	if (validConnection(mThisTile->structure(), tile->structure(), _d))
 	{
 		GraphWalker walker(Point_2d(x, y), depth, mTileMap);
 	}

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -12,18 +12,18 @@ using namespace NAS2D;
  * Check which way a tube is facing to determine if it connects to the destination tube.
  * Broken off into its own function while fixing issue #11 to avoid code duplication.
  */
-static bool checkSourceTubeAlignment(Structure* src, Direction _d)
+static bool checkSourceTubeAlignment(Structure* src, Direction direction)
 {
 	if (src->connectorDirection() == CONNECTOR_INTERSECTION || src->connectorDirection() == CONNECTOR_VERTICAL)
 	{
 		return true;
 	}
-	else if (_d == DIR_EAST || _d == DIR_WEST)
+	else if (direction == DIR_EAST || direction == DIR_WEST)
 	{
 		if (src->connectorDirection() == CONNECTOR_RIGHT)
 			return true;
 	}
-	else if (_d == DIR_NORTH || _d == DIR_SOUTH)
+	else if (direction == DIR_NORTH || direction == DIR_SOUTH)
 	{
 		if (src->connectorDirection() == CONNECTOR_LEFT)
 			return true;
@@ -36,13 +36,13 @@ static bool checkSourceTubeAlignment(Structure* src, Direction _d)
 /**
  * Utility function to check if there's a valid connection between src and dst.
  */
-static bool validConnection(Structure* src, Structure* dst, Direction _d)
+static bool validConnection(Structure* src, Structure* dst, Direction direction)
 {
 	if (src == nullptr || dst == nullptr)
 	{
 		throw std::runtime_error("GraphWalker::validConnection() was passed a NULL Pointer.");
 	}
-	if (_d == DIR_UP || _d == DIR_DOWN)
+	if (direction == DIR_UP || direction == DIR_DOWN)
 	{
 		if (src->isConnector() && src->connectorDirection() == CONNECTOR_VERTICAL) { return true; }
 		return false;
@@ -52,13 +52,13 @@ static bool validConnection(Structure* src, Structure* dst, Direction _d)
 		if (dst->connectorDirection() == CONNECTOR_INTERSECTION || dst->connectorDirection() == CONNECTOR_VERTICAL)
 		{
 			if (!src->isConnector()) { return true; }
-			else { return checkSourceTubeAlignment(src, _d); }
+			else { return checkSourceTubeAlignment(src, direction); }
 		}
-		else if (_d == DIR_EAST || _d == DIR_WEST)
+		else if (direction == DIR_EAST || direction == DIR_WEST)
 		{
 			if (dst->connectorDirection() == CONNECTOR_RIGHT) { return true; }
 		}
-		else if (_d == DIR_NORTH || _d == DIR_SOUTH)
+		else if (direction == DIR_NORTH || direction == DIR_SOUTH)
 		{
 			if (dst->connectorDirection() == CONNECTOR_LEFT) { return true; }
 		}
@@ -67,7 +67,7 @@ static bool validConnection(Structure* src, Structure* dst, Direction _d)
 	}
 	else if (src->isConnector())
 	{
-		return checkSourceTubeAlignment(src, _d);
+		return checkSourceTubeAlignment(src, direction);
 	}
 
 	return false;

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -2,6 +2,8 @@
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
 #include "GraphWalker.h"
+#include "DirectionOffset.h"
+
 
 using namespace NAS2D;
 
@@ -89,10 +91,10 @@ void GraphWalker::walkGraph()
 	if (mDepth > 0) { check(mGridPosition, mDepth - 1, DIR_UP); }
 	if (mDepth < mTileMap->maxDepth()) { check(mGridPosition, mDepth + 1, DIR_DOWN); }
 
-	check({mGridPosition.x(), mGridPosition.y() - 1}, mDepth, DIR_NORTH);
-	check({mGridPosition.x() + 1, mGridPosition.y()}, mDepth, DIR_EAST);
-	check({mGridPosition.x(), mGridPosition.y() + 1}, mDepth, DIR_SOUTH);
-	check({mGridPosition.x() - 1, mGridPosition.y()}, mDepth, DIR_WEST);
+	check(mGridPosition + DirectionNorth, mDepth, DIR_NORTH);
+	check(mGridPosition + DirectionEast, mDepth, DIR_EAST);
+	check(mGridPosition + DirectionSouth, mDepth, DIR_SOUTH);
+	check(mGridPosition + DirectionWest, mDepth, DIR_WEST);
 }
 
 

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -105,15 +105,16 @@ void GraphWalker::walkGraph()
  */
 void GraphWalker::check(int x, int y, int depth, Direction direction)
 {
-	if (!NAS2D::Rectangle<int>::Create({0, 0}, mTileMap->size()).contains({x, y})) { return; }
+	const NAS2D::Point point{x, y};
+	if (!NAS2D::Rectangle<int>::Create({0, 0}, mTileMap->size()).contains(point)) { return; }
 	if (depth < 0 || depth > mTileMap->maxDepth()) { return; }
 
-	Tile* tile = mTileMap->getTile(x, y, depth);
+	Tile* tile = mTileMap->getTile(point, depth);
 
 	if (tile->connected() || tile->mine() || !tile->excavated() || !tile->thingIsStructure()) { return; }
 
 	if (validConnection(mThisTile->structure(), tile->structure(), direction))
 	{
-		GraphWalker walker({x, y}, depth, mTileMap);
+		GraphWalker walker(point, depth, mTileMap);
 	}
 }

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -72,7 +72,7 @@ static bool validConnection(Structure* src, Structure* dst, Direction _d)
 }
 
 
-GraphWalker::GraphWalker(const NAS2D::Point_2d& point, int depth, TileMap* tileMap) :
+GraphWalker::GraphWalker(const NAS2D::Point<int>& point, int depth, TileMap* tileMap) :
 	mTileMap(tileMap),
 	mThisTile(tileMap->getTile(point, depth)),
 	mGridPosition(point),

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -86,13 +86,13 @@ void GraphWalker::walkGraph()
 {
 	mThisTile->connected(true);
 
-	if (mDepth > 0) { check(mGridPosition.x(), mGridPosition.y(), mDepth - 1, DIR_UP); }
-	if (mDepth < mTileMap->maxDepth()) { check(mGridPosition.x(), mGridPosition.y(), mDepth + 1, DIR_DOWN); }
+	if (mDepth > 0) { check(mGridPosition, mDepth - 1, DIR_UP); }
+	if (mDepth < mTileMap->maxDepth()) { check(mGridPosition, mDepth + 1, DIR_DOWN); }
 
-	check(mGridPosition.x(), mGridPosition.y() - 1, mDepth, DIR_NORTH);
-	check(mGridPosition.x() + 1, mGridPosition.y(), mDepth, DIR_EAST);
-	check(mGridPosition.x(), mGridPosition.y() + 1, mDepth, DIR_SOUTH);
-	check(mGridPosition.x() - 1, mGridPosition.y(), mDepth, DIR_WEST);
+	check({mGridPosition.x(), mGridPosition.y() - 1}, mDepth, DIR_NORTH);
+	check({mGridPosition.x() + 1, mGridPosition.y()}, mDepth, DIR_EAST);
+	check({mGridPosition.x(), mGridPosition.y() + 1}, mDepth, DIR_SOUTH);
+	check({mGridPosition.x() - 1, mGridPosition.y()}, mDepth, DIR_WEST);
 }
 
 
@@ -103,9 +103,8 @@ void GraphWalker::walkGraph()
  *			to take a source and destination tile instead of looking them up. By using the internal
  *			positional information in the Tiles we can deduce direction between source and destination.
  */
-void GraphWalker::check(int x, int y, int depth, Direction direction)
+void GraphWalker::check(NAS2D::Point<int> point, int depth, Direction direction)
 {
-	const NAS2D::Point point{x, y};
 	if (!NAS2D::Rectangle<int>::Create({0, 0}, mTileMap->size()).contains(point)) { return; }
 	if (depth < 0 || depth > mTileMap->maxDepth()) { return; }
 

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -103,7 +103,7 @@ void GraphWalker::walkGraph()
  *			to take a source and destination tile instead of looking them up. By using the internal
  *			positional information in the Tiles we can deduce direction between source and destination.
  */
-void GraphWalker::check(int x, int y, int depth, Direction _d)
+void GraphWalker::check(int x, int y, int depth, Direction direction)
 {
 	if (x < 0 || x > mTileMap->width() - 1 || y < 0 || y > mTileMap->height() - 1) { return; }
 	if (depth < 0 || depth > mTileMap->maxDepth()) { return; }
@@ -112,7 +112,7 @@ void GraphWalker::check(int x, int y, int depth, Direction _d)
 
 	if (tile->connected() || tile->mine() || !tile->excavated() || !tile->thingIsStructure()) { return; }
 
-	if (validConnection(mThisTile->structure(), tile->structure(), _d))
+	if (validConnection(mThisTile->structure(), tile->structure(), direction))
 	{
 		GraphWalker walker(Point_2d(x, y), depth, mTileMap);
 	}

--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -105,7 +105,7 @@ void GraphWalker::walkGraph()
  */
 void GraphWalker::check(int x, int y, int depth, Direction direction)
 {
-	if (x < 0 || x >= mTileMap->width() || y < 0 || y >= mTileMap->height()) { return; }
+	if (!NAS2D::Rectangle<int>::Create({0, 0}, mTileMap->size()).contains({x, y})) { return; }
 	if (depth < 0 || depth > mTileMap->maxDepth()) { return; }
 
 	Tile* tile = mTileMap->getTile(x, y, depth);

--- a/src/GraphWalker.h
+++ b/src/GraphWalker.h
@@ -12,7 +12,7 @@
 class GraphWalker
 {
 public:
-	GraphWalker(const NAS2D::Point_2d&, int, TileMap*);
+	GraphWalker(const NAS2D::Point_2d& point, int depth, TileMap* tileMap);
 	~GraphWalker() = default;
 	
 private:

--- a/src/GraphWalker.h
+++ b/src/GraphWalker.h
@@ -2,6 +2,8 @@
 
 #include "Map/TileMap.h"
 
+#include "NAS2D/Renderer/Point.h"
+
 
 /**
  * \brief	GraphWalker does a basic depth-first connection check

--- a/src/GraphWalker.h
+++ b/src/GraphWalker.h
@@ -20,7 +20,7 @@ private:
 
 private:
 	void walkGraph();
-	void check(int, int, int, Direction);
+	void check(int x, int y, int depth, Direction direction);
 
 private:
 	TileMap*		mTileMap = nullptr;

--- a/src/GraphWalker.h
+++ b/src/GraphWalker.h
@@ -12,7 +12,7 @@
 class GraphWalker
 {
 public:
-	GraphWalker(const NAS2D::Point_2d& point, int depth, TileMap* tileMap);
+	GraphWalker(const NAS2D::Point<int>& point, int depth, TileMap* tileMap);
 	~GraphWalker() = default;
 	
 private:
@@ -28,7 +28,7 @@ private:
 	TileMap* mTileMap = nullptr;
 	Tile* mThisTile = nullptr;
 
-	NAS2D::Point_2d mGridPosition;
+	NAS2D::Point<int> mGridPosition;
 	int mDepth = 0;
 };
 

--- a/src/GraphWalker.h
+++ b/src/GraphWalker.h
@@ -22,7 +22,7 @@ private:
 
 private:
 	void walkGraph();
-	void check(int x, int y, int depth, Direction direction);
+	void check(NAS2D::Point<int> point, int depth, Direction direction);
 
 private:
 	TileMap* mTileMap = nullptr;

--- a/src/GraphWalker.h
+++ b/src/GraphWalker.h
@@ -25,11 +25,10 @@ private:
 	void check(int x, int y, int depth, Direction direction);
 
 private:
-	TileMap*		mTileMap = nullptr;
+	TileMap* mTileMap = nullptr;
+	Tile* mThisTile = nullptr;
 
-	Tile*			mThisTile = nullptr;
-
-	NAS2D::Point_2d	mGridPosition;
-	int				mDepth = 0;
+	NAS2D::Point_2d mGridPosition;
+	int mDepth = 0;
 };
 


### PR DESCRIPTION
Reference: #217

Refactor `GraphWalker`, making better use of `Point` and `Vector`, and non-abbreviated variable names.
