### PR TITLE
Refactor ListBox::update

### DIFF
--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -284,21 +284,22 @@ void ListBox::update()
 	r.drawBoxFilled(listBounds, NAS2D::Color{0, 85, 0, 220});
 
 	// Highlight currently selected item
-	float itemY = rect().y() + static_cast<float>((mCurrentSelection * mLineHeight) - mCurrentOffset);
-	r.drawBoxFilled(rect().x(), itemY, static_cast<float>(mItemWidth), static_cast<float>(mLineHeight), mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
+	auto itemBounds = listBounds;
+	itemBounds.height() = mLineHeight;
+	itemBounds.y() += (mCurrentSelection * mLineHeight) - mCurrentOffset;
+	r.drawBoxFilled(itemBounds, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
 	
 	// Highlight On mouse Over
 
 	if (mCurrentHighlight != constants::NO_SELECTION)
 	{
-		itemY = rect().y() + static_cast<float>((mCurrentHighlight * mLineHeight) - mCurrentOffset);
-		r.drawBox(rect().x(), itemY, static_cast<float>(mItemWidth), static_cast<float>(mLineHeight), mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue());
+		r.drawBox(itemBounds, mHighlightBg);
 	}
 	
 	// display actuals values that are meant to be
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
-		itemY = rect().y() + (i * mLineHeight) - mCurrentOffset;
+		int itemY = rect().y() + (i * mLineHeight) - mCurrentOffset;
 		if (i == mCurrentHighlight)
 		{
 			r.drawTextShadow(*LST_FONT, mItems[i].Text, rect().x(), itemY, 1, mHighlightText.red(), mHighlightText.green(), mHighlightText.blue(), 0, 0, 0);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -270,8 +270,9 @@ void ListBox::update()
 
 	if (empty())
 	{
-		r.drawBoxFilled(rect(), 0, 0, 0);
-		hasFocus() ? r.drawBox(rect(), 0, 185, 0) : r.drawBox(rect(), 75, 75, 75);
+		r.drawBoxFilled(rect(), NAS2D::Color::Black);
+		const auto boxColor = hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75};
+		r.drawBox(rect(), boxColor);
 		return;
 	}
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -278,8 +278,10 @@ void ListBox::update()
 	r.clipRect(rect().x() - 1, rect().y(), rect().width() + 1, rect().height() + 1);
 
 	// draw boundaries of the widget
-	r.drawBox(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 0, 0, 100);
-	r.drawBoxFilled(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 85, 0, 220);
+	NAS2D::Rectangle<int> listBounds = rect();
+	listBounds.width() = mItemWidth;
+	r.drawBox(listBounds, NAS2D::Color{0, 0, 0, 100});
+	r.drawBoxFilled(listBounds, NAS2D::Color{0, 85, 0, 220});
 
 	// Highlight currently selected item
 	float itemY = rect().y() + static_cast<float>((mCurrentSelection * mLineHeight) - mCurrentOffset);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -300,14 +300,8 @@ void ListBox::update()
 	textPosition.y() -= mCurrentOffset;
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
-		if (i == mCurrentHighlight)
-		{
-			r.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, mHighlightText, NAS2D::Color::Black);
-		}
-		else
-		{
-			r.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, mText, NAS2D::Color::Black);
-		}
+		const auto textColor = (i == mCurrentHighlight) ? mHighlightText : mText;
+		r.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 		textPosition.y() += mLineHeight;
 	}
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -287,7 +287,7 @@ void ListBox::update()
 	// Highlight currently selected item
 	auto itemBounds = listBounds;
 	itemBounds.height() = mLineHeight;
-	itemBounds.y() += (mCurrentSelection * mLineHeight) - mCurrentOffset;
+	itemBounds.y() += static_cast<int>((mCurrentSelection * mLineHeight) - mCurrentOffset);
 	renderer.drawBoxFilled(itemBounds, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
 
 	// Highlight On mouse Over
@@ -298,7 +298,7 @@ void ListBox::update()
 	
 	// display actuals values that are meant to be
 	auto textPosition = listBounds.startPoint();
-	textPosition.y() -= mCurrentOffset;
+	textPosition.y() -= static_cast<int>(mCurrentOffset);
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
 		const auto textColor = (i == mCurrentHighlight) ? mHighlightText : mText;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -296,17 +296,19 @@ void ListBox::update()
 	}
 	
 	// display actuals values that are meant to be
