### PR TITLE
Use CTAD for Point, Vector, and Rectangle

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -540,7 +540,7 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		mTileMap[0][y][x].pushMine(m);
 		mTileMap[0][y][x].index(TERRAIN_DOZED);
 
-		mMineLocations.push_back(Point(x, y));
+		mMineLocations.push_back(Point{x, y});
 
 		/// \fixme	Legacy code to assist in updating older versions of save games between 0.7.5 and 0.7.6. Remove in 0.8.0
 		if (m->depth() == 0 && m->active()) { m->increaseDepth(); }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -540,7 +540,7 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		mTileMap[0][y][x].pushMine(m);
 		mTileMap[0][y][x].index(TERRAIN_DOZED);
 
-		mMineLocations.push_back(Point<int>(x, y));
+		mMineLocations.push_back(Point(x, y));
 
 		/// \fixme	Legacy code to assist in updating older versions of save games between 0.7.5 and 0.7.6. Remove in 0.8.0
 		if (m->depth() == 0 && m->active()) { m->increaseDepth(); }

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -54,7 +54,7 @@ public:
 
 	int tileMouseHoverX() const { return mMapHighlight.x() + mMapViewLocation.x(); }
 	int tileMouseHoverY() const { return mMapHighlight.y() + mMapViewLocation.y(); }
-	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point<int>(tileMouseHoverX(), tileMouseHoverY()); }
+	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point(tileMouseHoverX(), tileMouseHoverY()); }
 
 	const Point2dList& mineLocations() const { return mMineLocations; }
 	void removeMineLocation(const NAS2D::Point<int>& pt);

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -54,7 +54,7 @@ public:
 
 	int tileMouseHoverX() const { return mMapHighlight.x() + mMapViewLocation.x(); }
 	int tileMouseHoverY() const { return mMapHighlight.y() + mMapViewLocation.y(); }
-	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point(tileMouseHoverX(), tileMouseHoverY()); }
+	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point{tileMouseHoverX(), tileMouseHoverY()}; }
 
 	const Point2dList& mineLocations() const { return mMineLocations; }
 	void removeMineLocation(const NAS2D::Point<int>& pt);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1019,7 +1019,7 @@ void MapViewState::placeRobot()
 			if (!doYesNoMessage(constants::ALERT_DIGGER_MINE_TITLE, constants::ALERT_DIGGER_MINE)) { return; }
 
 			std::cout << "Digger destroyed a Mine at (" << mTileMap->tileMouseHoverX() << ", " << mTileMap->tileMouseHoverY() << ")." << std::endl;
-			mTileMap->removeMineLocation(Point(tile->x(), tile->y()));
+			mTileMap->removeMineLocation(Point{tile->x(), tile->y()});
 		}
 
 		// Die if tile is occupied or not excavated.

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1019,7 +1019,7 @@ void MapViewState::placeRobot()
 			if (!doYesNoMessage(constants::ALERT_DIGGER_MINE_TITLE, constants::ALERT_DIGGER_MINE)) { return; }
 
 			std::cout << "Digger destroyed a Mine at (" << mTileMap->tileMouseHoverX() << ", " << mTileMap->tileMouseHoverY() << ")." << std::endl;
-			mTileMap->removeMineLocation(Point<int>(tile->x(), tile->y()));
+			mTileMap->removeMineLocation(Point(tile->x(), tile->y()));
 		}
 
 		// Die if tile is occupied or not excavated.

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -69,7 +69,7 @@ void MapViewState::drawMiniMap()
 	bool isHeightmapToggled = mBtnToggleHeightmap.toggled();
 	renderer.drawImage(isHeightmapToggled ? mHeightMap : mMapDisplay, miniMapBoxFloat.startPoint());
 
