### PR TITLE
Fix ListBox Slider oddity

### DIFF
--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -306,8 +306,6 @@ void ListBox::update()
 		textPosition.y() += mLineHeight;
 	}
 
-	// FixMe: Shouldn't need this since it's in a UIContainer. Noticing that Slider
-	// doesn't play nice with the UIContainer.
 	mSlider.update();
 
 	renderer.clipRectClear();

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -48,6 +48,7 @@ void ListBox::_init()
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
 	Utility<EventHandler>::get().mouseWheel().connect(this, &ListBox::onMouseWheel);
 
+	mSlider.displayPosition(false);
 	mSlider.length(0);
 	mSlider.thumbPosition(0);
 	mSlider.change().connect(this, &ListBox::slideChanged);
@@ -63,7 +64,6 @@ void ListBox::onSizeChanged()
 {
 	clear();
 	add(&mSlider, rect().width() - 14, 0);
-	mSlider.displayPosition(false);
 	mSlider.size({14, rect().height()});
 	_updateItemDisplay();
 }

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -62,9 +62,6 @@ void ListBox::_init()
 
 void ListBox::onSizeChanged()
 {
-	clear();
-	add(&mSlider, rect().width() - 14, 0);
-	mSlider.size({14, rect().height()});
 	_updateItemDisplay();
 }
 
@@ -84,6 +81,8 @@ void ListBox::_updateItemDisplay()
 		mLineCount = static_cast<unsigned int>(height() / mLineHeight);
 		if (mLineCount < mItems.size())
 		{
+			mSlider.position({rect().x() + rect().width() - 14, rect().y()});
+			mSlider.size({14, rect().height()});
 			mSlider.length((mLineHeight * mItems.size()) - height());
 			mCurrentOffset = static_cast<std::size_t>(mSlider.thumbPosition());
 			mItemWidth = static_cast<unsigned int>(width() - mSlider.width());

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -17,7 +17,7 @@
 /**
  * Implements a ListBox control.
  */
-class ListBox: public UIContainer
+class ListBox: public Control
 {
 public:
 	using SelectionChangedCallback = NAS2D::Signals::Signal<>;
@@ -73,7 +73,7 @@ public:
 	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 
 protected:
-	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	virtual void onMouseMove(int x, int y, int relX, int relY);
 	void onMouseWheel(int x, int y);
 	virtual void slideChanged(float newPosition);

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -79,6 +79,8 @@ void ListBoxBase::_update_item_display()
 
 		if (mLineCount < mItems.size())
 		{
+			mSlider.position({rect().x() + rect().width() - 14, rect().y()});
+			mSlider.size({14, rect().height()});
 			mSlider.length((mItemHeight * mItems.size()) - height());
 			mCurrentOffset = static_cast<unsigned int>(mSlider.thumbPosition());
 			mItemWidth -= static_cast<unsigned int>(mSlider.width());
@@ -99,9 +101,6 @@ void ListBoxBase::_update_item_display()
  */
 void ListBoxBase::onSizeChanged()
 {
-	clear();
-	add(&mSlider, rect().width() - 14, 0);
-	mSlider.size({14, rect().height()});
 	_update_item_display();
 }
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -330,8 +330,6 @@ void ListBoxBase::update()
 	float highlight_y = positionY() + static_cast<float>((mCurrentHighlight * mItemHeight) - mCurrentOffset);
 	r.drawBoxFilled(positionX(), highlight_y, static_cast<float>(mItemWidth), static_cast<float>(mItemHeight), 0, 185, 0, 50);
 
-	// FixMe: Shouldn't need this since it's in a UIContainer. Noticing that Slider
-	// doesn't play nice with the UIContainer.
 	mSlider.update();
 
 	r.clipRectClear();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -48,6 +48,7 @@ void ListBoxBase::_init()
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBoxBase::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBoxBase::onMouseMove);
 
+	mSlider.displayPosition(false);
 	mSlider.length(0);
 	mSlider.thumbPosition(0);
 	mSlider.change().connect(this, &ListBoxBase::slideChanged);
@@ -100,7 +101,6 @@ void ListBoxBase::onSizeChanged()
 {
 	clear();
 	add(&mSlider, rect().width() - 14, 0);
-	mSlider.displayPosition(false);
 	mSlider.size({14, rect().height()});
 	_update_item_display();
 }

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -22,7 +22,7 @@
  * \note	This is an abstract class -- it will need to be inherited from
  *			in order to be used.
  */
-class ListBoxBase : public UIContainer
+class ListBoxBase : public Control
 {
 public:
 	/**
@@ -100,7 +100,7 @@ private:
 	void _init();
 	void slideChanged(float newPosition);
 
-	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseMove(int x, int y, int relX, int relY);
 	void onMouseWheel(int x, int y);
 


### PR DESCRIPTION
Closes #403.

Make `ListBox` derive directly from `Control`, rather than from `UIContainer`. The `ListBox` is a compound control, with a fixed set of members, and doesn't need support for arbitrary `Control` containment.
