### PR TITLE
Remove tab alignment

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -22,10 +22,10 @@ using namespace NAS2D;
 
 std::map<Difficulty, std::string> DIFFICULTY_STRING_TABLE
 {
-	{ Difficulty::Beginner,	constants::DIFFICULTY_BEGINNER },
-	{ Difficulty::Easy,		constants::DIFFICULTY_EASY },
-	{ Difficulty::Medium,	constants::DIFFICULTY_MEDIUM },
-	{ Difficulty::Hard,		constants::DIFFICULTY_HARD },
+	{ Difficulty::Beginner, constants::DIFFICULTY_BEGINNER },
+	{ Difficulty::Easy, constants::DIFFICULTY_EASY },
+	{ Difficulty::Medium, constants::DIFFICULTY_MEDIUM },
+	{ Difficulty::Hard, constants::DIFFICULTY_HARD },
 };
 
 std::string StringFromDifficulty(const Difficulty& difficulty)
@@ -49,21 +49,21 @@ Difficulty DifficultyFromString(std::string difficultyStr)
 
 std::map<Structure::StructureState, Color> STRUCTURE_COLOR_TABLE
 {
-	{ Structure::StructureState::UNDER_CONSTRUCTION,	Color{150, 150, 150, 100} },
-	{ Structure::StructureState::OPERATIONAL,			Color{0, 185, 0} },
-	{ Structure::StructureState::IDLE,					Color{0, 185, 0, 100} },
-	{ Structure::StructureState::DISABLED,				Color{220, 0, 0} },
-	{ Structure::StructureState::DESTROYED,				Color{220, 0, 0} }
+	{ Structure::StructureState::UNDER_CONSTRUCTION, Color{150, 150, 150, 100} },
+	{ Structure::StructureState::OPERATIONAL, Color{0, 185, 0} },
+	{ Structure::StructureState::IDLE, Color{0, 185, 0, 100} },
+	{ Structure::StructureState::DISABLED, Color{220, 0, 0} },
+	{ Structure::StructureState::DESTROYED, Color{220, 0, 0} }
 };
 
 
 std::map<Structure::StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 {
-	{ Structure::StructureState::UNDER_CONSTRUCTION,	Color{185, 185, 185, 100} },
-	{ Structure::StructureState::OPERATIONAL,			Color{0, 185, 0} },
-	{ Structure::StructureState::IDLE,					Color{0, 185, 0, 100} },
-	{ Structure::StructureState::DISABLED,				Color{220, 0, 0} },
-	{ Structure::StructureState::DESTROYED,				Color{220, 0, 0} }
+	{ Structure::StructureState::UNDER_CONSTRUCTION, Color{185, 185, 185, 100} },
+	{ Structure::StructureState::OPERATIONAL, Color{0, 185, 0} },
+	{ Structure::StructureState::IDLE, Color{0, 185, 0, 100} },
+	{ Structure::StructureState::DISABLED, Color{220, 0, 0} },
+	{ Structure::StructureState::DESTROYED, Color{220, 0, 0} }
 };
 
 
@@ -87,30 +87,30 @@ std::map<MineProductionRate, std::string> MINE_YIELD_TRANSLATION =
 
 std::map<DisabledReason, std::string> DISABLED_REASON_TABLE =
 {
-	{ DisabledReason::DISABLED_NONE,					constants::STRUCTURE_DISABLED_NONE },
+	{ DisabledReason::DISABLED_NONE, constants::STRUCTURE_DISABLED_NONE },
 
-	{ DisabledReason::DISABLED_CHAP,					constants::STRUCTURE_DISABLED_CHAP },
-	{ DisabledReason::DISABLED_DISCONNECTED,			constants::STRUCTURE_DISABLED_DISCONNECTED },
-	{ DisabledReason::DISABLED_ENERGY,					constants::STRUCTURE_DISABLED_ENERGY },
-	{ DisabledReason::DISABLED_POPULATION,				constants::STRUCTURE_DISABLED_POPULATION },
-	{ DisabledReason::DISABLED_REFINED_RESOURCES,		constants::STRUCTURE_DISABLED_REFINED_RESOURCES },
-	{ DisabledReason::DISABLED_STRUCTURAL_INTEGRITY,	constants::STRUCTURE_DISABLED_STRUCTURAL_INTEGRITY }
+	{ DisabledReason::DISABLED_CHAP, constants::STRUCTURE_DISABLED_CHAP },
+	{ DisabledReason::DISABLED_DISCONNECTED, constants::STRUCTURE_DISABLED_DISCONNECTED },
+	{ DisabledReason::DISABLED_ENERGY, constants::STRUCTURE_DISABLED_ENERGY },
+	{ DisabledReason::DISABLED_POPULATION, constants::STRUCTURE_DISABLED_POPULATION },
+	{ DisabledReason::DISABLED_REFINED_RESOURCES, constants::STRUCTURE_DISABLED_REFINED_RESOURCES },
+	{ DisabledReason::DISABLED_STRUCTURAL_INTEGRITY, constants::STRUCTURE_DISABLED_STRUCTURAL_INTEGRITY }
 };
 
 
 std::map<IdleReason, std::string> IDLE_REASON_TABLE =
 {
-	{ IdleReason::IDLE_NONE,										constants::STRUCTURE_IDLE_NONE },
+	{ IdleReason::IDLE_NONE, constants::STRUCTURE_IDLE_NONE },
 
-	{ IdleReason::IDLE_PLAYER_SET,									constants::STRUCTURE_IDLE_PLAYER_SET },
-	{ IdleReason::IDLE_INTERNAL_STORAGE_FULL,						constants::STRUCTURE_IDLE_INTERNAL_STORAGE_FULL },
-	{ IdleReason::IDLE_FACTORY_PRODUCTION_COMPLETE,					constants::STRUCTURE_IDLE_FACTORY_PRODUCTION_COMPLETE },
-	{ IdleReason::IDLE_FACTORY_INSUFFICIENT_RESOURCES,				constants::STRUCTURE_IDLE_FACTORY_INSUFFICIENT_RESOURCES },
-	{ IdleReason::IDLE_FACTORY_INSUFFICIENT_ROBOT_COMMAND_CAPACITY,	constants::STRUCTURE_IDLE_FACTORY_INSUFFICIENT_ROBOT_COMMAND_CAPACITY },
-	{ IdleReason::IDLE_FACTORY_INSUFFICIENT_WAREHOUSE_SPACE,		constants::STRUCTURE_IDLE_FACTORY_INSUFFICIENT_WAREHOUSE_SPACE },
-	{ IdleReason::IDLE_MINE_EXHAUSTED,								constants::STRUCTURE_IDLE_MINE_EXHAUSTED },
-	{ IdleReason::IDLE_MINE_INACTIVE,								constants::STRUCTURE_IDLE_MINE_INACTIVE },
-	{ IdleReason::IDLE_INSUFFICIENT_LUXURY_PRODUCT,					constants::STRUCTURE_IDLE_INSUFFICIENT_LUXURY_PRODUCT }
+	{ IdleReason::IDLE_PLAYER_SET, constants::STRUCTURE_IDLE_PLAYER_SET },
+	{ IdleReason::IDLE_INTERNAL_STORAGE_FULL, constants::STRUCTURE_IDLE_INTERNAL_STORAGE_FULL },
+	{ IdleReason::IDLE_FACTORY_PRODUCTION_COMPLETE, constants::STRUCTURE_IDLE_FACTORY_PRODUCTION_COMPLETE },
+	{ IdleReason::IDLE_FACTORY_INSUFFICIENT_RESOURCES, constants::STRUCTURE_IDLE_FACTORY_INSUFFICIENT_RESOURCES },
+	{ IdleReason::IDLE_FACTORY_INSUFFICIENT_ROBOT_COMMAND_CAPACITY, constants::STRUCTURE_IDLE_FACTORY_INSUFFICIENT_ROBOT_COMMAND_CAPACITY },
+	{ IdleReason::IDLE_FACTORY_INSUFFICIENT_WAREHOUSE_SPACE, constants::STRUCTURE_IDLE_FACTORY_INSUFFICIENT_WAREHOUSE_SPACE },
+	{ IdleReason::IDLE_MINE_EXHAUSTED, constants::STRUCTURE_IDLE_MINE_EXHAUSTED },
+	{ IdleReason::IDLE_MINE_INACTIVE, constants::STRUCTURE_IDLE_MINE_INACTIVE },
+	{ IdleReason::IDLE_INSUFFICIENT_LUXURY_PRODUCT, constants::STRUCTURE_IDLE_INSUFFICIENT_LUXURY_PRODUCT }
 };
 
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -65,14 +65,14 @@ enum MineProductionRate
  */
 enum DisabledReason
 {
-	DISABLED_NONE,						/**< Not Disabled, default reason. */
+	DISABLED_NONE, /**< Not Disabled, default reason. */
 
-	DISABLED_CHAP,						/**< Requires atmosphere, no atmosphere available. */
-	DISABLED_DISCONNECTED,				/**< Not connected to Command Center */
-	DISABLED_ENERGY,					/**< Not enough Energy to operate. */
-	DISABLED_POPULATION,				/**< Insufficient workers or scientists (or both) */
-	DISABLED_REFINED_RESOURCES,			/**< Insufficient mined and refined resources */
-	DISABLED_STRUCTURAL_INTEGRITY		/**< Structural integrity out of operating tolerances (damaged structure) */
+	DISABLED_CHAP, /**< Requires atmosphere, no atmosphere available. */
+	DISABLED_DISCONNECTED, /**< Not connected to Command Center */
+	DISABLED_ENERGY, /**< Not enough Energy to operate. */
+	DISABLED_POPULATION, /**< Insufficient workers or scientists (or both) */
+	DISABLED_REFINED_RESOURCES, /**< Insufficient mined and refined resources */
+	DISABLED_STRUCTURAL_INTEGRITY /**< Structural integrity out of operating tolerances (damaged structure) */
 };
 
 
@@ -105,7 +105,7 @@ enum ConnectorDir
 	CONNECTOR_INTERSECTION = 1,
 	CONNECTOR_RIGHT,
 	CONNECTOR_LEFT,
-	CONNECTOR_VERTICAL			// Functions as an intersection
+	CONNECTOR_VERTICAL // Functions as an intersection
 };
 
 

--- a/OPHD/Constants/UiConstants.h
+++ b/OPHD/Constants/UiConstants.h
@@ -34,9 +34,9 @@ namespace constants
 	// =====================================
 	// = MOUSE POINTERS
 	// =====================================
-	const std::string MOUSE_POINTER_NORMAL		= "ui/pointers/normal.png";
-	const std::string MOUSE_POINTER_PLACE_TILE	= "ui/pointers/place_tile.png";
-	const std::string MOUSE_POINTER_INSPECT		= "ui/pointers/inspect.png";
+	const std::string MOUSE_POINTER_NORMAL = "ui/pointers/normal.png";
+	const std::string MOUSE_POINTER_PLACE_TILE = "ui/pointers/place_tile.png";
+	const std::string MOUSE_POINTER_INSPECT = "ui/pointers/inspect.png";
 
 
 	// =====================================

--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -64,5 +64,5 @@ private:
 	using FontTable = std::map<FontId, NAS2D::Font*>;
 
 private:
-	FontTable	mFontTable;
+	FontTable mFontTable;
 };

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -112,7 +112,7 @@ void Tile::deleteThing()
 void Tile::removeThing()
 {
 	mThing = nullptr;
-	thingIsStructure(false);	// Cover all bases.
+	thingIsStructure(false); // Cover all bases.
 }
 
 

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -52,7 +52,7 @@ public:
 
 	bool hasMine() const { return mMine != nullptr; }
 
-	Structure*	structure();
+	Structure* structure();
 	Robot* robot();
 
 	bool thingIsStructure() const { return mThingIsStructure; }
@@ -78,18 +78,18 @@ protected:
 	void thingIsStructure(bool value) { mThingIsStructure = value; }
 
 private:
-	int				mIndex = 0;
+	int mIndex = 0;
 
-	int				mX = 0;						/**< Tile Position Information */
-	int				mY = 0;						/**< Tile Position Information */
-	int				mDepth = 0;					/**< Tile Position Information */
+	int mX = 0; /**< Tile Position Information */
+	int mY = 0; /**< Tile Position Information */
+	int mDepth = 0; /**< Tile Position Information */
 
-	Thing*			mThing = nullptr;
-	Mine*			mMine = nullptr;
+	Thing* mThing = nullptr;
+	Mine* mMine = nullptr;
 
-	NAS2D::Color	mColor = NAS2D::Color::Normal;
+	NAS2D::Color mColor = NAS2D::Color::Normal;
 
-	bool			mExcavated = true;			/**< Used when a Digger uncovers underground tiles. */
-	bool			mConnected = false;			/**< Flag indicating that this tile is connected to the Command Center. */
-	bool			mThingIsStructure = false;	/**< Flag indicating that the Thing in the tile is a Structure. */
+	bool mExcavated = true; /**< Used when a Digger uncovers underground tiles. */
+	bool mConnected = false; /**< Flag indicating that this tile is connected to the Command Center. */
+	bool mThingIsStructure = false; /**< Flag indicating that the Thing in the tile is a Structure. */
 };

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -18,36 +18,36 @@ using namespace NAS2D::Xml;
 // ===============================================================================
 // = CONSTANTS
 // ===============================================================================
-const std::string	MAP_TERRAIN_EXTENSION		= "_a.png";
+const std::string MAP_TERRAIN_EXTENSION = "_a.png";
 
-const int			MAP_WIDTH					= 300;
-const int			MAP_HEIGHT					= 150;
+const int MAP_WIDTH = 300;
+const int MAP_HEIGHT = 150;
 
-const int			TILE_WIDTH					= 128;
-const int			TILE_HEIGHT					= 64;
+const int TILE_WIDTH = 128;
+const int TILE_HEIGHT = 64;
 
-const int			TILE_HALF_WIDTH				= TILE_WIDTH / 2;
+const int TILE_HALF_WIDTH = TILE_WIDTH / 2;
 
-const int			TILE_HEIGHT_OFFSET			= 9;
-const int			TILE_HEIGHT_ABSOLUTE		= TILE_HEIGHT - TILE_HEIGHT_OFFSET;
-const int			TILE_HEIGHT_HALF_ABSOLUTE	= TILE_HEIGHT_ABSOLUTE / 2;
+const int TILE_HEIGHT_OFFSET = 9;
+const int TILE_HEIGHT_ABSOLUTE = TILE_HEIGHT - TILE_HEIGHT_OFFSET;
+const int TILE_HEIGHT_HALF_ABSOLUTE = TILE_HEIGHT_ABSOLUTE / 2;
 
-const double		THROB_SPEED					= 250.0; // Throb speed of mine beacon
+const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
 
 /** Tuple indicates percent of mines that should be of yields LOW, MED, HIGH */
-std::map<constants::PlanetHostility, std::tuple<float, float, float>>	HostilityMineYieldTable =
+std::map<constants::PlanetHostility, std::tuple<float, float, float>> HostilityMineYieldTable =
 {
-	{ constants::PlanetHostility::HOSTILITY_LOW,		{0.30f, 0.50f, 0.20f} },
-	{ constants::PlanetHostility::HOSTILITY_MEDIUM,	{0.45f, 0.35f, 0.20f} },
-	{ constants::PlanetHostility::HOSTILITY_HIGH,	{0.35f, 0.20f, 0.45f} },
+	{ constants::PlanetHostility::HOSTILITY_LOW, {0.30f, 0.50f, 0.20f} },
+	{ constants::PlanetHostility::HOSTILITY_MEDIUM, {0.45f, 0.35f, 0.20f} },
+	{ constants::PlanetHostility::HOSTILITY_HIGH, {0.35f, 0.20f, 0.45f} },
 };
 
 
 // ===============================================================================
 // = LOCAL VARIABLES
 // ===============================================================================
-Point<int>			TRANSFORM; /**< Used to adjust mouse and screen spaces based on position of the map field. */
+Point<int> TRANSFORM; /**< Used to adjust mouse and screen spaces based on position of the map field. */
 
 
 // ===============================================================================
@@ -514,9 +514,9 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 	XmlAttribute* attribute = view_parameters->firstAttribute();
 	while (attribute)
 	{
-		if (attribute->name() == "viewlocation_x")		{ attribute->queryIntValue(view_x); }
-		else if (attribute->name() == "viewlocation_y")	{ attribute->queryIntValue(view_y); }
-		else if (attribute->name() == "currentdepth")	{ attribute->queryIntValue(view_depth); }
+		if (attribute->name() == "viewlocation_x") { attribute->queryIntValue(view_x); }
+		else if (attribute->name() == "viewlocation_y") { attribute->queryIntValue(view_y); }
+		else if (attribute->name() == "currentdepth") { attribute->queryIntValue(view_depth); }
 		attribute = attribute->next();
 	}
 
@@ -529,8 +529,8 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		attribute = mine->toElement()->firstAttribute();
 		while (attribute)
 		{
-			if (attribute->name() == "x")		{ attribute->queryIntValue(x); }
-			else if (attribute->name() == "y")	{ attribute->queryIntValue(y); }
+			if (attribute->name() == "x") { attribute->queryIntValue(x); }
+			else if (attribute->name() == "y") { attribute->queryIntValue(y); }
 			attribute = attribute->next();
 		}
 
