### PR TITLE
Remove type alias uses

### DIFF
--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -141,7 +141,7 @@ private:
 	NAS2D::Point_2d		mMapHighlight;				/**< Tile the mouse is pointing to. */
 	NAS2D::Point_2d		mMapViewLocation;
 
-	NAS2D::Point_2df	mMapPosition;				/** Where to start drawing the TileMap on the screen. */
+	NAS2D::Point<float>	mMapPosition;				/** Where to start drawing the TileMap on the screen. */
 
 	Point2dList			mMineLocations;				/**< Location of all mines on the map. */
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -43,7 +43,7 @@ public:
 	bool isVisibleTile(NAS2D::Point<int> position) const { return isVisibleTile(position, mCurrentDepth); }
 	bool isVisibleTile(const Tile& t) { return isVisibleTile(t.position(), t.depth()); }
 
-	const NAS2D::Rectangle_2d& boundingBox() const { return mMapBoundingBox; }
+	const NAS2D::Rectangle<int>& boundingBox() const { return mMapBoundingBox; }
 
 	const NAS2D::Point<int>& mapViewLocation() const { return mMapViewLocation; }
 	void mapViewLocation(int x, int y) { mMapViewLocation = {x, y}; }
@@ -145,7 +145,7 @@ private:
 
 	Point2dList			mMineLocations;				/**< Location of all mines on the map. */
 
-	NAS2D::Rectangle_2d	mMapBoundingBox;			/** Area that the TileMap fills when drawn. */
+	NAS2D::Rectangle<int>	mMapBoundingBox;			/** Area that the TileMap fills when drawn. */
 
 	bool				mShowConnections = false;	/**< Flag indicating whether or not to highlight connectedness. */
 };

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -10,7 +10,7 @@
 
 #include <algorithm>
 
-using Point2dList = std::vector<NAS2D::Point_2d>;
+using Point2dList = std::vector<NAS2D::Point<int>>;
 
 class TileMap: public micropather::Graph
 {
@@ -45,19 +45,19 @@ public:
 
 	const NAS2D::Rectangle_2d& boundingBox() const { return mMapBoundingBox; }
 
-	const NAS2D::Point_2d& mapViewLocation() const { return mMapViewLocation; }
+	const NAS2D::Point<int>& mapViewLocation() const { return mMapViewLocation; }
 	void mapViewLocation(int x, int y) { mMapViewLocation = {x, y}; }
 	void centerMapOnTile(Tile*);
 
-	const NAS2D::Point_2d& tileHighlight() const { return mMapHighlight; }
+	const NAS2D::Point<int>& tileHighlight() const { return mMapHighlight; }
 	bool tileHighlightVisible() const;
 
 	int tileMouseHoverX() const { return mMapHighlight.x() + mMapViewLocation.x(); }
 	int tileMouseHoverY() const { return mMapHighlight.y() + mMapViewLocation.y(); }
-	NAS2D::Point_2d tileMouseHover() const { return NAS2D::Point_2d(tileMouseHoverX(), tileMouseHoverY()); }
+	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point<int>(tileMouseHoverX(), tileMouseHoverY()); }
 
 	const Point2dList& mineLocations() const { return mMineLocations; }
-	void removeMineLocation(const NAS2D::Point_2d& pt);
+	void removeMineLocation(const NAS2D::Point<int>& pt);
 
 	void toggleShowConnections() { mShowConnections = !mShowConnections; }
 
@@ -137,9 +137,9 @@ private:
 
 	NAS2D::Timer		mTimer;
 
-	NAS2D::Point_2d		mMousePosition;				/**< Current mouse position. */
-	NAS2D::Point_2d		mMapHighlight;				/**< Tile the mouse is pointing to. */
-	NAS2D::Point_2d		mMapViewLocation;
+	NAS2D::Point<int>		mMousePosition;				/**< Current mouse position. */
+	NAS2D::Point<int>		mMapHighlight;				/**< Tile the mouse is pointing to. */
+	NAS2D::Point<int>		mMapViewLocation;
 
 	NAS2D::Point<float>	mMapPosition;				/** Where to start drawing the TileMap on the screen. */
 

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -12,7 +12,7 @@
 #include "NAS2D/Mixer/Mixer.h"
 #include "NAS2D/Renderer/Renderer.h"
 
