### PR TITLE
C26439 move constructor/assignment must not throw: declare noexcept

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -6,7 +6,7 @@
 #include "Tile.h"
 
 
-Tile::Tile(Tile&& other) :
+Tile::Tile(Tile&& other) noexcept :
 	mIndex{other.mIndex},
 	mX{other.mX},
 	mY{other.mY},
@@ -22,7 +22,7 @@ Tile::Tile(Tile&& other) :
 }
 
 
-Tile& Tile::operator=(Tile&& other)
+Tile& Tile::operator=(Tile&& other) noexcept
 {
 	mIndex = other.mIndex;
 	mX = other.mX;

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -18,8 +18,8 @@ public:
 	Tile() = default;
 	Tile(const Tile& other) = delete;
 	Tile& operator=(const Tile& other) = delete;
-	Tile(Tile&& other);
-	Tile& operator=(Tile&& other);
+	Tile(Tile&& other) noexcept;
+	Tile& operator=(Tile&& other) noexcept;
 	~Tile();
 
 	int index() const { return mIndex; }


### PR DESCRIPTION
Reference: #320
Split from #370.

Declares `Tile`'s move constructor and move assignment operator as `noexcept`.
