### PR TITLE
Brace initialization of Color

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -50,20 +50,20 @@ Difficulty DifficultyFromString(std::string difficultyStr)
 std::map<Structure::StructureState, Color> STRUCTURE_COLOR_TABLE
 {
 	{ Structure::UNDER_CONSTRUCTION,	Color{150, 150, 150, 100} },
-	{ Structure::OPERATIONAL,			Color{0, 185, 0, 255} },
+	{ Structure::OPERATIONAL,			Color{0, 185, 0} },
 	{ Structure::IDLE,					Color{0, 185, 0, 100} },
-	{ Structure::DISABLED,				Color{220, 0, 0, 255} },
-	{ Structure::DESTROYED,				Color{220, 0, 0, 255} }
+	{ Structure::DISABLED,				Color{220, 0, 0} },
+	{ Structure::DESTROYED,				Color{220, 0, 0} }
 };
 
 
 std::map<Structure::StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 {
 	{ Structure::UNDER_CONSTRUCTION,	Color{185, 185, 185, 100} },
-	{ Structure::OPERATIONAL,			Color{0, 185, 0, 255} },
+	{ Structure::OPERATIONAL,			Color{0, 185, 0} },
 	{ Structure::IDLE,					Color{0, 185, 0, 100} },
-	{ Structure::DISABLED,				Color{220, 0, 0, 255} },
-	{ Structure::DESTROYED,				Color{220, 0, 0, 255} }
+	{ Structure::DISABLED,				Color{220, 0, 0} },
+	{ Structure::DESTROYED,				Color{220, 0, 0} }
 };
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -49,21 +49,21 @@ Difficulty DifficultyFromString(std::string difficultyStr)
 
 std::map<Structure::StructureState, Color> STRUCTURE_COLOR_TABLE
 {
-	{ Structure::UNDER_CONSTRUCTION,	Color(150, 150, 150, 100) },
-	{ Structure::OPERATIONAL,			Color(0, 185, 0, 255) },
-	{ Structure::IDLE,					Color(0, 185, 0, 100) },
-	{ Structure::DISABLED,				Color(220, 0, 0, 255) },
-	{ Structure::DESTROYED,				Color(220, 0, 0, 255) }
+	{ Structure::UNDER_CONSTRUCTION,	Color{150, 150, 150, 100} },
+	{ Structure::OPERATIONAL,			Color{0, 185, 0, 255} },
+	{ Structure::IDLE,					Color{0, 185, 0, 100} },
+	{ Structure::DISABLED,				Color{220, 0, 0, 255} },
+	{ Structure::DESTROYED,				Color{220, 0, 0, 255} }
 };
 
 
 std::map<Structure::StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 {
-	{ Structure::UNDER_CONSTRUCTION,	Color(185, 185, 185, 100) },
-	{ Structure::OPERATIONAL,			Color(0, 185, 0, 255) },
-	{ Structure::IDLE,					Color(0, 185, 0, 100) },
-	{ Structure::DISABLED,				Color(220, 0, 0, 255) },
-	{ Structure::DESTROYED,				Color(220, 0, 0, 255) }
+	{ Structure::UNDER_CONSTRUCTION,	Color{185, 185, 185, 100} },
+	{ Structure::OPERATIONAL,			Color{0, 185, 0, 255} },
+	{ Structure::IDLE,					Color{0, 185, 0, 100} },
+	{ Structure::DISABLED,				Color{220, 0, 0, 255} },
+	{ Structure::DESTROYED,				Color{220, 0, 0, 255} }
 };
 
 

--- a/OPHD/Constants/UiConstants.h
+++ b/OPHD/Constants/UiConstants.h
@@ -28,8 +28,8 @@ namespace constants
 	const int ROBODOZER_SHEET_ID = 0;
 	const int ROBOMINER_SHEET_ID = 2;
 
-	const NAS2D::Color MINE_COLOR(255, 0, 0, 255);
-	const NAS2D::Color ACTIVE_MINE_COLOR(255, 255, 0, 255);
+	const NAS2D::Color MINE_COLOR = NAS2D::Color::Red;
+	const NAS2D::Color ACTIVE_MINE_COLOR = NAS2D::Color::Yellow;
 
 	// =====================================
 	// = MOUSE POINTERS

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -98,7 +98,7 @@ void Structure::enable()
 	}
 
 	sprite().resume();