@@ -554,10 +554,10 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		attribute = tile->toElement()->firstAttribute();
 		while (attribute)
 		{
-			if (attribute->name() == "x")			{ attribute->queryIntValue(x); }
-			else if (attribute->name() == "y")		{ attribute->queryIntValue(y); }
-			else if (attribute->name() == "depth")	{ attribute->queryIntValue(depth); }
-			else if (attribute->name() == "index")	{ attribute->queryIntValue(index); }
+			if (attribute->name() == "x") { attribute->queryIntValue(x); }
+			else if (attribute->name() == "y") { attribute->queryIntValue(y); }
+			else if (attribute->name() == "depth") { attribute->queryIntValue(depth); }
+			else if (attribute->name() == "index") { attribute->queryIntValue(index); }
 
 			attribute = attribute->next();
 		}

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -108,8 +108,8 @@ private:
 	using TileArray = std::vector<TileGrid>;
 	
 private:
-	TileMap(const TileMap&) = delete;						/**< Not Allowed */
-	TileMap& operator=(const TileMap&) = delete;			/**< Not allowed */
+	TileMap(const TileMap&) = delete; /**< Not Allowed */
+	TileMap& operator=(const TileMap&) = delete; /**< Not allowed */
 
 private:
 	void buildMouseMap();
@@ -121,32 +121,32 @@ private:
 	MouseMapRegion getMouseMapRegion(int x, int y);
 
 private:
-	int					mEdgeLength = 0;
-	int					mWidth = 0;
-	int					mHeight = 0;
+	int mEdgeLength = 0;
+	int mWidth = 0;
+	int mHeight = 0;
 
-	int					mMaxDepth = 0;				/**< Maximum digging depth. */
-	int					mCurrentDepth = 0;			/**< Current depth level to view. */
+	int mMaxDepth = 0; /**< Maximum digging depth. */
+	int mCurrentDepth = 0; /**< Current depth level to view. */
 
-	std::string			mMapPath;
-	std::string			mTsetPath;
+	std::string mMapPath;
+	std::string mTsetPath;
 
-	TileArray			mTileMap;
+	TileArray mTileMap;
 
-	NAS2D::Image		mTileset;
-	NAS2D::Image		mMineBeacon;
+	NAS2D::Image mTileset;
+	NAS2D::Image mMineBeacon;
 
-	NAS2D::Timer		mTimer;
+	NAS2D::Timer mTimer;
 
-	NAS2D::Point<int>		mMousePosition;				/**< Current mouse position. */
-	NAS2D::Point<int>		mMapHighlight;				/**< Tile the mouse is pointing to. */
-	NAS2D::Point<int>		mMapViewLocation;
+	NAS2D::Point<int> mMousePosition; /**< Current mouse position. */
+	NAS2D::Point<int> mMapHighlight; /**< Tile the mouse is pointing to. */
+	NAS2D::Point<int> mMapViewLocation;
 
-	NAS2D::Point<float>	mMapPosition;				/** Where to start drawing the TileMap on the screen. */
+	NAS2D::Point<float> mMapPosition; /** Where to start drawing the TileMap on the screen. */
 
-	Point2dList			mMineLocations;				/**< Location of all mines on the map. */
+	Point2dList mMineLocations; /**< Location of all mines on the map. */
 
-	NAS2D::Rectangle<int>	mMapBoundingBox;			/** Area that the TileMap fills when drawn. */
+	NAS2D::Rectangle<int> mMapBoundingBox; /** Area that the TileMap fills when drawn. */
 
-	bool				mShowConnections = false;	/**< Flag indicating whether or not to highlight connectedness. */
+	bool mShowConnections = false; /**< Flag indicating whether or not to highlight connectedness. */
 };

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -312,10 +312,10 @@ void Mine::serialize(NAS2D::Xml::XmlElement* element)
 		XmlElement* vein = new XmlElement("vein");
 
 		vein->attribute("id", static_cast<int>(i));
-		vein->attribute("common_metals",	mv[OreType::ORE_COMMON_METALS]);
-		vein->attribute("common_minerals",	mv[OreType::ORE_COMMON_MINERALS]);
-		vein->attribute("rare_metals",		mv[OreType::ORE_RARE_METALS]);
-		vein->attribute("rare_minerals",	mv[OreType::ORE_RARE_MINERALS]);
+		vein->attribute("common_metals", mv[OreType::ORE_COMMON_METALS]);
+		vein->attribute("common_minerals", mv[OreType::ORE_COMMON_MINERALS]);
+		vein->attribute("rare_metals", mv[OreType::ORE_RARE_METALS]);
+		vein->attribute("rare_minerals", mv[OreType::ORE_RARE_MINERALS]);
 
 		element->linkEndChild(vein);
 	}

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -65,8 +65,8 @@ private:
 	Mine& operator=(const Mine&) = delete;
 
 private:
-	MineVeins			mVeins;									/**< Ore veins */
-	MineProductionRate	mProductionRate = MineProductionRate::PRODUCTION_RATE_LOW;	/**< Mine's production rate. */
+	MineVeins mVeins; /**< Ore veins */
+	MineProductionRate mProductionRate = MineProductionRate::PRODUCTION_RATE_LOW; /**< Mine's production rate. */
 	
 	/**
 	 * Flags indicating several states for the mine:
@@ -78,5 +78,5 @@ private:
 	 * [4] : Mine is active
 	 * [5] : Mine is exhausted
 	 */
-	std::bitset<6>		mFlags;									/**< Set of flags. */
+	std::bitset<6> mFlags; /**< Set of flags. */
 };

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -53,18 +53,18 @@ private:
 	int consume_food(int _food);
 
 private:
-	using PopulationTable = std::array<int, 5>	;
+	using PopulationTable = std::array<int, 5>;
 	using MoraleModifiers = std::array<MoraleModifier, 5>;
 
 private:
-	int			mBirthCount;				/**<  */
-	int			mDeathCount;				/**<  */
+	int mBirthCount; /**<  */
+	int mDeathCount; /**<  */
 
-	float				mStarveRate;				/**< Amount of population that dies during food shortages in percent. */
+	float mStarveRate; /**< Amount of population that dies during food shortages in percent. */
 
-	PopulationTable		mPopulation;				/**< Current population. */
-	PopulationTable		mPopulationGrowth;			/**< Population growth table. */
-	PopulationTable		mPopulationDeath;			/**< Population death table. */
+	PopulationTable mPopulation; /**< Current population. */
+	PopulationTable mPopulationGrowth; /**< Population growth table. */
+	PopulationTable mPopulationDeath; /**< Population death table. */
 
-	MoraleModifiers		mModifiers;					/**< Morale modifier table */
+	MoraleModifiers mModifiers; /**< Morale modifier table */
 };

--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -10,7 +10,7 @@ void BasicCheck(Population::PersonRole _role);
 /**
  * C'tor
  */
-PopulationPool::PopulationPool() :	mScientistsAsWorkers(0),
+PopulationPool::PopulationPool() : mScientistsAsWorkers(0),
 									mScientistsUsed(0),
 									mWorkersUsed(0),
 									mPopulation(nullptr)

--- a/OPHD/PopulationPool.h
+++ b/OPHD/PopulationPool.h
@@ -23,9 +23,9 @@ public:
 	int populationEmployed();
 
 private:
-	int				mScientistsAsWorkers;
-	int				mScientistsUsed;
-	int				mWorkersUsed;
+	int mScientistsAsWorkers;
+	int mScientistsUsed;
+	int mWorkersUsed;
 
-	Population*		mPopulation;
+	Population* mPopulation;
 };

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -159,15 +159,15 @@ void ProductPool::verifyCount()
  */
 void ProductPool::serialize(NAS2D::Xml::XmlElement* element)
 {
-	element->attribute(constants::SAVE_GAME_PRODUCT_DIGGER,				count(ProductType::PRODUCT_DIGGER));
-	element->attribute(constants::SAVE_GAME_PRODUCT_DOZER,				count(ProductType::PRODUCT_DOZER));
-	element->attribute(constants::SAVE_GAME_PRODUCT_MINER,				count(ProductType::PRODUCT_MINER));
-	element->attribute(constants::SAVE_GAME_PRODUCT_EXPLORER,			count(ProductType::PRODUCT_EXPLORER));
-	element->attribute(constants::SAVE_GAME_PRODUCT_TRUCK,				count(ProductType::PRODUCT_TRUCK));
-	element->attribute(constants::SAVE_GAME_PRODUCT_ROAD_MATERIALS,		count(ProductType::PRODUCT_ROAD_MATERIALS));
-	element->attribute(constants::SAVE_GAME_MAINTENANCE_PARTS,			count(ProductType::PRODUCT_MAINTENANCE_PARTS));
-	element->attribute(constants::SAVE_GAME_PRODUCT_CLOTHING,			count(ProductType::PRODUCT_CLOTHING));
-	element->attribute(constants::SAVE_GAME_PRODUCT_MEDICINE,			count(ProductType::PRODUCT_MEDICINE));
+	element->attribute(constants::SAVE_GAME_PRODUCT_DIGGER, count(ProductType::PRODUCT_DIGGER));
+	element->attribute(constants::SAVE_GAME_PRODUCT_DOZER, count(ProductType::PRODUCT_DOZER));
+	element->attribute(constants::SAVE_GAME_PRODUCT_MINER, count(ProductType::PRODUCT_MINER));
+	element->attribute(constants::SAVE_GAME_PRODUCT_EXPLORER, count(ProductType::PRODUCT_EXPLORER));
+	element->attribute(constants::SAVE_GAME_PRODUCT_TRUCK, count(ProductType::PRODUCT_TRUCK));
+	element->attribute(constants::SAVE_GAME_PRODUCT_ROAD_MATERIALS, count(ProductType::PRODUCT_ROAD_MATERIALS));
+	element->attribute(constants::SAVE_GAME_MAINTENANCE_PARTS, count(ProductType::PRODUCT_MAINTENANCE_PARTS));
+	element->attribute(constants::SAVE_GAME_PRODUCT_CLOTHING, count(ProductType::PRODUCT_CLOTHING));
+	element->attribute(constants::SAVE_GAME_PRODUCT_MEDICINE, count(ProductType::PRODUCT_MEDICINE));
 }
 
 
@@ -182,15 +182,15 @@ void ProductPool::deserialize(NAS2D::Xml::XmlElement* element)
 	XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
-		if (attribute->name() == constants::SAVE_GAME_PRODUCT_DIGGER)				{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_DIGGER]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_DOZER)			{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_DOZER]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_MINER)			{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_MINER]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_EXPLORER)		{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_EXPLORER]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_TRUCK)			{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_TRUCK]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_ROAD_MATERIALS)	{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_ROAD_MATERIALS]); }
-		else if (attribute->name() == constants::SAVE_GAME_MAINTENANCE_PARTS)		{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_MAINTENANCE_PARTS]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_CLOTHING)		{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_CLOTHING]); }
-		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_MEDICINE)		{ attribute->queryIntValue(mProducts[ProductType::PRODUCT_MEDICINE]); }
+		if (attribute->name() == constants::SAVE_GAME_PRODUCT_DIGGER) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_DIGGER]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_DOZER) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_DOZER]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_MINER) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_MINER]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_EXPLORER) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_EXPLORER]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_TRUCK) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_TRUCK]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_ROAD_MATERIALS) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_ROAD_MATERIALS]); }
+		else if (attribute->name() == constants::SAVE_GAME_MAINTENANCE_PARTS) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_MAINTENANCE_PARTS]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_CLOTHING) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_CLOTHING]); }
+		else if (attribute->name() == constants::SAVE_GAME_PRODUCT_MEDICINE) { attribute->queryIntValue(mProducts[ProductType::PRODUCT_MEDICINE]); }
 
 		attribute = attribute->next();
 	}

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -45,8 +45,8 @@ private:
 	friend void transferProductsPool(ProductPool&, ProductPool&);
 
 private:
-	ProductTypeCount	mProducts = {{ 0 }};
+	ProductTypeCount mProducts = {{ 0 }};
 
-	int					mCapacity = constants::BASE_PRODUCT_CAPACITY;
-	int					mCurrentStorageCount = 0;
+	int mCapacity = constants::BASE_PRODUCT_CAPACITY;
+	int mCurrentStorageCount = 0;
 };

--- a/OPHD/ProductionCost.h
+++ b/OPHD/ProductionCost.h
@@ -35,9 +35,9 @@ public:
 	int rareMinerals() const { return mRareMinerals; }
 
 private:
-	int				mTurnsToBuild = 0;
-	int				mCommonMetals = 0;
-	int				mCommonMinerals = 0;
-	int				mRareMetals = 0;
-	int				mRareMinerals = 0;
+	int mTurnsToBuild = 0;
+	int mCommonMetals = 0;
+	int mCommonMinerals = 0;
+	int mRareMetals = 0;
+	int mRareMinerals = 0;
 };

--- a/OPHD/ResourcePool.h
+++ b/OPHD/ResourcePool.h
@@ -29,7 +29,7 @@ public:
 		RESOURCE_FOOD,
 		RESOURCE_ENERGY,
 
-		RESOURCE_COUNT					/**< Number of available resource types. */
+		RESOURCE_COUNT /**< Number of available resource types. */
 	};
 
 
@@ -111,9 +111,9 @@ private:
 	using ResourceTable = std::array<int, ResourceType::RESOURCE_COUNT>;
 
 private:
-	int					_capacity = 0;			/**< Maximum available capacity of the ResourcePool. */
+	int _capacity = 0; /**< Maximum available capacity of the ResourcePool. */
 
-	ResourceTable		_resourceTable;
+	ResourceTable _resourceTable;
 
-	Callback			_observerCallback;
+	Callback _observerCallback;
 };

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -46,12 +46,12 @@ public:
 	const RobotList& robots() const { return mRobots; }
 
 private:
-	DiggerList		mDiggers;
-	DozerList		mDozers;
-	MinerList		mMiners;
+	DiggerList mDiggers;
+	DozerList mDozers;
+	MinerList mMiners;
 
-	RobotList		mRobots;	// List of all robots by pointer to base class
+	RobotList mRobots; // List of all robots by pointer to base class
 
-	uint32_t		mRobotControlMax = 0;
-	uint32_t		mRobotControlCount = 0;
+	uint32_t mRobotControlMax = 0;
+	uint32_t mRobotControlCount = 0;
 };

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -12,12 +12,12 @@
 #include "NAS2D/Mixer/Mixer.h"
 #include "NAS2D/Renderer/Renderer.h"
 
-NAS2D::Point<int> MOUSE_COORDS;									/**< Mouse Coordinates. Used by other states/wrapers. */
+NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wrapers. */
 
-MainReportsUiState* MAIN_REPORTS_UI = nullptr;			/**< Pointer to a MainReportsUiState. Memory is handled by GameState. */
-static MapViewState* MAP_VIEW = nullptr;				/**< Pointer to a MapViewState. Memory is handled by GameState. */
+MainReportsUiState* MAIN_REPORTS_UI = nullptr; /**< Pointer to a MainReportsUiState. Memory is handled by GameState. */
+static MapViewState* MAP_VIEW = nullptr; /**< Pointer to a MapViewState. Memory is handled by GameState. */
 
-static Wrapper* ACTIVE_STATE = nullptr;					/**< The currently active State. */
+static Wrapper* ACTIVE_STATE = nullptr; /**< The currently active State. */
 
 
 /**

--- a/OPHD/States/GameState.h
+++ b/OPHD/States/GameState.h
@@ -30,5 +30,5 @@ private:
 	void takeMeThere(Structure*);
 
 private:
-	NAS2D::State*	mReturnState = this;
+	NAS2D::State* mReturnState = this;
 };

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -45,19 +45,19 @@ private:
 	void fileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
 private:
-	NAS2D::Image		mBgImage;
+	NAS2D::Image mBgImage;
 
-	FileIo				mFileIoDialog;					/**< File IO window. */
+	FileIo mFileIoDialog; /**< File IO window. */
 
-	Button				btnNewGame;
-	Button				btnContinueGame;
-	Button				btnOptions;
-	Button				btnHelp;
-	Button				btnQuit;
+	Button btnNewGame;
+	Button btnContinueGame;
+	Button btnOptions;
+	Button btnHelp;
+	Button btnQuit;
 
-	MainMenuOptions		dlgOptions;
-	DifficultySelect	dlgNewGame;
+	MainMenuOptions dlgOptions;
+	DifficultySelect dlgNewGame;
 
-	Label				lblVersion;
-	NAS2D::State*		mReturnState = this;
+	Label lblVersion;
+	NAS2D::State* mReturnState = this;
 };

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -17,12 +17,12 @@
 using namespace NAS2D;
 
 
-extern Point<int>		MOUSE_COORDS;
+extern Point<int> MOUSE_COORDS;
 
-static Image*		WINDOW_BACKGROUND = nullptr;
+static Image* WINDOW_BACKGROUND = nullptr;
 
