### PR TITLE
Refactor TextArea::draw

### DIFF
--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -92,12 +92,12 @@ void TextArea::draw()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	if (highlight()) { r.drawBox(rect(), 255, 255, 255); }
+	if (highlight()) { r.drawBox(rect(), NAS2D::Color::White); }
 
 	if (!mFont) { return; }
 	
 	for (size_t i = 0; i < mFormattedList.size() && i < mNumLines; ++i)
 	{
-		r.drawText(*mFont, mFormattedList[i], positionX(), positionY() + (mFont->height() * i), mTextColor.red(), mTextColor.green(), mTextColor.blue(), mTextColor.alpha());
+		r.drawText(*mFont, mFormattedList[i], {positionX(), positionY() + (mFont->height() * i)}, mTextColor);
 	}
 }

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -95,9 +95,11 @@ void TextArea::draw()
 	if (highlight()) { r.drawBox(rect(), NAS2D::Color::White); }
 
 	if (!mFont) { return; }
-	
+
+	auto textPosition = mRect.startPoint().to<int>();
 	for (size_t i = 0; i < mFormattedList.size() && i < mNumLines; ++i)
 	{
-		r.drawText(*mFont, mFormattedList[i], {positionX(), positionY() + (mFont->height() * i)}, mTextColor);
+		r.drawText(*mFont, mFormattedList[i], textPosition, mTextColor);
+		textPosition.y() += mFont->height();
 	}
 }

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -90,16 +90,16 @@ void TextArea::update()
 
 void TextArea::draw()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	if (highlight()) { r.drawBox(rect(), NAS2D::Color::White); }
+	if (highlight()) { renderer.drawBox(rect(), NAS2D::Color::White); }
 
 	if (!mFont) { return; }
 
 	auto textPosition = mRect.startPoint().to<int>();
 	for (size_t i = 0; i < mFormattedList.size() && i < mNumLines; ++i)
 	{
-		r.drawText(*mFont, mFormattedList[i], textPosition, mTextColor);
+		renderer.drawText(*mFont, mFormattedList[i], textPosition, mTextColor);
 		textPosition.y() += mFont->height();
 	}
 }


### PR DESCRIPTION
Reference: #217

Refactor `TextArea::draw` to use packed parameter methods. Explicitly use integer coordinates for text output functions.
