### PR TITLE
Use packed parameter methods

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -252,7 +252,7 @@ void TileMap::buildMouseMap()
 	Image mousemap("ui/mouse_map.png");
 
 	// More sanity checks (mousemap should match dimensions of tile)
-	if (mousemap.width() != TILE_WIDTH || mousemap.height() != TILE_HEIGHT_ABSOLUTE)
+	if (mousemap.size() != Vector{TILE_WIDTH, TILE_HEIGHT_ABSOLUTE})
 	{
 		throw std::runtime_error("Mouse map is the wrong dimensions.");
 	}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -114,7 +114,7 @@ TileMap::TileMap(const std::string& map_path, const std::string& tset_path, int 
 	std::cout << "Loading '" << map_path << "'... ";
 	buildTerrainMap(map_path);
 	buildMouseMap();
-	initMapDrawParams(Utility<Renderer>::get().width(), Utility<Renderer>::get().height());
+	initMapDrawParams(Utility<Renderer>::get().size());
 
 	if (_s) { setupMines(_mc, hostility); }
 	std::cout << "finished!" << std::endl;
@@ -281,13 +281,13 @@ void TileMap::buildMouseMap()
 /**
  * Sets up position and drawing parememters for the tile map.
  */
-void TileMap::initMapDrawParams(int w, int h)
+void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 {
 	// Set up map draw position
-	mEdgeLength = w / TILE_WIDTH;
+	mEdgeLength = size.x / TILE_WIDTH;
 
-	mMapPosition = {static_cast<float>(w / 2 - (TILE_WIDTH / 2)), ((h - constants::BOTTOM_UI_HEIGHT) / 2) - ((static_cast<float>(mEdgeLength) / 2) * TILE_HEIGHT_ABSOLUTE)};
-	mMapBoundingBox = {(w / 2) - ((TILE_WIDTH * mEdgeLength) / 2), static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
+	mMapPosition = {static_cast<float>(size.x / 2 - (TILE_WIDTH / 2)), ((size.y - constants::BOTTOM_UI_HEIGHT) / 2) - ((static_cast<float>(mEdgeLength) / 2) * TILE_HEIGHT_ABSOLUTE)};
+	mMapBoundingBox = {(size.x / 2) - ((TILE_WIDTH * mEdgeLength) / 2), static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 
 	int transform = (mMapPosition.x() - mMapBoundingBox.x()) / TILE_WIDTH;
 	TRANSFORM = {-transform, transform};

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -75,7 +75,7 @@ public:
 	void injectMouse(int x, int y);
 	void injectMouse(NAS2D::Point<int> position) { mMousePosition = position; }
 
-	void initMapDrawParams(int, int);
+	void initMapDrawParams(NAS2D::Vector<int>);
 	
 	void draw();
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -329,7 +329,7 @@ NAS2D::State* MainMenuState::update()
 	Renderer& r = Utility<Renderer>::get();
 
 	r.clearScreen(0, 0, 0);
-	r.drawImage(mBgImage, r.center_x() - mBgImage.width() / 2, r.center_y() - mBgImage.height() / 2);
+	r.drawImage(mBgImage, r.center() - mBgImage.size() / 2);
 
 
 	if (!mFileIoDialog.visible() && !dlgOptions.visible())

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -313,7 +313,7 @@ void MapViewState::onActivate(bool /*newActiveValue*/)
 void MapViewState::onWindowResized(int w, int h)
 {
 	setupUiPositions(w, h);
-	mTileMap->initMapDrawParams(w, h);
+	mTileMap->initMapDrawParams({w, h});
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -149,7 +149,7 @@ void MapViewState::initialize()
 
 	r.setCursor(PointerType::POINTER_NORMAL);
 
-	setupUiPositions(r.width(), r.height());
+	setupUiPositions(r.size());
 
 	mPlayerResources.capacity(constants::BASE_STORAGE_CAPACITY);
 
@@ -312,7 +312,7 @@ void MapViewState::onActivate(bool /*newActiveValue*/)
  */
 void MapViewState::onWindowResized(int w, int h)
 {
-	setupUiPositions(w, h);
+	setupUiPositions({w, h});
 	mTileMap->initMapDrawParams({w, h});
 }
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -168,7 +168,7 @@ private:
 	void initUi();
 	void resetUi();
 
-	void setupUiPositions(int, int);
+	void setupUiPositions(NAS2D::Vector<int> size);
 
 	void checkRobotSelectionInterface(const std::string& rType, int sheetIndex, RobotType);
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -49,7 +49,7 @@ void MapViewState::save(const std::string& filePath)
 {
 	Renderer& r = Utility<Renderer>::get();
 	r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0, 100);
-	r.drawImage(*IMG_SAVING, r.center_x() - (IMG_SAVING->width() / 2), r.center_y() - (IMG_SAVING->height() / 2));
+	r.drawImage(*IMG_SAVING, r.center() - IMG_SAVING->size() / 2);
 	r.update();
 
 	XmlDocument doc;
@@ -101,7 +101,7 @@ void MapViewState::load(const std::string& filePath)
 
 	Renderer& r = Utility<Renderer>::get();
 	r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0, 100);
-	r.drawImage(*IMG_LOADING, r.center_x() - (IMG_LOADING->width() / 2), r.center_y() - (IMG_LOADING->height() / 2));
+	r.drawImage(*IMG_LOADING, r.center() - IMG_LOADING->size() / 2);
 	r.update();
 
 	mBtnToggleConnectedness.toggle(false);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -285,7 +285,7 @@ std::vector<void*> path;
 void MapViewState::nextTurn()
 {
 	NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
-	r.drawImage(*IMG_PROCESSING_TURN, r.center_x() - (IMG_PROCESSING_TURN->width() / 2), r.center_y() - (IMG_PROCESSING_TURN->height() / 2));
+	r.drawImage(*IMG_PROCESSING_TURN, r.center() - IMG_PROCESSING_TURN->size() / 2);
 	r.update();
 
 	clearMode();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -170,19 +170,19 @@ void MapViewState::initUi()
 }
 
 
-void MapViewState::setupUiPositions(int w, int h)
+void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 {
 	//NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI Area
-	BOTTOM_UI_AREA = {0, static_cast<int>(h - constants::BOTTOM_UI_HEIGHT), static_cast<int>(w), constants::BOTTOM_UI_HEIGHT};
+	BOTTOM_UI_AREA = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
 
 	// Menu / System Icon
-	MENU_ICON = {w - constants::MARGIN_TIGHT * 2 - constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2};
+	MENU_ICON = {size.x - constants::MARGIN_TIGHT * 2 - constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2};
 
 	// NAVIGATION BUTTONS
 	// Bottom line
-	MOVE_DOWN_ICON = {w - constants::MARGIN - 32, h - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
+	MOVE_DOWN_ICON = {size.x - constants::MARGIN - 32, size.y - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
 	MOVE_EAST_ICON = {MOVE_DOWN_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16};
 	MOVE_SOUTH_ICON = {MOVE_DOWN_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16};
 
@@ -192,10 +192,10 @@ void MapViewState::setupUiPositions(int w, int h)
 	MOVE_WEST_ICON = {MOVE_UP_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16};
 
 	// Mini Map
-	mMiniMapBoundingBox = {static_cast<int>(w - 300 - constants::MARGIN), static_cast<int>(BOTTOM_UI_AREA.y() + constants::MARGIN), 300, 150};
+	mMiniMapBoundingBox = {size.x - 300 - constants::MARGIN, static_cast<int>(BOTTOM_UI_AREA.y() + constants::MARGIN), 300, 150};
 
 	// Position UI Buttons
-	mBtnTurns.position(static_cast<float>(mMiniMapBoundingBox.x() - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT), static_cast<float>(h - constants::MARGIN - MAIN_BUTTON_SIZE));
+	mBtnTurns.position(static_cast<float>(mMiniMapBoundingBox.x() - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT), static_cast<float>(size.y - constants::MARGIN - MAIN_BUTTON_SIZE));
 	mBtnToggleHeightmap.position(mBtnTurns.positionX(), static_cast<float>(mMiniMapBoundingBox.y()));
 	mBtnToggleConnectedness.position(mBtnTurns.positionX(), static_cast<float>(mMiniMapBoundingBox.y() + constants::MAIN_BUTTON_SIZE + constants::MARGIN_TIGHT));
 
@@ -213,7 +213,7 @@ void MapViewState::setupUiPositions(int w, int h)
 	mAnnouncement.position(static_cast<float>(centerWindowWidth(mAnnouncement.width())), centerWindowHeight(mAnnouncement.height()) - 100.0f);
 	mGameOptionsDialog.position(static_cast<float>(centerWindowWidth(mGameOptionsDialog.width())), centerWindowHeight(mGameOptionsDialog.height()) - 100.0f);
 
-	mDiggerDirection.position(static_cast<float>(centerWindowWidth(mDiggerDirection.width())), static_cast<int>(h / 2.0f) - 125.0f);
+	mDiggerDirection.position(static_cast<float>(centerWindowWidth(mDiggerDirection.width())), static_cast<int>(size.y / 2.0f) - 125.0f);
 
 	mWarehouseInspector.position(static_cast<float>(centerWindowWidth(mWarehouseInspector.width())), centerWindowHeight(mWarehouseInspector.height()) - 100.0f);
 	mMineOperationsWindow.position(static_cast<float>(centerWindowWidth(mMineOperationsWindow.width())), centerWindowHeight(mMineOperationsWindow.height()) - 100.0f);

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -183,14 +183,15 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	// NAVIGATION BUTTONS
 	// Bottom line
-	MOVE_DOWN_ICON = {size.x - constants::MARGIN - 32, size.y - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
-	MOVE_EAST_ICON = {MOVE_DOWN_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16};
-	MOVE_SOUTH_ICON = {MOVE_DOWN_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16};
+	const auto navIconSpacing = 32 + constants::MARGIN_TIGHT;
+	MOVE_DOWN_ICON = {size.x - navIconSpacing, size.y - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
+	MOVE_EAST_ICON = {MOVE_DOWN_ICON.x() - navIconSpacing, MOVE_DOWN_ICON.y() + 8, 32, 16};
+	MOVE_SOUTH_ICON = {MOVE_DOWN_ICON.x() - 2 * navIconSpacing, MOVE_DOWN_ICON.y() + 8, 32, 16};
 
 	// Top line
-	MOVE_UP_ICON = {MOVE_DOWN_ICON.x(), MOVE_DOWN_ICON.y() - constants::MARGIN_TIGHT - 32, 32, 32};
-	MOVE_NORTH_ICON = {MOVE_UP_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16};
-	MOVE_WEST_ICON = {MOVE_UP_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16};
+	MOVE_UP_ICON = {MOVE_DOWN_ICON.x(), MOVE_DOWN_ICON.y() - navIconSpacing, 32, 32};
+	MOVE_NORTH_ICON = {MOVE_UP_ICON.x() - navIconSpacing, MOVE_UP_ICON.y() + 8, 32, 16};
+	MOVE_WEST_ICON = {MOVE_UP_ICON.x() - 2 * navIconSpacing, MOVE_UP_ICON.y() + 8, 32, 16};
 
 	// Mini Map
 	mMiniMapBoundingBox = {size.x - 300 - constants::MARGIN, static_cast<int>(BOTTOM_UI_AREA.y() + constants::MARGIN), 300, 150};

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -178,7 +178,8 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	BOTTOM_UI_AREA = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
 
 	// Menu / System Icon
-	MENU_ICON = {size.x - constants::MARGIN_TIGHT * 2 - constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2};
+	const auto menuIconSpacing = constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2;
+	MENU_ICON = {size.x - menuIconSpacing, 0, menuIconSpacing, menuIconSpacing};
 
 	// NAVIGATION BUTTONS
 	// Bottom line

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -121,7 +121,7 @@ NAS2D::State* SplashState::update()
 	}
 	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD)
 	{
-		unsigned int tick = BYLINE_TIMER.delta();
+		const unsigned int tick = BYLINE_TIMER.delta();
 		const auto logoPosition = r.center() - mLogoOutpostHd.size() / 2 - NAS2D::Vector{100, 0};
 
 		r.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -113,11 +113,7 @@ NAS2D::State* SplashState::update()
 
 	if (CURRENT_STATE == LogoState::LOGO_LAIRWORKS)
 	{
-		// Trunctation of fractional part of result is intentional
-		// to prevent fuzzy images due to texture filtering
-		int logoX = static_cast<int>(r.center_x() - mLogoLairworks.width() / 2);
-		int logoY = static_cast<int>(r.center_y() - mLogoLairworks.height() / 2);
-		r.drawImage(mLogoLairworks, static_cast<float>(logoX), static_cast<float>(logoY));
+		r.drawImage(mLogoLairworks, r.center() - mLogoLairworks.size() / 2);
 	}
 	if (CURRENT_STATE == LogoState::LOGO_NAS2D)
 	{

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -122,14 +122,10 @@ NAS2D::State* SplashState::update()
 	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD)
 	{
 		unsigned int tick = BYLINE_TIMER.delta();
-		
-		// Trunctation of fractional part of result is intentional
-		// to prevent fuzzy images due to texture filtering
-		int _x = static_cast<int>(r.center_x() - (mLogoOutpostHd.width() / 2)) - 100;
-		int _y = static_cast<int>(r.center_y() - (mLogoOutpostHd.height() / 2));
-		
-		r.drawImageRotated(mFlare, static_cast<float>(_x) + 302 - 512, static_cast<float>(_y) + 241 - 512, BYLINE_TIMER.tick() / 600.0f);
-		r.drawImage(mLogoOutpostHd, static_cast<float>(_x), static_cast<float>(_y));
+		const auto logoPosition = r.center() - mLogoOutpostHd.size() / 2 - NAS2D::Vector{100, 0};
+
+		r.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);
+		r.drawImage(mLogoOutpostHd, logoPosition);
 
 		BYLINE_SCALE += tick * BYLINE_SCALE_STEP;
 		BYLINE_ALPHA += tick * BYLINE_ALPHA_FADE_STEP;

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -117,12 +117,7 @@ NAS2D::State* SplashState::update()
 	}
 	if (CURRENT_STATE == LogoState::LOGO_NAS2D)
 	{
-
-		// Trunctation of fractional part of result is intentional
-		// to prevent fuzzy images due to texture filtering
-		int logoX = static_cast<int>(r.center_x() - mLogoNas2d.width() / 2);
-		int logoY = static_cast<int>(r.center_y() - mLogoNas2d.height() / 2);
-		r.drawImage(mLogoNas2d, static_cast<float>(logoX), static_cast<float>(logoY));
+		r.drawImage(mLogoNas2d, r.center() - mLogoNas2d.size() / 2);
 	}
 	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD)
 	{


### PR DESCRIPTION
Reference: #217

Use packed parameter methods where it makes sense to do so.

This covers a bit with `TileMap`, and many of the uses of `Image` sizes. This does not attempt to cover `Control` sizing or positioning, which still lacks packed parameter methods.