-Font*				BIG_FONT = nullptr;
-Font*				BIG_FONT_BOLD = nullptr;
+Font* BIG_FONT = nullptr;
+Font* BIG_FONT_BOLD = nullptr;
 
 
 /**
@@ -56,24 +56,23 @@ public:
 	bool Selected() { return _selected; }
 
 public:
-	std::string			Name;
+	std::string Name;
 
-	Image*				Img = nullptr;
+	Image* Img = nullptr;
 
-	Point<int>			TextPosition;
-	Point<int>			IconPosition;
+	Point<int> TextPosition;
+	Point<int> IconPosition;
 
-	Rectangle<int>		Rect;
+	Rectangle<int> Rect;
 
-	ReportInterface*	UiPanel = nullptr;
+	ReportInterface* UiPanel = nullptr;
 
 private:
-	bool				_selected = false;
-
+	bool _selected = false;
 };
 
 
-static std::array<Panel, NavigationPanel::PANEL_COUNT> Panels;	/**< Array of UI navigation panels. */
+static std::array<Panel, NavigationPanel::PANEL_COUNT> Panels; /**< Array of UI navigation panels. */
 
 
 /**

--- a/OPHD/States/MainReportsUiState.h
+++ b/OPHD/States/MainReportsUiState.h
@@ -45,5 +45,5 @@ private:
 	void exit();
 
 private:
-	ReportsUiCallback	mReportsUiCallback;
+	ReportsUiCallback mReportsUiCallback;
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -26,11 +26,11 @@
 using namespace NAS2D;
 
 
-const std::string	MAP_TERRAIN_EXTENSION		= "_a.png";
-const std::string	MAP_DISPLAY_EXTENSION		= "_b.png";
+const std::string MAP_TERRAIN_EXTENSION = "_a.png";
+const std::string MAP_DISPLAY_EXTENSION = "_b.png";
 
-extern NAS2D::Image* IMG_LOADING;	/// \fixme Find a sane place for this.
-extern NAS2D::Image* IMG_SAVING;	/// \fixme Find a sane place for this.
+extern NAS2D::Image* IMG_LOADING; /// \fixme Find a sane place for this.
+extern NAS2D::Image* IMG_SAVING; /// \fixme Find a sane place for this.
 extern Point<int> MOUSE_COORDS;
 extern MainReportsUiState* MAIN_REPORTS_UI;
 
@@ -50,7 +50,7 @@ Rectangle<int> MOVE_DOWN_ICON;
 
 std::string CURRENT_LEVEL_STRING;
 
-std::map <int, std::string>	LEVEL_STRING_TABLE = 
+std::map <int, std::string> LEVEL_STRING_TABLE = 
 {
 	{ constants::DEPTH_SURFACE, constants::LEVEL_SURFACE },
 	{ constants::DEPTH_UNDERGROUND_1, constants::LEVEL_UG1 },
@@ -134,7 +134,7 @@ MapViewState::~MapViewState()
 void MapViewState::setPopulationLevel(PopulationLevel popLevel)
 {
 	mLandersColonist = static_cast<int>(popLevel);
-	mLandersCargo = 2;	///\todo This should be set based on difficulty level.
+	mLandersCargo = 2; ///\todo This should be set based on difficulty level.
 }
 
 
@@ -818,7 +818,7 @@ void MapViewState::placeTubeEnd()
 	int xEnd = 0; int yEnd = 0;
 	bool endReach = false;
 	if (tubeStart.height() != 1) return;
-	tubeStart.height(0);	// the height is used as a boolean to indicate that we are
+	tubeStart.height(0); // the height is used as a boolean to indicate that we are
 	Tile* tile = mTileMap->getVisibleTile(mTileMapMouseHover, mTileMap->currentDepth());
 	if (!tile) { return; }
 
@@ -832,7 +832,7 @@ void MapViewState::placeTubeEnd()
 	case ConnectorDir::CONNECTOR_INTERSECTION:
 
 		if (abs(tubeStart.x() - tile->x()) >= abs(tubeStart.y() - tile->y())){
-			incX = 1;	// The sens will be on the longest spread on X or Y
+			incX = 1; // The sens will be on the longest spread on X or Y
 		}else{
 			incY = 1;
 		}

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -197,78 +197,78 @@ private:
 
 
 private:
-	NAS2D::FpsCounter			mFps;							/**< Main FPS Counter. */
+	NAS2D::FpsCounter mFps; /**< Main FPS Counter. */
 
-	TileMap*			mTileMap = nullptr;
+	TileMap* mTileMap = nullptr;
 
-	NAS2D::Image				mBackground;					/**< Background image drawn behind the tile map. */
-	NAS2D::Image				mMapDisplay;					/**< Satellite view of the Site Map. */
-	NAS2D::Image				mHeightMap;						/**< Height view of the Site Map. */
-	NAS2D::Image				mUiIcons;						/**< User interface icons. */
+	NAS2D::Image mBackground; /**< Background image drawn behind the tile map. */
+	NAS2D::Image mMapDisplay; /**< Satellite view of the Site Map. */
+	NAS2D::Image mHeightMap; /**< Height view of the Site Map. */
+	NAS2D::Image mUiIcons; /**< User interface icons. */
 
-	NAS2D::Point<int>			mTileMapMouseHover;				/**< Tile position the mouse is currently hovering over. */
+	NAS2D::Point<int> mTileMapMouseHover; /**< Tile position the mouse is currently hovering over. */
 
-	NAS2D::Rectangle<int>		mMiniMapBoundingBox;			/**< Area of the site map display. */
+	NAS2D::Rectangle<int> mMiniMapBoundingBox; /**< Area of the site map display. */
 
 	// POOL'S
-	ResourcePool		mPlayerResources;				/**< Player's current resources. */
-	RobotPool			mRobotPool;						/**< Robots that are currently available for use. */
-	PopulationPool		mPopulationPool;
+	ResourcePool mPlayerResources; /**< Player's current resources. */
+	RobotPool mRobotPool; /**< Robots that are currently available for use. */
+	PopulationPool mPopulationPool;
 
-	RobotTileTable		mRobotList;						/**< List of active robots and their positions on the map. */
+	RobotTileTable mRobotList; /**< List of active robots and their positions on the map. */
 
-	InsertMode			mInsertMode = InsertMode::INSERT_NONE;		/**< What's being inserted into the TileMap if anything. */
-	StructureID			mCurrentStructure = StructureID::SID_NONE;	/**< Structure being placed. */
-	RobotType			mCurrentRobot = RobotType::ROBOT_NONE;		/**< Robot being placed. */
+	InsertMode mInsertMode = InsertMode::INSERT_NONE; /**< What's being inserted into the TileMap if anything. */
+	StructureID mCurrentStructure = StructureID::SID_NONE; /**< Structure being placed. */
+	RobotType mCurrentRobot = RobotType::ROBOT_NONE; /**< Robot being placed. */
 
-	Population			mPopulation;
+	Population mPopulation;
 
-	//Music				mBgMusic;
+	//Music mBgMusic;
 
 	// USER INTERFACE
-	Button				mBtnTurns;						/**< Turns Button. */
-	Button				mBtnToggleHeightmap;			/**< Height Map Toggle Button. */
-	Button				mBtnToggleConnectedness;		/**< Connectedness view toggle button. */
+	Button mBtnTurns; /**< Turns Button. */
+	Button mBtnToggleHeightmap; /**< Height Map Toggle Button. */
+	Button mBtnToggleConnectedness; /**< Connectedness view toggle button. */
 
-	IconGrid			mStructures;					/**< Structures pick view. */
-	IconGrid			mRobots;						/**< Robots pick view. */
-	IconGrid			mConnections;					/**< Tubes pick view. */
+	IconGrid mStructures; /**< Structures pick view. */
+	IconGrid mRobots; /**< Robots pick view. */
+	IconGrid mConnections; /**< Tubes pick view. */
 
-	DiggerDirection		mDiggerDirection;				/**< Digger direction window. */
-	FactoryProduction	mFactoryProduction;				/**< Factory Production window. */
-	FileIo				mFileIoDialog;					/**< File IO window. */
-	GameOverDialog		mGameOverDialog;				/**< Game over window. */
-	GameOptionsDialog	mGameOptionsDialog;				/**< Options List window. */
-	MajorEventAnnouncement	mAnnouncement;				/**< Announcements window. */
-	MineOperationsWindow	mMineOperationsWindow;		/**< Mine Operations window. */
-	PopulationPanel		mPopulationPanel;				/**< Population panel. */
-	ResourceBreakdownPanel	mResourceBreakdownPanel;	/**< Resource Breakdown Panel. */
-	StructureInspector	mStructureInspector;			/**< Structure Inspector window. */
-	TileInspector		mTileInspector;					/**< Tile Inspector window. */
-	WarehouseInspector	mWarehouseInspector;			/**< Warehouse Inspector window. */
+	DiggerDirection mDiggerDirection; /**< Digger direction window. */
+	FactoryProduction mFactoryProduction; /**< Factory Production window. */
+	FileIo mFileIoDialog; /**< File IO window. */
+	GameOverDialog mGameOverDialog; /**< Game over window. */
+	GameOptionsDialog mGameOptionsDialog; /**< Options List window. */
+	MajorEventAnnouncement mAnnouncement; /**< Announcements window. */
+	MineOperationsWindow mMineOperationsWindow; /**< Mine Operations window. */
+	PopulationPanel mPopulationPanel; /**< Population panel. */
+	ResourceBreakdownPanel mResourceBreakdownPanel; /**< Resource Breakdown Panel. */
+	StructureInspector mStructureInspector; /**< Structure Inspector window. */
+	TileInspector mTileInspector; /**< Tile Inspector window. */
+	WarehouseInspector mWarehouseInspector; /**< Warehouse Inspector window. */
 
-	WindowStack			mWindowStack;					/**< Window stack manager. */
+	WindowStack mWindowStack; /**< Window stack manager. */
 
 	// SIGNALS
-	QuitCallback		mQuitCallback;					/**< Signal for posting quit event. */
-	ReportsUiCallback	mReportsUiCallback;				/**< Signal for bringing the Main Reports UI up. */
-	MapChangedCallback	mMapChangedCallback;			/**< Signal indicating that the map changed. */
+	QuitCallback mQuitCallback; /**< Signal for posting quit event. */
+	ReportsUiCallback mReportsUiCallback; /**< Signal for bringing the Main Reports UI up. */
+	MapChangedCallback mMapChangedCallback; /**< Signal indicating that the map changed. */
 
 	// MISCELLANEOUS
-	int					mTurnCount = 0;
+	int mTurnCount = 0;
 
-	int					mCurrentMorale = constants::DEFAULT_STARTING_MORALE;
-	int					mPreviousMorale = constants::DEFAULT_STARTING_MORALE;
+	int mCurrentMorale = constants::DEFAULT_STARTING_MORALE;
+	int mPreviousMorale = constants::DEFAULT_STARTING_MORALE;
 
-	int					mLandersColonist = 0;
-	int					mLandersCargo = 0;
+	int mLandersColonist = 0;
+	int mLandersCargo = 0;
 
-	int					mResidentialCapacity = 0;
+	int mResidentialCapacity = 0;
 
-	bool				mLeftButtonDown = false;		/**< Used for mouse drags on the mini map. */
-	bool				mLoadingExisting = false;		/**< Flag used for loading an existing game. */
-	bool				mPinResourcePanel = false;
-	bool				mPinPopulationPanel = false;
+	bool mLeftButtonDown = false; /**< Used for mouse drags on the mini map. */
+	bool mLoadingExisting = false; /**< Flag used for loading an existing game. */
+	bool mPinResourcePanel = false;
+	bool mPinPopulationPanel = false;
 
-	std::string			mExistingToLoad;				/**< Filename of the existing game to load. */
+	std::string mExistingToLoad; /**< Filename of the existing game to load. */
 };

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -63,7 +63,7 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
  * Called whenever a Factory's production is complete.
  */
 void MapViewState::factoryProductionComplete(Factory& factory)
