### PR TITLE
Remove extra semicolon at end of switch block

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -411,7 +411,7 @@ void TileMap::updateTileHighlight()
 
 	default:
 		break;
-	};
+	}
 }
 
 


### PR DESCRIPTION
Found with warning flag: `-Wextra-semi-stmt`