-NAS2D::Point_2d MOUSE_COORDS;									/**< Mouse Coordinates. Used by other states/wrapers. */
+NAS2D::Point<int> MOUSE_COORDS;									/**< Mouse Coordinates. Used by other states/wrapers. */
 
 MainReportsUiState* MAIN_REPORTS_UI = nullptr;			/**< Pointer to a MainReportsUiState. Memory is handled by GameState. */
 static MapViewState* MAP_VIEW = nullptr;				/**< Pointer to a MapViewState. Memory is handled by GameState. */

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -63,7 +63,7 @@ public:
 	Point<int>			TextPosition;
 	Point<int>			IconPosition;
 
-	Rectangle_2d		Rect;
+	Rectangle<int>		Rect;
 
 	ReportInterface*	UiPanel = nullptr;
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -17,7 +17,7 @@
 using namespace NAS2D;
 
 
-extern Point_2d		MOUSE_COORDS;
+extern Point<int>		MOUSE_COORDS;
 
 static Image*		WINDOW_BACKGROUND = nullptr;
 
@@ -60,8 +60,8 @@ public:
 
 	Image*				Img = nullptr;
 
-	Point_2d			TextPosition;
-	Point_2d			IconPosition;
+	Point<int>			TextPosition;
+	Point<int>			IconPosition;
 
 	Rectangle_2d		Rect;
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -31,7 +31,7 @@ const std::string	MAP_DISPLAY_EXTENSION		= "_b.png";
 
 extern NAS2D::Image* IMG_LOADING;	/// \fixme Find a sane place for this.
 extern NAS2D::Image* IMG_SAVING;	/// \fixme Find a sane place for this.
-extern Point_2d MOUSE_COORDS;
+extern Point<int> MOUSE_COORDS;
 extern MainReportsUiState* MAIN_REPORTS_UI;
 
 
@@ -337,7 +337,7 @@ void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifie
 	}
 
 	bool viewUpdated = false; // don't like flaggy code like this
-	Point_2d pt = mTileMap->mapViewLocation();
+	Point<int> pt = mTileMap->mapViewLocation();
 
 	switch(key)
 	{
@@ -531,7 +531,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 		mLeftButtonDown = true;
 
 		mWindowStack.updateStack(MOUSE_COORDS);
-		Point_2d pt = mTileMap->mapViewLocation();
+		Point<int> pt = mTileMap->mapViewLocation();
 
 		// Ugly
 		if (MENU_ICON.contains(MOUSE_COORDS))
@@ -1019,7 +1019,7 @@ void MapViewState::placeRobot()
 			if (!doYesNoMessage(constants::ALERT_DIGGER_MINE_TITLE, constants::ALERT_DIGGER_MINE)) { return; }
 
 			std::cout << "Digger destroyed a Mine at (" << mTileMap->tileMouseHoverX() << ", " << mTileMap->tileMouseHoverY() << ")." << std::endl;
-			mTileMap->removeMineLocation(Point_2d(tile->x(), tile->y()));
+			mTileMap->removeMineLocation(Point<int>(tile->x(), tile->y()));
 		}
 
 		// Die if tile is occupied or not excavated.

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -37,16 +37,16 @@ extern MainReportsUiState* MAIN_REPORTS_UI;
 
 int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
 
-Rectangle_2d MENU_ICON;
-Rectangle_2d RESOURCE_PANEL_PIN(0, 1, 8, 19);
-Rectangle_2d POPULATION_PANEL_PIN(675, 1, 8, 19);
+Rectangle<int> MENU_ICON;
+Rectangle<int> RESOURCE_PANEL_PIN(0, 1, 8, 19);
+Rectangle<int> POPULATION_PANEL_PIN(675, 1, 8, 19);
 