-	const auto miniMapOffset = mMiniMapBoundingBox.startPoint() - NAS2D::Point<int>{0, 0};
+	const auto miniMapOffset = mMiniMapBoundingBox.startPoint() - NAS2D::Point{0, 0};
 	const auto ccPosition = ccLocation();
 	if (ccPosition != CcNotPlaced)
 	{
@@ -142,7 +142,7 @@ void MapViewState::drawResourceInfo()
 	// Resources
 	int x = constants::MARGIN_TIGHT + 12;
 	int offsetX = constants::RESOURCE_ICON_SIZE + 40;
-	auto position = NAS2D::Point<int>{constants::MARGIN_TIGHT + 12, constants::MARGIN_TIGHT};
+	auto position = NAS2D::Point{constants::MARGIN_TIGHT + 12, constants::MARGIN_TIGHT};
 	constexpr auto textOffset = NAS2D::Vector{constants::RESOURCE_ICON_SIZE + constants::MARGIN, 3 - constants::MARGIN_TIGHT};
 
 	const auto unpinnedImageRect = NAS2D::Rectangle{0, 72, 8, 8};
@@ -287,7 +287,7 @@ void MapViewState::drawNavInfo()
 		const auto levelString = (i == 0) ? std::string{"S"} : std::to_string(i); // Set string for current level
 		bool isCurrentDepth = i == mTileMap->currentDepth();
 		NAS2D::Color color = isCurrentDepth ? NAS2D::Color::Red : NAS2D::Color{200, 200, 200}; // red for current depth : white for others
-		const auto position = NAS2D::Point<int>{iPosX - MAIN_FONT->width(levelString), iPosY}.to<float>();
+		const auto position = NAS2D::Point{iPosX - MAIN_FONT->width(levelString), iPosY}.to<float>();
 		renderer.drawText(*MAIN_FONT, levelString, position, color);
 		iPosX = iPosX - iWidth; // Shift position by one step left
 	}

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -74,7 +74,7 @@ void MapViewState::drawMiniMap()
 	if (ccPosition != CcNotPlaced)
 	{
 		const auto ccOffsetPosition = ccPosition + miniMapOffset;
-		const auto ccCommRangeImageRect = NAS2D::Rectangle<int>{166, 226, 30, 30};
+		const auto ccCommRangeImageRect = NAS2D::Rectangle{166, 226, 30, 30};
 		renderer.drawSubImage(mUiIcons, ccOffsetPosition - ccCommRangeImageRect.size() / 2, ccCommRangeImageRect);
 		renderer.drawBoxFilled(NAS2D::Rectangle<int>::Create(ccOffsetPosition - NAS2D::Vector<int>{1, 1}, NAS2D::Vector<int>{3, 3}), NAS2D::Color::White);
 	}
@@ -85,7 +85,7 @@ void MapViewState::drawMiniMap()
 		if (commTower->operational())
 		{
 			const auto commTowerPosition = structureManager.tileFromStructure(commTower)->position();
-			const auto commTowerRangeImageRect = NAS2D::Rectangle<int>{146, 236, 20, 20};
+			const auto commTowerRangeImageRect = NAS2D::Rectangle{146, 236, 20, 20};
 			renderer.drawSubImage(mUiIcons, commTowerPosition + miniMapOffset - commTowerRangeImageRect.size() / 2, commTowerRangeImageRect);
 		}
 	}
@@ -100,7 +100,7 @@ void MapViewState::drawMiniMap()
 		else if (!mine->exhausted()) { mineBeaconStatusOffsetX = 8; }
 		else { mineBeaconStatusOffsetX = 16; }
 
-		const auto mineImageRect = NAS2D::Rectangle<int>{mineBeaconStatusOffsetX, 0, 7, 7};
+		const auto mineImageRect = NAS2D::Rectangle{mineBeaconStatusOffsetX, 0, 7, 7};
 		renderer.drawSubImage(mUiIcons, minePosition + miniMapOffset - NAS2D::Vector<int>{2, 2}, mineImageRect);
 	}
 
@@ -145,8 +145,8 @@ void MapViewState::drawResourceInfo()
 	auto position = NAS2D::Point<int>{constants::MARGIN_TIGHT + 12, constants::MARGIN_TIGHT};
 	constexpr auto textOffset = NAS2D::Vector<int>{constants::RESOURCE_ICON_SIZE + constants::MARGIN, 3 - constants::MARGIN_TIGHT};
 
-	const auto unpinnedImageRect = NAS2D::Rectangle<int>{0, 72, 8, 8};
-	const auto pinnedImageRect = NAS2D::Rectangle<int>{8, 72, 8, 8};
+	const auto unpinnedImageRect = NAS2D::Rectangle{0, 72, 8, 8};
+	const auto pinnedImageRect = NAS2D::Rectangle{8, 72, 8, 8};
 
 	renderer.drawSubImage(mUiIcons, NAS2D::Point{2, 7}, mPinResourcePanel ? unpinnedImageRect : pinnedImageRect);
 	renderer.drawSubImage(mUiIcons, NAS2D::Point{675, 7}, mPinPopulationPanel ? unpinnedImageRect : pinnedImageRect);
@@ -190,12 +190,12 @@ void MapViewState::drawResourceInfo()
 	// Population / Morale
 	position.x() -= 17;
 	int popMoraleDeltaImageOffsetX = mCurrentMorale < mPreviousMorale ? 0 : (mCurrentMorale > mPreviousMorale ? 16 : 32);