+	auto textPosition = listBounds.startPoint();
+	textPosition.y() -= mCurrentOffset;
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
-		int itemY = rect().y() + (i * mLineHeight) - mCurrentOffset;
 		if (i == mCurrentHighlight)
 		{
-			r.drawTextShadow(*LST_FONT, mItems[i].Text, rect().x(), itemY, 1, mHighlightText.red(), mHighlightText.green(), mHighlightText.blue(), 0, 0, 0);
+			r.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, mHighlightText, NAS2D::Color::Black);
 		}
 		else
 		{
-			r.drawTextShadow(*LST_FONT, mItems[i].Text, rect().x(), itemY, 1, mText.red(), mText.green(), mText.blue(), 0, 0, 0);
+			r.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, mText, NAS2D::Color::Black);
 		}
+		textPosition.y() += mLineHeight;
 	}
 
 	mSlider.update();		// Shouldn't need this since it's in a UIContainer. Noticing that Slider

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -266,34 +266,34 @@ void ListBox::update()
 	// Ignore if menu is empty or invisible
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	if (empty())
 	{
-		r.drawBoxFilled(rect(), NAS2D::Color::Black);
+		renderer.drawBoxFilled(rect(), NAS2D::Color::Black);
 		const auto boxColor = hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75};
-		r.drawBox(rect(), boxColor);
+		renderer.drawBox(rect(), boxColor);
 		return;
 	}
 
-	r.clipRect(rect().x() - 1, rect().y(), rect().width() + 1, rect().height() + 1);
+	renderer.clipRect(rect().x() - 1, rect().y(), rect().width() + 1, rect().height() + 1);
 
 	// draw boundaries of the widget
 	NAS2D::Rectangle<int> listBounds = rect();
 	listBounds.width() = mItemWidth;
-	r.drawBox(listBounds, NAS2D::Color{0, 0, 0, 100});
-	r.drawBoxFilled(listBounds, NAS2D::Color{0, 85, 0, 220});
+	renderer.drawBox(listBounds, NAS2D::Color{0, 0, 0, 100});
+	renderer.drawBoxFilled(listBounds, NAS2D::Color{0, 85, 0, 220});
 
 	// Highlight currently selected item
 	auto itemBounds = listBounds;
 	itemBounds.height() = mLineHeight;
 	itemBounds.y() += (mCurrentSelection * mLineHeight) - mCurrentOffset;
-	r.drawBoxFilled(itemBounds, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
+	renderer.drawBoxFilled(itemBounds, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
 
 	// Highlight On mouse Over
 	if (mCurrentHighlight != constants::NO_SELECTION)
 	{
-		r.drawBox(itemBounds, mHighlightBg);
+		renderer.drawBox(itemBounds, mHighlightBg);
 	}
 	
 	// display actuals values that are meant to be
@@ -302,13 +302,13 @@ void ListBox::update()
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
 		const auto textColor = (i == mCurrentHighlight) ? mHighlightText : mText;
-		r.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+		renderer.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 		textPosition.y() += mLineHeight;
 	}
 
 	mSlider.update();		// Shouldn't need this since it's in a UIContainer. Noticing that Slider
 							// doesn't play nice with the UIContainer.
-	r.clipRectClear();
+	renderer.clipRectClear();
 }
 
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -288,9 +288,8 @@ void ListBox::update()
 	itemBounds.height() = mLineHeight;
 	itemBounds.y() += (mCurrentSelection * mLineHeight) - mCurrentOffset;
 	r.drawBoxFilled(itemBounds, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
-	
-	// Highlight On mouse Over
 
+	// Highlight On mouse Over
 	if (mCurrentHighlight != constants::NO_SELECTION)
 	{
 		r.drawBox(itemBounds, mHighlightBg);


### PR DESCRIPTION
Reference: #217

Refactor `ListBox::update`.

I noticed an odd `clipRect`, which appears to allow drawing outside the bounds of the control:
```cpp
	renderer.clipRect(rect().x() - 1, rect().y(), rect().width() + 1, rect().height() + 1);
```

I think this should actually be:
```cpp
	renderer.clipRect(rect());
```

As that would be a behaviour change, I left it out of the current refactor. I'll followup with an independent PR for that change.
