### PR TITLE
Use full Color compare in buildMouseMap

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -268,11 +268,11 @@ void TileMap::buildMouseMap()
 		for(size_t col = 0; col < TILE_WIDTH; col++)
 		{
 			const Color c = mousemap.pixelColor(static_cast<int>(col), static_cast<int>(row));
-			if (c == NAS2D::Color::Yellow)	{ mMouseMap[row][col] = MMR_BOTTOM_RIGHT; }
-			else if (c == NAS2D::Color::Red)				{ mMouseMap[row][col] = MMR_TOP_LEFT; }
-			else if (c == NAS2D::Color::Blue)				{ mMouseMap[row][col] = MMR_TOP_RIGHT; }
-			else if (c == NAS2D::Color::Green)				{ mMouseMap[row][col] = MMR_BOTTOM_LEFT; }
-			else									{ mMouseMap[row][col] = MMR_MIDDLE; }
+			if (c == NAS2D::Color::Yellow) { mMouseMap[row][col] = MMR_BOTTOM_RIGHT; }
+			else if (c == NAS2D::Color::Red) { mMouseMap[row][col] = MMR_TOP_LEFT; }
+			else if (c == NAS2D::Color::Blue) { mMouseMap[row][col] = MMR_TOP_RIGHT; }
+			else if (c == NAS2D::Color::Green) { mMouseMap[row][col] = MMR_BOTTOM_LEFT; }
+			else { mMouseMap[row][col] = MMR_MIDDLE; }
 		}
 	}
 }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -267,11 +267,11 @@ void TileMap::buildMouseMap()
 	{
 		for(size_t col = 0; col < TILE_WIDTH; col++)
 		{
-			Color c = mousemap.pixelColor(static_cast<int>(col), static_cast<int>(row));
-			if (c.red() == 255 && c.green() == 255)	{ mMouseMap[row][col] = MMR_BOTTOM_RIGHT; }
-			else if (c.red() == 255)				{ mMouseMap[row][col] = MMR_TOP_LEFT; }
-			else if (c.blue() == 255)				{ mMouseMap[row][col] = MMR_TOP_RIGHT; }
-			else if (c.green() == 255)				{ mMouseMap[row][col] = MMR_BOTTOM_LEFT; }
+			const Color c = mousemap.pixelColor(static_cast<int>(col), static_cast<int>(row));
+			if (c == NAS2D::Color::Yellow)	{ mMouseMap[row][col] = MMR_BOTTOM_RIGHT; }
+			else if (c == NAS2D::Color::Red)				{ mMouseMap[row][col] = MMR_TOP_LEFT; }
+			else if (c == NAS2D::Color::Blue)				{ mMouseMap[row][col] = MMR_TOP_RIGHT; }
+			else if (c == NAS2D::Color::Green)				{ mMouseMap[row][col] = MMR_BOTTOM_LEFT; }
 			else									{ mMouseMap[row][col] = MMR_MIDDLE; }
 		}
 	}


### PR DESCRIPTION
Reference: #217

Use full `Color` comparisons in `buildMouseMap`. This is perhaps more fully accurate, and removes references to individual color components.

At this point, there are only about 2 places left in OPHD that reference individual color components from an already packed `Color` struct.