-Rectangle_2d MOVE_NORTH_ICON;
-Rectangle_2d MOVE_SOUTH_ICON;
-Rectangle_2d MOVE_EAST_ICON;
-Rectangle_2d MOVE_WEST_ICON;
-Rectangle_2d MOVE_UP_ICON;
-Rectangle_2d MOVE_DOWN_ICON;
+Rectangle<int> MOVE_NORTH_ICON;
+Rectangle<int> MOVE_SOUTH_ICON;
+Rectangle<int> MOVE_EAST_ICON;
+Rectangle<int> MOVE_WEST_ICON;
+Rectangle<int> MOVE_UP_ICON;
+Rectangle<int> MOVE_DOWN_ICON;
 
 std::string CURRENT_LEVEL_STRING;
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -206,7 +206,7 @@ private:
 	NAS2D::Image				mHeightMap;						/**< Height view of the Site Map. */
 	NAS2D::Image				mUiIcons;						/**< User interface icons. */
 
-	NAS2D::Point_2d			mTileMapMouseHover;				/**< Tile position the mouse is currently hovering over. */
+	NAS2D::Point<int>			mTileMapMouseHover;				/**< Tile position the mouse is currently hovering over. */
 
 	NAS2D::Rectangle_2d		mMiniMapBoundingBox;			/**< Area of the site map display. */
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -102,7 +102,7 @@ private:
 	void drawUI();
 	void drawMiniMap();
 	void drawNavInfo();
-	bool drawNavIcon(NAS2D::Renderer& r, const NAS2D::Rectangle_2d& currentIconBounds, const NAS2D::Rectangle_2d& subImageBounds, const NAS2D::Color& iconColor, const NAS2D::Color& iconHighlightColor);
+	bool drawNavIcon(NAS2D::Renderer& r, const NAS2D::Rectangle<int>& currentIconBounds, const NAS2D::Rectangle<int>& subImageBounds, const NAS2D::Color& iconColor, const NAS2D::Color& iconHighlightColor);
 
 	void drawResourceInfo();
 	void drawRobotInfo();
@@ -118,7 +118,7 @@ private:
 	void placeStructure();
 	void placeTubes();
 	
-	NAS2D::Rectangle_2d tubeStart;
+	NAS2D::Rectangle<int> tubeStart;
 	void placeTubeStart();
 	void placeTubeEnd();
 
@@ -208,7 +208,7 @@ private:
 
 	NAS2D::Point<int>			mTileMapMouseHover;				/**< Tile position the mouse is currently hovering over. */
 
-	NAS2D::Rectangle_2d		mMiniMapBoundingBox;			/**< Area of the site map display. */
+	NAS2D::Rectangle<int>		mMiniMapBoundingBox;			/**< Area of the site map display. */
 
 	// POOL'S
 	ResourcePool		mPlayerResources;				/**< Player's current resources. */

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -14,14 +14,14 @@
 #include <vector>
 #include <algorithm>
 
-extern NAS2D::Rectangle_2d MENU_ICON;
+extern NAS2D::Rectangle<int> MENU_ICON;
 
-extern NAS2D::Rectangle_2d MOVE_NORTH_ICON;
-extern NAS2D::Rectangle_2d MOVE_SOUTH_ICON;
-extern NAS2D::Rectangle_2d MOVE_EAST_ICON;
-extern NAS2D::Rectangle_2d MOVE_WEST_ICON;
-extern NAS2D::Rectangle_2d MOVE_UP_ICON;
-extern NAS2D::Rectangle_2d MOVE_DOWN_ICON;
+extern NAS2D::Rectangle<int> MOVE_NORTH_ICON;
+extern NAS2D::Rectangle<int> MOVE_SOUTH_ICON;
+extern NAS2D::Rectangle<int> MOVE_EAST_ICON;
+extern NAS2D::Rectangle<int> MOVE_WEST_ICON;
+extern NAS2D::Rectangle<int> MOVE_UP_ICON;
+extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 extern NAS2D::Point<int> MOUSE_COORDS;
 
