### PR TITLE
Suggest override States

### DIFF
--- a/src/States/GameState.h
+++ b/src/States/GameState.h
@@ -9,12 +9,12 @@ class GameState : public NAS2D::State
 {
 public:
 	GameState();
-	virtual ~GameState();
+	~GameState() override;
 
 	void mapviewstate(MapViewState*);
 
-	virtual void initialize() final;
-	virtual State* update() final;
+	void initialize() override final;
+	State* update() override final;
 
 private:
 	void onMouseMove(int x, int y, int relX, int relY);

--- a/src/States/GameState.h
+++ b/src/States/GameState.h
@@ -13,8 +13,8 @@ public:
 
 	void mapviewstate(MapViewState*);
 
-	void initialize() override final;
-	State* update() override final;
+	void initialize() override;
+	State* update() override;
 
 private:
 	void onMouseMove(int x, int y, int relX, int relY);

--- a/src/States/MainReportsUiState.h
+++ b/src/States/MainReportsUiState.h
@@ -32,8 +32,8 @@ protected:
 	State* update() override;
 
 private:
-	virtual void _deactivate() final;
-	virtual void _activate() final;
+	void _deactivate() override final;
+	void _activate() override final;
 
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);

--- a/src/States/MainReportsUiState.h
+++ b/src/States/MainReportsUiState.h
@@ -32,8 +32,8 @@ protected:
 	State* update() override;
 
 private:
-	void _deactivate() override final;
-	void _activate() override final;
+	void _deactivate() override;
+	void _activate() override;
 
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -80,8 +80,8 @@ protected:
 	State* update() override;
 
 private:
-	void _deactivate() override final;
-	void _activate() override final;
+	void _deactivate() override;
+	void _activate() override;
 	
 	// EVENT HANDLERS
 	void onActivate(bool newActiveValue);

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -80,8 +80,8 @@ protected:
 	State* update() override;
 
 private:
-	virtual void _deactivate() final;
-	virtual void _activate() final;
+	void _deactivate() override final;
+	void _activate() override final;
 	
 	// EVENT HANDLERS
 	void onActivate(bool newActiveValue);


### PR DESCRIPTION
Reference: #307 (`-Wsuggest-override`), #338, #322
Related: #339, #340, #341, #342, #343, #344
Contains changes to States that were missed by #339.

Add suggested uses of `override` to member functions in the `States/` folder.

Code now compiles cleanly with GCC-8 using `-Wsuggest-override`.
