### PR TITLE
Fix extra semicolon warnings for pather

### DIFF
--- a/OPHD/MicroPather/micropather.h
+++ b/OPHD/MicroPather/micropather.h
@@ -51,16 +51,16 @@ distribution.
 #if defined(DEBUG)
 #   if defined(_MSC_VER)
 #       // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
-#       define MPASSERT( x )           if ( !((void)0,(x))) { __debugbreak(); } //if ( !(x)) WinDebugBreak()
+#       define MPASSERT( x )           do { if ( !((void)0,(x))) { __debugbreak(); } } while(false) //if ( !(x)) WinDebugBreak()
 #   elif defined (ANDROID_NDK)
 #       include <android/log.h>
-#       define MPASSERT( x )           if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); }
+#       define MPASSERT( x )           do { if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); } } while(false)
 #   else
 #       include <assert.h>
 #       define MPASSERT                assert
 #   endif
 #   else
-#       define MPASSERT( x )           {}
+#       define MPASSERT( x )           do {} while(false)
 #endif
 
 


### PR DESCRIPTION
Found with warning flag: `-Wextra-semi-stmt`

----

The macro is modified such that it requires semicolon termination. This allows the parser to eat the semicolon at the place where the macro is expanded. This results in more normal looking code, where the macro invocation may look like a regular function call, terminated with a semicolon.

Reference:
https://wiki.sei.cmu.edu/confluence/display/c/PRE10-C.+Wrap+multistatement+macros+in+a+do-while+loop
https://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html