-{	
+{
 	switch (factory.productWaiting())
 	{
 	case ProductType::PRODUCT_DIGGER:

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -17,8 +17,8 @@
 
 using RobotTileTable = std::map<Robot*, Tile*>;
 
-class Warehouse;	/**< Forward declaration for getAvailableWarehouse() function. */
-class RobotCommand;	/**< Forward declaration for getAvailableRobotCommand() function. */
+class Warehouse; /**< Forward declaration for getAvailableWarehouse() function. */
+class RobotCommand; /**< Forward declaration for getAvailableRobotCommand() function. */
 
 extern const NAS2D::Point<int> CcNotPlaced;
 NAS2D::Point<int>& ccLocation();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -35,7 +35,7 @@ extern std::string CURRENT_LEVEL_STRING;
 extern std::map <int, std::string> LEVEL_STRING_TABLE;
 
 
-extern NAS2D::Image* IMG_LOADING;	/// \fixme	Hate having these as externs.
+extern NAS2D::Image* IMG_LOADING; /// \fixme	Hate having these as externs.
 extern NAS2D::Image* IMG_SAVING;
 
 
@@ -170,7 +170,7 @@ void MapViewState::load(const std::string& filePath)
 	 * having already been loaded in order to match up the robots in the save game to
 	 * the RCC.
 	 */
-	readRobots(root->firstChildElement("robots"));	
+	readRobots(root->firstChildElement("robots"));
 	readStructures(root->firstChildElement("structures"));
 
 	readResources(root->firstChildElement("resources"), mPlayerResources);
@@ -254,14 +254,14 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 		attribute = robot->toElement()->firstAttribute();
 		while (attribute)
 		{
-			if (attribute->name() == "id")				{ attribute->queryIntValue(id); }
-			else if (attribute->name() == "type")		{ attribute->queryIntValue(type); }
-			else if (attribute->name() == "age")		{ attribute->queryIntValue(age); }
-			else if (attribute->name() == "production")	{ attribute->queryIntValue(production_time); }
-			else if (attribute->name() == "x")			{ attribute->queryIntValue(x); }
-			else if (attribute->name() == "y")			{ attribute->queryIntValue(y); }
-			else if (attribute->name() == "depth")		{ attribute->queryIntValue(depth); }
-			else if (attribute->name() == "direction")	{ attribute->queryIntValue(direction); }
+			if (attribute->name() == "id") { attribute->queryIntValue(id); }
+			else if (attribute->name() == "type") { attribute->queryIntValue(type); }
+			else if (attribute->name() == "age") { attribute->queryIntValue(age); }
+			else if (attribute->name() == "production") { attribute->queryIntValue(production_time); }
+			else if (attribute->name() == "x") { attribute->queryIntValue(x); }
+			else if (attribute->name() == "y") { attribute->queryIntValue(y); }
+			else if (attribute->name() == "depth") { attribute->queryIntValue(depth); }
+			else if (attribute->name() == "direction") { attribute->queryIntValue(direction); }
 
 			attribute = attribute->next();
 		}
@@ -290,7 +290,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 			break;
 		}
 
-		if (!r) { continue; }	// Could be done in the default handler in the above switch
+		if (!r) { continue; } // Could be done in the default handler in the above switch
 								// but may be better here as an explicit statement.
 
 		r->fuelCellAge(age);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 
 
-extern NAS2D::Image* IMG_PROCESSING_TURN;	/// \fixme Find a sane place for this.
+extern NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
 
 
 /**
@@ -217,7 +217,7 @@ void MapViewState::updateResources()
 		if (!truck.empty())
 		{
 			smelter->storage().pushResources(truck);
-			break;	// we're at max capacity in our storage, dump what's left in the smelter it came from and barf.
+			break; // we're at max capacity in our storage, dump what's left in the smelter it came from and barf.
 		}
 	}
 }

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -19,7 +19,7 @@
 
 using namespace constants;
 
-NAS2D::Rectangle<int>	BOTTOM_UI_AREA;
+NAS2D::Rectangle<int> BOTTOM_UI_AREA;
 
 
 /**
@@ -34,9 +34,9 @@ extern NAS2D::Rectangle<int> MOVE_UP_ICON;
 extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 
-extern NAS2D::Image* IMG_LOADING;	/// \fixme Find a sane place for this.
-extern NAS2D::Image* IMG_SAVING;	/// \fixme Find a sane place for this.
-extern NAS2D::Image* IMG_PROCESSING_TURN;	/// \fixme Find a sane place for this.
+extern NAS2D::Image* IMG_LOADING; /// \fixme Find a sane place for this.
+extern NAS2D::Image* IMG_SAVING; /// \fixme Find a sane place for this.
+extern NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
 
 
 /**

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -61,20 +61,20 @@ private:
 	Planet& operator=(const Planet&) = delete;
 
 private:
-	int					mTick = 0;
+	int mTick = 0;
 
-	int					mMaxMines = 0;
-	int					mMaxDigDepth = 0;
+	int mMaxMines = 0;
+	int mMaxDigDepth = 0;
 
-	NAS2D::Image		mImage;
-	NAS2D::Point<int>		mPosition;
+	NAS2D::Image mImage;
+	NAS2D::Point<int> mPosition;
 
-	PlanetType			mType = PlanetType::PLANET_TYPE_NONE;
+	PlanetType mType = PlanetType::PLANET_TYPE_NONE;
 
-	MouseCallback		mMouseEnterCallback;
-	MouseCallback		mMouseExitCallback;
+	MouseCallback mMouseEnterCallback;
+	MouseCallback mMouseExitCallback;
 
-	bool				mMouseInArea = false;
+	bool mMouseInArea = false;
 
-	NAS2D::Timer		mTimer;
+	NAS2D::Timer mTimer;
 };

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -50,10 +50,10 @@ public:
 	}
 
 private:
-	NAS2D::Image	mSheet;
-	NAS2D::Timer	mTimer;
+	NAS2D::Image mSheet;
+	NAS2D::Timer mTimer;
 
-	std::size_t			mFrame = 0;
+	std::size_t mFrame = 0;
 };
 
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -42,29 +42,29 @@ private:
 	void drawStar(int, int);
 
 private:
-	NAS2D::Image	mBg;
+	NAS2D::Image mBg;
 
-	NAS2D::Image	mStarFlare;
-	NAS2D::Image	mDetailFlare;
-	NAS2D::Image	mDetailFlare2;
+	NAS2D::Image mStarFlare;
+	NAS2D::Image mDetailFlare;
+	NAS2D::Image mDetailFlare2;
 
-	NAS2D::Image	mCloud1;
-	NAS2D::Image	mCloud2;
+	NAS2D::Image mCloud1;
+	NAS2D::Image mCloud2;
 
-	NAS2D::Music	mBgMusic;
+	NAS2D::Music mBgMusic;
 
-	NAS2D::Sound	mSelect;
-	NAS2D::Sound	mHover;
+	NAS2D::Sound mSelect;
+	NAS2D::Sound mHover;
 
-	NAS2D::Point<int>	mMousePosition;
+	NAS2D::Point<int> mMousePosition;
 
-	PlanetPtrList	mPlanets;
+	PlanetPtrList mPlanets;
 
-	Button			mQuit;
+	Button mQuit;
 
-	TextArea		mPlanetDescription;
+	TextArea mPlanetDescription;
 
-	NAS2D::Timer	mTimer;
+	NAS2D::Timer mTimer;
 
-	NAS2D::State*	mReturnState = this;
+	NAS2D::State* mReturnState = this;
 };

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -34,11 +34,12 @@ enum LogoState
 LogoState CURRENT_STATE = LogoState::LOGO_NONE;
 
 
-SplashState::SplashState() :	mLogoLairworks("sys/lairworks-logo.png"),
-								mLogoNas2d("sys/nas2d_logo.png"),
-								mLogoOutpostHd("sys/ophd_large.png"),
-								mFlare("sys/flare_0.png"),
-								mByline("sys/byline.png")
+SplashState::SplashState() :
+	mLogoLairworks("sys/lairworks-logo.png"),
+	mLogoNas2d("sys/nas2d_logo.png"),
+	mLogoOutpostHd("sys/ophd_large.png"),
+	mFlare("sys/flare_0.png"),
+	mByline("sys/byline.png")
 {}
 
 

--- a/OPHD/States/SplashState.h
+++ b/OPHD/States/SplashState.h
@@ -28,15 +28,15 @@ private:
 	void skipSplash();
 
 private:
-	NAS2D::Image				mLogoLairworks;
-	NAS2D::Image				mLogoNas2d;
-	NAS2D::Image				mLogoOutpostHd;
-	NAS2D::Image				mFlare;
-	NAS2D::Image				mByline;
+	NAS2D::Image mLogoLairworks;
+	NAS2D::Image mLogoNas2d;
+	NAS2D::Image mLogoOutpostHd;
+	NAS2D::Image mFlare;
+	NAS2D::Image mByline;
 
-	NAS2D::Point<int>			mMousePosition;
+	NAS2D::Point<int> mMousePosition;
 
-	NAS2D::Timer				mTimer;
+	NAS2D::Timer mTimer;
 
-	NAS2D::State*				mReturnState = this;
+	NAS2D::State* mReturnState = this;
 };

--- a/OPHD/States/Wrapper.h
+++ b/OPHD/States/Wrapper.h
@@ -52,7 +52,7 @@ private:
 
 
 private:
-	bool	_active;
+	bool _active;
 };
 
 

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -10,7 +10,7 @@ std::array<ResourcePool, StructureID::SID_COUNT> StructureCatalogue::mStructureR
 std::array<PopulationRequirements, StructureID::SID_COUNT> StructureCatalogue::mPopulationRequirementsTable = {};
 
 
-const float	DEFAULT_RECYCLE_VALUE = 0.9f;	/**	Default recycle value. Currently set at 90% but this should probably be
+const float DEFAULT_RECYCLE_VALUE = 0.9f; /**	Default recycle value. Currently set at 90% but this should probably be
 											 *	lowered for actual gameplay with modifiers to improve efficiency. */
 
 
@@ -252,31 +252,31 @@ bool StructureCatalogue::canBuild(const ResourcePool& source, StructureID type)
 void StructureCatalogue::buildCostTable()
 {
 	// RESOURCES: COMM_MET_ORE, COMM_MIN_ORE, RARE_MET_ORE, RARE_MIN_ORE, COMM_MET, COMM_MIN, RARE_MET, RARE_MIN
-	mStructureCostTable[StructureID::SID_AGRIDOME]				= ResourcePool(0, 0, 0, 0, 20, 10, 5, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_CHAP]					= ResourcePool(0, 0, 0, 0, 50, 10, 20, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_COMMAND_CENTER]			= ResourcePool(0, 0, 0, 0, 100, 75, 65, 35, 0, 0);
-	mStructureCostTable[StructureID::SID_COMMERCIAL]				= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_COMM_TOWER]				= ResourcePool(0, 0, 0, 0, 30, 10, 5, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_FUSION_REACTOR]			= ResourcePool(0, 0, 0, 0, 75, 25, 50, 30, 0, 0);
-	mStructureCostTable[StructureID::SID_HOT_LABORATORY]			= ResourcePool(0, 0, 0, 0, 45, 10, 15, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_LABORATORY]				= ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_MEDICAL_CENTER]			= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_NURSERY]				= ResourcePool(0, 0, 0, 0, 20, 10, 5, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_PARK]					= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_SURFACE_POLICE]			= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_UNDERGROUND_POLICE]		= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_RECREATION_CENTER]		= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_RED_LIGHT_DISTRICT]		= ResourcePool(0, 0, 0, 0, 20, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_RESIDENCE]				= ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
-	mStructureCostTable[StructureID::SID_ROBOT_COMMAND]			= ResourcePool(0, 0, 0, 0, 75, 50, 45, 25, 0, 0);
-	mStructureCostTable[StructureID::SID_SMELTER]				= ResourcePool(0, 0, 0, 0, 30, 20, 10, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_SOLAR_PANEL1]			= ResourcePool(0, 0, 0, 0, 10, 20, 5, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_SOLAR_PLANT]			= ResourcePool(0, 0, 0, 0, 50, 25, 50, 20, 0, 0);
-	mStructureCostTable[StructureID::SID_STORAGE_TANKS]			= ResourcePool(0, 0, 0, 0, 15, 5, 6, 1, 0, 0);
-	mStructureCostTable[StructureID::SID_SURFACE_FACTORY]		= ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_UNDERGROUND_FACTORY]	= ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_UNIVERSITY]				= ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
-	mStructureCostTable[StructureID::SID_WAREHOUSE]				= ResourcePool(0, 0, 0, 0, 15, 5, 6, 1, 0, 0);
+	mStructureCostTable[StructureID::SID_AGRIDOME] = ResourcePool(0, 0, 0, 0, 20, 10, 5, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_CHAP] = ResourcePool(0, 0, 0, 0, 50, 10, 20, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_COMMAND_CENTER] = ResourcePool(0, 0, 0, 0, 100, 75, 65, 35, 0, 0);
+	mStructureCostTable[StructureID::SID_COMMERCIAL] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_COMM_TOWER] = ResourcePool(0, 0, 0, 0, 30, 10, 5, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_FUSION_REACTOR] = ResourcePool(0, 0, 0, 0, 75, 25, 50, 30, 0, 0);
+	mStructureCostTable[StructureID::SID_HOT_LABORATORY] = ResourcePool(0, 0, 0, 0, 45, 10, 15, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_LABORATORY] = ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_MEDICAL_CENTER] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_NURSERY] = ResourcePool(0, 0, 0, 0, 20, 10, 5, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_PARK] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_SURFACE_POLICE] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_UNDERGROUND_POLICE] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_RECREATION_CENTER] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_RED_LIGHT_DISTRICT] = ResourcePool(0, 0, 0, 0, 20, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_RESIDENCE] = ResourcePool(0, 0, 0, 0, 25, 5, 2, 0, 0, 0);
+	mStructureCostTable[StructureID::SID_ROBOT_COMMAND] = ResourcePool(0, 0, 0, 0, 75, 50, 45, 25, 0, 0);
+	mStructureCostTable[StructureID::SID_SMELTER] = ResourcePool(0, 0, 0, 0, 30, 20, 10, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_SOLAR_PANEL1] = ResourcePool(0, 0, 0, 0, 10, 20, 5, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_SOLAR_PLANT] = ResourcePool(0, 0, 0, 0, 50, 25, 50, 20, 0, 0);
+	mStructureCostTable[StructureID::SID_STORAGE_TANKS] = ResourcePool(0, 0, 0, 0, 15, 5, 6, 1, 0, 0);
+	mStructureCostTable[StructureID::SID_SURFACE_FACTORY] = ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_UNDERGROUND_FACTORY] = ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_UNIVERSITY] = ResourcePool(0, 0, 0, 0, 20, 10, 10, 5, 0, 0);
+	mStructureCostTable[StructureID::SID_WAREHOUSE] = ResourcePool(0, 0, 0, 0, 15, 5, 6, 1, 0, 0);
 }
 
 
@@ -292,13 +292,13 @@ void StructureCatalogue::buildRecycleValueTable()
 
 	// Set recycling values for landers and automatically built structures.
 	// RESOURCES: COMM_MET_ORE, COMM_MIN_ORE, RARE_MET_ORE, RARE_MIN_ORE, COMM_MET, COMM_MIN, RARE_MET, RARE_MIN
-	mStructureRecycleValueTable[StructureID::SID_MINE_FACILITY]		= ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
-	mStructureRecycleValueTable[StructureID::SID_CARGO_LANDER]		= ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
-	mStructureRecycleValueTable[StructureID::SID_COLONIST_LANDER]	= ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
-	mStructureRecycleValueTable[StructureID::SID_SEED_LANDER]		= ResourcePool(0, 0, 0, 0, 10, 5, 5, 5, 0, 0);
-	mStructureRecycleValueTable[StructureID::SID_SEED_FACTORY]		= ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
-	mStructureRecycleValueTable[StructureID::SID_SEED_POWER]			= ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
-	mStructureRecycleValueTable[StructureID::SID_SEED_SMELTER]		= ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_MINE_FACILITY] = ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_CARGO_LANDER] = ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_COLONIST_LANDER] = ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_SEED_LANDER] = ResourcePool(0, 0, 0, 0, 10, 5, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_SEED_FACTORY] = ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_SEED_POWER] = ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
+	mStructureRecycleValueTable[StructureID::SID_SEED_SMELTER] = ResourcePool(0, 0, 0, 0, 15, 10, 5, 5, 0, 0);
 
 }
 
@@ -308,30 +308,30 @@ void StructureCatalogue::buildRecycleValueTable()
  */
 void StructureCatalogue::buildPopulationRequirementsTable()
 {
-	//												WORKERS, SCIENTISTS
-	mPopulationRequirementsTable[StructureID::SID_AGRIDOME]				= { 1, 0 };
-	mPopulationRequirementsTable[StructureID::SID_CHAP]					= { 2, 0 };
-	mPopulationRequirementsTable[StructureID::SID_COMMAND_CENTER]		= { 3, 0 };
-	mPopulationRequirementsTable[StructureID::SID_COMMERCIAL]			= { 1, 0 };
-	mPopulationRequirementsTable[StructureID::SID_FUSION_REACTOR]		= { 1, 2 };
-	mPopulationRequirementsTable[StructureID::SID_HOT_LABORATORY]		= { 1, 5 };
-	mPopulationRequirementsTable[StructureID::SID_LABORATORY]			= { 1, 5 };
-	mPopulationRequirementsTable[StructureID::SID_MEDICAL_CENTER]		= { 1, 2 };
-	mPopulationRequirementsTable[StructureID::SID_NURSERY]				= { 1, 1 };
-	mPopulationRequirementsTable[StructureID::SID_PARK]					= { 1, 0 };
-	mPopulationRequirementsTable[StructureID::SID_SURFACE_POLICE]		= { 5, 0 };
-	mPopulationRequirementsTable[StructureID::SID_UNDERGROUND_POLICE]	= { 5, 0 };
-	mPopulationRequirementsTable[StructureID::SID_RECREATION_CENTER]		= { 2, 0 };
-	mPopulationRequirementsTable[StructureID::SID_RED_LIGHT_DISTRICT]	= { 2, 0 };
-	mPopulationRequirementsTable[StructureID::SID_ROBOT_COMMAND]			= { 4, 0 };
-	mPopulationRequirementsTable[StructureID::SID_SEED_FACTORY]			= { 2, 0 };
-	mPopulationRequirementsTable[StructureID::SID_SEED_SMELTER]			= { 2, 0 };
-	mPopulationRequirementsTable[StructureID::SID_SMELTER]				= { 4, 0 };
-	mPopulationRequirementsTable[StructureID::SID_SOLAR_PANEL1]			= { 1, 0 };
-	mPopulationRequirementsTable[StructureID::SID_SURFACE_FACTORY]		= { 4, 0 };
-	mPopulationRequirementsTable[StructureID::SID_UNDERGROUND_FACTORY]	= { 2, 0 };
-	mPopulationRequirementsTable[StructureID::SID_UNIVERSITY]			= { 1, 3 };
-	mPopulationRequirementsTable[StructureID::SID_WAREHOUSE]				= { 1, 0 };
+	// WORKERS, SCIENTISTS
+	mPopulationRequirementsTable[StructureID::SID_AGRIDOME] = { 1, 0 };
+	mPopulationRequirementsTable[StructureID::SID_CHAP] = { 2, 0 };
+	mPopulationRequirementsTable[StructureID::SID_COMMAND_CENTER] = { 3, 0 };
+	mPopulationRequirementsTable[StructureID::SID_COMMERCIAL] = { 1, 0 };
+	mPopulationRequirementsTable[StructureID::SID_FUSION_REACTOR] = { 1, 2 };
+	mPopulationRequirementsTable[StructureID::SID_HOT_LABORATORY] = { 1, 5 };
+	mPopulationRequirementsTable[StructureID::SID_LABORATORY] = { 1, 5 };
+	mPopulationRequirementsTable[StructureID::SID_MEDICAL_CENTER] = { 1, 2 };
+	mPopulationRequirementsTable[StructureID::SID_NURSERY] = { 1, 1 };
+	mPopulationRequirementsTable[StructureID::SID_PARK] = { 1, 0 };
+	mPopulationRequirementsTable[StructureID::SID_SURFACE_POLICE] = { 5, 0 };
+	mPopulationRequirementsTable[StructureID::SID_UNDERGROUND_POLICE] = { 5, 0 };
+	mPopulationRequirementsTable[StructureID::SID_RECREATION_CENTER] = { 2, 0 };
+	mPopulationRequirementsTable[StructureID::SID_RED_LIGHT_DISTRICT] = { 2, 0 };
+	mPopulationRequirementsTable[StructureID::SID_ROBOT_COMMAND] = { 4, 0 };
+	mPopulationRequirementsTable[StructureID::SID_SEED_FACTORY] = { 2, 0 };
+	mPopulationRequirementsTable[StructureID::SID_SEED_SMELTER] = { 2, 0 };
+	mPopulationRequirementsTable[StructureID::SID_SMELTER] = { 4, 0 };
+	mPopulationRequirementsTable[StructureID::SID_SOLAR_PANEL1] = { 1, 0 };
+	mPopulationRequirementsTable[StructureID::SID_SURFACE_FACTORY] = { 4, 0 };
+	mPopulationRequirementsTable[StructureID::SID_UNDERGROUND_FACTORY] = { 2, 0 };
+	mPopulationRequirementsTable[StructureID::SID_UNIVERSITY] = { 1, 3 };
+	mPopulationRequirementsTable[StructureID::SID_WAREHOUSE] = { 1, 0 };
 }
 
 

--- a/OPHD/StructureCatalogue.h
+++ b/OPHD/StructureCatalogue.h
@@ -36,8 +36,8 @@ public:
 	static bool canBuild(const ResourcePool& source, StructureID type);
 
 private:
-	StructureCatalogue() {}	// Explicitly declared private to prevent instantiation.
-	~StructureCatalogue() {}	// Explicitly declared private to prevent instantiation.
+	StructureCatalogue() {} // Explicitly declared private to prevent instantiation.
+	~StructureCatalogue() {} // Explicitly declared private to prevent instantiation.
 
 	static void buildCostTable();
 	static void buildPopulationRequirementsTable();

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -66,25 +66,25 @@ void StructureManager::update(ResourcePool& resourcePool, PopulationPool& popPoo
 	// Called separately so that 1) high priority structures can be updated first and
 	// 2) so that resource handling code (like energy) can be handled between update
 	// calls to lower priority structures.
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_LANDER]);				// No resource needs
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_COMMAND]);			// Self sufficient
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_ENERGY_PRODUCTION]);	// Nothing can work without energy
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_LANDER]); // No resource needs
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_COMMAND]); // Self sufficient
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_ENERGY_PRODUCTION]); // Nothing can work without energy
 
 	updateEnergyProduction(resourcePool, popPool);
 
 	// Basic resource production
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_MINE]);				// Can't operate without resources.
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_MINE]); // Can't operate without resources.
 	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_SMELTER]);
 
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_LIFE_SUPPORT]);		// Air, water food must come before others
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_LIFE_SUPPORT]); // Air, water food must come before others
 	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_FOOD_PRODUCTION]);
 
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_MEDICAL_CENTER]);		// No medical facilities, people die
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_MEDICAL_CENTER]); // No medical facilities, people die
 	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_NURSERY]);
 
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_FACTORY]);			// Production
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_FACTORY]); // Production
 
-	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_STORAGE]);			// Everything else.
+	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_STORAGE]); // Everything else.
 	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_PARK]);
 	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_SURFACE_POLICE]);
 	updateStructures(resourcePool, popPool, mStructureLists[Structure::StructureClass::CLASS_UNDERGROUND_POLICE]);
@@ -467,7 +467,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 			for (std::size_t i = 0; i < rl.size(); ++i)
 			{
 				str << rl[i]->id();
-				if (i != rl.size() - 1) { str << ","; }	// kind of a kludge
+				if (i != rl.size() - 1) { str << ","; } // kind of a kludge
 			}
 
 			robots->attribute("robots", str.str());

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -55,8 +55,8 @@ private:
 	bool structureConnected(Structure* st) { return mStructureTileTable[st]->connected(); }
 
 private:
-	StructureTileTable	mStructureTileTable;		/**< List mapping Structure's to a particular tile. */
-	StructureClassTable	mStructureLists;			/**< Map containing all of the structure list types available. */
+	StructureTileTable mStructureTileTable; /**< List mapping Structure's to a particular tile. */
+	StructureClassTable mStructureLists; /**< Map containing all of the structure list types available. */
 
-	int					mTotalEnergyOutput = 0;		/**< Total energy output of all energy producers in the structure list. */
+	int mTotalEnergyOutput = 0; /**< Total energy output of all energy producers in the structure list. */
 };

--- a/OPHD/StructureTranslator.h
+++ b/OPHD/StructureTranslator.h
@@ -38,6 +38,6 @@ private:
 
 	static void buildTables();
 
-	static std::map<std::string, StructureID>		_stringToStructureTable;
-	static std::array<std::string, StructureID::SID_COUNT>		_structureToStringTable;
+	static std::map<std::string, StructureID> _stringToStructureTable;
+	static std::array<std::string, StructureID::SID_COUNT> _structureToStringTable;
 };

--- a/OPHD/Things/Robots/Robodigger.h
+++ b/OPHD/Things/Robots/Robodigger.h
@@ -9,8 +9,9 @@
 class Robodigger: public Robot
 {
 public:
-	Robodigger():	Robot(constants::ROBODIGGER, "robots/robodigger.sprite"),
-					mDirection(Direction::DIR_DOWN)
+	Robodigger() :
+		Robot(constants::ROBODIGGER, "robots/robodigger.sprite"),
+		mDirection(Direction::DIR_DOWN)
 	{
 		sprite().play("running");
 	}

--- a/OPHD/Things/Robots/Robodigger.h
+++ b/OPHD/Things/Robots/Robodigger.h
@@ -23,5 +23,5 @@ public:
 
 private:
 
-	Direction		mDirection;
+	Direction mDirection;
 };

--- a/OPHD/Things/Robots/Robot.cpp
+++ b/OPHD/Things/Robots/Robot.cpp
@@ -14,8 +14,8 @@ void Robot::startTask(int turns)
 	{
 		mTurnsToCompleteTask = 1;
 		return;
-	}	
-		
+	}
+
 	mTurnsToCompleteTask = turns;
 }
 

--- a/OPHD/Things/Robots/Robot.cpp
+++ b/OPHD/Things/Robots/Robot.cpp
@@ -3,7 +3,8 @@
 
 #include "Robot.h"
 
-Robot::Robot(const std::string& name, const std::string& sprite_path) :	Thing(name, sprite_path)
+Robot::Robot(const std::string& name, const std::string& sprite_path) :
+	Thing(name, sprite_path)
 {}
 
 

--- a/OPHD/Things/Robots/Robot.h
+++ b/OPHD/Things/Robots/Robot.h
@@ -34,12 +34,12 @@ protected:
 	void updateTask();
 
 private:
-	int				mId = 0;
-	int				mFuelCellAge = 0;
-	int				mTurnsToCompleteTask = 0;
+	int mId = 0;
+	int mFuelCellAge = 0;
+	int mTurnsToCompleteTask = 0;
 
-	bool			mSelfDestruct = false;
+	bool mSelfDestruct = false;
 
-	TaskCallback	mTaskCompleteCallback;
-	Callback		mSelfDestructCallback;
+	TaskCallback mTaskCompleteCallback;
+	Callback mSelfDestructCallback;
 };

--- a/OPHD/Things/Structures/AirShaft.h
+++ b/OPHD/Things/Structures/AirShaft.h
@@ -6,7 +6,7 @@
 class AirShaft: public Structure
 {
 public:
-	AirShaft():	Structure(constants::AIR_SHAFT, "structures/air_shaft.sprite", StructureClass::CLASS_TUBE)
+	AirShaft() : Structure(constants::AIR_SHAFT, "structures/air_shaft.sprite", StructureClass::CLASS_TUBE)
 	{
 		sprite().play(constants::STRUCTURE_STATE_OPERATIONAL);
 		maxAge(400);

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -41,6 +41,6 @@ private:
 	CargoLander& operator=(const CargoLander&) = delete;
 
 private:
-	Callback	mDeploy;
-	Tile*		mTile = nullptr;
+	Callback mDeploy;
+	Tile* mTile = nullptr;
 };

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -37,7 +37,7 @@ protected:
 	}
 
 private:
-	Callback	mDeploy;
+	Callback mDeploy;
 
-	Tile*		mTile;
+	Tile* mTile;
 };

--- a/OPHD/Things/Structures/CommTower.h
+++ b/OPHD/Things/Structures/CommTower.h
@@ -4,7 +4,7 @@
 
 #include "../../Constants.h"
 
-class CommTower :	public Structure
+class CommTower : public Structure
 {
 public:
 

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -41,7 +41,8 @@ const ProductionCost& productCost(ProductType _pt)
 
 
 
-Factory::Factory(const std::string& name, const std::string& spritePath) :	Structure(name, spritePath, StructureClass::CLASS_FACTORY)
+Factory::Factory(const std::string& name, const std::string& spritePath) :
+	Structure(name, spritePath, StructureClass::CLASS_FACTORY)
 {}
 
 

--- a/OPHD/Things/Structures/Factory.h
+++ b/OPHD/Things/Structures/Factory.h
@@ -61,17 +61,17 @@ protected:
 	ResourcePool* resourcePool() { return mResourcesPool; }
 
 private:
-	int								mTurnsCompleted = 0;
-	int								mTurnsToComplete = 0;
+	int mTurnsCompleted = 0;
+	int mTurnsToComplete = 0;
 
-	ProductType						mProduct = ProductType::PRODUCT_NONE;
-	ProductType						mProductWaiting = ProductType::PRODUCT_NONE;	/**< Product that is waiting to be pulled from the factory. */
+	ProductType mProduct = ProductType::PRODUCT_NONE;
+	ProductType mProductWaiting = ProductType::PRODUCT_NONE; /**< Product that is waiting to be pulled from the factory. */
 
-	ProductionTypeList				mAvailableProducts;			/**< List of products that the Factory can produce. */
+	ProductionTypeList mAvailableProducts; /**< List of products that the Factory can produce. */
 
-	ProductionCallback				mProductionComplete;		/**< Callback used when production is complete. */
+	ProductionCallback mProductionComplete; /**< Callback used when production is complete. */
 
-	ResourcePool*					mResourcesPool = nullptr;	/**< Pointer to the player's resource pool. UGLY. */
+	ResourcePool* mResourcesPool = nullptr; /**< Pointer to the player's resource pool. UGLY. */
 };
 
 const ProductionCost& productCost(ProductType);

--- a/OPHD/Things/Structures/MineFacility.h
+++ b/OPHD/Things/Structures/MineFacility.h
@@ -42,10 +42,10 @@ private:
 	void activated() override;
 
 private:
-	int							mMaxDepth = 0;				/**< Maximum digging depth. */
-	int							mDigTurnsRemaining = 0;		/**< Turns remaining before extension is complete. */
+	int mMaxDepth = 0; /**< Maximum digging depth. */
+	int mDigTurnsRemaining = 0; /**< Turns remaining before extension is complete. */
 
-	Mine*						mMine = nullptr;			/**< Mine that this facility manages. */
+	Mine* mMine = nullptr; /**< Mine that this facility manages. */
 
-	ExtensionCompleteCallback	mExtensionComplete;			/**< Called whenever an extension is completed. */
+	ExtensionCompleteCallback mExtensionComplete; /**< Called whenever an extension is completed. */
 };

--- a/OPHD/Things/Structures/Residence.h
+++ b/OPHD/Things/Structures/Residence.h
@@ -33,5 +33,5 @@ protected:
 	}
 
 protected:
-	int		mCapacity = 25;		/**< Override this value in derived residences.*/
+	int mCapacity = 25; /**< Override this value in derived residences.*/
 };

--- a/OPHD/Things/Structures/RobotCommand.h
+++ b/OPHD/Things/Structures/RobotCommand.h
@@ -39,5 +39,5 @@ protected:
 	}
 
 private:
-	RobotList	mRobotList;
+	RobotList mRobotList;
 };

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -46,7 +46,7 @@ protected:
 	}
 
 private:
-	Callback	mDeploy;
+	Callback mDeploy;
 
-	int			mX = 0, mY = 0;
+	int mX = 0, mY = 0;
 };

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -10,8 +10,10 @@ public:
 
 public:
 	SeedLander() = delete;
-	SeedLander(int x, int y):	Structure(constants::SEED_LANDER, "structures/seed_0.sprite", StructureClass::CLASS_LANDER),
-								mX(x), mY(y)
+	SeedLander(int x, int y) :
+		Structure(constants::SEED_LANDER, "structures/seed_0.sprite", StructureClass::CLASS_LANDER),
+		mX(x),
+		mY(y)
 	{
 		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(50);

--- a/OPHD/Things/Structures/SeedPower.h
+++ b/OPHD/Things/Structures/SeedPower.h
@@ -5,7 +5,8 @@
 class SeedPower: public Structure
 {
 public:
-	SeedPower():	Structure(constants::SEED_POWER, "structures/seed_1.sprite", StructureClass::CLASS_ENERGY_PRODUCTION)
+	SeedPower() :
+		Structure(constants::SEED_POWER, "structures/seed_1.sprite", StructureClass::CLASS_ENERGY_PRODUCTION)
 	{
 		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(150);

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -11,11 +11,11 @@
  */
 std::map<Structure::StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
 {
-	{ Structure::StructureState::UNDER_CONSTRUCTION,	"Under Construction" },
-	{ Structure::StructureState::OPERATIONAL,			"Operational" },
-	{ Structure::StructureState::IDLE,					"Idle" },
-	{ Structure::StructureState::DISABLED,				"Disabled" },
-	{ Structure::StructureState::DESTROYED,				"Destroyed" },
+	{ Structure::StructureState::UNDER_CONSTRUCTION, "Under Construction" },
+	{ Structure::StructureState::OPERATIONAL, "Operational" },
+	{ Structure::StructureState::IDLE, "Idle" },
+	{ Structure::StructureState::DISABLED, "Disabled" },
+	{ Structure::StructureState::DESTROYED, "Destroyed" },
 };
 
 
@@ -24,27 +24,27 @@ std::map<Structure::StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
  */
 std::map<Structure::StructureClass, std::string> STRUCTURE_CLASS_TRANSLATION =
 {
-	{ Structure::StructureClass::CLASS_COMMAND,				"Command" },
-	{ Structure::StructureClass::CLASS_COMM,				"Communication" },
-	{ Structure::StructureClass::CLASS_COMMERCIAL,			"Commercial" },
-	{ Structure::StructureClass::CLASS_ENERGY_PRODUCTION,	"Energy Production" },
-	{ Structure::StructureClass::CLASS_FACTORY,				"Factory" },
-	{ Structure::StructureClass::CLASS_FOOD_PRODUCTION,		"Food Production" },
-	{ Structure::StructureClass::CLASS_LABORATORY,			"Laboratory" },
-	{ Structure::StructureClass::CLASS_LANDER,				"Lander" },
-	{ Structure::StructureClass::CLASS_LIFE_SUPPORT,		"Life Support" },
-	{ Structure::StructureClass::CLASS_MINE,				"Mine Facility" },
-	{ Structure::StructureClass::CLASS_PARK,				"Park / Reservoir" },
-	{ Structure::StructureClass::CLASS_SURFACE_POLICE,		"Police" },
-	{ Structure::StructureClass::CLASS_UNDERGROUND_POLICE,	"Police" },
-	{ Structure::StructureClass::CLASS_RECREATION_CENTER,	"Recreation Center" },
-	{ Structure::StructureClass::CLASS_RECYCLING,			"Recycling" },
-	{ Structure::StructureClass::CLASS_RESIDENCE,			"Residential" },
-	{ Structure::StructureClass::CLASS_SMELTER,				"Raw Ore Processing" },
-	{ Structure::StructureClass::CLASS_STORAGE,				"Storage" },
-	{ Structure::StructureClass::CLASS_TUBE,				"Tube" },
-	{ Structure::StructureClass::CLASS_UNDEFINED,			"UNDEFINED" },
-	{ Structure::StructureClass::CLASS_UNIVERSITY,			"University" }
+	{ Structure::StructureClass::CLASS_COMMAND, "Command" },
+	{ Structure::StructureClass::CLASS_COMM, "Communication" },
+	{ Structure::StructureClass::CLASS_COMMERCIAL, "Commercial" },
+	{ Structure::StructureClass::CLASS_ENERGY_PRODUCTION, "Energy Production" },
+	{ Structure::StructureClass::CLASS_FACTORY, "Factory" },
+	{ Structure::StructureClass::CLASS_FOOD_PRODUCTION, "Food Production" },
+	{ Structure::StructureClass::CLASS_LABORATORY, "Laboratory" },
+	{ Structure::StructureClass::CLASS_LANDER, "Lander" },
+	{ Structure::StructureClass::CLASS_LIFE_SUPPORT, "Life Support" },
+	{ Structure::StructureClass::CLASS_MINE, "Mine Facility" },
+	{ Structure::StructureClass::CLASS_PARK, "Park / Reservoir" },
+	{ Structure::StructureClass::CLASS_SURFACE_POLICE, "Police" },
+	{ Structure::StructureClass::CLASS_UNDERGROUND_POLICE, "Police" },
+	{ Structure::StructureClass::CLASS_RECREATION_CENTER, "Recreation Center" },
+	{ Structure::StructureClass::CLASS_RECYCLING, "Recycling" },
+	{ Structure::StructureClass::CLASS_RESIDENCE, "Residential" },
+	{ Structure::StructureClass::CLASS_SMELTER, "Raw Ore Processing" },
+	{ Structure::StructureClass::CLASS_STORAGE, "Storage" },
+	{ Structure::StructureClass::CLASS_TUBE, "Tube" },
+	{ Structure::StructureClass::CLASS_UNDEFINED, "UNDEFINED" },
+	{ Structure::StructureClass::CLASS_UNIVERSITY, "University" }
 };
 
 
@@ -225,11 +225,11 @@ void Structure::forced_state_change(StructureState _s, DisabledReason _dr, IdleR
 		//enable();
 	}
 
-	if (_s == StructureState::OPERATIONAL)				{ enable(); }
-	else if (_s == StructureState::IDLE)				{ idle(_ir); }
-	else if (_s == StructureState::DISABLED)			{ disable(_dr); }
-	else if (_s == StructureState::DESTROYED)			{ destroy(); }
-	else if (_s == StructureState::UNDER_CONSTRUCTION)	{ mStructureState = StructureState::UNDER_CONSTRUCTION; } // Kludge
+	if (_s == StructureState::OPERATIONAL) { enable(); }
+	else if (_s == StructureState::IDLE) { idle(_ir); }
+	else if (_s == StructureState::DISABLED) { disable(_dr); }
+	else if (_s == StructureState::DESTROYED) { destroy(); }
+	else if (_s == StructureState::UNDER_CONSTRUCTION) { mStructureState = StructureState::UNDER_CONSTRUCTION; } // Kludge
 }
 
 

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -63,9 +63,9 @@ const std::string& structureClassDescription(Structure::StructureClass _class)
 /**
  * C'tor
  */
-Structure::Structure(const std::string& name, const std::string& spritePath, StructureClass structureClass):	Thing(name, spritePath),
+Structure::Structure(const std::string& name, const std::string& spritePath, StructureClass structureClass) :
+	Thing(name, spritePath),
 	mStructureClass(structureClass)
-
 {
 	mPopulationRequirements.fill(0);
 	mPopulationAvailable.fill(0);

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -55,7 +55,7 @@ public:
 		CLASS_SMELTER,
 		CLASS_STORAGE,
 		CLASS_TUBE,
-		CLASS_UNDEFINED,			/**< Used for structures that have no need for classification. */
+		CLASS_UNDEFINED, /**< Used for structures that have no need for classification. */
 		CLASS_UNIVERSITY,
 		CLASS_WAREHOUSE
 	};
@@ -118,7 +118,7 @@ public:
 	bool isRobotCommand() const { return structureClass() == StructureClass::CLASS_ROBOT_COMMAND; }
 	bool isMineFacility() const { return structureClass() == StructureClass::CLASS_MINE; }
 	bool energyProducer() const { return structureClass() == StructureClass::CLASS_ENERGY_PRODUCTION; }
-	bool isConnector() const { return structureClass() == StructureClass::CLASS_TUBE; }	/** Indicates that the structure can act as a connector (tube) */
+	bool isConnector() const { return structureClass() == StructureClass::CLASS_TUBE; } /** Indicates that the structure can act as a connector (tube) */
 
 	/**
 	 * Set the current age of the Structure.
@@ -169,30 +169,30 @@ private:
 	virtual void activated() {}
 
 private:
-	int						mTurnsToBuild = 0;			/**< Number of turns it takes to build the Structure. */
-	int						mAge = 0;					/**< Age of the Structure in turns. */
-	int						mMaxAge = 0;				/**< Maximum number of turns the Structure can remain in good repair. */
+	int mTurnsToBuild = 0; /**< Number of turns it takes to build the Structure. */
+	int mAge = 0; /**< Age of the Structure in turns. */
+	int mMaxAge = 0; /**< Maximum number of turns the Structure can remain in good repair. */
 
-	StructureState			mStructureState = StructureState::UNDER_CONSTRUCTION;			/**< State the structure is in. */
-	StructureClass			mStructureClass;								/**< Indicates the Structure's Type. */
-	ConnectorDir			mConnectorDirection = ConnectorDir::CONNECTOR_INTERSECTION;	/**< Directions available for connections. */
+	StructureState mStructureState = StructureState::UNDER_CONSTRUCTION; /**< State the structure is in. */
+	StructureClass mStructureClass; /**< Indicates the Structure's Type. */
+	ConnectorDir mConnectorDirection = ConnectorDir::CONNECTOR_INTERSECTION; /**< Directions available for connections. */
 
-	PopulationRequirements	mPopulationRequirements;	/**< Population requirements for structure operation. */
-	PopulationRequirements	mPopulationAvailable;		/**< Determine how many of each type of population required was actually supplied to the structure. */
+	PopulationRequirements mPopulationRequirements; /**< Population requirements for structure operation. */
+	PopulationRequirements mPopulationAvailable; /**< Determine how many of each type of population required was actually supplied to the structure. */
 
-	ResourcePool			mResourcesInput;			/**< Resources needed to operate the Structure. */
-	ResourcePool			mResourcesOutput;			/**< Resources provided by the Structure if operating properly. */
+	ResourcePool mResourcesInput; /**< Resources needed to operate the Structure. */
+	ResourcePool mResourcesOutput; /**< Resources provided by the Structure if operating properly. */
 
-	ResourcePool			mProductionPool;			/**< Resource pool used for production. */
-	ResourcePool			mStoragePool;				/**< Resource storage pool. */
+	ResourcePool mProductionPool; /**< Resource pool used for production. */
+	ResourcePool mStoragePool; /**< Resource storage pool. */
 
-	DisabledReason			mDisabledReason = DisabledReason::DISABLED_NONE;
-	IdleReason				mIdleReason = IdleReason::IDLE_NONE;
+	DisabledReason mDisabledReason = DisabledReason::DISABLED_NONE;
+	IdleReason mIdleReason = IdleReason::IDLE_NONE;
 
-	bool					mRepairable = true;			/**< Indicates whether or not the Structure can be repaired. Useful for forcing some Structures to die at the end of their life. */
-	bool					mRequiresCHAP = true;		/**< Indicates that the Structure needs to have an active CHAP facility in order to operate. */
-	bool					mSelfSustained = false;		/**< Indicates that the Structure is self contained and can operate by itself. */
-	bool					mForcedIdle = false;		/**< Indicates that the Structure was manually set to Idle by the user and should remain that way until the user says otherwise. */
+	bool mRepairable = true; /**< Indicates whether or not the Structure can be repaired. Useful for forcing some Structures to die at the end of their life. */
+	bool mRequiresCHAP = true; /**< Indicates that the Structure needs to have an active CHAP facility in order to operate. */
+	bool mSelfSustained = false; /**< Indicates that the Structure is self contained and can operate by itself. */
+	bool mForcedIdle = false; /**< Indicates that the Structure was manually set to Idle by the user and should remain that way until the user says otherwise. */
 };
 
 

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -67,5 +67,5 @@ private:
 	}
 
 private:
-	bool	mUnderground;
+	bool mUnderground;
 };

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -10,8 +10,9 @@
 class Tube : public Structure
 {
 public:
-	Tube(ConnectorDir dir, bool underground) :	Structure(constants::TUBE, "structures/tubes.sprite", StructureClass::CLASS_TUBE),
-												mUnderground(underground)
+	Tube(ConnectorDir dir, bool underground) :
+		Structure(constants::TUBE, "structures/tubes.sprite", StructureClass::CLASS_TUBE),
+		mUnderground(underground)
 	{
 		connectorDirection(dir);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/Warehouse.h
+++ b/OPHD/Things/Structures/Warehouse.h
@@ -23,7 +23,7 @@ protected:
 	{
 		resourcesIn().energy(1);
 	}
-	
+
 private:
-	ProductPool			mProducts;
+	ProductPool mProducts;
 };

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -59,10 +59,10 @@ private:
 	Thing& operator=(const Thing& thing) = delete;
 
 private:
-	std::string		mName;			/**< Name of the Thing. */
-	NAS2D::Sprite	mSprite;		/**< Sprite used to represent the Thing. */
+	std::string mName; /**< Name of the Thing. */
+	NAS2D::Sprite mSprite; /**< Sprite used to represent the Thing. */
 
-	bool			mIsDead = false;/**< Thing is dead and should be cleaned up. */
+	bool mIsDead = false;/**< Thing is dead and should be cleaned up. */
 
-	DieCallback		mDieCallback;
+	DieCallback mDieCallback;
 };

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -55,18 +55,18 @@ private:
 	void draw() override;
 
 private:
-	State				mState = State::STATE_NORMAL;		/**< Current state of the Button. */
-	Type				mType = Type::BUTTON_NORMAL;		/**< Modifies Button behavior. */
+	State mState = State::STATE_NORMAL; /**< Current state of the Button. */
+	Type mType = Type::BUTTON_NORMAL; /**< Modifies Button behavior. */
 
-	NAS2D::Image*		mImage = nullptr;			/**< Image to draw centered on the Button. */
+	NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
 
-	NAS2D::ImageList	mSkinNormal;
-	NAS2D::ImageList	mSkinHover;
-	NAS2D::ImageList	mSkinPressed;
+	NAS2D::ImageList mSkinNormal;
+	NAS2D::ImageList mSkinHover;
+	NAS2D::ImageList mSkinPressed;
 
-	NAS2D::Font*		mFont = nullptr;			/**< Buttons can have different font sizes. */
+	NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 
-	ClickCallback		mCallback;					/**< Object to notify when the Button is activated. */
+	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 
-	bool				mMouseHover = false;		/**< Mouse is within the bounds of the Button. */
+	bool mMouseHover = false; /**< Mouse is within the bounds of the Button. */
 };

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -31,9 +31,9 @@ protected:
 	void onTextChanged() override;
 	
 private:
-	NAS2D::Image	mSkin;
+	NAS2D::Image mSkin;
 
-	ClickCallback	mCallback;			/**< Object to notify when the Button is activated. */
+	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 
-	bool			mChecked = false;
+	bool mChecked = false;
 };

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -50,13 +50,13 @@ private:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
 private:
-	Button					btnDown;
-	ListBox					lstItems;
-	TextField				txtField;
+	Button btnDown;
+	ListBox lstItems;
+	TextField txtField;
 
-	NAS2D::Rectangle<float>    mBaseArea;
+	NAS2D::Rectangle<float> mBaseArea;
 
-	SelectionChanged        mSelectionChanged;
+	SelectionChanged mSelectionChanged;
 
-	std::size_t            mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
+	std::size_t mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
 };

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -87,20 +87,20 @@ protected:
 	virtual void onTextChanged() { mTextChanged(this); }
 
 protected:
-	PositionChangedCallback		mPositionChanged;	/**< Callback fired whenever the position of the Control changes. */
-	ResizeCallback				mResized;
-	TextChangedCallback			mTextChanged;
+	PositionChangedCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
+	ResizeCallback mResized;
+	TextChangedCallback mTextChanged;
 
-	NAS2D::Rectangle<float>	mRect;				/**< Area of the Control. */
+	NAS2D::Rectangle<float> mRect; /**< Area of the Control. */
 
 private:
 	virtual void draw() {}
 
 protected:
-	std::string				mText;				/**< Internal text string. */
+	std::string mText; /**< Internal text string. */
 
-	bool					mEnabled = true;	/**< Flag indicating whether or not the Control is enabled. */
-	bool					mHasFocus = false;	/**< Flag indicating that the Control has input focus. */
-	bool					mVisible = true;	/**< Flag indicating visibility of the Control. */
-	bool					mHighlight = false;	/**< Flag indicating that this Control is highlighted. */
+	bool mEnabled = true; /**< Flag indicating whether or not the Control is enabled. */
+	bool mHasFocus = false; /**< Flag indicating that the Control has input focus. */
+	bool mVisible = true; /**< Flag indicating visibility of the Control. */
+	bool mHighlight = false; /**< Flag indicating that this Control is highlighted. */
 };

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -306,8 +306,10 @@ void ListBox::update()
 		textPosition.y() += mLineHeight;
 	}
 
-	mSlider.update();		// Shouldn't need this since it's in a UIContainer. Noticing that Slider
-							// doesn't play nice with the UIContainer.
+	// FixMe: Shouldn't need this since it's in a UIContainer. Noticing that Slider
+	// doesn't play nice with the UIContainer.
+	mSlider.update();
+
 	renderer.clipRectClear();
 }
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -29,8 +29,8 @@ public:
 		bool operator==(const std::string& rhs) { return Text == rhs; }
 		bool operator<(const ListBoxItem& lhs) { return Text < lhs.Text; }
 
-		std::string		Text;			/**< Text of the ListBoxItem. */
-		int				Tag = 0;		/**< User defined int data attached to the item. */
+		std::string Text; /**< Text of the ListBoxItem. */
+		int Tag = 0; /**< User defined int data attached to the item. */
 	};
 
 	using ListBoxItems = std::vector<ListBoxItem>;
@@ -44,8 +44,8 @@ public:
 
 	void sort() { if (mSorted) { std::sort(mItems.begin(), mItems.end()); } }
 
-	void textColor(const NAS2D::Color& color)	{ mText = color; }
-	void selectColor(const NAS2D::Color& color)	{ mHighlightBg = color; }
+	void textColor(const NAS2D::Color& color) { mText = color; }
+	void selectColor(const NAS2D::Color& color) { mHighlightBg = color; }
 
 	void addItem(const std::string& item, int tag = 0);
 	void removeItem(const std::string& item);
@@ -87,22 +87,22 @@ private:
 	void _init();
 
 private:
-	std::size_t				mCurrentHighlight = constants::NO_SELECTION;	/**< Currently highlighted selection index. */
-	std::size_t				mCurrentSelection = 0;							/**< Current selection index. */
-	std::size_t				mCurrentOffset = 0;								/**< Current selection index. */
+	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
+	std::size_t mCurrentSelection = 0; /**< Current selection index. */
+	std::size_t mCurrentOffset = 0; /**< Current selection index. */
 
-	unsigned int				mItemWidth = 0;									/**< Width of items. */
-	unsigned int				mLineHeight = 0;								/**< Height of an item line. */
-	unsigned int				mLineCount = 0;									/**< Number of lines that can be displayed. */
+	unsigned int mItemWidth = 0; /**< Width of items. */
+	unsigned int mLineHeight = 0; /**< Height of an item line. */
+	unsigned int mLineCount = 0; /**< Number of lines that can be displayed. */
 
-	ListBoxItems				mItems;											/**< List of items preserved in the order in which they're added. */
+	ListBoxItems mItems; /**< List of items preserved in the order in which they're added. */
 
-	NAS2D::Color				mText = NAS2D::Color::White;					/**< Text Color */
-	NAS2D::Color				mHighlightBg = NAS2D::Color::DarkGreen;				/**< Highlight Background color. */
-	NAS2D::Color				mHighlightText = NAS2D::Color::White;			/**< Text Color for an item that is currently highlighted. */
+	NAS2D::Color mText = NAS2D::Color::White; /**< Text Color */
+	NAS2D::Color mHighlightBg = NAS2D::Color::DarkGreen; /**< Highlight Background color. */
+	NAS2D::Color mHighlightText = NAS2D::Color::White; /**< Text Color for an item that is currently highlighted. */
 
-	SelectionChangedCallback	mSelectionChanged;								/**< Callback for selection changed callback. */
-	Slider						mSlider;
+	SelectionChangedCallback mSelectionChanged; /**< Callback for selection changed callback. */
+	Slider mSlider;
 	
-	bool						mSorted = false;								/**< Flag indicating that all Items should be sorted. */
+	bool mSorted = false; /**< Flag indicating that all Items should be sorted. */
 };

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -330,7 +330,9 @@ void ListBoxBase::update()
 	float highlight_y = positionY() + static_cast<float>((mCurrentHighlight * mItemHeight) - mCurrentOffset);
 	r.drawBoxFilled(positionX(), highlight_y, static_cast<float>(mItemWidth), static_cast<float>(mItemHeight), 0, 185, 0, 50);
 
-	mSlider.update();		// Shouldn't need this since it's in a UIContainer. Noticing that Slider
-							// doesn't play nice with the UIContainer.
+	// FixMe: Shouldn't need this since it's in a UIContainer. Noticing that Slider
+	// doesn't play nice with the UIContainer.
+	mSlider.update();
+
 	r.clipRectClear();
 }

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -44,7 +44,7 @@ public:
 
 	public:
 		std::string Text;
-		NAS2D::Point<int>	Size;
+		NAS2D::Point<int> Size;
 	};
 
 public:
@@ -94,7 +94,7 @@ protected:
 
 
 protected:
-	ItemList					mItems;											/**< List of Items. */
+	ItemList mItems; /**< List of Items. */
 
 private:
 	void _init();
@@ -107,20 +107,20 @@ private:
 	void onSizeChanged() override;
 
 private:
-	unsigned int				mCurrentHighlight = constants::NO_SELECTION;	/**< Currently highlighted selection index. */
-	unsigned int				mCurrentSelection = constants::NO_SELECTION;	/**< Current selection index. */
-	unsigned int				mCurrentOffset = 0;								/**< Draw Offset. */
+	unsigned int mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
+	unsigned int mCurrentSelection = constants::NO_SELECTION; /**< Current selection index. */
+	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
 
-	unsigned int				mItemHeight = 1;								/**< Height of a ListBoxItem. */
-	unsigned int				mItemWidth = 0;									/**< Width of a ListBoxItem. */
-	unsigned int				mLineCount = 0;									/**< Number of lines that can be displayed. */
+	unsigned int mItemHeight = 1; /**< Height of a ListBoxItem. */
+	unsigned int mItemWidth = 0; /**< Width of a ListBoxItem. */
+	unsigned int mLineCount = 0; /**< Number of lines that can be displayed. */
 
-	NAS2D::Point<int>				mMousePosition;									/**< Mouse coordinates. */
+	NAS2D::Point<int> mMousePosition; /**< Mouse coordinates. */
 
-	NAS2D::Color				mText = NAS2D::Color::White;					/**< Text Color */
-	NAS2D::Color				mHighlightBg = NAS2D::Color::DarkGreen;				/**< Highlight Background color. */
-	NAS2D::Color				mHighlightText = NAS2D::Color::White;			/**< Text Color for an item that is currently highlighted. */
+	NAS2D::Color mText = NAS2D::Color::White; /**< Text Color */
+	NAS2D::Color mHighlightBg = NAS2D::Color::DarkGreen; /**< Highlight Background color. */
+	NAS2D::Color mHighlightText = NAS2D::Color::White; /**< Text Color for an item that is currently highlighted. */
 
-	SelectionChangedCallback	mSelectionChanged;								/**< Callback for selection changed callback. */
-	Slider						mSlider;										/**< Slider control. */
+	SelectionChangedCallback mSelectionChanged; /**< Callback for selection changed callback. */
+	Slider mSlider; /**< Slider control. */
 };

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -39,11 +39,11 @@ protected:
 	void parentContainer(UIContainer* parent);
 
 private:
