### PR TITLE
Deprecated copy dtor

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -7,13 +7,6 @@
 
 
 /**
- * C'tor
- */
-Tile::Tile()
-{}
-
-
-/**
  * D'tor
  */
 Tile::~Tile()

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -6,6 +6,22 @@
 #include "Tile.h"
 
 
+Tile::Tile(Tile&& other) :
+	mIndex{other.mIndex},
+	mX{other.mX},
+	mY{other.mY},
+	mDepth{other.mDepth},
+	mThing{other.mThing},
+	mMine{other.mMine},
+	mColor{other.mColor},
+	mExcavated{other.mExcavated},
+	mThingIsStructure{other.mThingIsStructure}
+{
+	other.mThing = nullptr;
+	other.mMine = nullptr;
+}
+
+
 /**
  * D'tor
  */

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -22,6 +22,25 @@ Tile::Tile(Tile&& other) :
 }
 
 
+Tile& Tile::operator=(Tile&& other)
+{
+	mIndex = other.mIndex;
+	mX = other.mX;
+	mY = other.mY;
+	mDepth = other.mDepth;
+	mThing = other.mThing;
+	mMine = other.mMine;
+	mColor = other.mColor;
+	mExcavated = other.mExcavated;
+	mThingIsStructure = other.mThingIsStructure;
+
+	other.mThing = nullptr;
+	other.mMine = nullptr;
+
+	return *this;
+}
+
+
 /**
  * D'tor
  */

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -17,6 +17,7 @@ class Tile
 public:
 	Tile() = default;
 	Tile(Tile&& other);
+	Tile& operator=(Tile&& other);
 	~Tile();
 
 	int index() const { return mIndex; }

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -16,6 +16,8 @@ class Tile
 {
 public:
 	Tile() = default;
+	Tile(const Tile& other) = delete;
+	Tile& operator=(const Tile& other) = delete;
 	Tile(Tile&& other);
 	Tile& operator=(Tile&& other);
 	~Tile();

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -16,6 +16,7 @@ class Tile
 {
 public:
 	Tile() = default;
+	Tile(Tile&& other);
 	~Tile();
 
 	int index() const { return mIndex; }

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -15,7 +15,7 @@
 class Tile
 {
 public:
-	Tile();
+	Tile() = default;
 	~Tile();
 
 	int index() const { return mIndex; }

--- a/OPHD/ProductionCost.h
+++ b/OPHD/ProductionCost.h
@@ -19,8 +19,6 @@ public:
 		mRareMinerals(rareMinerals)
 	{}
 
-	~ProductionCost() {}
-
 	void clear()
 	{
 		mTurnsToBuild = 0;

--- a/OPHD/ProductionCost.h
+++ b/OPHD/ProductionCost.h
@@ -9,7 +9,7 @@
 class ProductionCost
 {
 public:
-	ProductionCost() {}
+	ProductionCost() = default;
 
 	ProductionCost(int turns, int commonMetals, int commonMinerals, int rareMetals, int rareMinerals) :
 		mTurnsToBuild(turns),


### PR DESCRIPTION
Reference: #307 (`-Wdeprecated-copy-dtor`)

A copy or move constructor is needed for types to be usable by certain standard containers. This is needed to support operations such as `std::vector::resize`, or construction of `std::map`.

Having an explicit destructor can suppress generation of an automatic copy constructor.

Sample warning message:

> warning: definition of implicit copy constructor for 'ProductionCost' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-dtor]

Reference: [Copy constructors](https://en.cppreference.com/w/cpp/language/copy_constructor)
> The generation of the implicitly-defined copy constructor is deprecated if T has a user-defined destructor or user-defined copy assignment operator.
