### PR TITLE
Virtual destructor overrides

### DIFF
--- a/src/Things/Structures/SeedLander.h
+++ b/src/Things/Structures/SeedLander.h
@@ -23,8 +23,6 @@ public:
 		enable();
 	}
 
-	virtual ~SeedLander() = default;
-
 	void position(int x, int y)
 	{
 		mX = x;

--- a/src/UI/Core/Label.h
+++ b/src/UI/Core/Label.h
@@ -25,7 +25,6 @@ class Label : public Control
 {
 public:
 	Label(std::string newText = "");
-	virtual ~Label() = default;
 
 	void font(NAS2D::Font* font);
 	bool empty() const { return text().empty(); }

--- a/src/UI/Core/TextArea.h
+++ b/src/UI/Core/TextArea.h
@@ -12,7 +12,6 @@ class TextArea : public Control
 {
 public:
 	TextArea() = default;
-	virtual ~TextArea() = default;
 
 	void textColor(const NAS2D::Color& color) { mTextColor = color; }
 

--- a/src/UI/DifficultySelect.h
+++ b/src/UI/DifficultySelect.h
@@ -9,7 +9,7 @@ public:
 	using CancelCallback = NAS2D::Signals::Signal<>;
 
 	DifficultySelect();
-	virtual ~DifficultySelect();
+	virtual ~DifficultySelect() override;
 
 	virtual void update() override;
 	

--- a/src/UI/DifficultySelect.h
+++ b/src/UI/DifficultySelect.h
@@ -9,16 +9,16 @@ public:
 	using CancelCallback = NAS2D::Signals::Signal<>;
 
 	DifficultySelect();
-	virtual ~DifficultySelect() override;
+	~DifficultySelect() override;
 
-	virtual void update() override;
+	void update() override;
 	
 	OkClickCallback& ok() { return mOkCallback; }
 	CancelCallback& cancel() { return mCancelCallback; }
 
 protected:
 	virtual void init();
-	virtual void visibilityChanged(bool visible) override;
+	void visibilityChanged(bool visible) override;
 
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);

--- a/src/UI/MainMenuOptions.h
+++ b/src/UI/MainMenuOptions.h
@@ -6,13 +6,13 @@ class MainMenuOptions : public Window
 {
 public:
 	MainMenuOptions();
-	virtual ~MainMenuOptions() override;
+	~MainMenuOptions() override;
 
-	virtual void update() override;
+	void update() override;
 
 protected:
 	virtual void init();
-	virtual void visibilityChanged(bool visible) override;
+	void visibilityChanged(bool visible) override;
 
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);

--- a/src/UI/MainMenuOptions.h
+++ b/src/UI/MainMenuOptions.h
@@ -6,7 +6,7 @@ class MainMenuOptions : public Window
 {
 public:
 	MainMenuOptions();
-	virtual ~MainMenuOptions();
+	virtual ~MainMenuOptions() override;
 
 	virtual void update() override;
 

--- a/src/UI/PopulationPanel.h
+++ b/src/UI/PopulationPanel.h
@@ -8,8 +8,6 @@ class PopulationPanel: public Control
 {
 public:
 	PopulationPanel();
-	
-	virtual ~PopulationPanel() = default;
 
 	void population(Population* pop) { mPopulation = pop; }
 	void morale(int* m) { mMorale = m; }

--- a/src/UI/ProductListBox.h
+++ b/src/UI/ProductListBox.h
@@ -14,7 +14,6 @@ public:
 	{
 	public:
 		ProductListBoxItem() = default;
-		virtual ~ProductListBoxItem() = default;
 
 	public:
 		size_t count = 0;				/**< Count of the product. */
@@ -23,7 +22,6 @@ public:
 
 public:
 	ProductListBox();
-	virtual ~ProductListBox() = default;
 
 	void productPool(ProductPool&);
 

--- a/src/UI/ResourceBreakdownPanel.h
+++ b/src/UI/ResourceBreakdownPanel.h
@@ -9,7 +9,6 @@ class ResourceBreakdownPanel : public Control
 {
 public:
 	ResourceBreakdownPanel();
-	virtual ~ResourceBreakdownPanel() = default;
 
 	void playerResources(ResourcePool* rp) { mPlayerResources = rp; }
 	ResourcePool& previousResources() { return mPreviousResources; }


### PR DESCRIPTION
Reference: #307 (`-Winconsistent-missing-destructor-override`)

Mark destructors with `override` in derived classes. Remove explicit destructors in derived classes that have only a `default` implementation.