-	NAS2D::Image	mSkin;
-	Label			mLabel;
-	ClickCallback	mCallback;			/**< Object to notify when the Button is activated. */
-	UIContainer*	mParentContainer{nullptr};
-	bool			mChecked{false};
+	NAS2D::Image mSkin;
+	Label mLabel;
+	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
+	UIContainer* mParentContainer{nullptr};
+	bool mChecked{false};
 
 	friend class UIContainer;
 };

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -24,7 +24,7 @@ static Font* SLD_FONT = nullptr;
 /**
  * C'tor
  */
-Slider::Slider() :	Control()
+Slider::Slider() : Control()
 {
 	SLD_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Slider::onMouseDown);
@@ -393,17 +393,17 @@ void Slider::draw()
 	}
 	else
 	{
-		r.drawImageRect(mSlideBar.x(), mSlideBar.y(), mSlideBar.width(), mSlideBar.height(), mSkinMiddle);	// slide area
-		r.drawImageRect(mButton1.x(), mButton1.y(), mButton1.height(), mButton1.height(), mSkinButton1);	// left button
-		r.drawImageRect(mButton2.x(), mButton2.y(), mButton2.height(), mButton2.height(), mSkinButton2);	// right button
+		r.drawImageRect(mSlideBar.x(), mSlideBar.y(), mSlideBar.width(), mSlideBar.height(), mSkinMiddle); // slide area
+		r.drawImageRect(mButton1.x(), mButton1.y(), mButton1.height(), mButton1.height(), mSkinButton1); // left button
+		r.drawImageRect(mButton2.x(), mButton2.y(), mButton2.height(), mButton2.height(), mSkinButton2); // right button
 
 		// Slider
-		mSlider.height(mSlideBar.height());	// height = slide bar height
+		mSlider.height(mSlideBar.height()); // height = slide bar height
 
 		// Fractional value can be dropped to avoid 'fuzzy' rendering due to texture filtering
 		int width_i = static_cast<int>(mSlideBar.width() / (mLength + 1.0f));
 		mSlider.width(static_cast<float>(width_i)); //relative width
-		if (mSlider.width() < mSlider.height())	// not too relative. Minimum = Heigt itself
+		if (mSlider.width() < mSlider.height()) // not too relative. Minimum = Heigt itself
 		{
 			mSlider.width(mSlider.height());
 		}

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -28,8 +28,8 @@ public:
 	 */
 	enum SliderType
 	{
-		SLIDER_VERTICAL,	/*!< Vertical slider. */
-		SLIDER_HORIZONTAL	/*!< Horizontal slider. */
+		SLIDER_VERTICAL, /*!< Vertical slider. */
+		SLIDER_HORIZONTAL /*!< Horizontal slider. */
 	};
 
 	using ValueChangedCallback = NAS2D::Signals::Signal<float>; /*!< type for Callback on value changed. */
@@ -38,77 +38,77 @@ public:
 	Slider();
 	~Slider() override;
 
-	void thumbPosition(float value);		/*!< Set the current position. */
-	float thumbPosition();					/*!< Get the current position. */
-	void changeThumbPosition(float change);	/*!< Adds the change amount to the current position. */
+	void thumbPosition(float value); /*!< Set the current position. */
+	float thumbPosition(); /*!< Get the current position. */
+	void changeThumbPosition(float change); /*!< Adds the change amount to the current position. */
 
-	void thumbPositionNormalized(float value);		/*!< Set the current position. */
-	float thumbPositionNormalized();					/*!< Get the current position. */
+	void thumbPositionNormalized(float value); /*!< Set the current position. */
+	float thumbPositionNormalized(); /*!< Get the current position. */
 
-	bool displayPosition() { return mDisplayPosition;}			/*!< Get the position display flag. */
-	void displayPosition(bool value) { mDisplayPosition = value; }	/*!< Set the position display flag. */
+	bool displayPosition() { return mDisplayPosition;} /*!< Get the position display flag. */
+	void displayPosition(bool value) { mDisplayPosition = value; } /*!< Set the position display flag. */
 
-	float length(); 			/*!< Get the max value for the slide area. */
-	void length(float length);	/*!< Set the max value for the slide area. */
+	float length(); /*!< Get the max value for the slide area. */
+	void length(float length); /*!< Set the max value for the slide area. */
 	
-	bool backward() { return mBackward; }	 	/*!< Get the backward flag. */
-	void backward(bool isBackward) { mBackward = isBackward; } 	/*!< Set the backward flag. */
+	bool backward() { return mBackward; } /*!< Get the backward flag. */
+	void backward(bool isBackward) { mBackward = isBackward; } /*!< Set the backward flag. */
 
-	void update() override; 							/*!< Called to display the slider. */
-	void size(NAS2D::Vector<float> size); 	/*!< Set the slider size. */
+	void update() override; /*!< Called to display the slider. */
+	void size(NAS2D::Vector<float> size); /*!< Set the slider size. */
 
-	ValueChangedCallback& change() { return mCallback; } 	/*!< Give the callback to enable another control or a window to dis/connect to this event call. */
+	ValueChangedCallback& change() { return mCallback; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
 
 protected:
-	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y); 	/*!< Event raised on mouse button down. */
-	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y); 	/*!< Event raised on mouse button up. */
-	virtual void onMouseMove(int x, int y, int dX, int dY); 	/*!< Event raised on mouse move. */
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y); /*!< Event raised on mouse button down. */
+	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y); /*!< Event raised on mouse button up. */
+	virtual void onMouseMove(int x, int y, int dX, int dY); /*!< Event raised on mouse move. */
 	
 private:
 	float positionInternal();
 	void positionInternal(float newPosition);
 
-	void setSkins();	/*!< Helper function that load the gui skin on the first update call. */
-	void draw() override;		/*!< Draw the widget on screen. */
-	void logic();		/*!< Compute some values before drawing the control. */
+	void setSkins(); /*!< Helper function that load the gui skin on the first update call. */
+	void draw() override; /*!< Draw the widget on screen. */
+	void logic(); /*!< Compute some values before drawing the control. */
 
 	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle<float>& rect, float value);
 
 private:
-	NAS2D::Timer			mTimer;
+	NAS2D::Timer mTimer;
 
-	ValueChangedCallback	mCallback;					/*!< Callback executed when the value is changed. */
+	ValueChangedCallback mCallback; /*!< Callback executed when the value is changed. */
 
-	SliderType				mSliderType{SliderType::SLIDER_VERTICAL};				/*!< Type of the Slider. */
+	SliderType mSliderType{SliderType::SLIDER_VERTICAL}; /*!< Type of the Slider. */
 	
 	// mouse event related vars
-	NAS2D::Point<int>			mMousePosition;				/**< Mouse coordinates. */
+	NAS2D::Point<int> mMousePosition; /**< Mouse coordinates. */
 
-	bool					mMouseHoverSlide = false;	/*!< Mouse is within the bounds of the Button. */
-	bool					mThumbPressed = false;		/*!< Flag to indicate if this control is pressed. */
+	bool mMouseHoverSlide = false; /*!< Mouse is within the bounds of the Button. */
+	bool mThumbPressed = false; /*!< Flag to indicate if this control is pressed. */
 
 	// Slider values
-	float					mPosition = 0.0f;			/*!< Current value that represent the position of the slider. */
-	float					mLength = 0.0f;				/*!< Maximum value for the position of the slider. */
+	float mPosition = 0.0f; /*!< Current value that represent the position of the slider. */
+	float mLength = 0.0f; /*!< Maximum value for the position of the slider. */
 
-	bool					mBackward = false;			/*!< Does the value returned in backward mode . */
+	bool mBackward = false; /*!< Does the value returned in backward mode . */
 
 	// Slider button responses
-	uint32_t				mPressedAccumulator = 0;	/**< Accumulation value for pressed responses. */
-	bool					mButton1Held = false;		/**< Flag indicating that a button is being held down. */
-	bool					mButton2Held = false;		/**< Flag indicating that a button is being held down. */
+	uint32_t mPressedAccumulator = 0; /**< Accumulation value for pressed responses. */
+	bool mButton1Held = false; /**< Flag indicating that a button is being held down. */
+	bool mButton2Held = false; /**< Flag indicating that a button is being held down. */
 
 
 	// drawing vars
-	NAS2D::ImageList		mSkinButton1;				/*!< Skin for button 1 (Up or Left). */
-	NAS2D::ImageList		mSkinButton2;				/*!< Skin for button 2 (Down or Right). */
-	NAS2D::ImageList		mSkinMiddle;				/*!< Skin for the slide area. */
+	NAS2D::ImageList mSkinButton1; /*!< Skin for button 1 (Up or Left). */
+	NAS2D::ImageList mSkinButton2; /*!< Skin for button 2 (Down or Right). */
+	NAS2D::ImageList mSkinMiddle; /*!< Skin for the slide area. */
 	
-	NAS2D::ImageList		mSkinSlider;				/*!< Skin for the slider. */
-	bool					mDisplayPosition = false;	/*!< Indicate if the slider display the value on mouse over. */
+	NAS2D::ImageList mSkinSlider; /*!< Skin for the slider. */
+	bool mDisplayPosition = false; /*!< Indicate if the slider display the value on mouse over. */
 	
-	NAS2D::Rectangle<float>	mButton1;					/*!< Area on screen where the second button is displayed. (Down/Left) */
-	NAS2D::Rectangle<float>	mButton2;					/*!< Area on screen where the first button is displayed. (Up/Right)*/
-	NAS2D::Rectangle<float>	mSlideBar;					/*!< Area on screen where the slide area is displayed. */
-	NAS2D::Rectangle<float>	mSlider;					/*!< Area on screen where the slider is displayed. */
+	NAS2D::Rectangle<float> mButton1; /*!< Area on screen where the second button is displayed. (Down/Left) */
+	NAS2D::Rectangle<float> mButton2; /*!< Area on screen where the first button is displayed. (Up/Right)*/
+	NAS2D::Rectangle<float> mSlideBar; /*!< Area on screen where the slide area is displayed. */
+	NAS2D::Rectangle<float> mSlider; /*!< Area on screen where the slider is displayed. */
 };

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -31,11 +31,11 @@ private:
 	void processString();
 
 private:
-	std::size_t		mNumLines = 0;
+	std::size_t mNumLines = 0;
 
-	StringList	mFormattedList;
+	StringList mFormattedList;
 
-	NAS2D::Color	mTextColor = NAS2D::Color::White;
+	NAS2D::Color mTextColor = NAS2D::Color::White;
 
-	NAS2D::Font*	mFont = nullptr;
+	NAS2D::Font* mFont = nullptr;
 };

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -158,7 +158,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 	if (!hasFocus() || !editable() || !visible()) { return; }
 
 	switch(key)
-	{	
+	{
 		// COMMAND KEYS
 		case EventHandler::KeyCode::KEY_BACKSPACE:
 			if(!text().empty() && mCursorPosition > 0)

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -68,20 +68,20 @@ private:
 	void updateCursor();
 
 private:
-	NAS2D::Timer		mCursorTimer;					/**< Timer for the cursor blink. */
+	NAS2D::Timer mCursorTimer; /**< Timer for the cursor blink. */
 
-	int 				mCursorPosition = 0;			/**< Position of the Insertion Cursor. */
-	int 				mCursorX = 0;					/**< Pixel position of the Cursor. */
-	int 				mScrollOffset = 0;				/**< Scroller offset. */
+	int mCursorPosition = 0; /**< Position of the Insertion Cursor. */
+	int mCursorX = 0; /**< Pixel position of the Cursor. */
+	int mScrollOffset = 0; /**< Scroller offset. */
 
-	std::size_t				mMaxCharacters = 0;				/**< Max number of characters allowed in the text field. */
+	std::size_t mMaxCharacters = 0; /**< Max number of characters allowed in the text field. */
 
-	BorderVisibility	mBorderVisibility = BorderVisibility::FOCUS_ONLY;	/**< Border visibility flag. */
+	BorderVisibility mBorderVisibility = BorderVisibility::FOCUS_ONLY; /**< Border visibility flag. */
 
-	NAS2D::ImageList	mSkinNormal;
-	NAS2D::ImageList	mSkinFocus;
+	NAS2D::ImageList mSkinNormal;
+	NAS2D::ImageList mSkinFocus;
 
-	bool				mEditable = true;				/**< Toggle editing of the field. */
-	bool				mShowCursor = true;				/**< Flag indicating whether or not to draw the cursor. */
-	bool				mNumbersOnly = false;			/**< Flag indicating that only numerals should be used */
+	bool mEditable = true; /**< Toggle editing of the field. */
+	bool mShowCursor = true; /**< Flag indicating whether or not to draw the cursor. */
+	bool mNumbersOnly = false; /**< Flag indicating that only numerals should be used */
 };

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -29,9 +29,9 @@ private:
 	void _init();
 
 private:
-	bool				mMouseDrag = false;
-	bool				mAnchored = false;
+	bool mMouseDrag = false;
+	bool mAnchored = false;
 
-	NAS2D::ImageList	mTitle;
-	NAS2D::ImageList	mBody;
+	NAS2D::ImageList mTitle;
+	NAS2D::ImageList mBody;
 };

--- a/OPHD/UI/Core/WindowStack.h
+++ b/OPHD/UI/Core/WindowStack.h
@@ -29,5 +29,5 @@ private:
 	using WindowList = std::list<Window*>;
 
 private:
-	WindowList		mWindowList;
+	WindowList mWindowList;
 };

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -49,18 +49,18 @@ private:
 	void btnDiggerWestClicked();
 
 private:
-	DiggerDirection(const DiggerDirection&) = delete;				/**< Not allowed. */
-	DiggerDirection& operator=(const DiggerDirection&) = delete;	/**< Not allowed. */
+	DiggerDirection(const DiggerDirection&) = delete; /**< Not allowed. */
+	DiggerDirection& operator=(const DiggerDirection&) = delete; /**< Not allowed. */
 
 private:
-	Button				btnDown;
-	Button				btnNorth;
-	Button				btnEast;
-	Button				btnSouth;
-	Button				btnWest;
-	Button				btnCancel;
+	Button btnDown;
+	Button btnNorth;
+	Button btnEast;
+	Button btnSouth;
+	Button btnWest;
+	Button btnCancel;
 
-	Callback			mCallback;
+	Callback mCallback;
 
-	Tile*				mTile = nullptr;
+	Tile* mTile = nullptr;
 };

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -31,7 +31,7 @@ public:
 
 	public:
 		Factory* factory = nullptr;
-		NAS2D::Point<int>	icon_slice;
+		NAS2D::Point<int> icon_slice;
 	};
 
 public:

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -40,18 +40,17 @@ private:
 	FactoryProduction& operator=(const FactoryProduction&) = delete;
 
 private:
-	Factory*			mFactory = nullptr;
+	Factory* mFactory = nullptr;
 
-	ProductType			mProduct = ProductType::PRODUCT_NONE;
-	ProductionCost		mProductCost;
+	ProductType mProduct = ProductType::PRODUCT_NONE;
+	ProductionCost mProductCost;
 
-	IconGrid			mProductGrid;
+	IconGrid mProductGrid;
 
-	Button				btnOkay;
-	Button				btnCancel;
-	Button				btnClearSelection;
-	Button				btnApply;
+	Button btnOkay;
+	Button btnCancel;
+	Button btnClearSelection;
+	Button btnApply;
 
-	CheckBox			chkIdle;
-
+	CheckBox chkIdle;
 };

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -128,8 +128,8 @@ void FileIo::scanDirectory(const std::string& directory)
 	{
 		if (!f.isDirectory(directory + dirList[i]))
 		{
-			dirList[i].resize(dirList[i].size() - 4);	// Assumes a file save extension of 3 characters.
-														// This is a naive approach.
+			// FixMe: Naive approach: Assumes a file save extension of 3 characters.
+			dirList[i].resize(dirList[i].size() - 4);
 			mListBox.addItem(dirList[i]);
 		}
 	}

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -70,7 +70,7 @@ void FileIo::init()
  */
 void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
 {
-	if (!visible()) { return; }	// ignore key presses when hidden.
+	if (!visible()) { return; } // ignore key presses when hidden.
 
 	if (mListBox.rect().to<int>().contains(NAS2D::Point{x, y}))
 	{
@@ -87,7 +87,7 @@ void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
  */
 void FileIo::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
-	if (!visible()) { return; }	// ignore key presses when hidden.
+	if (!visible()) { return; } // ignore key presses when hidden.
 
 	if (key == EventHandler::KeyCode::KEY_ENTER || key == EventHandler::KeyCode::KEY_KP_ENTER)
 	{
@@ -155,7 +155,7 @@ void FileIo::fileNameModified(Control* control)
 
 	const std::string RestrictedFilenameChars = "\\/:*?\"<>|";
 
-	if (sFile.empty())	// no blank filename
+	if (sFile.empty()) // no blank filename
 		btnFileOp.enabled(false);
 	else if (sFile.find_first_of(RestrictedFilenameChars) != std::string::npos)
 		btnFileOp.enabled(false);

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -46,14 +46,14 @@ private:
 	void fileNameModified(Control* control);
 
 private:
-	FileOperationCallback	mCallback;
+	FileOperationCallback mCallback;
 
-	FileOperation			mMode;
+	FileOperation mMode;
 
-	Button					btnClose;
-	Button					btnFileOp;
+	Button btnClose;
+	Button btnFileOp;
 
-	TextField				txtFileName;
+	TextField txtFileName;
 
-	ListBox					mListBox;
+	ListBox mListBox;
 };

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -35,13 +35,13 @@ private:
 	void enabledChanged() override;
 
 private:
-	Button			btnSave;
-	Button			btnLoad;
-	Button			btnReturn;
-	Button			btnClose;
+	Button btnSave;
+	Button btnLoad;
+	Button btnReturn;
+	Button btnClose;
 
-	ClickCallback	mCallbackSave;
-	ClickCallback	mCallbackLoad;
-	ClickCallback	mCallbackReturn;
-	ClickCallback	mCallbackClose;
+	ClickCallback mCallbackSave;
+	ClickCallback mCallbackLoad;
+	ClickCallback mCallbackReturn;
+	ClickCallback mCallbackClose;
 };

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -26,9 +26,9 @@ private:
 	void btnCloseClicked();
 
 private:
-	NAS2D::Image	mHeader;
+	NAS2D::Image mHeader;
 
-	Button			btnClose;
+	Button btnClose;
 
-	ClickCallback	mCallback;
+	ClickCallback mCallback;
 };

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -31,9 +31,9 @@ public:
 	public:
 		IconGridItem() {}
 
