### PR TITLE
Refactor MapViewState::deploySeedLander

### DIFF
--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -165,7 +165,7 @@ void MapViewState::deploySeedLander(int x, int y)
 	ss->sprite().setFrame(10);
 	structureManager.addStructure(ss, mTileMap->getTile(point + DirectionSouthEast));
 
-	// Robots only become available after the SEED Factor is deployed.
+	// Robots only become available after the SEED Factory is deployed.
 	mRobots.addItem(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, ROBOT_DOZER);
 	mRobots.addItem(constants::ROBODIGGER, constants::ROBODIGGER_SHEET_ID, ROBOT_DIGGER);
 	mRobots.addItem(constants::ROBOMINER, constants::ROBOMINER_SHEET_ID, ROBOT_MINER);

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -131,6 +131,8 @@ void MapViewState::deployCargoLander()
 void MapViewState::deploySeedLander(int x, int y)
 {
 	const NAS2D::Point point{x, y};
+
+	// Bulldoze lander region
 	for (const auto& direction : DirectionScan3x3)
 	{
 		mTileMap->getTile(point + direction)->index(TERRAIN_DOZED);
@@ -138,6 +140,7 @@ void MapViewState::deploySeedLander(int x, int y)
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
+	// Place initial tubes
 	for (const auto& direction : DirectionClockwise4)
 	{
 		structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(point + direction));

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -136,33 +136,35 @@ void MapViewState::deploySeedLander(int x, int y)
 		mTileMap->getTile(point + direction)->index(TERRAIN_DOZED);
 	}
 
-	// TOP ROW
-	NAS2D::Utility<StructureManager>::get().addStructure(new SeedPower(), mTileMap->getTile(x - 1, y - 1));
+	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y - 1));
+	// TOP ROW
+	structureManager.addStructure(new SeedPower(), mTileMap->getTile(x - 1, y - 1));
+
+	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y - 1));
 
 	CommandCenter* cc = static_cast<CommandCenter*>(StructureCatalogue::get(SID_COMMAND_CENTER));
 	cc->sprite().setFrame(3);
-	NAS2D::Utility<StructureManager>::get().addStructure(cc, mTileMap->getTile(x + 1, y - 1));
+	structureManager.addStructure(cc, mTileMap->getTile(x + 1, y - 1));
 	ccLocation() = {x + 1, y - 1};
 
 	// MIDDLE ROW
-	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x - 1, y));
+	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x - 1, y));
 
-	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x + 1, y));
+	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x + 1, y));
 
 	// BOTTOM ROW
 	SeedFactory* sf = static_cast<SeedFactory*>(StructureCatalogue::get(SID_SEED_FACTORY));
 	sf->resourcePool(&mPlayerResources);
 	sf->productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 	sf->sprite().setFrame(7);
-	NAS2D::Utility<StructureManager>::get().addStructure(sf, mTileMap->getTile(x - 1, y + 1));
+	structureManager.addStructure(sf, mTileMap->getTile(x - 1, y + 1));
 
-	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y + 1));
+	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y + 1));
 
 	SeedSmelter* ss = static_cast<SeedSmelter*>(StructureCatalogue::get(SID_SEED_SMELTER));
 	ss->sprite().setFrame(10);
-	NAS2D::Utility<StructureManager>::get().addStructure(ss, mTileMap->getTile(x + 1, y + 1));
+	structureManager.addStructure(ss, mTileMap->getTile(x + 1, y + 1));
 
 	// Robots only become available after the SEED Factor is deployed.
 	mRobots.addItem(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, ROBOT_DOZER);

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -7,6 +7,7 @@
 // ==================================================================================
 #include "MapViewState.h"
 
+#include "../DirectionOffset.h"
 #include "../StructureCatalogue.h"
 
 #include "../Things/Robots/Robots.h"
@@ -129,26 +130,25 @@ void MapViewState::deployCargoLander()
  */
 void MapViewState::deploySeedLander(int x, int y)
 {
-	mTileMap->getTile(x, y)->index(TERRAIN_DOZED);
+	const NAS2D::Point point{x, y};
+	for (const auto& direction : DirectionScan3x3)
+	{
+		mTileMap->getTile(point + direction)->index(TERRAIN_DOZED);
+	}
 
 	// TOP ROW
 	NAS2D::Utility<StructureManager>::get().addStructure(new SeedPower(), mTileMap->getTile(x - 1, y - 1));
-	mTileMap->getTile(x - 1, y - 1)->index(TERRAIN_DOZED);
 
 	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y - 1));
-	mTileMap->getTile(x, y - 1)->index(TERRAIN_DOZED);
 
 	CommandCenter* cc = static_cast<CommandCenter*>(StructureCatalogue::get(SID_COMMAND_CENTER));
 	cc->sprite().setFrame(3);
 	NAS2D::Utility<StructureManager>::get().addStructure(cc, mTileMap->getTile(x + 1, y - 1));
