### PR TITLE
Refactor product list box draw item

### DIFF
--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -37,11 +37,9 @@ static void drawItem(Renderer& r, ProductListBox::ProductListBoxItem& item, floa
 	r.drawLine(x + FIRST_STOP, y + 2, x + FIRST_STOP, y + LIST_ITEM_HEIGHT - 2, ITEM_COLOR);
 	r.drawLine(x + SECOND_STOP, y + 2, x + SECOND_STOP, y + LIST_ITEM_HEIGHT - 2, ITEM_COLOR);
 
-	r.drawText(*MAIN_FONT_BOLD, item.Text, x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset,
-		ITEM_COLOR.red(), ITEM_COLOR.green(), ITEM_COLOR.blue(), ITEM_COLOR.alpha());
+	r.drawText(*MAIN_FONT_BOLD, item.Text, {x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, ITEM_COLOR);
 
-	r.drawText(*MAIN_FONT, "Quantity: " + std::to_string(item.count), x + FIRST_STOP + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2),
-		ITEM_COLOR.red(), ITEM_COLOR.green(), ITEM_COLOR.blue(), ITEM_COLOR.alpha());
+	r.drawText(*MAIN_FONT, "Quantity: " + std::to_string(item.count), {x + FIRST_STOP + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2)}, ITEM_COLOR);
 	
 	drawBasicProgressBar(x + static_cast<float>(SECOND_STOP) + 5, y + 10, static_cast<float>(FIRST_STOP) - 10, 10, item.usage, 2);
 }

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -31,12 +31,12 @@ static int SECOND_STOP = 0;
 static void drawItem(Renderer& r, ProductListBox::ProductListBoxItem& item, float x, float y, float w, float offset, bool highlight)
 {
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { r.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, HIGHLIGHT_COLOR.red(), HIGHLIGHT_COLOR.green(), HIGHLIGHT_COLOR.blue(), HIGHLIGHT_COLOR.alpha()); }
+	if (highlight) { r.drawBoxFilled({x, y - offset, w, LIST_ITEM_HEIGHT}, HIGHLIGHT_COLOR); }
 
-	r.drawBox(x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4, ITEM_COLOR.red(), ITEM_COLOR.green(), ITEM_COLOR.blue(), ITEM_COLOR.alpha());
+	r.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, ITEM_COLOR);
 
-	r.drawLine(x + FIRST_STOP, y + 2, x + FIRST_STOP, y + LIST_ITEM_HEIGHT - 2, ITEM_COLOR);
-	r.drawLine(x + SECOND_STOP, y + 2, x + SECOND_STOP, y + LIST_ITEM_HEIGHT - 2, ITEM_COLOR);
+	r.drawLine({x + FIRST_STOP, y + 2}, {x + FIRST_STOP, y + LIST_ITEM_HEIGHT - 2}, ITEM_COLOR);
+	r.drawLine({x + SECOND_STOP, y + 2}, {x + SECOND_STOP, y + LIST_ITEM_HEIGHT - 2}, ITEM_COLOR);
 
 	r.drawText(*MAIN_FONT_BOLD, item.Text, {x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, ITEM_COLOR);
 

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -21,6 +21,7 @@ static Font* MAIN_FONT_BOLD = nullptr;
 
 
 static Color ITEM_COLOR(0, 185, 0, 255);
+static Color HIGHLIGHT_COLOR(0, 185, 0, 75);
 
 
 static int FIRST_STOP = 0;
@@ -30,7 +31,7 @@ static int SECOND_STOP = 0;
 static void drawItem(Renderer& r, ProductListBox::ProductListBoxItem& item, float x, float y, float w, float offset, bool highlight)
 {
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { r.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, ITEM_COLOR.red(), ITEM_COLOR.green(), ITEM_COLOR.blue(), 75); }
+	if (highlight) { r.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, HIGHLIGHT_COLOR.red(), HIGHLIGHT_COLOR.green(), HIGHLIGHT_COLOR.blue(), HIGHLIGHT_COLOR.alpha()); }
 
 	r.drawBox(x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4, ITEM_COLOR.red(), ITEM_COLOR.green(), ITEM_COLOR.blue(), ITEM_COLOR.alpha());
 


### PR DESCRIPTION
Reference: #217

I started on this earlier, but then got distracted. There's more to do, though the current changes stand on their own, so I'm going to submit this much for now.

Cleans up some uses of unpacked `Color` values. Eliminates some of the few remaining uses of `.red()`, etc. If all of them can be removed, then changing `Color` to have public fields will be pretty trivial.
