### PR TITLE
Convert `typedef` declarations to `using` aliases

### DIFF
--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -290,7 +290,7 @@ enum ProductType
 using PopulationRequirements = std::array<int, 2>;
 
 class Robot;
-typedef std::vector<Robot*> RobotList;
+using RobotList = std::vector<Robot*>;
 
 extern std::map<int, std::string> TILE_INDEX_TRANSLATION;
 extern std::map<MineProductionRate, std::string> MINE_YIELD_TRANSLATION;

--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -60,8 +60,8 @@ public:
 	}
 
 private:
-	typedef std::pair<std::string, std::size_t> FontId;
-	typedef std::map<FontId, NAS2D::Font*> FontTable;
+	using FontId = std::pair<std::string, std::size_t>;
+	using FontTable = std::map<FontId, NAS2D::Font*>;
 
 private:
 	FontTable	mFontTable;

--- a/OPHD/MicroPather/micropather.h
+++ b/OPHD/MicroPather/micropather.h
@@ -66,14 +66,14 @@ distribution.
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 )
 	#include <stdlib.h>
-	typedef uintptr_t		MP_UPTR;
+	using MP_UPTR = uintptr_t;
 #elif defined (__GNUC__) && (__GNUC__ >= 3 )
 	#include <stdint.h>
 	#include <stdlib.h>
-	typedef uintptr_t		MP_UPTR;
+	using MP_UPTR = uintptr_t;
 #else
 	// Assume not 64 bit pointers. Get a new compiler.
-	typedef std::size_t MP_UPTR;
+	using MP_UPTR = std::size_t;
 #endif
 
 namespace micropather

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -21,8 +21,8 @@ public:
 		ORE_RARE_MINERALS,
 	};
 
-	typedef std::array<int, 4> MineVein;
-	typedef std::vector<MineVein> MineVeins;
+	using MineVein = std::array<int, 4>;
+	using MineVeins = std::vector<MineVein>;
 
 public:
 	Mine();

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -53,8 +53,8 @@ private:
 	uint32_t consume_food(uint32_t _food);
 
 private:
-	typedef std::array<uint32_t, 5>		PopulationTable;
-	typedef std::array<MoraleModifier, 5> MoraleModifiers;
+	using PopulationTable = std::array<uint32_t, 5>	;
+	using MoraleModifiers = std::array<MoraleModifier, 5>;
 
 private:
 	uint32_t			mBirthCount;				/**<  */

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -12,7 +12,7 @@
 class ProductPool
 {
 public:
-	typedef std::array<int, ProductType::PRODUCT_COUNT>	ProductTypeCount;
+	using ProductTypeCount = std::array<int, ProductType::PRODUCT_COUNT>;
 
 public:
 	ProductPool() = default;

--- a/OPHD/ResourcePool.h
+++ b/OPHD/ResourcePool.h
@@ -108,7 +108,7 @@ public:
 	Callback& resourceObserver() { return _observerCallback; }
 
 private:
-	typedef std::array<int, ResourceType::RESOURCE_COUNT> ResourceTable;
+	using ResourceTable = std::array<int, ResourceType::RESOURCE_COUNT>;
 
 private:
 	int					_capacity = 0;			/**< Maximum available capacity of the ResourcePool. */

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -8,10 +8,10 @@
 class RobotPool
 {
 public:
-	typedef std::vector<Robodigger*> DiggerList;
-	typedef std::vector<Robodozer*> DozerList;
-	typedef std::vector<Robominer*> MinerList;
-	typedef std::map<Robot*, Tile*> RobotTileTable;
+	using DiggerList = std::vector<Robodigger*>;
+	using DozerList = std::vector<Robodozer*>;
+	using MinerList = std::vector<Robominer*>;
+	using RobotTileTable = std::map<Robot*, Tile*>;
 
 public:
 	RobotPool();

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -15,7 +15,7 @@
 #include "../Map/TileMap.h"
 
 
-typedef std::map<Robot*, Tile*> RobotTileTable;
+using RobotTileTable = std::map<Robot*, Tile*>;
 
 class Warehouse;	/**< Forward declaration for getAvailableWarehouse() function. */
 class RobotCommand;	/**< Forward declaration for getAvailableRobotCommand() function. */

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -26,7 +26,7 @@ protected:
 	State* update() override;
 
 private:
-	typedef std::vector<Planet*> PlanetPtrList;
+	using PlanetPtrList = std::vector<Planet*>;
 
 private:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);

--- a/OPHD/States/Wrapper.h
+++ b/OPHD/States/Wrapper.h
@@ -56,4 +56,4 @@ private:
 };
 
 