-	const auto popMoraleDirectionImageRect = NAS2D::Rectangle<int>{popMoraleDeltaImageOffsetX, 48, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
+	const auto popMoraleDirectionImageRect = NAS2D::Rectangle{popMoraleDeltaImageOffsetX, 48, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, popMoraleDirectionImageRect);
 
 	position.x() += 17;
 	const auto moraleLevel = (std::clamp(mCurrentMorale, 1, 999) / 200);
-	const auto popMoraleImageRect = NAS2D::Rectangle<int>{176 + moraleLevel * constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
+	const auto popMoraleImageRect = NAS2D::Rectangle{176 + moraleLevel * constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, popMoraleImageRect);
 	renderer.drawText(*MAIN_FONT, std::to_string(mPopulation.size()), position + textOffset, NAS2D::Color::White);
 
@@ -209,14 +209,14 @@ void MapViewState::drawResourceInfo()
 
 	// Turns
 	position.x() = static_cast<int>(renderer.width() - 80);
-	const auto turnImageRect = NAS2D::Rectangle<int>{128, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
+	const auto turnImageRect = NAS2D::Rectangle{128, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, turnImageRect);
 	renderer.drawText(*MAIN_FONT, std::to_string(mTurnCount), position + textOffset, NAS2D::Color::White);
 
 	position = MENU_ICON.startPoint() + NAS2D::Vector<int>{constants::MARGIN_TIGHT, constants::MARGIN_TIGHT};
 	bool isMouseInMenu = MENU_ICON.contains(MOUSE_COORDS);
 	int menuGearHighlightOffsetX = isMouseInMenu ? 144 : 128;
-	const auto menuImageRect = NAS2D::Rectangle<int>{menuGearHighlightOffsetX, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
+	const auto menuImageRect = NAS2D::Rectangle{menuGearHighlightOffsetX, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, menuImageRect);
 }
 
@@ -270,12 +270,12 @@ void MapViewState::drawNavInfo()
 {
 	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	drawNavIcon(renderer, MOVE_DOWN_ICON, NAS2D::Rectangle<int>{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_UP_ICON, NAS2D::Rectangle<int>{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_EAST_ICON, NAS2D::Rectangle<int>{32, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_WEST_ICON, NAS2D::Rectangle<int>{32, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_NORTH_ICON, NAS2D::Rectangle<int>{0, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_SOUTH_ICON, NAS2D::Rectangle<int>{0, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_DOWN_ICON, NAS2D::Rectangle{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_UP_ICON, NAS2D::Rectangle{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_EAST_ICON, NAS2D::Rectangle{32, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_WEST_ICON, NAS2D::Rectangle{32, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_NORTH_ICON, NAS2D::Rectangle{0, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, MOVE_SOUTH_ICON, NAS2D::Rectangle{0, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
 
 	// display the levels "bar"
 	int iWidth = MAIN_FONT->width("IX"); // set steps character patern width

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -76,7 +76,7 @@ void MapViewState::drawMiniMap()
 		const auto ccOffsetPosition = ccPosition + miniMapOffset;
 		const auto ccCommRangeImageRect = NAS2D::Rectangle{166, 226, 30, 30};
 		renderer.drawSubImage(mUiIcons, ccOffsetPosition - ccCommRangeImageRect.size() / 2, ccCommRangeImageRect);
-		renderer.drawBoxFilled(NAS2D::Rectangle<int>::Create(ccOffsetPosition - NAS2D::Vector<int>{1, 1}, NAS2D::Vector<int>{3, 3}), NAS2D::Color::White);
+		renderer.drawBoxFilled(NAS2D::Rectangle<int>::Create(ccOffsetPosition - NAS2D::Vector{1, 1}, NAS2D::Vector{3, 3}), NAS2D::Color::White);
 	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
@@ -101,7 +101,7 @@ void MapViewState::drawMiniMap()
 		else { mineBeaconStatusOffsetX = 16; }
 
 		const auto mineImageRect = NAS2D::Rectangle{mineBeaconStatusOffsetX, 0, 7, 7};
-		renderer.drawSubImage(mUiIcons, minePosition + miniMapOffset - NAS2D::Vector<int>{2, 2}, mineImageRect);
+		renderer.drawSubImage(mUiIcons, minePosition + miniMapOffset - NAS2D::Vector{2, 2}, mineImageRect);
 	}
 
 	for (auto tile : path)
@@ -118,10 +118,10 @@ void MapViewState::drawMiniMap()
 
 	const auto& viewLocation = mTileMap->mapViewLocation();
 	const auto edgeLength = mTileMap->edgeLength();
-	const auto viewBoxSize = NAS2D::Vector<int>{edgeLength, edgeLength};
+	const auto viewBoxSize = NAS2D::Vector{edgeLength, edgeLength};
 	const auto viewBoxPosition = viewLocation + miniMapOffset;
 
-	renderer.drawBox(NAS2D::Rectangle<int>::Create(viewBoxPosition + NAS2D::Vector<int>{1, 1}, viewBoxSize), NAS2D::Color{0, 0, 0, 180});
+	renderer.drawBox(NAS2D::Rectangle<int>::Create(viewBoxPosition + NAS2D::Vector{1, 1}, viewBoxSize), NAS2D::Color{0, 0, 0, 180});
 	renderer.drawBox(NAS2D::Rectangle<int>::Create(viewBoxPosition, viewBoxSize), NAS2D::Color::White);
 
 	renderer.clipRectClear();
@@ -143,7 +143,7 @@ void MapViewState::drawResourceInfo()
 	int x = constants::MARGIN_TIGHT + 12;
 	int offsetX = constants::RESOURCE_ICON_SIZE + 40;
 	auto position = NAS2D::Point<int>{constants::MARGIN_TIGHT + 12, constants::MARGIN_TIGHT};
-	constexpr auto textOffset = NAS2D::Vector<int>{constants::RESOURCE_ICON_SIZE + constants::MARGIN, 3 - constants::MARGIN_TIGHT};
+	constexpr auto textOffset = NAS2D::Vector{constants::RESOURCE_ICON_SIZE + constants::MARGIN, 3 - constants::MARGIN_TIGHT};
 
 	const auto unpinnedImageRect = NAS2D::Rectangle{0, 72, 8, 8};
 	const auto pinnedImageRect = NAS2D::Rectangle{8, 72, 8, 8};
@@ -213,7 +213,7 @@ void MapViewState::drawResourceInfo()
 	renderer.drawSubImage(mUiIcons, position, turnImageRect);
 	renderer.drawText(*MAIN_FONT, std::to_string(mTurnCount), position + textOffset, NAS2D::Color::White);
 
-	position = MENU_ICON.startPoint() + NAS2D::Vector<int>{constants::MARGIN_TIGHT, constants::MARGIN_TIGHT};
+	position = MENU_ICON.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, constants::MARGIN_TIGHT};
 	bool isMouseInMenu = MENU_ICON.contains(MOUSE_COORDS);
 	int menuGearHighlightOffsetX = isMouseInMenu ? 144 : 128;
 	const auto menuImageRect = NAS2D::Rectangle{menuGearHighlightOffsetX, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -136,7 +136,7 @@ bool checkStructurePlacement(Tile* tile, Direction dir)
  */
 bool validTubeConnection(TileMap* tilemap, int x, int y, ConnectorDir dir)
 {
-	const auto point = NAS2D::Point<int>{x, y};
+	const auto point = NAS2D::Point{x, y};
 	return checkTubeConnection(tilemap->getTile(point + DirectionEast, tilemap->currentDepth()), DIR_EAST, dir) ||
 		checkTubeConnection(tilemap->getTile(point + DirectionWest, tilemap->currentDepth()), DIR_WEST, dir) ||
 		checkTubeConnection(tilemap->getTile(point + DirectionSouth, tilemap->currentDepth()), DIR_SOUTH, dir) ||
@@ -151,7 +151,7 @@ bool validTubeConnection(TileMap* tilemap, int x, int y, ConnectorDir dir)
  */
 bool validStructurePlacement(TileMap* tilemap, int x, int y)
 {
-	const auto point = NAS2D::Point<int>{x, y};
+	const auto point = NAS2D::Point{x, y};
 	return checkStructurePlacement(tilemap->getTile(point + DirectionNorth, tilemap->currentDepth()), DIR_NORTH) ||
 		checkStructurePlacement(tilemap->getTile(point + DirectionEast, tilemap->currentDepth()), DIR_EAST) ||
 		checkStructurePlacement(tilemap->getTile(point + DirectionSouth, tilemap->currentDepth()), DIR_SOUTH) ||

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 	constexpr auto PlanetRadius = 64;
-	constexpr auto PlanetSize = NAS2D::Vector<int>{PlanetRadius * 2, PlanetRadius * 2};
+	constexpr auto PlanetSize = NAS2D::Vector{PlanetRadius * 2, PlanetRadius * 2};
 }
 
 

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -83,6 +83,6 @@ void Planet::update()
 	}
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto spriteFrameOffset = NAS2D::Point<int>{mTick % 8 * PlanetSize.x, ((mTick % 64) / 8) * PlanetSize.y};
+	const auto spriteFrameOffset = NAS2D::Point{mTick % 8 * PlanetSize.x, ((mTick % 64) / 8) * PlanetSize.y};
 	renderer.drawSubImage(mImage, mPosition.to<float>(), spriteFrameOffset.to<float>(), PlanetSize.to<float>());
 }


### PR DESCRIPTION
Use Class Template Argument Deduction (CTAD) for `Point`, `Vector`, and `Rectangle`, for shorthand construction syntax.