-	mTileMap->getTile(x + 1, y - 1)->index(TERRAIN_DOZED);
 	ccLocation() = {x + 1, y - 1};
 
 	// MIDDLE ROW
-	mTileMap->getTile(x - 1, y)->index(TERRAIN_DOZED);
 	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x - 1, y));
 
-	mTileMap->getTile(x + 1, y)->index(TERRAIN_DOZED);
 	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x + 1, y));
 
 	// BOTTOM ROW
@@ -157,15 +157,12 @@ void MapViewState::deploySeedLander(int x, int y)
 	sf->productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 	sf->sprite().setFrame(7);
 	NAS2D::Utility<StructureManager>::get().addStructure(sf, mTileMap->getTile(x - 1, y + 1));
-	mTileMap->getTile(x - 1, y + 1)->index(TERRAIN_DOZED);
 
-	mTileMap->getTile(x, y + 1)->index(TERRAIN_DOZED);
 	NAS2D::Utility<StructureManager>::get().addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y + 1));
 
 	SeedSmelter* ss = static_cast<SeedSmelter*>(StructureCatalogue::get(SID_SEED_SMELTER));
 	ss->sprite().setFrame(10);
 	NAS2D::Utility<StructureManager>::get().addStructure(ss, mTileMap->getTile(x + 1, y + 1));
-	mTileMap->getTile(x + 1, y + 1)->index(TERRAIN_DOZED);
 
 	// Robots only become available after the SEED Factor is deployed.
 	mRobots.addItem(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, ROBOT_DOZER);

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -144,23 +144,23 @@ void MapViewState::deploySeedLander(int x, int y)
 	}
 
 	// TOP ROW
-	structureManager.addStructure(new SeedPower(), mTileMap->getTile(x - 1, y - 1));
+	structureManager.addStructure(new SeedPower(), mTileMap->getTile(point + DirectionNorthWest));
 
 	CommandCenter* cc = static_cast<CommandCenter*>(StructureCatalogue::get(SID_COMMAND_CENTER));
 	cc->sprite().setFrame(3);
-	structureManager.addStructure(cc, mTileMap->getTile(x + 1, y - 1));
-	ccLocation() = {x + 1, y - 1};
+	structureManager.addStructure(cc, mTileMap->getTile(point + DirectionNorthEast));
+	ccLocation() = point + DirectionNorthEast;
 
 	// BOTTOM ROW
 	SeedFactory* sf = static_cast<SeedFactory*>(StructureCatalogue::get(SID_SEED_FACTORY));
 	sf->resourcePool(&mPlayerResources);
 	sf->productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 	sf->sprite().setFrame(7);
-	structureManager.addStructure(sf, mTileMap->getTile(x - 1, y + 1));
+	structureManager.addStructure(sf, mTileMap->getTile(point + DirectionSouthWest));
 
 	SeedSmelter* ss = static_cast<SeedSmelter*>(StructureCatalogue::get(SID_SEED_SMELTER));
 	ss->sprite().setFrame(10);
-	structureManager.addStructure(ss, mTileMap->getTile(x + 1, y + 1));
+	structureManager.addStructure(ss, mTileMap->getTile(point + DirectionSouthEast));
 
 	// Robots only become available after the SEED Factor is deployed.
 	mRobots.addItem(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, ROBOT_DOZER);

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -138,20 +138,18 @@ void MapViewState::deploySeedLander(int x, int y)
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
+	for (const auto& direction : DirectionClockwise4)
+	{
+		structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(point + direction));
+	}
+
 	// TOP ROW
 	structureManager.addStructure(new SeedPower(), mTileMap->getTile(x - 1, y - 1));
-
-	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y - 1));
 
 	CommandCenter* cc = static_cast<CommandCenter*>(StructureCatalogue::get(SID_COMMAND_CENTER));
 	cc->sprite().setFrame(3);
 	structureManager.addStructure(cc, mTileMap->getTile(x + 1, y - 1));
 	ccLocation() = {x + 1, y - 1};
-
-	// MIDDLE ROW
-	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x - 1, y));
-
-	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x + 1, y));
 
 	// BOTTOM ROW
 	SeedFactory* sf = static_cast<SeedFactory*>(StructureCatalogue::get(SID_SEED_FACTORY));
@@ -159,8 +157,6 @@ void MapViewState::deploySeedLander(int x, int y)
 	sf->productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 	sf->sprite().setFrame(7);
 	structureManager.addStructure(sf, mTileMap->getTile(x - 1, y + 1));
-
-	structureManager.addStructure(new Tube(CONNECTOR_INTERSECTION, false), mTileMap->getTile(x, y + 1));
 
 	SeedSmelter* ss = static_cast<SeedSmelter*>(StructureCatalogue::get(SID_SEED_SMELTER));
 	ss->sprite().setFrame(10);


### PR DESCRIPTION
Reference: #217
Reference: #335

Refactor `MapViewState::deploySeedLander` to use `Point` , `Vector`, and named direction offsets.
