### PR TITLE
C26459 Uninitialized member variable.

### DIFF
--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -79,7 +79,7 @@ private:
 
 	ValueChangedCallback	mCallback;					/*!< Callback executed when the value is changed. */
 
-	SliderType				mSliderType;				/*!< Type of the Slider. */
+	SliderType				mSliderType{SliderType::SLIDER_VERTICAL};				/*!< Type of the Slider. */
 	
 	// mouse event related vars
 	NAS2D::Point<int>			mMousePosition;				/**< Mouse coordinates. */


### PR DESCRIPTION
Reference: #320
Split from PR #370

Always initialize member variables.

- `Slider::mSliderType`