@@ -256,7 +256,7 @@ void MapViewState::drawRobotInfo()
 	}
 }
 
-bool MapViewState::drawNavIcon(NAS2D::Renderer& renderer, const NAS2D::Rectangle_2d& currentIconBounds, const NAS2D::Rectangle_2d& subImageBounds, const NAS2D::Color& iconColor, const NAS2D::Color& iconHighlightColor) {
+bool MapViewState::drawNavIcon(NAS2D::Renderer& renderer, const NAS2D::Rectangle<int>& currentIconBounds, const NAS2D::Rectangle<int>& subImageBounds, const NAS2D::Color& iconColor, const NAS2D::Color& iconHighlightColor) {
 	bool isMouseInIcon = currentIconBounds.contains(MOUSE_COORDS);
 	NAS2D::Color color = isMouseInIcon ? iconHighlightColor : iconColor;
 	renderer.drawSubImage(mUiIcons, currentIconBounds.startPoint(), subImageBounds, color);
@@ -270,12 +270,12 @@ void MapViewState::drawNavInfo()
 {
 	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	drawNavIcon(renderer, MOVE_DOWN_ICON, NAS2D::Rectangle_2d{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_UP_ICON, NAS2D::Rectangle_2d{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_EAST_ICON, NAS2D::Rectangle_2d{32, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_WEST_ICON, NAS2D::Rectangle_2d{32, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_NORTH_ICON, NAS2D::Rectangle_2d{0, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_SOUTH_ICON, NAS2D::Rectangle_2d{0, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_DOWN_ICON, NAS2D::Rectangle<int>{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_UP_ICON, NAS2D::Rectangle<int>{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_EAST_ICON, NAS2D::Rectangle<int>{32, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_WEST_ICON, NAS2D::Rectangle<int>{32, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_NORTH_ICON, NAS2D::Rectangle<int>{0, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_SOUTH_ICON, NAS2D::Rectangle<int>{0, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
 
 	// display the levels "bar"
 	int iWidth = MAIN_FONT->width("IX"); // set steps character patern width

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -23,7 +23,7 @@ extern NAS2D::Rectangle_2d MOVE_WEST_ICON;
 extern NAS2D::Rectangle_2d MOVE_UP_ICON;
 extern NAS2D::Rectangle_2d MOVE_DOWN_ICON;
 
-extern NAS2D::Point_2d MOUSE_COORDS;
+extern NAS2D::Point<int> MOUSE_COORDS;
 
 extern NAS2D::Font* MAIN_FONT; /// yuck
 extern std::vector<void*> path;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -318,7 +318,7 @@ bool selfSustained(StructureID id)
 /** 
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool outOfCommRange(Point_2d& cc_location, TileMap* tile_map, Tile* current_tile)
+bool outOfCommRange(Point<int>& cc_location, TileMap* tile_map, Tile* current_tile)
 {
 	Tile* tile = tile_map->getVisibleTile();
 

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -30,7 +30,7 @@ bool validStructurePlacement(TileMap* tilemap, int x, int y);
 bool validLanderSite(Tile* t);
 bool landingSiteSuitable(TileMap* tilemap, int x, int y);
 bool structureIsLander(StructureID id);
-bool outOfCommRange(NAS2D::Point_2d& cc_location, TileMap* tile_map, Tile* current_tile);
+bool outOfCommRange(NAS2D::Point<int>& cc_location, TileMap* tile_map, Tile* current_tile);
 bool selfSustained(StructureID id);
 
 int totalStorage(StructureList& sl);

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -19,19 +19,19 @@
 
 using namespace constants;
 
-NAS2D::Rectangle_2d	BOTTOM_UI_AREA;
+NAS2D::Rectangle<int>	BOTTOM_UI_AREA;
 
 
 /**
  * \fixme	Yuck, not thrilled with this but whatever, it works.
  */
-extern NAS2D::Rectangle_2d MENU_ICON;
-extern NAS2D::Rectangle_2d MOVE_NORTH_ICON;
-extern NAS2D::Rectangle_2d MOVE_SOUTH_ICON;
-extern NAS2D::Rectangle_2d MOVE_EAST_ICON;
-extern NAS2D::Rectangle_2d MOVE_WEST_ICON;
-extern NAS2D::Rectangle_2d MOVE_UP_ICON;
-extern NAS2D::Rectangle_2d MOVE_DOWN_ICON;
+extern NAS2D::Rectangle<int> MENU_ICON;
+extern NAS2D::Rectangle<int> MOVE_NORTH_ICON;
+extern NAS2D::Rectangle<int> MOVE_SOUTH_ICON;
+extern NAS2D::Rectangle<int> MOVE_EAST_ICON;
+extern NAS2D::Rectangle<int> MOVE_WEST_ICON;
+extern NAS2D::Rectangle<int> MOVE_UP_ICON;
+extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 
 extern NAS2D::Image* IMG_LOADING;	/// \fixme Find a sane place for this.

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -35,7 +35,7 @@ public:
 
 	PlanetType type() const { return mType; }
 
-	void position(const NAS2D::Point_2d& _pt) { mPosition = _pt; }
+	void position(const NAS2D::Point<int>& _pt) { mPosition = _pt; }
 	void position(int x, int y) { mPosition = {x, y}; }
 
 	int x() const { return mPosition.x(); }
@@ -67,7 +67,7 @@ private:
 	int					mMaxDigDepth = 0;
 
 	NAS2D::Image		mImage;
-	NAS2D::Point_2d		mPosition;
+	NAS2D::Point<int>		mPosition;
 
 	PlanetType			mType = PLANET_TYPE_NONE;
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -56,7 +56,7 @@ private:
 	NAS2D::Sound	mSelect;
 	NAS2D::Sound	mHover;
 
-	NAS2D::Point_2d	mMousePosition;
+	NAS2D::Point<int>	mMousePosition;
 
 	PlanetPtrList	mPlanets;
 

--- a/OPHD/States/SplashState.h
+++ b/OPHD/States/SplashState.h
@@ -34,7 +34,7 @@ private:
 	NAS2D::Image				mFlare;
 	NAS2D::Image				mByline;
 
-	NAS2D::Point_2d			mMousePosition;
+	NAS2D::Point<int>			mMousePosition;
 
 	NAS2D::Timer				mTimer;
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -109,7 +109,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point_2d click(x, y);
+		Point<int> click(x, y);
 
 		if(rect().contains(click))
 		{
@@ -133,7 +133,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point_2d click(x, y);
+		Point<int> click(x, y);
 		
 		if(mType == Type::BUTTON_NORMAL)
 		{

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -54,7 +54,7 @@ private:
 	ListBox					lstItems;
 	TextField				txtField;
 
-	NAS2D::Rectangle_2df    mBaseArea;
+	NAS2D::Rectangle<float>    mBaseArea;
 
 	SelectionChanged        mSelectionChanged;
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -149,7 +149,7 @@ Control::ResizeCallback& Control::resized()
  * 
  * \return	A const reference to a Rectangle_2d object.
  */
-const Rectangle_2df& Control::rect() const
+const Rectangle<float>& Control::rect() const
 {
 	return mRect;
 }

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -11,7 +11,7 @@ using namespace NAS2D;
  * 
  * \param pos	2D Coordinate to position the Control at.
  */
-void Control::position(const Point_2d& pos)
+void Control::position(const Point<int>& pos)
 {
 	position(static_cast<float>(pos.x()), static_cast<float>(pos.y()));
 }

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -147,7 +147,7 @@ Control::ResizeCallback& Control::resized()
 /**
  * Gets the rectangular area that the Control occupies.
  * 
- * \return	A const reference to a Rectangle_2d object.
+ * \return	A const reference to a Rectangle<int> object.
  */
 const Rectangle<float>& Control::rect() const
 {

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -22,7 +22,7 @@ void Control::position(const Point_2d& pos)
  * 
  * \param pos	2D Coordinate to position the Control at.
  */
-void Control::position(const Point_2df& pos)
+void Control::position(const Point<float>& pos)
 {
 	position(pos.x(), pos.y());
 }

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -24,7 +24,7 @@ public:
 	Control() = default;
 	virtual ~Control() = default;
 
-	void position(const NAS2D::Point_2d& pos);
+	void position(const NAS2D::Point<int>& pos);
 	void position(const NAS2D::Point<float>& pos);
 	void position(float x, float y);
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -45,7 +45,7 @@ public:
 	virtual void hide() { visible(false); }
 	virtual void show() { visible(true); }
 
-	const NAS2D::Rectangle_2df& rect() const;
+	const NAS2D::Rectangle<float>& rect() const;
 
 	virtual void hasFocus(bool focus);
 	bool hasFocus() const;
@@ -92,7 +92,7 @@ protected:
 	ResizeCallback				mResized;
 	TextChangedCallback			mTextChanged;
 
-	NAS2D::Rectangle_2df	mRect;				/**< Area of the Control. */
+	NAS2D::Rectangle<float>	mRect;				/**< Area of the Control. */
 
 private:
 	virtual void draw() {}

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -25,7 +25,7 @@ public:
 	virtual ~Control() = default;
 
 	void position(const NAS2D::Point_2d& pos);
-	void position(const NAS2D::Point_2df& pos);
+	void position(const NAS2D::Point<float>& pos);
 	void position(float x, float y);
 
 	float positionX();

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -44,7 +44,7 @@ public:
 
 	public:
 		std::string Text;
-		NAS2D::Point_2d	Size;
+		NAS2D::Point<int>	Size;
 	};
 
 public:
@@ -115,7 +115,7 @@ private:
 	unsigned int				mItemWidth = 0;									/**< Width of a ListBoxItem. */
 	unsigned int				mLineCount = 0;									/**< Number of lines that can be displayed. */
 
-	NAS2D::Point_2d				mMousePosition;									/**< Mouse coordinates. */
+	NAS2D::Point<int>				mMousePosition;									/**< Mouse coordinates. */
 
 	NAS2D::Color				mText = NAS2D::Color::White;					/**< Text Color */
 	NAS2D::Color				mHighlightBg = NAS2D::Color::DarkGreen;				/**< Highlight Background color. */

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -177,7 +177,7 @@ void Slider::positionInternal(float newPosition)
 }
 
 
-void Slider::_buttonCheck(bool& buttonFlag, Rectangle_2df& rect, float value)
+void Slider::_buttonCheck(bool& buttonFlag, Rectangle<float>& rect, float value)
 {
 	if (rect.to<int>().contains(mMousePosition))
 	{

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -72,7 +72,7 @@ private:
 	void draw() override;		/*!< Draw the widget on screen. */
 	void logic();		/*!< Compute some values before drawing the control. */
 
-	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle_2df& rect, float value);
+	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle<float>& rect, float value);
 
 private:
 	NAS2D::Timer			mTimer;
@@ -107,8 +107,8 @@ private:
 	NAS2D::ImageList		mSkinSlider;				/*!< Skin for the slider. */
 	bool					mDisplayPosition = false;	/*!< Indicate if the slider display the value on mouse over. */
 	
-	NAS2D::Rectangle_2df	mButton1;					/*!< Area on screen where the second button is displayed. (Down/Left) */
-	NAS2D::Rectangle_2df	mButton2;					/*!< Area on screen where the first button is displayed. (Up/Right)*/
-	NAS2D::Rectangle_2df	mSlideBar;					/*!< Area on screen where the slide area is displayed. */
-	NAS2D::Rectangle_2df	mSlider;					/*!< Area on screen where the slider is displayed. */
+	NAS2D::Rectangle<float>	mButton1;					/*!< Area on screen where the second button is displayed. (Down/Left) */
+	NAS2D::Rectangle<float>	mButton2;					/*!< Area on screen where the first button is displayed. (Up/Right)*/
+	NAS2D::Rectangle<float>	mSlideBar;					/*!< Area on screen where the slide area is displayed. */
+	NAS2D::Rectangle<float>	mSlider;					/*!< Area on screen where the slider is displayed. */
 };

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -82,7 +82,7 @@ private:
 	SliderType				mSliderType;				/*!< Type of the Slider. */
 	
 	// mouse event related vars
-	NAS2D::Point_2d			mMousePosition;				/**< Mouse coordinates. */
+	NAS2D::Point<int>			mMousePosition;				/**< Mouse coordinates. */
 
 	bool					mMouseHoverSlide = false;	/*!< Mouse is within the bounds of the Button. */
 	bool					mThumbPressed = false;		/*!< Flag to indicate if this control is pressed. */

--- a/OPHD/UI/Core/WindowStack.h
+++ b/OPHD/UI/Core/WindowStack.h
@@ -13,10 +13,10 @@ public:
 	void addWindow(Window* window);
 	void removeWindow(Window* window);
 
-	bool pointInWindow(const NAS2D::Point_2d& p) const { return pointInWindow(p.x(), p.y()); }
+	bool pointInWindow(const NAS2D::Point<int>& p) const { return pointInWindow(p.x(), p.y()); }
 	bool pointInWindow(int x, int y) const;
 
-	void updateStack(const NAS2D::Point_2d& p) { updateStack(p.x(), p.y()); }
+	void updateStack(const NAS2D::Point<int>& p) { updateStack(p.x(), p.y()); }
 	void updateStack(int x, int y);
 
 	void bringToFront(Window* window);

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -31,7 +31,7 @@ public:
 
 	public:
 		Factory* factory = nullptr;
-		NAS2D::Point_2d	icon_slice;
+		NAS2D::Point<int>	icon_slice;
 	};
 
 public:

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -39,7 +39,7 @@ public:
 	protected:
 		friend class IconGrid;
 
-		NAS2D::Point_2df pos;
+		NAS2D::Point<float> pos;
 	};
 
 	typedef NAS2D::Signals::Signal<const IconGridItem*> Callback;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -17,8 +17,8 @@ using namespace NAS2D;
 
 static float SORT_BY_PRODUCT_POSITION = 0;
 
-static Rectangle_2df FACTORY_LISTBOX;
-static Rectangle_2df DETAIL_PANEL;
+static Rectangle<float> FACTORY_LISTBOX;
+static Rectangle<float> DETAIL_PANEL;
 
 static Font* FONT = nullptr;
 static Font* FONT_BOLD = nullptr;

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -34,11 +34,11 @@ static Color			RARE_MET_COL = Color::White;
 static Color			RARE_MIN_COL = Color::White;
 
 
-std::map<ResourceTrend, Point_2df> ICON_SLICE
+std::map<ResourceTrend, Point<float>> ICON_SLICE
 {
-	{ RESOURCE_TREND_NONE,	Point_2df(16.0f, 64.0f) },
-	{ RESOURCE_TREND_UP,	Point_2df(8.0f, 64.0f) },
-	{ RESOURCE_TREND_DOWN,	Point_2df(0.0f, 64.0f) }
+	{ RESOURCE_TREND_NONE,	Point<float>(16.0f, 64.0f) },
+	{ RESOURCE_TREND_UP,	Point<float>(8.0f, 64.0f) },
+	{ RESOURCE_TREND_DOWN,	Point<float>(0.0f, 64.0f) }
 };
 
 


### PR DESCRIPTION
Replace uses of type alises:
- `Point_2df` --> `Point<float>`
- `Point_2d` --> `Point<int>`
- `Rectangle_2df` --> `Rectangle<float>`
- `Rectangle_2d` --> `Rectangle<int>`

This makes use consistent for `Point`, `Vector`, and `Rectangle`.
