### PR TITLE
Label adjustments

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -133,8 +133,7 @@ void MainMenuState::positionButtons()
 	dlgOptions.position(center - dlgOptions.size() / 2);
 	dlgNewGame.position(center - dlgNewGame.size() / 2);
 
-	Font* tiny_font = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	lblVersion.position(r.width() - tiny_font->width(constants::VERSION) - 5, r.height() - tiny_font->height() - 5);
+	lblVersion.position(NAS2D::Point{0, 0} + r.size() - lblVersion.size());
 }
 
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -93,9 +93,7 @@ void MainMenuState::initialize()
 	dlgOptions.hide();
 
 	Font* tiny_font = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
 	lblVersion.font(tiny_font);
-	lblVersion.position(r.width() - lblVersion.width() - 5, r.height() - lblVersion.height() - 5);
 	lblVersion.color(NAS2D::Color::White);
 
 	positionButtons();
@@ -218,9 +216,6 @@ void MainMenuState::onKeyDown(NAS2D::EventHandler::KeyCode /*key*/, NAS2D::Event
 void MainMenuState::onWindowResized(int /*width*/, int /*height*/)
 {
 	positionButtons();
-
-	auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
-	lblVersion.position(r.width() - lblVersion.width() - 5, r.height() - lblVersion.height() - 5);
 }
 
 

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -8,7 +8,7 @@
 
 #include "NAS2D/Utility.h"
 
-static const int FIELD_PADDING = 4;
+static const int FIELD_PADDING = 2;
 static NAS2D::Font* TXT_FONT = nullptr;
 
 

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -39,8 +39,8 @@ void Label::update()
 
 	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const auto textPosition = mRect.startPoint().to<int>();
-	renderer.drawText(*TXT_FONT, text(), textPosition + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING}, textColor);
+	const auto textPosition = mRect.startPoint().to<int>() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING};
+	renderer.drawText(*TXT_FONT, text(), textPosition, textColor);
 }
 
 

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -22,7 +22,7 @@ Label::Label(std::string newText)
 
 void Label::autoSize()
 {
-	size(textSize() + NAS2D::Vector{0, FIELD_PADDING * 2});
+	size(textSize() + NAS2D::Vector{FIELD_PADDING * 2, FIELD_PADDING * 2});
 }
 
 


### PR DESCRIPTION
Use symmetric padding around `Label` text, and update how the version text is positioned on the main menu screen, making use of natural `Label` sizing.
