### PR TITLE
Control text protected

### DIFF
--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -265,16 +265,3 @@ Control::TextChangedCallback& Control::textChanged()
 {
 	return mTextChanged;
 }
-
-
-/**
- * Internal version of the text() function which allows
- * non-const access to the text contained in the Control.
- * 
- * \note	This is an internal function and may not be
- *			called outside of the Control class.
- */
-std::string& Control::_text()
-{
-	return mText;
-}

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -247,12 +247,3 @@ void Control::text(const std::string& text)
 	mText = text;
 	onTextChanged();
 }
-
-
-/**
- * Gets callback for text changed events.
- */
-Control::TextChangedCallback& Control::textChanged()
-{
-	return mTextChanged;
-}

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -250,15 +250,6 @@ void Control::text(const std::string& text)
 
 
 /**
- * Gets the text of the Control.
- */
-const std::string& Control::text() const
-{
-	return mText;
-}
-
-
-/**
  * Gets callback for text changed events.
  */
 Control::TextChangedCallback& Control::textChanged()

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -100,7 +100,7 @@ protected:
 private:
 	virtual void draw() {}
 
-private:
+protected:
 	std::string				mText;				/**< Internal text string. */
 
 	bool					mEnabled = true;	/**< Flag indicating whether or not the Control is enabled. */

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -52,7 +52,7 @@ public:
 
 	void text(const std::string& text);
 	const std::string& text() const { return mText; }
-	TextChangedCallback& textChanged();
+	TextChangedCallback& textChanged() { return mTextChanged; }
 
 	NAS2D::Vector<float> size() const { return mRect.size(); }
 	void size(NAS2D::Vector<float> newSize);

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -51,7 +51,7 @@ public:
 	bool hasFocus() const;
 
 	void text(const std::string& text);
-	const std::string& text() const;
+	const std::string& text() const { return mText; }
 	TextChangedCallback& textChanged();
 
 	NAS2D::Vector<float> size() const { return mRect.size(); }

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -88,8 +88,6 @@ protected:
 	virtual void onSizeChanged() { mResized(this); }
 	virtual void onTextChanged() { mTextChanged(this); }
 
-	std::string& _text();
-
 protected:
 	PositionChangedCallback		mPositionChanged;	/**< Callback fired whenever the position of the Control changes. */
 	ResizeCallback				mResized;

--- a/OPHD/UI/Core/Label.h
+++ b/OPHD/UI/Core/Label.h
@@ -29,7 +29,7 @@ public:
 	void autoSize();
 	void font(NAS2D::Font* font);
 	bool empty() const { return text().empty(); }
-	void clear() { _text().clear(); }
+	void clear() { mText.clear(); }
 	void update() override;
 
 	int textWidth() const;

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -143,7 +143,7 @@ void TextField::onTextInput(const std::string& _s)
 
 	if (mNumbersOnly && !std::isdigit(_s[0], LOC)) { return; }
 
-	_text() = _text().insert(mCursorPosition, _s);
+	mText = mText.insert(mCursorPosition, _s);
 
 	if (text().length() - prvLen != 0u)
 	{
@@ -164,7 +164,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			if(!text().empty() && mCursorPosition > 0)
 			{
 				mCursorPosition--;
-				_text().erase(mCursorPosition, 1);
+				mText.erase(mCursorPosition, 1);
 				onTextChanged();
 			}
 			break;
@@ -180,7 +180,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 		case EventHandler::KeyCode::KEY_DELETE:
 			if (text().length() > 0)
 			{
-				_text() = _text().erase(mCursorPosition, 1);
+				mText = mText.erase(mCursorPosition, 1);
 				onTextChanged();
 			}
 			break;

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -44,7 +44,7 @@ public:
 	bool editable() const;
 
 	bool empty() const { return text().empty(); }
-	void clear() { _text().clear(); }
+	void clear() { mText.clear(); }
 
 	void border(BorderVisibility visibility);
 	void resetCursorPosition();


### PR DESCRIPTION
Change `Control` member field access from `private` to `protected`. Generally `protected` access should be preferred for member fields that may be usable by derived classes. That should be most member fields defined in base classes. Only mark fields as `private` if they should not be modifiable by derived classes.

Of course, it's still questionable if all controls should even have a text field, though that's another problem for another PR.