-	sprite().color(NAS2D::Color{255, 255, 255, 255});
+	sprite().color(NAS2D::Color::White);
 	state(OPERATIONAL);
 	mDisabledReason = DISABLED_NONE;
 	mIdleReason = IDLE_NONE;

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -20,8 +20,8 @@ static Font* MAIN_FONT = nullptr;
 static Font* MAIN_FONT_BOLD = nullptr;
 
 
-static Color ITEM_COLOR(0, 185, 0, 255);
-static Color HIGHLIGHT_COLOR(0, 185, 0, 75);
+static Color ITEM_COLOR{0, 185, 0, 255};
+static Color HIGHLIGHT_COLOR{0, 185, 0, 75};
 
 
 static int FIRST_STOP = 0;

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -20,7 +20,7 @@ static Font* MAIN_FONT = nullptr;
 static Font* MAIN_FONT_BOLD = nullptr;
 
 
-static Color ITEM_COLOR{0, 185, 0, 255};
+static Color ITEM_COLOR{0, 185, 0};
 static Color HIGHLIGHT_COLOR{0, 185, 0, 75};
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -554,7 +554,7 @@ void FactoryReport::cboFilterByProductSelectionChanged()
  */
 void FactoryReport::drawDetailPane(Renderer& renderer)
 {
-	NAS2D::Color defaultTextColor(0, 185, 0);
+	NAS2D::Color defaultTextColor{0, 185, 0};
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	renderer.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -182,7 +182,7 @@ void FactoryReport::init()
 
 	txtProductDescription.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	txtProductDescription.height(128);
-	txtProductDescription.textColor(NAS2D::Color{0, 185, 0, 255});
+	txtProductDescription.textColor(NAS2D::Color{0, 185, 0});
 	txtProductDescription.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
 
 	SORT_BY_PRODUCT_POSITION = cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() - FONT->width("Filter by Product");

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -44,9 +44,9 @@ std::map<ResourceTrend, Point<float>> ICON_SLICE
 
 std::map<ResourceTrend, Color> TEXT_COLOR
 {
-	{ RESOURCE_TREND_NONE,	Color(255, 255, 255, 255) },
-	{ RESOURCE_TREND_UP,	Color(0, 185, 0, 255) },
-	{ RESOURCE_TREND_DOWN,	Color(255, 0, 0, 255) }
+	{ RESOURCE_TREND_NONE,	Color{255, 255, 255, 255} },
+	{ RESOURCE_TREND_UP,	Color{0, 185, 0, 255} },
+	{ RESOURCE_TREND_DOWN,	Color{255, 0, 0, 255} }
 };
 
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -44,9 +44,9 @@ std::map<ResourceTrend, Point<float>> ICON_SLICE
 
 std::map<ResourceTrend, Color> TEXT_COLOR
 {
-	{ RESOURCE_TREND_NONE,	Color{255, 255, 255} },
+	{ RESOURCE_TREND_NONE,	Color::White },
 	{ RESOURCE_TREND_UP,	Color{0, 185, 0} },
-	{ RESOURCE_TREND_DOWN,	Color{255, 0, 0} }
+	{ RESOURCE_TREND_DOWN,	Color::Red }
 };
 
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -44,9 +44,9 @@ std::map<ResourceTrend, Point<float>> ICON_SLICE
 
 std::map<ResourceTrend, Color> TEXT_COLOR
 {
-	{ RESOURCE_TREND_NONE,	Color{255, 255, 255, 255} },
-	{ RESOURCE_TREND_UP,	Color{0, 185, 0, 255} },
-	{ RESOURCE_TREND_DOWN,	Color{255, 0, 0, 255} }
+	{ RESOURCE_TREND_NONE,	Color{255, 255, 255} },
+	{ RESOURCE_TREND_UP,	Color{0, 185, 0} },
+	{ RESOURCE_TREND_DOWN,	Color{255, 0, 0} }
 };
 
 


### PR DESCRIPTION
Use brace initialization of `Color` objects.

Remove explicit full alpha channels, and use named color constants where possible.
