### PR TITLE
Add new `TileMap::getTile` overload, for default depth

### DIFF
--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -34,7 +34,7 @@ public:
 	Tile* getTile(int x, int y, int level);
 	Tile* getTile(int x, int y) { return getTile(x, y, mCurrentDepth); }
 	Tile* getTile(NAS2D::Point<int> position, int level) { return getTile(position.x(), position.y(), level); }
-	Tile* getTile(NAS2D::Point<int> position) { return getTile(position.x(), position.y(), mCurrentDepth); }
+	Tile* getTile(NAS2D::Point<int> position) { return getTile(position, mCurrentDepth); }
 
 	Tile* getVisibleTile(NAS2D::Point<int> position, int level);
 	Tile* getVisibleTile() { return getVisibleTile(tileMouseHover(), mCurrentDepth); }

--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -34,6 +34,7 @@ public:
 	Tile* getTile(int x, int y, int level);
 	Tile* getTile(int x, int y) { return getTile(x, y, mCurrentDepth); }
 	Tile* getTile(NAS2D::Point<int> position, int level) { return getTile(position.x(), position.y(), level); }
+	Tile* getTile(NAS2D::Point<int> position) { return getTile(position.x(), position.y(), mCurrentDepth); }
 
 	Tile* getVisibleTile(NAS2D::Point<int> position, int level);
 	Tile* getVisibleTile() { return getVisibleTile(tileMouseHover(), mCurrentDepth); }


### PR DESCRIPTION
Noticed this was missing from the API, and will be needed to refactor various functions.
