### PR TITLE
Add Label::textSize and Label::autoSize

### DIFF
--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -16,14 +16,14 @@ Label::Label(std::string newText)
 {
 	text(newText);
 	TXT_FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	height(static_cast<float>(TXT_FONT->height() + FIELD_PADDING * 2));
+	size(textSize() + NAS2D::Vector{0, FIELD_PADDING * 2});
 }
 
 
 void Label::font(NAS2D::Font* font)
 {
 	TXT_FONT = font;
-	height(static_cast<float>(TXT_FONT->height() + FIELD_PADDING * 2));
+	size(textSize() + NAS2D::Vector{0, FIELD_PADDING * 2});
 }
 
 

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -16,6 +16,12 @@ Label::Label(std::string newText)
 {
 	text(newText);
 	TXT_FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	autoSize();
+}
+
+
+void Label::autoSize()
+{
 	size(textSize() + NAS2D::Vector{0, FIELD_PADDING * 2});
 }
 
@@ -23,7 +29,7 @@ Label::Label(std::string newText)
 void Label::font(NAS2D::Font* font)
 {
 	TXT_FONT = font;
-	size(textSize() + NAS2D::Vector{0, FIELD_PADDING * 2});
+	autoSize();
 }
 
 

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -44,7 +44,7 @@ void Label::color(const NAS2D::Color& color)
 }
 
 
-int Label::width() const
+int Label::textWidth() const
 {
 	return TXT_FONT->width(text());
 }

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -48,3 +48,8 @@ int Label::textWidth() const
 {
 	return TXT_FONT->width(text());
 }
+
+NAS2D::Vector<int> Label::textSize() const
+{
+	return {TXT_FONT->width(text()), TXT_FONT->height()};
+}

--- a/OPHD/UI/Core/Label.h
+++ b/OPHD/UI/Core/Label.h
@@ -31,7 +31,7 @@ public:
 	void clear() { _text().clear(); }
 	void update() override;
 
-	int width() const;
+	int textWidth() const;
 
 	void color(const NAS2D::Color& color);
 

--- a/OPHD/UI/Core/Label.h
+++ b/OPHD/UI/Core/Label.h
@@ -32,6 +32,7 @@ public:
 	void update() override;
 
 	int textWidth() const;
+	NAS2D::Vector<int> textSize() const;
 
 	void color(const NAS2D::Color& color);
 

--- a/OPHD/UI/Core/Label.h
+++ b/OPHD/UI/Core/Label.h
@@ -26,6 +26,7 @@ class Label : public Control
 public:
 	Label(std::string newText = "");
 
+	void autoSize();
 	void font(NAS2D::Font* font);
 	bool empty() const { return text().empty(); }
 	void clear() { _text().clear(); }


### PR DESCRIPTION
Add `Label::textSize()` and `Label::autoSize()` to easily determine text size and to resize a `Label` to match the current text size.