-		std::string name;			/**< Name of the Item. Can be empty. */
+		std::string name; /**< Name of the Item. Can be empty. */
 
-		int meta = 0;				/**< User defined integer value. Optional. */
+		int meta = 0; /**< User defined integer value. Optional. */
 		bool available = true;
 
 	protected:
@@ -107,22 +107,22 @@ private:
 	void raiseChangedEvent();
 
 private:
-	Index					mHighlightIndex = constants::NO_SELECTION;		/**< Current highlight index. */
-	Index					mCurrentSelection = constants::NO_SELECTION;	/**< Currently selected item index. */
+	Index mHighlightIndex = constants::NO_SELECTION; /**< Current highlight index. */
+	Index mCurrentSelection = constants::NO_SELECTION; /**< Currently selected item index. */
 
-	int					mIconSize = 0;				/**< Size of the icons. */
-	int					mIconMargin = 0;			/**< Spacing between icons and edges of the IconGrid. */
+	int mIconSize = 0; /**< Size of the icons. */
+	int mIconMargin = 0; /**< Spacing between icons and edges of the IconGrid. */
 
-	bool				mShowTooltip = false;		/**< Flag indicating that we want a tooltip drawn near an icon when hovering over it. */
-	bool				mSorted = true;			/**< Flag indicating that the IconGrid should be sorted. */
+	bool mShowTooltip = false; /**< Flag indicating that we want a tooltip drawn near an icon when hovering over it. */
+	bool mSorted = true; /**< Flag indicating that the IconGrid should be sorted. */
 
-	NAS2D::Image		mIconSheet;					/**< Image containing the icons. */
+	NAS2D::Image mIconSheet; /**< Image containing the icons. */
 
-	NAS2D::ImageList	mSkin;
+	NAS2D::ImageList mSkin;
 
-	NAS2D::Vector<int>	mGridSize;					/**< Dimensions of the grid that can be contained in the IconGrid with the current Icon Size and Icon Margin. */
+	NAS2D::Vector<int> mGridSize; /**< Dimensions of the grid that can be contained in the IconGrid with the current Icon Size and Icon Margin. */
 
-	IconItemList		mIconItemList;				/**< List of items. */
+	IconItemList mIconItemList; /**< List of items. */
 
-	Callback			mCallback;					/**< Callback whenever a selection is made. */
+	Callback mCallback; /**< Callback whenever a selection is made. */
 };

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -33,9 +33,9 @@ private:
 	MajorEventAnnouncement& operator=(const MajorEventAnnouncement&) = delete;
 
 private:
-	NAS2D::Image			mHeader;
+	NAS2D::Image mHeader;
 
-	std::string		mMessage;
+	std::string mMessage;
 
-	Button			btnClose;
+	Button btnClose;
 };

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -13,42 +13,42 @@ using namespace NAS2D;
  * during frame updates to improve overall performance (basically, to avoid
  * expensive string operations).
  */
-static std::string		COMMON_METALS_COUNT;
-static std::string		COMMON_MINERALS_COUNT;
-static std::string		RARE_METALS_COUNT;
-static std::string		RARE_MINERALS_COUNT;
+static std::string COMMON_METALS_COUNT;
+static std::string COMMON_MINERALS_COUNT;
+static std::string RARE_METALS_COUNT;
+static std::string RARE_MINERALS_COUNT;
 
-static std::string		STATUS_STRING;
-static std::string		EXTENTION_TIME_REMAINING;
+static std::string STATUS_STRING;
+static std::string EXTENTION_TIME_REMAINING;
 
-static int				COMMON_METALS_ORE_POSITION;
-static int				COMMON_MINERALS_ORE_POSITION;
-static int				RARE_METALS_ORE_POSITION;
-static int				RARE_MINERALS_ORE_POSITION;
+static int COMMON_METALS_ORE_POSITION;
+static int COMMON_MINERALS_ORE_POSITION;
+static int RARE_METALS_ORE_POSITION;
+static int RARE_MINERALS_ORE_POSITION;
 
-static std::string		MINE_YIELD;
-static std::string		MINE_DEPTH;
+static std::string MINE_YIELD;
+static std::string MINE_DEPTH;
 
-static const int		MINE_YIELD_POSITION = 148;
-static int				MINE_YIELD_DESCRIPTION_POSITION = 0;
+static const int MINE_YIELD_POSITION = 148;
+static int MINE_YIELD_DESCRIPTION_POSITION = 0;
 
-static int				MINE_STATUS_POSITION;
-static int				EXTENSION_TURNS_REMAINING_POSITION;
+static int MINE_STATUS_POSITION;
+static int EXTENSION_TURNS_REMAINING_POSITION;
 
-static const int		MINE_DEPTH_POSITION = 300;
-static int				MINE_DEPTH_VALUE_POSITION;
+static const int MINE_DEPTH_POSITION = 300;
+static int MINE_DEPTH_VALUE_POSITION;
 
-static Font*			FONT = nullptr;
-static Font*			FONT_BOLD = nullptr;
+static Font* FONT = nullptr;
+static Font* FONT_BOLD = nullptr;
 
 
 /** 
  * Positional constants used in several places.
  */
-const int				COMMON_METALS_POS = 46;
-const int				COMMON_MINERALS_POS = 135;
-const int				RARE_METALS_POS = 224;
-const int				RARE_MINERALS_POS = 312;
+const int COMMON_METALS_POS = 46;
+const int COMMON_MINERALS_POS = 135;
+const int RARE_METALS_POS = 224;
+const int RARE_MINERALS_POS = 312;
 
 
 /**

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -41,19 +41,19 @@ private:
 	void btnIdleClicked();
 
 private:
-	MineFacility*		mFacility = nullptr;
+	MineFacility* mFacility = nullptr;
 
-	NAS2D::Image		mUiIcon;
-	NAS2D::Image		mIcons;
+	NAS2D::Image mUiIcon;
+	NAS2D::Image mIcons;
 
-	NAS2D::ImageList	mPanel;
+	NAS2D::ImageList mPanel;
 
-	CheckBox			chkCommonMetals;
-	CheckBox			chkCommonMinerals;
-	CheckBox			chkRareMetals;
-	CheckBox			chkRareMinerals;
+	CheckBox chkCommonMetals;
+	CheckBox chkCommonMinerals;
+	CheckBox chkRareMetals;
+	CheckBox chkRareMinerals;
 
-	Button				btnIdle;
-	Button				btnExtendShaft;
-	Button				btnOkay;
+	Button btnIdle;
+	Button btnExtendShaft;
+	Button btnOkay;
 };

--- a/OPHD/UI/ProductListBox.h
+++ b/OPHD/UI/ProductListBox.h
@@ -16,8 +16,8 @@ public:
 		ProductListBoxItem() = default;
 
 	public:
-		std::size_t count = 0;				/**< Count of the product. */
-		float usage = 0.0f;				/**< Usage of available capacity. */
+		std::size_t count = 0; /**< Count of the product. */
+		float usage = 0.0f; /**< Usage of available capacity. */
 	};
 
 public:

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -92,21 +92,21 @@ void FactoryReport::init()
 	FONT_BIG = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_HUGE);
 	FONT_BIG_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
-	FACTORY_SEED	= new Image("ui/interface/factory_seed.png");
-	FACTORY_AG		= new Image("ui/interface/factory_ag.png");
-	FACTORY_UG		= new Image("ui/interface/factory_ug.png");
+	FACTORY_SEED = new Image("ui/interface/factory_seed.png");
+	FACTORY_AG = new Image("ui/interface/factory_ag.png");
+	FACTORY_UG = new Image("ui/interface/factory_ug.png");
 
 	/// \todo Decide if this is the best place to have these images live or if it should be done at program start.
 	PRODUCT_IMAGE_ARRAY.fill(nullptr);
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DIGGER]				= new Image("ui/interface/product_robodigger.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DOZER]				= new Image("ui/interface/product_robodozer.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MINER]				= new Image("ui/interface/product_robominer.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_EXPLORER]			= new Image("ui/interface/product_roboexplorer.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_TRUCK]				= new Image("ui/interface/product_truck.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_ROAD_MATERIALS]		= new Image("ui/interface/product_road_materials.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MAINTENANCE_PARTS]	= new Image("ui/interface/product_maintenance_parts.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_CLOTHING]			= new Image("ui/interface/product_clothing.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MEDICINE]			= new Image("ui/interface/product_medicine.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DIGGER] = new Image("ui/interface/product_robodigger.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DOZER] = new Image("ui/interface/product_robodozer.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MINER] = new Image("ui/interface/product_robominer.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_EXPLORER] = new Image("ui/interface/product_roboexplorer.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_TRUCK] = new Image("ui/interface/product_truck.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_ROAD_MATERIALS] = new Image("ui/interface/product_road_materials.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MAINTENANCE_PARTS] = new Image("ui/interface/product_maintenance_parts.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_CLOTHING] = new Image("ui/interface/product_clothing.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MEDICINE] = new Image("ui/interface/product_medicine.png");
 
 	_PRODUCT_NONE = new Image("ui/interface/product_none.png");
 

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -59,24 +59,24 @@ private:
 	void visibilityChanged(bool visible) override;
 
 private:
-	Button			btnShowAll;
-	Button			btnShowSurface;
-	Button			btnShowUnderground;
-	Button			btnShowActive;
-	Button			btnShowIdle;
-	Button			btnShowDisabled;
+	Button btnShowAll;
+	Button btnShowSurface;
+	Button btnShowUnderground;
+	Button btnShowActive;
+	Button btnShowIdle;
+	Button btnShowDisabled;
 
-	Button			btnIdle;
-	Button			btnClearProduction;
-	Button			btnTakeMeThere;
+	Button btnIdle;
+	Button btnClearProduction;
+	Button btnTakeMeThere;
 
-	Button			btnApply;
+	Button btnApply;
 
-	ComboBox		cboFilterByProduct;
+	ComboBox cboFilterByProduct;
 
-	FactoryListBox	lstFactoryList;
+	FactoryListBox lstFactoryList;
 
-	ListBox			lstProducts;
+	ListBox lstProducts;
 
-	TextArea		txtProductDescription;
+	TextArea txtProductDescription;
 };

--- a/OPHD/UI/Reports/ReportInterface.h
+++ b/OPHD/UI/Reports/ReportInterface.h
@@ -51,5 +51,5 @@ public:
 	TakeMeThere& takeMeThereCallback() { return mTakeMeThereCallback; }
 
 private:
-	TakeMeThere		mTakeMeThereCallback;
+	TakeMeThere mTakeMeThereCallback;
 };

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -104,10 +104,10 @@ WarehouseReport::~WarehouseReport()
  */
 void WarehouseReport::init()
 {
-	FONT_BOLD		= Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
-	FONT_MED		= Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
-	FONT_MED_BOLD	= Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-	FONT_BIG_BOLD	= Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
+	FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	FONT_MED = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
+	FONT_MED_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
+	FONT_BIG_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
 	WAREHOUSE_IMG = new Image("ui/interface/warehouse.png");
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -57,14 +57,14 @@ private:
 	void drawRightPanel(NAS2D::Renderer&);
 
 private:
-	Button				btnShowAll;
-	Button				btnSpaceAvailable;
-	Button				btnFull;
-	Button				btnEmpty;
-	Button				btnDisabled;
+	Button btnShowAll;
+	Button btnSpaceAvailable;
+	Button btnFull;
+	Button btnEmpty;
+	Button btnDisabled;
 
-	Button				btnTakeMeThere;
+	Button btnTakeMeThere;
 
-	StructureListBox	lstStructures;
-	ProductListBox		lstProducts;
+	StructureListBox lstStructures;
+	ProductListBox lstProducts;
 };

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -77,17 +77,17 @@ void ResourceBreakdownPanel::update()
 
 	static std::map<ResourceTrend, Point<int>> ICON_SLICE
 	{
-		{ ResourceTrend::RESOURCE_TREND_NONE,	Point{16, 64} },
-		{ ResourceTrend::RESOURCE_TREND_UP,	Point{8, 64} },
-		{ ResourceTrend::RESOURCE_TREND_DOWN,	Point{0, 64} }
+		{ ResourceTrend::RESOURCE_TREND_NONE, Point{16, 64} },
+		{ ResourceTrend::RESOURCE_TREND_UP, Point{8, 64} },
+		{ ResourceTrend::RESOURCE_TREND_DOWN, Point{0, 64} }
 	};
 
 
 	static std::map<ResourceTrend, Color> TEXT_COLOR
 	{
-		{ ResourceTrend::RESOURCE_TREND_NONE,	Color::White },
-		{ ResourceTrend::RESOURCE_TREND_UP,	Color{0, 185, 0} },
-		{ ResourceTrend::RESOURCE_TREND_DOWN,	Color::Red }
+		{ ResourceTrend::RESOURCE_TREND_NONE, Color::White },
+		{ ResourceTrend::RESOURCE_TREND_UP, Color{0, 185, 0} },
+		{ ResourceTrend::RESOURCE_TREND_DOWN, Color::Red }
 	};
 
 	const auto commonMetalImageRect = NAS2D::Rectangle{64, 16, 16, 16};

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -18,9 +18,9 @@ public:
 	void update() override;
 
 private:
-	NAS2D::Image		mIcons;
-	NAS2D::ImageList	mSkin;
+	NAS2D::Image mIcons;
+	NAS2D::ImageList mSkin;
 
-	ResourcePool		mPreviousResources;
-	ResourcePool*		mPlayerResources = nullptr;
+	ResourcePool mPreviousResources;
+	ResourcePool* mPlayerResources = nullptr;
 };

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -30,13 +30,13 @@ private:
 	StructureInspector& operator=(const StructureInspector&) = delete;
 
 private:
-	Button			btnClose;
+	Button btnClose;
 
-	TextArea		txtStateDescription;
+	TextArea txtStateDescription;
 
-	NAS2D::Image	mIcons;
+	NAS2D::Image mIcons;
 
-	std::string		mStructureClass;
+	std::string mStructureClass;
 
-	Structure*		mStructure = nullptr;
+	Structure* mStructure = nullptr;
 };

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -22,9 +22,9 @@ public:
 		~StructureListBoxItem() override;
 
 	public:
-		Structure* structure = nullptr;	/**< Pointer to a Structure. */
-		std::string structureState;		/**< String description of the state of a Structure. */
-		std::size_t colorIndex = 0;			/**< Index to use from the listbox color table. */
+		Structure* structure = nullptr; /**< Pointer to a Structure. */
+		std::string structureState; /**< String description of the state of a Structure. */
+		std::size_t colorIndex = 0; /**< Index to use from the listbox color table. */
 	};
 
 public:

--- a/OPHD/UI/TileInspector.h
+++ b/OPHD/UI/TileInspector.h
@@ -25,6 +25,6 @@ private:
 	void btnCloseClicked();
 
 private:
-	Button		btnClose;
-	Tile*		mTile = nullptr;
+	Button btnClose;
+	Tile* mTile = nullptr;
 };

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -31,6 +31,6 @@ private:
 	WarehouseInspector& operator=(const WarehouseInspector&) = delete;
 
 private:
-	Warehouse*			mWarehouse = nullptr;
-	Button				btnClose;
+	Warehouse* mWarehouse = nullptr;
+	Button btnClose;
 };

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -64,8 +64,8 @@ int main(int /*argc*/, char *argv[])
 
 	std::cout << "OutpostHD " << constants::VERSION << std::endl << std::endl;
 
-	StructureCatalogue::init();		// only needs to be done once at the start of the program.
-	StructureTranslator::init();	// only needs to be done once at the start of the program.
+	StructureCatalogue::init(); // only needs to be done once at the start of the program.
+	StructureTranslator::init(); // only needs to be done once at the start of the program.
 
 	try
 	{


### PR DESCRIPTION
Remove tab alignment of variable declarations and comments. Reformat initializer lists.

Does not remove tabs within comments.