-typedef std::stack<Wrapper*> WrapperStack;
+using WrapperStack = std::stack<Wrapper*>;

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -45,8 +45,8 @@ public:
 protected:
 
 private:
-	typedef std::map<Structure*, Tile*> StructureTileTable;
-	typedef std::map<Structure::StructureClass, StructureList> StructureClassTable;
+	using StructureTileTable = std::map<Structure*, Tile*>;
+	using StructureClassTable = std::map<Structure::StructureClass, StructureList>;
 
 private:
 	void updateStructures(ResourcePool& resourcePool, PopulationPool& popPool, StructureList& sl);

--- a/OPHD/Things/Robots/Robot.h
+++ b/OPHD/Things/Robots/Robot.h
@@ -6,8 +6,8 @@
 class Robot: public Thing
 {
 public:
-	typedef NAS2D::Signals::Signal<> Callback;
-	typedef NAS2D::Signals::Signal<Robot*> TaskCallback;
+	using Callback = NAS2D::Signals::Signal<>;
+	using TaskCallback = NAS2D::Signals::Signal<Robot*>;
 
 public:
 	Robot(const std::string& name, const std::string& sprite_path);

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -9,7 +9,7 @@ class CargoLander : public Structure
 {
 public:
 
-	typedef NAS2D::Signals::Signal<> Callback;
+	using Callback = NAS2D::Signals::Signal<>;
 
 	CargoLander(Tile* t) : Structure(constants::CARGO_LANDER, "structures/lander_0.sprite", StructureClass::CLASS_LANDER), mTile(t)
 	{

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -8,7 +8,7 @@
 class ColonistLander : public Structure
 {
 public:
-	typedef NAS2D::Signals::Signal<> Callback;
+	using Callback = NAS2D::Signals::Signal<>;
 
 public:
 

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -5,7 +5,7 @@
 
 #include "Factory.h"
 
-typedef std::map<ProductType, ProductionCost> ProductionTypeTable;
+using ProductionTypeTable = std::map<ProductType, ProductionCost>;
 
 
 /**

--- a/OPHD/Things/Structures/Factory.h
+++ b/OPHD/Things/Structures/Factory.h
@@ -22,9 +22,9 @@ class Factory : public Structure
 {
 public:
 	// Callback providing what was complete and a reference to the Factory.
-	typedef NAS2D::Signals::Signal<Factory&> ProductionCallback;
+	using ProductionCallback = NAS2D::Signals::Signal<Factory&>;
 
-	typedef std::vector<ProductType> ProductionTypeList;
+	using ProductionTypeList = std::vector<ProductType>;
 
 public:
 	Factory(const std::string& name, const std::string& spritePath);

--- a/OPHD/Things/Structures/MineFacility.h
+++ b/OPHD/Things/Structures/MineFacility.h
@@ -10,7 +10,7 @@
 class MineFacility: public Structure
 {
 public:
-	typedef NAS2D::Signals::Signal<MineFacility*> ExtensionCompleteCallback;
+	using ExtensionCompleteCallback = NAS2D::Signals::Signal<MineFacility*>;
 public:
 	MineFacility(Mine* mine);
 

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -6,7 +6,7 @@
 class SeedLander: public Structure
 {
 public:
-	typedef NAS2D::Signals::Signal<int, int> Callback;
+	using Callback = NAS2D::Signals::Signal<int, int>;
 
 public:
 	SeedLander() = delete;

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -14,7 +14,7 @@ class Tile;
 class Thing
 {
 public:
-	typedef NAS2D::Signals::Signal<Thing*> DieCallback;
+	using DieCallback = NAS2D::Signals::Signal<Thing*>;
 
 public:
 	Thing(const std::string& name, const std::string& spritePath) :

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -19,7 +19,7 @@ public:
 	};
 
 public:
-	typedef NAS2D::Signals::Signal<> ClickCallback;
+	using ClickCallback = NAS2D::Signals::Signal<>;
 
 public:
 	Button(std::string newText = "");

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -11,7 +11,7 @@
 class CheckBox : public Control
 {
 public:
-	typedef NAS2D::Signals::Signal<> ClickCallback;
+	using ClickCallback = NAS2D::Signals::Signal<>;
 
 public:
 	CheckBox(std::string newText = "");

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -16,9 +16,9 @@
 class Control
 {
 public:
-	typedef NAS2D::Signals::Signal<Control*> ResizeCallback;
-	typedef NAS2D::Signals::Signal<Control*> TextChangedCallback;
-	typedef NAS2D::Signals::Signal<float, float> PositionChangedCallback;
+	using ResizeCallback = NAS2D::Signals::Signal<Control*>;
+	using TextChangedCallback = NAS2D::Signals::Signal<Control*>;
+	using PositionChangedCallback = NAS2D::Signals::Signal<float, float>;
 
 public:
 	Control() = default;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -20,7 +20,7 @@
 class ListBox: public UIContainer
 {
 public:
-	typedef NAS2D::Signals::Signal<> SelectionChangedCallback;
+	using SelectionChangedCallback = NAS2D::Signals::Signal<>;
 
 	struct ListBoxItem
 	{

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -14,7 +14,7 @@ class UIContainer;
 class RadioButton : public Control
 {
 public:
-	typedef NAS2D::Signals::Signal<> ClickCallback;
+	using ClickCallback = NAS2D::Signals::Signal<>;
 
 public:
 	RadioButton(std::string newText = "");

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -32,7 +32,7 @@ public:
 		SLIDER_HORIZONTAL	/*!< Horizontal slider. */
 	};
 
-	typedef NAS2D::Signals::Signal<float> ValueChangedCallback; /*!< type for Callback on value changed. */
+	using ValueChangedCallback = NAS2D::Signals::Signal<float>; /*!< type for Callback on value changed. */
 
 public:
 	Slider();

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -20,7 +20,7 @@ public:
 	void update() override;
 
 private:
-	typedef std::vector<std::string> StringList;
+	using StringList = std::vector<std::string>;
 
 private:
 	void onSizeChanged() override;

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -19,7 +19,7 @@ public:
 		SEL_WEST
 	};
 
-	typedef NAS2D::Signals::Signal<DiggerSelection, Tile*> Callback;
+	using Callback = NAS2D::Signals::Signal<DiggerSelection, Tile*>;
 
 public:
 	DiggerDirection();

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -15,7 +15,7 @@ public:
 		FILE_SAVE
 	};
 
-	typedef NAS2D::Signals::Signal<const std::string&, FileOperation> FileOperationCallback;
+	using FileOperationCallback = NAS2D::Signals::Signal<const std::string&, FileOperation>;
 
 public:
 	FileIo();

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -5,7 +5,7 @@
 class GameOptionsDialog : public Window
 {
 public:
-	typedef NAS2D::Signals::Signal<> ClickCallback;
+	using ClickCallback = NAS2D::Signals::Signal<>;
 
 public:
 	GameOptionsDialog();

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -5,7 +5,7 @@
 class GameOverDialog : public Window
 {
 public:
-	typedef NAS2D::Signals::Signal<> ClickCallback;
+	using ClickCallback = NAS2D::Signals::Signal<>;
 
 public:
 	GameOverDialog();

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -42,7 +42,7 @@ public:
 		NAS2D::Point<float> pos;
 	};
 
-	typedef NAS2D::Signals::Signal<const IconGridItem*> Callback;
+	using Callback = NAS2D::Signals::Signal<const IconGridItem*>;
 
 public:
 	IconGrid();
@@ -97,8 +97,8 @@ protected:
 	virtual void sizeChanged();
 
 private:
-	typedef std::vector<IconGridItem> IconItemList;
-	typedef IconItemList::size_type Index;
+	using IconItemList = std::vector<IconGridItem>;
+	using Index = IconItemList::size_type;
 
 private:
 	void updateGrid();


### PR DESCRIPTION
The newer `using` alias syntax is generally easier to read than the old `typedef` syntax. A corresponding update has already been made to NAS2D.

References:
https://github.com/lairworks/nas2d-core/issues/316
https://github.com/lairworks/nas2d-core/issues/338
https://github.com/lairworks/nas2d-core/pull/323
https://github.com/lairworks/nas2d-core/pull/342
