### PR TITLE
Linux release package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ commands:
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror"
       - run: make package
+      - store_artifacts:
+          path: .build/package/
 
 jobs:
   build-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ commands:
       - run: git submodule update --init
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror"
+      - run: make package
 
 jobs:
   build-linux:

--- a/makefile
+++ b/makefile
@@ -9,6 +9,10 @@ NAS2DINCLUDEDIR := $(NAS2DDIR)
 NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
+# Determine OS (Linux, Darwin, ...)
+CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
+TARGET_OS ?= $(CURRENT_OS)
+
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ NAS2DDIR := nas2d-core/
 NAS2DINCLUDEDIR := $(NAS2DDIR)
 NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
+PACKAGEDIR := $(BUILDDIR)/package/
 
 # Determine OS (Linux, Darwin, ...)
 CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
@@ -56,6 +57,19 @@ $(OBJDIR)%.d: ;
 .PRECIOUS: $(OBJDIR)%.d
 
 include $(wildcard $(patsubst $(SRCDIR)%.cpp,$(OBJDIR)%.d,$(SRCS)))
+
+
+VERSION = $(shell git describe --tags --dirty)
+CONFIG = $(TARGET_OS).x64
+PACKAGE_NAME = $(PACKAGEDIR)ophd-$(VERSION)-$(CONFIG).tar.gz
+
+.PHONY: package
+package: $(PACKAGE_NAME)
+
+$(PACKAGE_NAME): $(EXE)
+	@mkdir -p "$(PACKAGEDIR)"
+	tar -czf $(PACKAGE_NAME) $(EXE)
+
 
 .PHONY: clean clean-all
 clean:


### PR DESCRIPTION
Add `makefile` rule to build a release `package`:
```
make package
```

Archive is tagged with the most recent git tag, plus modifiers to indicate additional commits or dirty (uncommitted) changes. A different submodule counts as a dirty change. The archive is also tagged with the build configuration, such as target OS and architecture.

Examples:
```
ophd-v0.7.11-Linux.x64.tar.gz
ophd-v0.7.11-1111-g444a8ce-Linux.x64.tar.gz
ophd-v0.7.11-1111-g444a8ce-dirty-Linux.x64.tar.gz
```
- `ophd` - base package name
- `v0.7.11` - most recent git tag (version)
- `-1111-g444a8ce` - (optional) marks recent commits since tag
  - 1111 additional commits since tag, ending at `g`it tag `444a8ce`
- `-dirty` - (optional) marks local uncommitted modifications
- `Linux.x64` - build config (target OS, and architecture)

----

Have CI build a release package, and store it as a build artifact.

----

Linux build config change.

----

Related:
- Issue #601
- PR #523
