### PR TITLE
Add `std::` prefix to `std::size_t`

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -233,13 +233,13 @@ const std::string& productDescription(ProductType type)
 {
 	if (type == ProductType::PRODUCT_NONE) { return constants::NONE; }
 
-	return PRODUCT_DESCRIPTION_TABLE[static_cast<size_t>(type)];
+	return PRODUCT_DESCRIPTION_TABLE[static_cast<std::size_t>(type)];
 }
 
 
 ProductType productTypeFromDescription(const std::string& description)
 {
-	for (size_t i = 0; i < PRODUCT_DESCRIPTION_TABLE.size(); ++i)
+	for (std::size_t i = 0; i < PRODUCT_DESCRIPTION_TABLE.size(); ++i)
 	{
 		if (PRODUCT_DESCRIPTION_TABLE[i] == description)
 		{
@@ -264,13 +264,13 @@ const std::string& idleReason(IdleReason _i)
 }
 
 
-Color& structureColorFromIndex(size_t index)
+Color& structureColorFromIndex(std::size_t index)
 {
 	return STRUCTURE_COLOR_TABLE[static_cast<Structure::StructureState>(index)];
 }
 
 
-Color& structureTextColorFromIndex(size_t index)
+Color& structureTextColorFromIndex(std::size_t index)
 {
 	return STRUCTURE_TEXT_COLOR_TABLE[static_cast<Structure::StructureState>(index)];
 }

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -325,7 +325,7 @@ const std::string& idleReason(IdleReason);
  */
 void drawBasicProgressBar(float x, float y, float width, float height, float percent, float padding = 4.0f);
 
-NAS2D::Color& structureColorFromIndex(size_t);
-NAS2D::Color& structureTextColorFromIndex(size_t);
+NAS2D::Color& structureColorFromIndex(std::size_t);
+NAS2D::Color& structureTextColorFromIndex(std::size_t);
 
 bool windowMaximized();

--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -44,7 +44,7 @@ public:
 	 * \warning	The pointer returned by font() is owned by FontManager. Do not dispose of the
 	 *			pointer manually.
 	 */
-	NAS2D::Font* font(const std::string& name, size_t size)
+	NAS2D::Font* font(const std::string& name, std::size_t size)
 	{
 		auto it = mFontTable.find(FontId(name, size));
 		if (it != mFontTable.end())
@@ -60,7 +60,7 @@ public:
 	}
 
 private:
-	typedef std::pair<std::string, size_t> FontId;
+	typedef std::pair<std::string, std::size_t> FontId;
 	typedef std::map<FontId, NAS2D::Font*> FontTable;
 
 private:

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -161,11 +161,11 @@ void TileMap::buildTerrainMap(const std::string& path)
 
 	Image heightmap(path + MAP_TERRAIN_EXTENSION);
 
-	mTileMap.resize(static_cast<size_t>(mMaxDepth) + 1);
+	mTileMap.resize(static_cast<std::size_t>(mMaxDepth) + 1);
 	for(int level = 0; level <= mMaxDepth; level++)
 	{
 		mTileMap[level].resize(height());
-		for (size_t i = 0; i < mTileMap[level].size(); i++)
+		for (std::size_t i = 0; i < mTileMap[level].size(); i++)
 		{
 			mTileMap[level][i].resize(width());
 		}
@@ -258,14 +258,14 @@ void TileMap::buildMouseMap()
 	}
 	
 	mMouseMap.resize(TILE_HEIGHT_ABSOLUTE);
-	for (size_t i = 0; i < mMouseMap.size(); i++)
+	for (std::size_t i = 0; i < mMouseMap.size(); i++)
 	{
 		mMouseMap[i].resize(TILE_WIDTH);
 	}
 
-	for(size_t row = 0; row < TILE_HEIGHT_ABSOLUTE; row++)
+	for(std::size_t row = 0; row < TILE_HEIGHT_ABSOLUTE; row++)
 	{
-		for(size_t col = 0; col < TILE_WIDTH; col++)
+		for(std::size_t col = 0; col < TILE_WIDTH; col++)
 		{
 			const Color c = mousemap.pixelColor(static_cast<int>(col), static_cast<int>(row));
 			if (c == NAS2D::Color::Yellow) { mMouseMap[row][col] = MouseMapRegion::MMR_BOTTOM_RIGHT; }
@@ -466,7 +466,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 	XmlElement *mines = new XmlElement("mines");
 	element->linkEndChild(mines);
 
-	for (size_t i = 0; i < mMineLocations.size(); ++i)
+	for (std::size_t i = 0; i < mMineLocations.size(); ++i)
 	{
 		XmlElement *mine = new XmlElement("mine");
 		mine->attribute("x", mMineLocations[i].x());

--- a/OPHD/MicroPather/micropather.cpp
+++ b/OPHD/MicroPather/micropather.cpp
@@ -334,7 +334,7 @@ unsigned PathNodePool::Hash(void* voidval)
 	const unsigned char *p = (unsigned char *)(&val);
 	unsigned int h = 2166136261;
 
-	for( size_t i=0; i<sizeof(MP_UPTR); ++i, ++p ) {
+	for( std::size_t i=0; i<sizeof(MP_UPTR); ++i, ++p ) {
 		h ^= *p;
 		h *= 16777619;
 	}

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -11,10 +11,10 @@ using namespace NAS2D::Xml;
 /**
  * Helper function that gets the total amount of ore 
  */
-static int getOreCount(const Mine::MineVeins& veins, Mine::OreType ore, size_t depth)
+static int getOreCount(const Mine::MineVeins& veins, Mine::OreType ore, std::size_t depth)
 {
 	int _value = 0;
-	for (size_t i = 0; i < depth; ++i)
+	for (std::size_t i = 0; i < depth; ++i)
 	{
 		_value += veins[i][ore];
 	}
@@ -270,7 +270,7 @@ int Mine::pull(OreType type, int quantity)
 {
 	int pulled_count = 0, to_pull = quantity;
 
-	for (size_t i = 0; i < mVeins.size(); ++i)
+	for (std::size_t i = 0; i < mVeins.size(); ++i)
 	{
 		MineVein& vein = mVeins[i];
 
@@ -305,7 +305,7 @@ void Mine::serialize(NAS2D::Xml::XmlElement* element)
 	element->attribute("yield", productionRate());
 	element->attribute("flags", mFlags.to_string());
 
-	for (size_t i = 0; i < mVeins.size(); ++i)
+	for (std::size_t i = 0; i < mVeins.size(); ++i)
 	{
 		const MineVein& mv = mVeins[i];
 

--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -104,7 +104,7 @@ void Population::addPopulation(PersonRole role, uint32_t count)
 int Population::size()
 {
 	uint32_t count = 0;
-	for (size_t i = 0; i < mPopulation.size(); ++i)
+	for (std::size_t i = 0; i < mPopulation.size(); ++i)
 	{
 		count += mPopulation[i];
 	}

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -52,7 +52,7 @@ static int computeCurrentStorage(const ProductPool::ProductTypeCount& products)
 {
 	int stored = 0;
 
-	for (size_t i = 0; i < static_cast<size_t>(ProductType::PRODUCT_COUNT); ++i)
+	for (std::size_t i = 0; i < static_cast<std::size_t>(ProductType::PRODUCT_COUNT); ++i)
 	{
 		stored +=storageRequired(static_cast<ProductType>(i), products[i]);
 	}

--- a/OPHD/ResourcePool.cpp
+++ b/OPHD/ResourcePool.cpp
@@ -154,7 +154,7 @@ void ResourcePool::food(int amount) { resource(ResourceType::RESOURCE_FOOD, amou
 int ResourcePool::currentLevel() const
 {
 	int cc = 0;
-	for (size_t i = 0; i < ResourceType::RESOURCE_COUNT; ++i)
+	for (std::size_t i = 0; i < ResourceType::RESOURCE_COUNT; ++i)
 	{
 		ResourceType _rt = static_cast<ResourceType>(i);
 		if (_rt != ResourceType::RESOURCE_ENERGY && _rt != ResourceType::RESOURCE_FOOD)

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -923,7 +923,7 @@ void MapViewState::placeRobot()
 			mMineOperationsWindow.hide();
 			mTileMap->removeMineLocation(mTileMap->tileMouseHover());
 			tile->pushMine(nullptr);
-			for (size_t i = 0; i <= static_cast<size_t>(mTileMap->maxDepth()); ++i)
+			for (std::size_t i = 0; i <= static_cast<std::size_t>(mTileMap->maxDepth()); ++i)
 			{
 				Tile* _t = mTileMap->getTile(mTileMap->tileMouseHover(), static_cast<int>(i));
 
@@ -975,7 +975,7 @@ void MapViewState::placeRobot()
 			Utility<StructureManager>::get().removeStructure(_s);
 			tile->deleteThing();
 			Utility<StructureManager>::get().disconnectAll();
-			static_cast<Robodozer*>(r)->tileIndex(static_cast<size_t>(TerrainType::TERRAIN_DOZED));
+			static_cast<Robodozer*>(r)->tileIndex(static_cast<std::size_t>(TerrainType::TERRAIN_DOZED));
 			checkConnectedness();
 		}
 		else if (tile->index() == TerrainType::TERRAIN_DOZED)
@@ -986,7 +986,7 @@ void MapViewState::placeRobot()
 
 		r->startTask(tile->index());
 		mRobotPool.insertRobotIntoTable(mRobotList, r, tile);
-		static_cast<Robodozer*>(r)->tileIndex(static_cast<size_t>(tile->index()));
+		static_cast<Robodozer*>(r)->tileIndex(static_cast<std::size_t>(tile->index()));
 		tile->index(TerrainType::TERRAIN_DOZED);
 
 		if(!mRobotPool.robotAvailable(RobotType::ROBOT_DOZER))

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -194,7 +194,7 @@ bool validLanderSite(Tile* tile)
 int totalStorage(StructureList& sl)
 {
 	int storage = 0;
-	for (size_t i = 0; i < sl.size(); ++i)
+	for (std::size_t i = 0; i < sl.size(); ++i)
 	{
 		if (sl[i]->operational())
 		{
@@ -284,7 +284,7 @@ void updateRobotControl(RobotPool& robotPool)
 	uint32_t _maxRobots = 0;
 	if (CommandCenter.size() > 0) { _maxRobots += 3; }
 	// the 10 per robot command facility
-	for (size_t s = 0; s < RobotCommand.size(); ++s)
+	for (std::size_t s = 0; s < RobotCommand.size(); ++s)
 	{
 		if (RobotCommand[s]->operational()) { _maxRobots += 10; }
 	}
@@ -354,7 +354,7 @@ bool outOfCommRange(Point<int>& cc_location, TileMap* tile_map, Tile* current_ti
  * \return	Returns a pointer to a Warehouse structure or \c nullptr if
  *			there are no warehouses available with the required space.
  */
-Warehouse* getAvailableWarehouse(ProductType type, size_t count)
+Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
 {
 	for (auto _st : Utility<StructureManager>::get().structureList(Structure::StructureClass::CLASS_WAREHOUSE))
 	{
@@ -402,7 +402,7 @@ void transferProductsPool(ProductPool& source, ProductPool& destination)
 
 	auto& src = source.mProducts;
 
-	for (size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
+	for (std::size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
 	{
 		if (destination.availableStorage() == 0) { return; }
 

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -35,7 +35,7 @@ bool selfSustained(StructureID id);
 
 int totalStorage(StructureList& sl);
 
-Warehouse* getAvailableWarehouse(ProductType type, size_t count);
+Warehouse* getAvailableWarehouse(ProductType type, std::size_t count);
 RobotCommand* getAvailableRobotCommand();
 
 bool simulateMoveProducts(Warehouse*);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -431,10 +431,10 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 
 				const RobotList& rl = mRobotPool.robots();
 
-				for (size_t i = 0; i < rl_str.size(); ++i)
+				for (std::size_t i = 0; i < rl_str.size(); ++i)
 				{
 					int _rid = std::stoi(rl_str[i]);
-					for (size_t ri = 0; ri < rl.size(); ++ri)
+					for (std::size_t ri = 0; ri < rl.size(); ++ri)
 					{
 						if (rl[ri]->id() == _rid)
 						{

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -58,7 +58,7 @@ void MapViewState::updatePopulation()
 		remainder -= pullFood(mPlayerResources, remainder);
 	}
 
-	for (size_t i = 0; i < foodproducers.size(); ++i)
+	for (std::size_t i = 0; i < foodproducers.size(); ++i)
 	{
 		if (remainder <= 0) { break; }
 
@@ -115,7 +115,7 @@ void MapViewState::updateCommercial()
 	}
 
 	auto _comm_r_it = _commercial.rbegin();
-	for (size_t i = 0; i < static_cast<size_t>(luxuryCount) && _comm_r_it != _commercial.rend(); ++i, ++_comm_r_it)
+	for (std::size_t i = 0; i < static_cast<std::size_t>(luxuryCount) && _comm_r_it != _commercial.rend(); ++i, ++_comm_r_it)
 	{
 		if ((*_comm_r_it)->operational())
 		{

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -53,7 +53,7 @@ private:
 	NAS2D::Image	mSheet;
 	NAS2D::Timer	mTimer;
 
-	size_t			mFrame = 0;
+	std::size_t			mFrame = 0;
 };
 
 
@@ -161,7 +161,7 @@ State* PlanetSelectState::update()
 
 	drawStar(-40, -55);
 
-	for (size_t i = 0; i < mPlanets.size(); ++i)
+	for (std::size_t i = 0; i < mPlanets.size(); ++i)
 	{
 		mPlanets[i]->update();
 	}
@@ -237,7 +237,7 @@ State* PlanetSelectState::update()
 
 void PlanetSelectState::onMouseDown(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
 {
-	for (size_t i = 0; i < mPlanets.size(); ++i)
+	for (std::size_t i = 0; i < mPlanets.size(); ++i)
 	{
 		if (mPlanets[i]->mouseHovering())
 		{
@@ -261,7 +261,7 @@ void PlanetSelectState::onMousePlanetEnter()
 {
 	Utility<Mixer>::get().playSound(mHover);
 
-	for (size_t i = 0; i < mPlanets.size(); ++i)
+	for (std::size_t i = 0; i < mPlanets.size(); ++i)
 	{
 		// FIXME: Ugly, will be difficult to maintain in the future.
 		if (mPlanets[i]->mouseHovering())

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -285,7 +285,7 @@ void StructureCatalogue::buildCostTable()
  */
 void StructureCatalogue::buildRecycleValueTable()
 {
-	for (size_t i = 0; i < StructureID::SID_COUNT; ++i)
+	for (std::size_t i = 0; i < StructureID::SID_COUNT; ++i)
 	{
 		mStructureRecycleValueTable[static_cast<StructureID>(i)] = recycleValue(static_cast<StructureID>(i), DEFAULT_RECYCLE_VALUE);
 	}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -129,7 +129,7 @@ void StructureManager::updateStructures(ResourcePool& resourcePool, PopulationPo
 	PopulationRequirements* _populationAvailable = nullptr;
 
 	Structure* structure = nullptr;
-	for (size_t i = 0; i < sl.size(); ++i)
+	for (std::size_t i = 0; i < sl.size(); ++i)
 	{
 		structure = sl[i];
 		structure->update();
@@ -213,7 +213,7 @@ void StructureManager::updateFactoryProduction()
 {
 	StructureList& sl = mStructureLists[Structure::StructureClass::CLASS_FACTORY];
 
-	for (size_t i = 0; i < sl.size(); ++i)
+	for (std::size_t i = 0; i < sl.size(); ++i)
 	{
 		static_cast<Factory*>(sl[i])->updateProduction();
 	}
@@ -266,7 +266,7 @@ void StructureManager::removeStructure(Structure* st)
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
 
-	for (size_t i = 0; i < sl.size(); ++i)
+	for (std::size_t i = 0; i < sl.size(); ++i)
 	{
 		if (sl[i] == st)
 		{
@@ -321,7 +321,7 @@ int StructureManager::count() const
 int StructureManager::getCountInState(Structure::StructureClass st, Structure::StructureState state)
 {
 	int count = 0;
-	for (size_t i = 0; i < structureList(st).size(); ++i)
+	for (std::size_t i = 0; i < structureList(st).size(); ++i)
 	{
 		if (structureList(st)[i]->state() == state)
 		{
@@ -464,7 +464,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 			const RobotList& rl = static_cast<RobotCommand*>(it->first)->robots();
 
 			std::stringstream str;
-			for (size_t i = 0; i < rl.size(); ++i)
+			for (std::size_t i = 0; i < rl.size(); ++i)
 			{
 				str << rl[i]->id();
 				if (i != rl.size() - 1) { str << ","; }	// kind of a kludge

--- a/OPHD/Templates.h
+++ b/OPHD/Templates.h
@@ -19,7 +19,7 @@ void transferProductsStructure(T& source, T& destination)
 	auto& src = source->products().mProducts;
 	auto& dest = destination->products();
 
-	for (size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
+	for (std::size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
 	{
 		if (dest.availableStorage() == 0) { return; }
 

--- a/OPHD/Things/Robots/Robodozer.h
+++ b/OPHD/Things/Robots/Robodozer.h
@@ -12,11 +12,11 @@ public:
 		sprite().play("running");
 	}
 
-	void tileIndex(size_t index) { mTileIndex = index; }
-	size_t tileIndex() const { return mTileIndex; }
+	void tileIndex(std::size_t index) { mTileIndex = index; }
+	std::size_t tileIndex() const { return mTileIndex; }
 
 	void update() override { updateTask(); }
 
 private:
-	size_t mTileIndex = 0;
+	std::size_t mTileIndex = 0;
 };

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -85,7 +85,7 @@ bool Button::toggled() const
 }
 
 
-void Button::fontSize(size_t size)
+void Button::fontSize(std::size_t size)
 {
 	mFont = Utility<FontManager>::get().font(constants::FONT_PRIMARY, size);
 }

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -30,7 +30,7 @@ public:
 	void toggle(bool toggle);
 	bool toggled() const;
 
-	void fontSize(size_t);
+	void fontSize(std::size_t);
 
 	void image(const std::string& path);
 	bool hasImage() const;

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -72,7 +72,7 @@ void ListBoxBase::_update_item_display()
 {
 	mItemWidth = static_cast<unsigned int>(width());
 
-	if ((mItemHeight * mItems.size()) > static_cast<size_t>(height()))
+	if ((mItemHeight * mItems.size()) > static_cast<std::size_t>(height()))
 	{
 		mLineCount = static_cast<int>(height() / mItemHeight);
 
@@ -125,7 +125,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	// A few basic checks
 	if (!rect().contains(mMousePosition) || mCurrentHighlight == constants::NO_SELECTION) { return; }
 	if (mSlider.visible() && mSlider.rect().contains(Point{x, y})) { return; }
-	if (static_cast<size_t>(mCurrentHighlight) >= mItems.size()) { return; }
+	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size()) { return; }
 
 	setSelection(mCurrentHighlight);
 }
@@ -156,7 +156,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 
 	mCurrentHighlight = (y - static_cast<int>(positionY()) + mCurrentOffset) / mItemHeight;
 
-	if (static_cast<size_t>(mCurrentHighlight) >= mItems.size())
+	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 	}
@@ -238,7 +238,7 @@ void ListBoxBase::clearItems()
 /**
  * Number of items in the ListBoxBase.
  */
-size_t ListBoxBase::count() const
+std::size_t ListBoxBase::count() const
 {
 	return mItems.size();
 }

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -55,7 +55,7 @@ public:
 	void removeItem(ListBoxItem*);
 	void clearItems();
 
-	size_t count() const;
+	std::size_t count() const;
 	bool empty() const;
 
 	unsigned int currentHighlight() const;

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -13,7 +13,7 @@
 using namespace NAS2D;
 
 
-void TextArea::font(const std::string& font, size_t size)
+void TextArea::font(const std::string& font, std::size_t size)
 {
 	mFont = Utility<FontManager>::get().font(font, size);
 }
@@ -27,7 +27,7 @@ void TextArea::processString()
 
 	StringList tokenList = split_string(text().c_str(), ' ');
 	
-	size_t w = 0, i = 0;
+	std::size_t w = 0, i = 0;
 	while (i < tokenList.size())
 	{
 		std::string line;
@@ -59,7 +59,7 @@ void TextArea::processString()
 		mFormattedList.push_back(line);
 	}
 
-	mNumLines = static_cast<size_t>(height() / mFont->height());
+	mNumLines = static_cast<std::size_t>(height() / mFont->height());
 }
 
 
@@ -97,7 +97,7 @@ void TextArea::draw()
 	if (!mFont) { return; }
 
 	auto textPosition = mRect.startPoint().to<int>();
-	for (size_t i = 0; i < mFormattedList.size() && i < mNumLines; ++i)
+	for (std::size_t i = 0; i < mFormattedList.size() && i < mNumLines; ++i)
 	{
 		renderer.drawText(*mFont, mFormattedList[i], textPosition, mTextColor);
 		textPosition.y() += mFont->height();

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -15,7 +15,7 @@ public:
 
 	void textColor(const NAS2D::Color& color) { mTextColor = color; }
 
-	void font(const std::string&, size_t);
+	void font(const std::string&, std::size_t);
 
 	void update() override;
 
@@ -31,7 +31,7 @@ private:
 	void processString();
 
 private:
-	size_t		mNumLines = 0;
+	std::size_t		mNumLines = 0;
 
 	StringList	mFormattedList;
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -97,7 +97,7 @@ void TextField::numbers_only(bool _b)
  * 
  * \note	Calling this with \c 0 will clear character limit.
  */
-void TextField::maxCharacters(size_t count)
+void TextField::maxCharacters(std::size_t count)
 {
 	mMaxCharacters = count;
 }
@@ -192,7 +192,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		case EventHandler::KeyCode::KEY_RIGHT:
-			if(static_cast<size_t>(mCursorPosition) < text().length())
+			if(static_cast<std::size_t>(mCursorPosition) < text().length())
 				++mCursorPosition;
 			break;
 
@@ -203,7 +203,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		case EventHandler::KeyCode::KEY_KP6:
-			if((static_cast<size_t>(mCursorPosition) < text().length()) && !Utility<EventHandler>::get().query_numlock())
+			if((static_cast<std::size_t>(mCursorPosition) < text().length()) && !Utility<EventHandler>::get().query_numlock())
 				++mCursorPosition;
 			break;
 
@@ -241,7 +241,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 
 	// Figure out where the click occured within the visible string.
 	int i = 0;
-	while(static_cast<size_t>(i) <= text().size() - mScrollOffset)
+	while(static_cast<std::size_t>(i) <= text().size() - mScrollOffset)
 	{
 		std::string cmpStr = text().substr(mScrollOffset, i);
 		int strLen = TXT_FONT->width(cmpStr);

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -50,7 +50,7 @@ public:
 	void resetCursorPosition();
 	void numbers_only(bool);
 
-	void maxCharacters(size_t count);
+	void maxCharacters(std::size_t count);
 
 	void update() override;
 
@@ -74,7 +74,7 @@ private:
 	int 				mCursorX = 0;					/**< Pixel position of the Cursor. */
 	int 				mScrollOffset = 0;				/**< Scroller offset. */
 
-	size_t				mMaxCharacters = 0;				/**< Max number of characters allowed in the text field. */
+	std::size_t				mMaxCharacters = 0;				/**< Max number of characters allowed in the text field. */
 
 	BorderVisibility	mBorderVisibility = BorderVisibility::FOCUS_ONLY;	/**< Border visibility flag. */
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -126,7 +126,7 @@ void FactoryListBox::removeItem(Factory* factory)
 void FactoryListBox::currentSelection(Factory* f)
 {
 	if (mItems.empty() || f == nullptr) { return; }
-	for (size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems[i]);
 		if (item->factory == f)
@@ -157,7 +157,7 @@ void FactoryListBox::update()
 	r.clipRect(rect());
 
 	// ITEMS
-	for (size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		drawItem(r, *static_cast<FactoryListBoxItem*>(mItems[i]),
 			positionX(),

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -196,7 +196,7 @@ void FactoryProduction::factory(Factory* newFactory)
 		throw std::runtime_error("FactoryProduction::factory(): Factory provided with an empty production type list.");
 	}
 
-	for (size_t i = 0; i < ptlist.size(); ++i)
+	for (std::size_t i = 0; i < ptlist.size(); ++i)
 	{
 		mProductGrid.addItem(productDescription(ptlist[i]), ptlist[i], ptlist[i]);
 	}

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -124,7 +124,7 @@ void FileIo::scanDirectory(const std::string& directory)
 
 	mListBox.dropAllItems();
 
-	for (size_t i = 0; i < dirList.size(); ++i)
+	for (std::size_t i = 0; i < dirList.size(); ++i)
 	{
 		if (!f.isDirectory(directory + dirList[i]))
 		{

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -113,7 +113,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	mCurrentSelection = translateCoordsToIndex(mousePoint - startPoint);
 
-	if (static_cast<size_t>(mCurrentSelection) >= mIconItemList.size())
+	if (static_cast<std::size_t>(mCurrentSelection) >= mIconItemList.size())
 	{
 		mCurrentSelection = constants::NO_SELECTION;
 	}
@@ -146,7 +146,7 @@ void IconGrid::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 	// Assumes all coordinates are not negative.
 	mHighlightIndex = translateCoordsToIndex(mousePoint - startPoint);
 
-	if (static_cast<size_t>(mHighlightIndex) >= mIconItemList.size())
+	if (static_cast<std::size_t>(mHighlightIndex) >= mIconItemList.size())
 	{
 		mHighlightIndex = constants::NO_SELECTION;
 	}
@@ -291,7 +291,7 @@ bool IconGrid::itemExists(const std::string& item)
 		return false;
 	}
 
-	for (size_t i = 0; i < mIconItemList.size(); i++)
+	for (std::size_t i = 0; i < mIconItemList.size(); i++)
 	{
 		if (toLowercase(mIconItemList[i].name) == toLowercase(item))
 		{
@@ -328,7 +328,7 @@ void IconGrid::clearSelection()
  */
 void IconGrid::selection(int newSelection)
 {
-	if (static_cast<size_t>(newSelection) >= mIconItemList.size())
+	if (static_cast<std::size_t>(newSelection) >= mIconItemList.size())
 		return;
 
 	mCurrentSelection = newSelection;
@@ -348,7 +348,7 @@ void IconGrid::selection(int newSelection)
  */
 void IconGrid::selection_meta(int selectionMetaValue)
 {
-	for (size_t i = 0; i < mIconItemList.size(); ++i)
+	for (std::size_t i = 0; i < mIconItemList.size(); ++i)
 	{
 		if (mIconItemList[i].meta == selectionMetaValue)
 		{
@@ -363,7 +363,7 @@ void IconGrid::incrementSelection()
 {
 	++mCurrentSelection;
 
-	if (static_cast<size_t>(mCurrentSelection) >= mIconItemList.size())
+	if (static_cast<std::size_t>(mCurrentSelection) >= mIconItemList.size())
 		mCurrentSelection = 0;
 
 	raiseChangedEvent();
@@ -421,7 +421,7 @@ void IconGrid::update()
 
 	if (mIconItemList.empty()) { return; }
 
-	for (size_t i = 0; i < mIconItemList.size(); ++i)
+	for (std::size_t i = 0; i < mIconItemList.size(); ++i)
 	{
 		int x_pos = static_cast<int>(i) % mGridSize.x;
 		int y_pos = static_cast<int>(i) / mGridSize.x; //-V537

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -73,7 +73,7 @@ void ProductListBox::productPool(ProductPool& pool)
 {
 	clearItems();
 
-	for (size_t product_type = 0; product_type < static_cast<size_t>(ProductType::PRODUCT_COUNT); ++product_type)
+	for (std::size_t product_type = 0; product_type < static_cast<std::size_t>(ProductType::PRODUCT_COUNT); ++product_type)
 	{
 		if (pool.count(static_cast<ProductType>(product_type)) > 0)
 		{
@@ -105,7 +105,7 @@ void ProductListBox::update()
 	FIRST_STOP = static_cast<int>(item_width() * 0.33f);
 	SECOND_STOP = static_cast<int>(item_width() * 0.66f);
 
-	for (size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		drawItem(r, *static_cast<ProductListBoxItem*>(mItems[i]),
 			positionX(),

--- a/OPHD/UI/ProductListBox.h
+++ b/OPHD/UI/ProductListBox.h
@@ -16,7 +16,7 @@ public:
 		ProductListBoxItem() = default;
 
 	public:
-		size_t count = 0;				/**< Count of the product. */
+		std::size_t count = 0;				/**< Count of the product. */
 		float usage = 0.0f;				/**< Usage of available capacity. */
 	};
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -114,7 +114,7 @@ void StructureListBox::currentSelection(Structure* structure)
 {
 	if (mItems.empty() || structure == nullptr) { return; }
 
-	for (size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		StructureListBoxItem* item = static_cast<StructureListBoxItem*>(mItems[i]);
 		if (item->structure == structure)
@@ -154,7 +154,7 @@ void StructureListBox::update()
 	r.clipRect(rect());
 
 	// ITEMS
-	for (size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		drawItem(r, *static_cast<StructureListBoxItem*>(mItems[i]),
 			positionX(),

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -24,7 +24,7 @@ public:
 	public:
 		Structure* structure = nullptr;	/**< Pointer to a Structure. */
 		std::string structureState;		/**< String description of the state of a Structure. */
-		size_t colorIndex = 0;			/**< Index to use from the listbox color table. */
+		std::size_t colorIndex = 0;			/**< Index to use from the listbox color table. */
 	};
 
 public:


### PR DESCRIPTION
Global Search/Replace:
- `size_t` => `std::size_t` (will double the prefix on already prefixed names)
- `std::std::size_t` => `std::size_t` (remove doubled prefixes)

Noticed in: https://github.com/OutpostUniverse/OPHD/pull/368#pullrequestreview-391286022
