### PR TITLE
Rename `r` to `renderer` and use `auto&`

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -326,7 +326,7 @@ bool TileMap::tileHighlightVisible() const
 
 void TileMap::draw()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	int tsetOffset = mCurrentDepth > 0 ? TILE_HEIGHT : 0;
 

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -115,7 +115,7 @@ void GameState::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
  */
 void GameState::fadeComplete()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	if (renderer.isFaded())
 	{
 		mReturnState = new MainMenuState();

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -115,8 +115,8 @@ void GameState::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
  */
 void GameState::fadeComplete()
 {
-	NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
-	if (r.isFaded())
+	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	if (renderer.isFaded())
 	{
 		mReturnState = new MainMenuState();
 	}

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -114,7 +114,7 @@ void MainMenuState::initialize()
  */
 void MainMenuState::positionButtons()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	const auto center = renderer.center().to<int>();
 
 	auto buttonPosition = center - NAS2D::Vector{100, (35 * 4) / 2};
@@ -323,7 +323,7 @@ void MainMenuState::btnQuitClicked()
  */
 NAS2D::State* MainMenuState::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.clearScreen(0, 0, 0);
 	renderer.drawImage(mBgImage, renderer.center() - mBgImage.size() / 2);

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -114,8 +114,8 @@ void MainMenuState::initialize()
  */
 void MainMenuState::positionButtons()
 {
-	Renderer& r = Utility<Renderer>::get();
-	const auto center = r.center().to<int>();
+	Renderer& renderer = Utility<Renderer>::get();
+	const auto center = renderer.center().to<int>();
 
 	auto buttonPosition = center - NAS2D::Vector{100, (35 * 4) / 2};
 
@@ -133,7 +133,7 @@ void MainMenuState::positionButtons()
 	dlgOptions.position(center - dlgOptions.size() / 2);
 	dlgNewGame.position(center - dlgNewGame.size() / 2);
 
-	lblVersion.position(NAS2D::Point{0, 0} + r.size() - lblVersion.size());
+	lblVersion.position(NAS2D::Point{0, 0} + renderer.size() - lblVersion.size());
 }
 
 
@@ -323,18 +323,18 @@ void MainMenuState::btnQuitClicked()
  */
 NAS2D::State* MainMenuState::update()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.clearScreen(0, 0, 0);
-	r.drawImage(mBgImage, r.center() - mBgImage.size() / 2);
+	renderer.clearScreen(0, 0, 0);
+	renderer.drawImage(mBgImage, renderer.center() - mBgImage.size() / 2);
 
 
 	if (!mFileIoDialog.visible() && !dlgOptions.visible())
 	{
 		const auto padding = NAS2D::Vector{5, 5};
 		const auto menuRect = NAS2D::Rectangle<int>::Create(btnNewGame.rect().startPoint() - padding, btnQuit.rect().endPoint() + padding);
-		r.drawBoxFilled(menuRect, NAS2D::Color{0, 0, 0, 150});
-		r.drawBox(menuRect, NAS2D::Color{0, 185, 0, 255});
+		renderer.drawBoxFilled(menuRect, NAS2D::Color{0, 0, 0, 150});
+		renderer.drawBox(menuRect, NAS2D::Color{0, 185, 0, 255});
 
 		btnNewGame.update();
 		btnContinueGame.update();
@@ -358,7 +358,7 @@ NAS2D::State* MainMenuState::update()
 
 	lblVersion.update();
 
-	if (r.isFading())
+	if (renderer.isFading())
 	{
 		return this;
 	}

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -204,20 +204,20 @@ void MainReportsUiState::initialize()
 	Panels[NavigationPanel::PANEL_SPACEPORT].Img = new Image("ui/icons/spaceport.png");
 	Panels[NavigationPanel::PANEL_SPACEPORT].Name = "Space Ports";
 
-	Renderer& r = Utility<Renderer>::get();
-	setPanelRects(static_cast<int>(r.width()));
+	Renderer& renderer = Utility<Renderer>::get();
+	setPanelRects(static_cast<int>(renderer.width()));
 
 	// INIT UI REPORT PANELS
 	ReportInterface* factory_report = new FactoryReport();
 	Panels[NavigationPanel::PANEL_PRODUCTION].UiPanel = factory_report;
 	factory_report->position(0, 48);
-	factory_report->size({r.width(), r.height() - 48});
+	factory_report->size({renderer.width(), renderer.height() - 48});
 	factory_report->hide();
 
 	ReportInterface* warehouse_report = new WarehouseReport();
 	Panels[NavigationPanel::PANEL_WAREHOUSE].UiPanel = warehouse_report;
 	warehouse_report->position(0, 48);
-	warehouse_report->size({r.width(), r.height() - 48});
+	warehouse_report->size({renderer.width(), renderer.height() - 48});
 	warehouse_report->hide();
 }
 
@@ -396,12 +396,12 @@ MainReportsUiState::TakeMeThereList MainReportsUiState::takeMeThere()
  */
 State* MainReportsUiState::update()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.clearScreen(35, 35, 35);
-	r.drawBoxFilled(0, 0, r.width(), 48, 0, 0, 0);
+	renderer.clearScreen(35, 35, 35);
+	renderer.drawBoxFilled(0, 0, renderer.width(), 48, 0, 0, 0);
 
-	for (Panel& panel : Panels) { drawPanel(r, panel); }
+	for (Panel& panel : Panels) { drawPanel(renderer, panel); }
 
 	return this;
 }

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -204,7 +204,7 @@ void MainReportsUiState::initialize()
 	Panels[NavigationPanel::PANEL_SPACEPORT].Img = new Image("ui/icons/spaceport.png");
 	Panels[NavigationPanel::PANEL_SPACEPORT].Name = "Space Ports";
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	setPanelRects(static_cast<int>(renderer.width()));
 
 	// INIT UI REPORT PANELS
@@ -396,7 +396,7 @@ MainReportsUiState::TakeMeThereList MainReportsUiState::takeMeThere()
  */
 State* MainReportsUiState::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.clearScreen(35, 35, 35);
 	renderer.drawBoxFilled(0, 0, renderer.width(), 48, 0, 0, 0);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -145,11 +145,11 @@ void MapViewState::initialize()
 {
 	// UI
 	initUi();
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.setCursor(PointerType::POINTER_NORMAL);
+	renderer.setCursor(PointerType::POINTER_NORMAL);
 
-	setupUiPositions(r.size());
+	setupUiPositions(renderer.size());
 
 	mPlayerResources.capacity(constants::BASE_STORAGE_CAPACITY);
 
@@ -209,24 +209,24 @@ void MapViewState::focusOnStructure(Structure* s)
  */
 State* MapViewState::update()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.drawImageStretched(mBackground, 0, 0, r.width(), r.height());
+	renderer.drawImageStretched(mBackground, 0, 0, renderer.width(), renderer.height());
 
 	// FIXME: Ugly / hacky
 	if (mGameOverDialog.visible())
 	{
-		r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0, 255);
+		renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 255);
 		mGameOverDialog.update();
 
-		if (r.isFading()) { return this; }
+		if (renderer.isFading()) { return this; }
 
 		return this;
 	}
 
 	// explicit current level
 	Font* font = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-	r.drawText(*font, CURRENT_LEVEL_STRING, r.width() - font->width(CURRENT_LEVEL_STRING) - 5, mMiniMapBoundingBox.y() - font->height() - 12, 255, 255, 255);
+	renderer.drawText(*font, CURRENT_LEVEL_STRING, renderer.width() - font->width(CURRENT_LEVEL_STRING) - 5, mMiniMapBoundingBox.y() - font->height() - 12, 255, 255, 255);
 	
 	if (!mGameOptionsDialog.visible() && !mGameOverDialog.visible() && !mFileIoDialog.visible())
 	{
@@ -238,12 +238,12 @@ State* MapViewState::update()
 	// FIXME: Ugly / hacky
 	if (mGameOptionsDialog.visible() || mFileIoDialog.visible())
 	{
-		r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0, 165);
+		renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 165);
 	}
 
 	drawUI();
 
-	if (r.isFading()) { return this; }
+	if (renderer.isFading()) { return this; }
 
 	return this;
 }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -145,7 +145,7 @@ void MapViewState::initialize()
 {
 	// UI
 	initUi();
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.setCursor(PointerType::POINTER_NORMAL);
 
@@ -209,7 +209,7 @@ void MapViewState::focusOnStructure(Structure* s)
  */
 State* MapViewState::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImageStretched(mBackground, 0, 0, renderer.width(), renderer.height());
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -102,7 +102,7 @@ private:
 	void drawUI();
 	void drawMiniMap();
 	void drawNavInfo();
-	bool drawNavIcon(NAS2D::Renderer& r, const NAS2D::Rectangle<int>& currentIconBounds, const NAS2D::Rectangle<int>& subImageBounds, const NAS2D::Color& iconColor, const NAS2D::Color& iconHighlightColor);
+	bool drawNavIcon(NAS2D::Renderer& renderer, const NAS2D::Rectangle<int>& currentIconBounds, const NAS2D::Rectangle<int>& subImageBounds, const NAS2D::Color& iconColor, const NAS2D::Color& iconHighlightColor);
 
 	void drawResourceInfo();
 	void drawRobotInfo();

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -62,7 +62,7 @@ namespace {
  */
 void MapViewState::drawMiniMap()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto miniMapBoxFloat = mMiniMapBoundingBox.to<float>();
 	renderer.clipRect(miniMapBoxFloat);
 
@@ -133,7 +133,7 @@ void MapViewState::drawMiniMap()
  */
 void MapViewState::drawResourceInfo()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	renderer.drawBoxFilled(NAS2D::Rectangle<float>{0, 0, renderer.width(), constants::RESOURCE_ICON_SIZE + 4}, NAS2D::Color{39, 39, 39});
 	renderer.drawBox(NAS2D::Rectangle<float>{0, 0, renderer.width(), constants::RESOURCE_ICON_SIZE + 4}, NAS2D::Color{21, 21, 21});
@@ -228,7 +228,7 @@ void MapViewState::drawRobotInfo()
 {
 	if (ccLocation() == CcNotPlaced) { return; }
 
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Robots: Miner (last one), Dozer (middle one), Digger (first one)
 	// Start from the bottom - The bottom UI Height - Icons Height - 8 (1 offset to avoid the last to be glued with at the border)
@@ -268,7 +268,7 @@ bool MapViewState::drawNavIcon(NAS2D::Renderer& renderer, const NAS2D::Rectangle
  */
 void MapViewState::drawNavInfo()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	drawNavIcon(renderer, MOVE_DOWN_ICON, NAS2D::Rectangle{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
 	drawNavIcon(renderer, MOVE_UP_ICON, NAS2D::Rectangle{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -47,7 +47,7 @@ extern int ROBOT_ID_COUNTER; /// \fixme Kludge
  */
 void MapViewState::save(const std::string& filePath)
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 100);
 	renderer.drawImage(*IMG_SAVING, renderer.center() - IMG_SAVING->size() / 2);
 	renderer.update();
@@ -99,7 +99,7 @@ void MapViewState::load(const std::string& filePath)
 {
 	resetUi();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 100);
 	renderer.drawImage(*IMG_LOADING, renderer.center() - IMG_LOADING->size() / 2);
 	renderer.update();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -47,10 +47,10 @@ extern int ROBOT_ID_COUNTER; /// \fixme Kludge
  */
 void MapViewState::save(const std::string& filePath)
 {
-	Renderer& r = Utility<Renderer>::get();
-	r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0, 100);
-	r.drawImage(*IMG_SAVING, r.center() - IMG_SAVING->size() / 2);
-	r.update();
+	Renderer& renderer = Utility<Renderer>::get();
+	renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 100);
+	renderer.drawImage(*IMG_SAVING, renderer.center() - IMG_SAVING->size() / 2);
+	renderer.update();
 
 	XmlDocument doc;
 
@@ -99,10 +99,10 @@ void MapViewState::load(const std::string& filePath)
 {
 	resetUi();
 
-	Renderer& r = Utility<Renderer>::get();
-	r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0, 100);
-	r.drawImage(*IMG_LOADING, r.center() - IMG_LOADING->size() / 2);
-	r.update();
+	Renderer& renderer = Utility<Renderer>::get();
+	renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 100);
+	renderer.drawImage(*IMG_LOADING, renderer.center() - IMG_LOADING->size() / 2);
+	renderer.update();
 
 	mBtnToggleConnectedness.toggle(false);
 	mBtnToggleHeightmap.toggle(false);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -284,9 +284,9 @@ std::vector<void*> path;
  */
 void MapViewState::nextTurn()
 {
-	NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
-	r.drawImage(*IMG_PROCESSING_TURN, r.center() - IMG_PROCESSING_TURN->size() / 2);
-	r.update();
+	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	renderer.drawImage(*IMG_PROCESSING_TURN, renderer.center() - IMG_PROCESSING_TURN->size() / 2);
+	renderer.update();
 
 	clearMode();
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -284,7 +284,7 @@ std::vector<void*> path;
  */
 void MapViewState::nextTurn()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.drawImage(*IMG_PROCESSING_TURN, renderer.center() - IMG_PROCESSING_TURN->size() / 2);
 	renderer.update();
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -72,7 +72,7 @@ static inline int centerWindowHeight(float height)
  */
 void MapViewState::initUi()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	mDiggerDirection.directionSelected().connect(this, &MapViewState::diggerSelectionDialog);
 	mDiggerDirection.hide();
@@ -172,7 +172,7 @@ void MapViewState::initUi()
 
 void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 {
-	//NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	//auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI Area
 	BOTTOM_UI_AREA = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
@@ -357,7 +357,7 @@ void MapViewState::populateStructureMenu()
 */
 void MapViewState::drawUI()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI
 	renderer.drawBoxFilled(BOTTOM_UI_AREA, 39, 39, 39);

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -72,18 +72,18 @@ static inline int centerWindowHeight(float height)
  */
 void MapViewState::initUi()
 {
-	NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
+	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	mDiggerDirection.directionSelected().connect(this, &MapViewState::diggerSelectionDialog);
 	mDiggerDirection.hide();
 
-	mTileInspector.position(r.center_x() - mTileInspector.width() / 2.0f, r.height() / 2.0f - 175.0f);
+	mTileInspector.position(renderer.center_x() - mTileInspector.width() / 2.0f, renderer.height() / 2.0f - 175.0f);
 	mTileInspector.hide();
 
-	mStructureInspector.position(r.center_x() - mStructureInspector.width() / 2.0f, r.height() / 2.0f - 175.0f);
+	mStructureInspector.position(renderer.center_x() - mStructureInspector.width() / 2.0f, renderer.height() / 2.0f - 175.0f);
 	mStructureInspector.hide();
 
-	mFactoryProduction.position(r.center_x() - mFactoryProduction.width() / 2.0f, 175.0f);
+	mFactoryProduction.position(renderer.center_x() - mFactoryProduction.width() / 2.0f, 175.0f);
 	mFactoryProduction.hide();
 
 	mFileIoDialog.setMode(FileIo::FileOperation::FILE_SAVE);
@@ -120,11 +120,11 @@ void MapViewState::initUi()
 	mWindowStack.addWindow(&mWarehouseInspector);
 	mWindowStack.addWindow(&mMineOperationsWindow);
 
-	BOTTOM_UI_AREA = {0, static_cast<int>(r.height() - constants::BOTTOM_UI_HEIGHT), static_cast<int>(r.width()), constants::BOTTOM_UI_HEIGHT};
+	BOTTOM_UI_AREA = {0, static_cast<int>(renderer.height() - constants::BOTTOM_UI_HEIGHT), static_cast<int>(renderer.width()), constants::BOTTOM_UI_HEIGHT};
 
 	// BUTTONS
 	mBtnTurns.image("ui/icons/turns.png");
-	mBtnTurns.position(static_cast<float>(mMiniMapBoundingBox.x() - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT), static_cast<float>(r.height() - constants::MARGIN - MAIN_BUTTON_SIZE));
+	mBtnTurns.position(static_cast<float>(mMiniMapBoundingBox.x() - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT), static_cast<float>(renderer.height() - constants::MARGIN - MAIN_BUTTON_SIZE));
 	mBtnTurns.size(static_cast<float>(constants::MAIN_BUTTON_SIZE));
 	mBtnTurns.click().connect(this, &MapViewState::btnTurnsClicked);
 	mBtnTurns.enabled(false);
@@ -172,7 +172,7 @@ void MapViewState::initUi()
 
 void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 {
-	//NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
+	//NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI Area
 	BOTTOM_UI_AREA = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
@@ -357,12 +357,12 @@ void MapViewState::populateStructureMenu()
 */
 void MapViewState::drawUI()
 {
-	NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
+	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI
-	r.drawBoxFilled(BOTTOM_UI_AREA, 39, 39, 39);
-	r.drawBox(BOTTOM_UI_AREA, 21, 21, 21);
-	r.drawLine(static_cast<float>(BOTTOM_UI_AREA.x() + 1), static_cast<float>(BOTTOM_UI_AREA.y()), static_cast<float>(BOTTOM_UI_AREA.x() + BOTTOM_UI_AREA.width() - 2), static_cast<float>(BOTTOM_UI_AREA.y()), 56, 56, 56);
+	renderer.drawBoxFilled(BOTTOM_UI_AREA, 39, 39, 39);
+	renderer.drawBox(BOTTOM_UI_AREA, 21, 21, 21);
+	renderer.drawLine(static_cast<float>(BOTTOM_UI_AREA.x() + 1), static_cast<float>(BOTTOM_UI_AREA.y()), static_cast<float>(BOTTOM_UI_AREA.x() + BOTTOM_UI_AREA.width() - 2), static_cast<float>(BOTTOM_UI_AREA.y()), 56, 56, 56);
 
 	drawMiniMap();
 	drawResourceInfo();

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -31,7 +31,7 @@ public:
 
 	void update(int x, int y)
 	{
-		Renderer& renderer = Utility<Renderer>::get();
+		auto& renderer = Utility<Renderer>::get();
 
 		if (mTimer.accumulator() > 7)
 		{
@@ -100,7 +100,7 @@ void PlanetSelectState::initialize()
 	mPlanets.push_back(new Planet(Planet::PlanetType::PLANET_TYPE_MARS));
 	mPlanets.push_back(new Planet(Planet::PlanetType::PLANET_TYPE_GANYMEDE));
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	const auto viewportSize = renderer.size().to<int>();
 	mPlanets[0]->position(viewportSize.x / 4 - 64, viewportSize.y / 2 - 64);
 	mPlanets[0]->mouseEnter().connect(this, &PlanetSelectState::onMousePlanetEnter);
@@ -142,7 +142,7 @@ void PlanetSelectState::initialize()
 void PlanetSelectState::drawStar(int x, int y)
 {
 	float rotation = (mTimer.tick() / 125.0f);
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	renderer.drawImageRotated(mStarFlare, static_cast<float>(x), static_cast<float>(y), -rotation * 0.75f, 255, 255, 0, 180);
 	renderer.drawImageRotated(mDetailFlare2, static_cast<float>(x), static_cast<float>(y), -rotation * 0.25f, 255, 255, 100, 255);
 	renderer.drawImageRotated(mDetailFlare, static_cast<float>(x), static_cast<float>(y), rotation, 255, 255, 255, 255);
@@ -151,7 +151,7 @@ void PlanetSelectState::drawStar(int x, int y)
 
 State* PlanetSelectState::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImageStretched(mBg, 0, 0, renderer.width(), renderer.height());
 

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -97,7 +97,7 @@ void SplashState::skipSplash()
  */
 NAS2D::State* SplashState::update()
 {
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	if (renderer.isFaded() && !renderer.isFading() && mTimer.accumulator() > FADE_PAUSE_TIME)
 	{

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -97,45 +97,45 @@ void SplashState::skipSplash()
  */
 NAS2D::State* SplashState::update()
 {
-	NAS2D::Renderer& r = NAS2D::Utility<NAS2D::Renderer>::get();
+	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	if (r.isFaded() && !r.isFading() && mTimer.accumulator() > FADE_PAUSE_TIME)
+	if (renderer.isFaded() && !renderer.isFading() && mTimer.accumulator() > FADE_PAUSE_TIME)
 	{
 		if (mReturnState != this) { return mReturnState; }
 
 		setNextState(CURRENT_STATE);
-		r.fadeIn(FADE_LENGTH);
+		renderer.fadeIn(FADE_LENGTH);
 		mTimer.reset();
 	}
 
-	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD) { r.drawBoxFilled(0, 0, r.width(), r.height(), 0, 0, 0); }
-	else { r.drawBoxFilled(0, 0, r.width(), r.height(), 255, 255, 255); }
+	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD) { renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0); }
+	else { renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 255, 255, 255); }
 
 
 	if (CURRENT_STATE == LogoState::LOGO_LAIRWORKS)
 	{
-		r.drawImage(mLogoLairworks, r.center() - mLogoLairworks.size() / 2);
+		renderer.drawImage(mLogoLairworks, renderer.center() - mLogoLairworks.size() / 2);
 	}
 	if (CURRENT_STATE == LogoState::LOGO_NAS2D)
 	{
-		r.drawImage(mLogoNas2d, r.center() - mLogoNas2d.size() / 2);
+		renderer.drawImage(mLogoNas2d, renderer.center() - mLogoNas2d.size() / 2);
 	}
 	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD)
 	{
 		const unsigned int tick = BYLINE_TIMER.delta();
-		const auto logoPosition = r.center() - mLogoOutpostHd.size() / 2 - NAS2D::Vector{100, 0};
+		const auto logoPosition = renderer.center() - mLogoOutpostHd.size() / 2 - NAS2D::Vector{100, 0};
 
-		r.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);
-		r.drawImage(mLogoOutpostHd, logoPosition);
+		renderer.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);
+		renderer.drawImage(mLogoOutpostHd, logoPosition);
 
 		BYLINE_SCALE += tick * BYLINE_SCALE_STEP;
 		BYLINE_ALPHA += tick * BYLINE_ALPHA_FADE_STEP;
 		BYLINE_ALPHA = std::clamp(BYLINE_ALPHA, -3000.0f, 255.0f);
 
-		if(BYLINE_ALPHA > 0.0f) { r.drawImage(mByline, r.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), r.center_y() + 25, BYLINE_SCALE, 255, 255, 255, static_cast<uint8_t>(BYLINE_ALPHA)); }
+		if(BYLINE_ALPHA > 0.0f) { renderer.drawImage(mByline, renderer.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), renderer.center_y() + 25, BYLINE_SCALE, 255, 255, 255, static_cast<uint8_t>(BYLINE_ALPHA)); }
 	}
 	
-	if (r.isFading()) { return this; }
+	if (renderer.isFading()) { return this; }
 
 	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD)
 	{
@@ -147,7 +147,7 @@ NAS2D::State* SplashState::update()
 	}
 	else if (mTimer.accumulator() > PAUSE_TIME)
 	{
-		r.fadeOut(FADE_LENGTH);
+		renderer.fadeOut(FADE_LENGTH);
 		mTimer.reset();
 	}
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -167,7 +167,7 @@ void Button::draw()
 {
 	if (!visible()) { return; }
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	if (enabled() && mMouseHover && mState != State::STATE_PRESSED)
 	{

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -167,36 +167,36 @@ void Button::draw()
 {
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	if (enabled() && mMouseHover && mState != State::STATE_PRESSED)
 	{
-		r.drawImageRect(rect(), mSkinHover);
+		renderer.drawImageRect(rect(), mSkinHover);
 	}
 	else if (mState == State::STATE_NORMAL)
 	{
-		r.drawImageRect(rect(), mSkinNormal);
+		renderer.drawImageRect(rect(), mSkinNormal);
 	}
 	else
 	{
-		r.drawImageRect(rect(), mSkinPressed);
+		renderer.drawImageRect(rect(), mSkinPressed);
 	}
 
 	if (mImage)
 	{
-		r.drawImage(*mImage, rect().center() - mImage->size() / 2);
+		renderer.drawImage(*mImage, rect().center() - mImage->size() / 2);
 	}
 	else
 	{
 		// force text to be drawn on integer bounds, otherwise it can look 'fuzzy' due to texture blending
 		const auto textPosition = rect().center().to<int>() - NAS2D::Vector{mFont->width(text()), mFont->height()} / 2;
-		r.drawText(*mFont, text(), textPosition, NAS2D::Color::White);
+		renderer.drawText(*mFont, text(), textPosition, NAS2D::Color::White);
 	}
 
 	/// \fixme	Naive... would rather set a b&w shader instead.
 	if (!enabled())
 	{
-		r.drawBoxFilled(rect(), NAS2D::Color{125, 125, 125, 100});
+		renderer.drawBoxFilled(rect(), NAS2D::Color{125, 125, 125, 100});
 	}
 }
 

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -120,7 +120,7 @@ void CheckBox::onSizeChanged()
  */
 void CheckBox::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	const auto uncheckedIconRect = NAS2D::Rectangle{0, 0, 13, 13};
 	const auto checkedIconRect = NAS2D::Rectangle{13, 0, 13, 13};

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -120,11 +120,11 @@ void CheckBox::onSizeChanged()
  */
 void CheckBox::update()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	const auto uncheckedIconRect = NAS2D::Rectangle{0, 0, 13, 13};
 	const auto checkedIconRect = NAS2D::Rectangle{13, 0, 13, 13};
 
-	r.drawSubImage(mSkin, position(), (mChecked ? checkedIconRect : uncheckedIconRect));
-	r.drawText(*CBOX_FONT, text(), position() + NAS2D::Vector{20, 0}, NAS2D::Color::White);
+	renderer.drawSubImage(mSkin, position(), (mChecked ? checkedIconRect : uncheckedIconRect));
+	renderer.drawText(*CBOX_FONT, text(), position() + NAS2D::Vector{20, 0}, NAS2D::Color::White);
 }

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -37,7 +37,7 @@ void Label::update()
 {
 	if(!visible()) { return; }
 
-	NAS2D::Renderer& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const auto textPosition = mRect.startPoint().to<int>() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING};
 	renderer.drawText(*TXT_FONT, text(), textPosition, textColor);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -265,7 +265,7 @@ void ListBox::update()
 	// Ignore if menu is empty or invisible
 	if (!visible()) { return; }
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	if (empty())
 	{

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -316,20 +316,20 @@ void ListBoxBase::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	// CONTROL EXTENTS
-	r.drawBoxFilled(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 0, 0, 255);
+	renderer.drawBoxFilled(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 0, 0, 255);
 
-	hasFocus() ? r.drawBox(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 185, 0, 255) : r.drawBox(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 75, 75, 75, 255);
+	hasFocus() ? renderer.drawBox(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 185, 0, 255) : renderer.drawBox(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 75, 75, 75, 255);
 
-	r.clipRect(rect());
+	renderer.clipRect(rect());
 
 	// MOUSE HIGHLIGHT
 	float highlight_y = positionY() + static_cast<float>((mCurrentHighlight * mItemHeight) - mCurrentOffset);
-	r.drawBoxFilled(positionX(), highlight_y, static_cast<float>(mItemWidth), static_cast<float>(mItemHeight), 0, 185, 0, 50);
+	renderer.drawBoxFilled(positionX(), highlight_y, static_cast<float>(mItemWidth), static_cast<float>(mItemHeight), 0, 185, 0, 50);
 
 	mSlider.update();
 
-	r.clipRectClear();
+	renderer.clipRectClear();
 }

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -316,7 +316,7 @@ void ListBoxBase::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	// CONTROL EXTENTS
 	renderer.drawBoxFilled(rect().x(), rect().y(), static_cast<float>(mItemWidth), rect().height(), 0, 0, 0, 255);

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -128,7 +128,7 @@ void RadioButton::onSizeChanged()
  */
 void RadioButton::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	const auto unselectedIconRect = NAS2D::Rectangle{0, 0, 13, 13};
 	const auto selectedIconRect = NAS2D::Rectangle{13, 0, 13, 13};

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -128,11 +128,11 @@ void RadioButton::onSizeChanged()
  */
 void RadioButton::update()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	const auto unselectedIconRect = NAS2D::Rectangle{0, 0, 13, 13};
 	const auto selectedIconRect = NAS2D::Rectangle{13, 0, 13, 13};
 
-	r.drawSubImage(mSkin, position(), (mChecked ? selectedIconRect : unselectedIconRect));
-	r.drawText(*CBOX_FONT, text(), position() + NAS2D::Vector{20, 0}, NAS2D::Color::White);
+	renderer.drawSubImage(mSkin, position(), (mChecked ? selectedIconRect : unselectedIconRect));
+	renderer.drawText(*CBOX_FONT, text(), position() + NAS2D::Vector{20, 0}, NAS2D::Color::White);
 }

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -364,15 +364,15 @@ void Slider::update()
  */
 void Slider::draw()
 {
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 	float _thumbPosition = 0.0f;
 
 	if (mSliderType == SliderType::SLIDER_VERTICAL)
 	{
-		r.drawImageRect(mSlideBar.x(), mSlideBar.y(), mSlideBar.width(), mSlideBar.height(), mSkinMiddle);// slide area
-		r.drawImageRect(mButton1.x(), mButton1.y(), mButton1.height(), mButton1.height(), mSkinButton1);// top button
-		r.drawImageRect(mButton2.x(), mButton2.y(), mButton2.height(), mButton2.height(), mSkinButton2);// bottom button
-		//r.drawImageRect(mButtonUp.x(), mButtonUp.y(), mButtonUp.height(), mButtonUp.height(), mSkinButtonLeft);// top button
+		renderer.drawImageRect(mSlideBar.x(), mSlideBar.y(), mSlideBar.width(), mSlideBar.height(), mSkinMiddle);// slide area
+		renderer.drawImageRect(mButton1.x(), mButton1.y(), mButton1.height(), mButton1.height(), mSkinButton1);// top button
+		renderer.drawImageRect(mButton2.x(), mButton2.y(), mButton2.height(), mButton2.height(), mSkinButton2);// bottom button
+		//renderer.drawImageRect(mButtonUp.x(), mButtonUp.y(), mButtonUp.height(), mButtonUp.height(), mSkinButtonLeft);// top button
 
 		// Slider
 		mSlider.width(mSlideBar.width()); // height = slide bar height
@@ -389,13 +389,13 @@ void Slider::draw()
 
 		mSlider.x(mSlideBar.x());
 		mSlider.y(mSlideBar.y() + _thumbPosition);
-		r.drawImageRect(mSlider.x(), mSlider.y(), mSlider.width(), mSlider.height(), mSkinSlider);
+		renderer.drawImageRect(mSlider.x(), mSlider.y(), mSlider.width(), mSlider.height(), mSkinSlider);
 	}
 	else
 	{
-		r.drawImageRect(mSlideBar.x(), mSlideBar.y(), mSlideBar.width(), mSlideBar.height(), mSkinMiddle); // slide area
-		r.drawImageRect(mButton1.x(), mButton1.y(), mButton1.height(), mButton1.height(), mSkinButton1); // left button
-		r.drawImageRect(mButton2.x(), mButton2.y(), mButton2.height(), mButton2.height(), mSkinButton2); // right button
+		renderer.drawImageRect(mSlideBar.x(), mSlideBar.y(), mSlideBar.width(), mSlideBar.height(), mSkinMiddle); // slide area
+		renderer.drawImageRect(mButton1.x(), mButton1.y(), mButton1.height(), mButton1.height(), mSkinButton1); // left button
+		renderer.drawImageRect(mButton2.x(), mButton2.y(), mButton2.height(), mButton2.height(), mSkinButton2); // right button
 
 		// Slider
 		mSlider.height(mSlideBar.height()); // height = slide bar height
@@ -412,7 +412,7 @@ void Slider::draw()
 
 		mSlider.x(mSlideBar.x() + _thumbPosition);
 		mSlider.y(mSlideBar.y());
-		r.drawImageRect(mSlider.x(), mSlider.y(), mSlider.width(), mSlider.height(), mSkinSlider);
+		renderer.drawImageRect(mSlider.x(), mSlider.y(), mSlider.width(), mSlider.height(), mSkinSlider);
 	}
 
 	if (mDisplayPosition && mMouseHoverSlide)
@@ -433,9 +433,9 @@ void Slider::draw()
 			y = static_cast<int>(mSlideBar.y() - 2) - height;
 		}
 
-		r.drawBox(NAS2D::Rectangle{x, y, width, height}, NAS2D::Color{255, 255, 255, 180});
-		r.drawBoxFilled(NAS2D::Rectangle{x + 1, y + 1, width - 2, height - 2}, NAS2D::Color{0, 0, 0, 180});
-		r.drawText(*SLD_FONT, textHover, NAS2D::Point{x + 2, y + 2}, NAS2D::Color{220, 220, 220});
+		renderer.drawBox(NAS2D::Rectangle{x, y, width, height}, NAS2D::Color{255, 255, 255, 180});
+		renderer.drawBoxFilled(NAS2D::Rectangle{x + 1, y + 1, width - 2, height - 2}, NAS2D::Color{0, 0, 0, 180});
+		renderer.drawText(*SLD_FONT, textHover, NAS2D::Point{x + 2, y + 2}, NAS2D::Color{220, 220, 220});
 	}
 }
 

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -364,7 +364,7 @@ void Slider::update()
  */
 void Slider::draw()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	float _thumbPosition = 0.0f;
 
 	if (mSliderType == SliderType::SLIDER_VERTICAL)

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -90,7 +90,7 @@ void TextArea::update()
 
 void TextArea::draw()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	if (highlight()) { renderer.drawBox(rect(), NAS2D::Color::White); }
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -316,14 +316,14 @@ void TextField::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	if (hasFocus() && editable()) { r.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkinFocus); }
-	else { r.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkinNormal); }
+	if (hasFocus() && editable()) { renderer.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkinFocus); }
+	else { renderer.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkinNormal); }
 
-	if (highlight()) { r.drawBox(rect(), 255, 255, 0); }
+	if (highlight()) { renderer.drawBox(rect(), 255, 255, 0); }
 
 	drawCursor();
 
-	r.drawText(*TXT_FONT, text(), positionX() + FIELD_PADDING, positionY() + FIELD_PADDING, 255, 255, 255);
+	renderer.drawText(*TXT_FONT, text(), positionX() + FIELD_PADDING, positionY() + FIELD_PADDING, 255, 255, 255);
 }

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -316,7 +316,7 @@ void TextField::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	if (hasFocus() && editable()) { renderer.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkinFocus); }
 	else { renderer.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkinNormal); }

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -96,7 +96,7 @@ void Window::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImage(mTitle[0], rect().x(), rect().y());
 	renderer.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, sWindowTitleBarHeight);

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -96,15 +96,15 @@ void Window::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.drawImage(mTitle[0], rect().x(), rect().y());
-	r.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, sWindowTitleBarHeight);
-	r.drawImage(mTitle[2], rect().x() + rect().width() - 4, rect().y());
+	renderer.drawImage(mTitle[0], rect().x(), rect().y());
+	renderer.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, sWindowTitleBarHeight);
+	renderer.drawImage(mTitle[2], rect().x() + rect().width() - 4, rect().y());
 
-	r.drawImageRect(rect().x(), rect().y() + 20, rect().width(), rect().height() - 20, mBody);
+	renderer.drawImageRect(rect().x(), rect().y() + 20, rect().width(), rect().height() - 20, mBody);
 
-	r.drawText(*WINDOW_TITLE_FONT, text(), rect().x() + 5, rect().y() + 2, 255, 255, 255);
+	renderer.drawText(*WINDOW_TITLE_FONT, text(), rect().x() + 5, rect().y() + 2, 255, 255, 255);
 
 	UIContainer::update();
 }

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -152,7 +152,7 @@ void FactoryListBox::update()
 	if (!visible()) { return; }
 	ListBoxBase::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.clipRect(rect());
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -17,7 +17,7 @@ static Font* MAIN_FONT = nullptr;
 static Font* MAIN_FONT_BOLD = nullptr;
 
 
-static void drawItem(Renderer& r, FactoryListBox::FactoryListBoxItem& item, float x, float y, float w, float offset, bool highlight)
+static void drawItem(Renderer& renderer, FactoryListBox::FactoryListBoxItem& item, float x, float y, float w, float offset, bool highlight)
 {
 	Factory* f = item.factory;
 
@@ -25,14 +25,14 @@ static void drawItem(Renderer& r, FactoryListBox::FactoryListBoxItem& item, floa
 	const auto& structureTextColor = structureTextColorFromIndex(f->state());
 
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { r.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, structureColor.red, structureColor.green, structureColor.blue, 75); }
+	if (highlight) { renderer.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, structureColor.red, structureColor.green, structureColor.blue, 75); }
 
-	r.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, structureColor);
-	r.drawSubImage(*STRUCTURE_ICONS, x + 8, y + 8 - offset, static_cast<float>(item.icon_slice.x()), static_cast<float>(item.icon_slice.y()), 46.0f, 46.0f, 255, 255, 255, structureColor.alpha);
+	renderer.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, structureColor);
+	renderer.drawSubImage(*STRUCTURE_ICONS, x + 8, y + 8 - offset, static_cast<float>(item.icon_slice.x()), static_cast<float>(item.icon_slice.y()), 46.0f, 46.0f, 255, 255, 255, structureColor.alpha);
 
-	r.drawText(*MAIN_FONT_BOLD, f->name(), {x + 64, ((y + 29) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
+	renderer.drawText(*MAIN_FONT_BOLD, f->name(), {x + 64, ((y + 29) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
 
-	r.drawText(*MAIN_FONT, productDescription(f->productType()), {x + w - 112, ((y + 19) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
+	renderer.drawText(*MAIN_FONT, productDescription(f->productType()), {x + w - 112, ((y + 19) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
 	
 	// PROGRESS BAR
 	float percentage = (f->productType() == ProductType::PRODUCT_NONE) ? 0.0f : (f->productionTurnsCompleted() / f->productionTurnsToComplete());
@@ -152,14 +152,14 @@ void FactoryListBox::update()
 	if (!visible()) { return; }
 	ListBoxBase::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.clipRect(rect());
+	renderer.clipRect(rect());
 
 	// ITEMS
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		drawItem(r, *static_cast<FactoryListBoxItem*>(mItems[i]),
+		drawItem(renderer, *static_cast<FactoryListBoxItem*>(mItems[i]),
 			positionX(),
 			positionY() + (i * LIST_ITEM_HEIGHT),
 			static_cast<float>(item_width()),
@@ -167,5 +167,5 @@ void FactoryListBox::update()
 			i == ListBoxBase::currentSelection());
 	}
 
-	r.clipRectClear();
+	renderer.clipRectClear();
 }

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -218,7 +218,7 @@ void FactoryProduction::update()
 
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -49,7 +49,7 @@ void GameOverDialog::update()
 
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -49,11 +49,11 @@ void GameOverDialog::update()
 
 	Window::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
+	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
 	const auto& font = *Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	r.drawText(font, "You have failed. Your colony is dead.", position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
+	renderer.drawText(font, "You have failed. Your colony is dead.", position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -415,10 +415,10 @@ void IconGrid::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	//r.drawBoxFilled(rect(), 0, 0, 0);
-	r.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkin);
+	//renderer.drawBoxFilled(rect(), 0, 0, 0);
+	renderer.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkin);
 
 	if (mIconItemList.empty()) { return; }
 
@@ -431,16 +431,16 @@ void IconGrid::update()
 		float y = static_cast<float>((rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos));
 
 		if (mIconItemList[i].available)
-			r.drawSubImage(mIconSheet, x, y, mIconItemList[i].pos.x(), mIconItemList[i].pos.y(), static_cast<float>(mIconSize), static_cast<float>(mIconSize));
+			renderer.drawSubImage(mIconSheet, x, y, mIconItemList[i].pos.x(), mIconItemList[i].pos.y(), static_cast<float>(mIconSize), static_cast<float>(mIconSize));
 		else
-			r.drawSubImage(mIconSheet, x, y, mIconItemList[i].pos.x(), mIconItemList[i].pos.y(), static_cast<float>(mIconSize), static_cast<float>(mIconSize), 255, 0, 0, 255);
+			renderer.drawSubImage(mIconSheet, x, y, mIconItemList[i].pos.x(), mIconItemList[i].pos.y(), static_cast<float>(mIconSize), static_cast<float>(mIconSize), 255, 0, 0, 255);
 	}
 
 	if (mCurrentSelection != constants::NO_SELECTION)
 	{
 		int x_pos = (static_cast<int>(mCurrentSelection) % mGridSize.x);
 		int y_pos = (static_cast<int>(mCurrentSelection) / mGridSize.x); //-V537
-		r.drawBox((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos),
+		renderer.drawBox((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos),
 			(rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos),
 			static_cast<float>(mIconSize),
 			static_cast<float>(mIconSize), 0, 100, 255);
@@ -454,22 +454,22 @@ void IconGrid::update()
 		int x = static_cast<int>((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos));
 		int y = static_cast<int>((rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos));
 
-		r.drawBox(static_cast<float>(x), static_cast<float>(y), static_cast<float>(mIconSize), static_cast<float>(mIconSize), 0, 180, 0);
+		renderer.drawBox(static_cast<float>(x), static_cast<float>(y), static_cast<float>(mIconSize), static_cast<float>(mIconSize), 0, 180, 0);
 
 		// Name Tooltip
 		if (mShowTooltip)
 		{
-			r.drawBoxFilled(static_cast<float>(x),
+			renderer.drawBoxFilled(static_cast<float>(x),
 							static_cast<float>(y - 15),
 							static_cast<float>(FONT->width(mIconItemList[mHighlightIndex].name) + 4),
 							static_cast<float>(FONT->height()), 245, 245, 245);
 			
-			r.drawBox(	static_cast<float>(x),
+			renderer.drawBox(	static_cast<float>(x),
 						static_cast<float>(y - 15),
 						static_cast<float>(FONT->width(mIconItemList[mHighlightIndex].name) + 4),
 						static_cast<float>(FONT->height()), 175, 175, 175);
 			
-			r.drawText(*FONT, mIconItemList[mHighlightIndex].name, static_cast<float>(x + 2), static_cast<float>(y - 15), 0, 0, 0);
+			renderer.drawText(*FONT, mIconItemList[mHighlightIndex].name, static_cast<float>(x + 2), static_cast<float>(y - 15), 0, 0, 0);
 		}
 	}
 }

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -415,7 +415,7 @@ void IconGrid::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	//renderer.drawBoxFilled(rect(), 0, 0, 0);
 	renderer.drawImageRect(rect().x(), rect().y(), rect().width(), rect().height(), mSkin);

--- a/OPHD/UI/MainMenuOptions.cpp
+++ b/OPHD/UI/MainMenuOptions.cpp
@@ -86,10 +86,10 @@ void MainMenuOptions::init()
 
 	std::size_t currentResolutionSelection = 0;
 	{
-		auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
-		auto resolutions = r.getDisplayModes();
-		const auto currentResolution = r.getWindowClientArea();
-		const auto closestResolution = r.getClosestMatchingDisplayMode(NAS2D::DisplayDesc{currentResolution.x, currentResolution.y});
+		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+		auto resolutions = renderer.getDisplayModes();
+		const auto currentResolution = renderer.getWindowClientArea();
+		const auto closestResolution = renderer.getClosestMatchingDisplayMode(NAS2D::DisplayDesc{currentResolution.x, currentResolution.y});
 		const auto s = resolutions.size();
 		for (auto i = std::size_t{0}; i < s; ++i)
 		{

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -66,7 +66,7 @@ void MajorEventAnnouncement::update()
 
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -66,11 +66,11 @@ void MajorEventAnnouncement::update()
 
 	Window::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
+	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
 	const auto& font = *Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	r.drawText(font, mMessage, position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
+	renderer.drawText(font, mMessage, position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -267,48 +267,48 @@ void MineOperationsWindow::update()
 
 	Window::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.drawImage(mUiIcon, rect().x() + 10, rect().y() + 30);
+	renderer.drawImage(mUiIcon, rect().x() + 10, rect().y() + 30);
 
-	r.drawText(*FONT_BOLD, "Mine Yield:", rect().x() + MINE_YIELD_POSITION, rect().y() + 30, 255, 255, 255);
-	r.drawText(*FONT, MINE_YIELD, rect().x() + MINE_YIELD_DESCRIPTION_POSITION, rect().y() + 30, 255, 255, 255);
+	renderer.drawText(*FONT_BOLD, "Mine Yield:", rect().x() + MINE_YIELD_POSITION, rect().y() + 30, 255, 255, 255);
+	renderer.drawText(*FONT, MINE_YIELD, rect().x() + MINE_YIELD_DESCRIPTION_POSITION, rect().y() + 30, 255, 255, 255);
 
-	r.drawText(*FONT_BOLD, "Status:", rect().x() + MINE_YIELD_POSITION, rect().y() + 45, 255, 255, 255);
+	renderer.drawText(*FONT_BOLD, "Status:", rect().x() + MINE_YIELD_POSITION, rect().y() + 45, 255, 255, 255);
 
 	if (mFacility->extending()) { STATUS_STRING = "Digging New Level"; }
 	else if (mFacility->mine()->exhausted()) { STATUS_STRING = "Exhausted"; }
 	else { STATUS_STRING = structureStateDescription(mFacility->state()); }
 	
-	r.drawText(*FONT, STATUS_STRING, rect().x() + MINE_STATUS_POSITION, rect().y() + 45, 255, 255, 255);
+	renderer.drawText(*FONT, STATUS_STRING, rect().x() + MINE_STATUS_POSITION, rect().y() + 45, 255, 255, 255);
 
 	if (mFacility && mFacility->extending())
 	{
-		r.drawText(*FONT_BOLD, "Turns Remaining:", rect().x() + MINE_YIELD_POSITION, rect().y() + 60, 255, 255, 255);
-		r.drawText(*FONT, EXTENTION_TIME_REMAINING, rect().x() + EXTENSION_TURNS_REMAINING_POSITION, rect().y() + 60, 255, 255, 255);
+		renderer.drawText(*FONT_BOLD, "Turns Remaining:", rect().x() + MINE_YIELD_POSITION, rect().y() + 60, 255, 255, 255);
+		renderer.drawText(*FONT, EXTENTION_TIME_REMAINING, rect().x() + EXTENSION_TURNS_REMAINING_POSITION, rect().y() + 60, 255, 255, 255);
 	}
 
-	r.drawText(*FONT_BOLD, "Depth:", rect().x() + MINE_DEPTH_POSITION, rect().y() + 30, 255, 255, 255);
-	r.drawText(*FONT, MINE_DEPTH, rect().x() + MINE_DEPTH_VALUE_POSITION, rect().y() + 30, 255, 255, 255);
+	renderer.drawText(*FONT_BOLD, "Depth:", rect().x() + MINE_DEPTH_POSITION, rect().y() + 30, 255, 255, 255);
+	renderer.drawText(*FONT, MINE_DEPTH, rect().x() + MINE_DEPTH_VALUE_POSITION, rect().y() + 30, 255, 255, 255);
 
 	// REMAINING ORE PANEL
-	r.drawText(*FONT_BOLD, "Remaining Resources", rect().x() + 10, rect().y() + 164, 255, 255, 255);
+	renderer.drawText(*FONT_BOLD, "Remaining Resources", rect().x() + 10, rect().y() + 164, 255, 255, 255);
 
-	r.drawImageRect(rect().x() + 10, rect().y() + 180, rect().width() - 20, 40, mPanel);
+	renderer.drawImageRect(rect().x() + 10, rect().y() + 180, rect().width() - 20, 40, mPanel);
 
-	r.drawLine(rect().x() + 98, rect().y() + 180, rect().x() + 98, rect().y() + 219, 22, 22, 22);
-	r.drawLine(rect().x() + 187, rect().y() + 180, rect().x() + 187, rect().y() + 219, 22, 22, 22);
-	r.drawLine(rect().x() + 275, rect().y() + 180, rect().x() + 275, rect().y() + 219, 22, 22, 22);
+	renderer.drawLine(rect().x() + 98, rect().y() + 180, rect().x() + 98, rect().y() + 219, 22, 22, 22);
+	renderer.drawLine(rect().x() + 187, rect().y() + 180, rect().x() + 187, rect().y() + 219, 22, 22, 22);
+	renderer.drawLine(rect().x() + 275, rect().y() + 180, rect().x() + 275, rect().y() + 219, 22, 22, 22);
 	
-	r.drawLine(rect().x() + 11, rect().y() + 200, rect().x() + rect().width() - 11, rect().y() + 200, 22, 22, 22);
+	renderer.drawLine(rect().x() + 11, rect().y() + 200, rect().x() + rect().width() - 11, rect().y() + 200, 22, 22, 22);
 
-	r.drawSubImage(mIcons, rect().x() + COMMON_METALS_POS, rect().y() + 183, 64, 0, 16, 16);
-	r.drawSubImage(mIcons, rect().x() + COMMON_MINERALS_POS, rect().y() + 183, 96, 0, 16, 16);
-	r.drawSubImage(mIcons, rect().x() + RARE_METALS_POS, rect().y() + 183, 80, 0, 16, 16);
-	r.drawSubImage(mIcons, rect().x() + RARE_MINERALS_POS, rect().y() + 183, 112, 0, 16, 16);
+	renderer.drawSubImage(mIcons, rect().x() + COMMON_METALS_POS, rect().y() + 183, 64, 0, 16, 16);
+	renderer.drawSubImage(mIcons, rect().x() + COMMON_MINERALS_POS, rect().y() + 183, 96, 0, 16, 16);
+	renderer.drawSubImage(mIcons, rect().x() + RARE_METALS_POS, rect().y() + 183, 80, 0, 16, 16);
+	renderer.drawSubImage(mIcons, rect().x() + RARE_MINERALS_POS, rect().y() + 183, 112, 0, 16, 16);
 
-	r.drawText(*FONT, COMMON_METALS_COUNT, rect().x() + COMMON_METALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
-	r.drawText(*FONT, COMMON_MINERALS_COUNT, rect().x() + COMMON_MINERALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
-	r.drawText(*FONT, RARE_METALS_COUNT, rect().x() + RARE_METALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
-	r.drawText(*FONT, RARE_MINERALS_COUNT, rect().x() + RARE_MINERALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
+	renderer.drawText(*FONT, COMMON_METALS_COUNT, rect().x() + COMMON_METALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
+	renderer.drawText(*FONT, COMMON_MINERALS_COUNT, rect().x() + COMMON_MINERALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
+	renderer.drawText(*FONT, RARE_METALS_COUNT, rect().x() + RARE_METALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
+	renderer.drawText(*FONT, RARE_MINERALS_COUNT, rect().x() + RARE_MINERALS_ORE_POSITION, rect().y() + 202, 255, 255, 255);
 }

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -267,7 +267,7 @@ void MineOperationsWindow::update()
 
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImage(mUiIcon, rect().x() + 10, rect().y() + 30);
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -33,7 +33,7 @@ PopulationPanel::PopulationPanel() : mIcons("ui/icons.png")
 
 void PopulationPanel::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	renderer.drawImageRect(rect(), mSkin);
 
 	auto position = NAS2D::Point{positionX() + 5, positionY() + 5};

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -28,19 +28,19 @@ static int FIRST_STOP = 0;
 static int SECOND_STOP = 0;
 
 
-static void drawItem(Renderer& r, ProductListBox::ProductListBoxItem& item, float x, float y, float w, float offset, bool highlight)
+static void drawItem(Renderer& renderer, ProductListBox::ProductListBoxItem& item, float x, float y, float w, float offset, bool highlight)
 {
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { r.drawBoxFilled({x, y - offset, w, LIST_ITEM_HEIGHT}, HIGHLIGHT_COLOR); }
+	if (highlight) { renderer.drawBoxFilled({x, y - offset, w, LIST_ITEM_HEIGHT}, HIGHLIGHT_COLOR); }
 
-	r.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, ITEM_COLOR);
+	renderer.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, ITEM_COLOR);
 
-	r.drawLine({x + FIRST_STOP, y + 2}, {x + FIRST_STOP, y + LIST_ITEM_HEIGHT - 2}, ITEM_COLOR);
-	r.drawLine({x + SECOND_STOP, y + 2}, {x + SECOND_STOP, y + LIST_ITEM_HEIGHT - 2}, ITEM_COLOR);
+	renderer.drawLine({x + FIRST_STOP, y + 2}, {x + FIRST_STOP, y + LIST_ITEM_HEIGHT - 2}, ITEM_COLOR);
+	renderer.drawLine({x + SECOND_STOP, y + 2}, {x + SECOND_STOP, y + LIST_ITEM_HEIGHT - 2}, ITEM_COLOR);
 
-	r.drawText(*MAIN_FONT_BOLD, item.Text, {x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, ITEM_COLOR);
+	renderer.drawText(*MAIN_FONT_BOLD, item.Text, {x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, ITEM_COLOR);
 
-	r.drawText(*MAIN_FONT, "Quantity: " + std::to_string(item.count), {x + FIRST_STOP + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2)}, ITEM_COLOR);
+	renderer.drawText(*MAIN_FONT, "Quantity: " + std::to_string(item.count), {x + FIRST_STOP + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2)}, ITEM_COLOR);
 	
 	drawBasicProgressBar(x + static_cast<float>(SECOND_STOP) + 5, y + 10, static_cast<float>(FIRST_STOP) - 10, 10, item.usage, 2);
 }
@@ -98,16 +98,16 @@ void ProductListBox::update()
 	if (!visible()) { return; }
 	ListBoxBase::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.clipRect(rect());
+	renderer.clipRect(rect());
 
 	FIRST_STOP = static_cast<int>(item_width() * 0.33f);
 	SECOND_STOP = static_cast<int>(item_width() * 0.66f);
 
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		drawItem(r, *static_cast<ProductListBoxItem*>(mItems[i]),
+		drawItem(renderer, *static_cast<ProductListBoxItem*>(mItems[i]),
 			positionX(),
 			positionY() + (i * LIST_ITEM_HEIGHT),
 			static_cast<float>(item_width()),
@@ -115,5 +115,5 @@ void ProductListBox::update()
 			i == ListBoxBase::currentSelection());
 	}
 
-	r.clipRectClear();
+	renderer.clipRectClear();
 }

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -98,7 +98,7 @@ void ProductListBox::update()
 	if (!visible()) { return; }
 	ListBoxBase::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.clipRect(rect());
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -639,7 +639,7 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 void FactoryReport::update()
 {
 	if (!visible()) { return; }
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawLine(cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 10, rect().y() + 10, cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 10, rect().y() + rect().height() - 10, 0, 185, 0);
 	renderer.drawText(*FONT, "Filter by Product", SORT_BY_PRODUCT_POSITION, rect().y() + 10, 0, 185, 0);

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -600,23 +600,23 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 /**
  * 
  */
-void FactoryReport::drawProductPane(Renderer& r)
+void FactoryReport::drawProductPane(Renderer& renderer)
 {
-	r.drawText(*FONT_BIG_BOLD, "Production", DETAIL_PANEL.x(), DETAIL_PANEL.y() + 180, 0, 185, 0);
+	renderer.drawText(*FONT_BIG_BOLD, "Production", DETAIL_PANEL.x(), DETAIL_PANEL.y() + 180, 0, 185, 0);
 
 	float position_x = DETAIL_PANEL.x() + lstProducts.width() + 20.0f;
 
 	if (SELECTED_PRODUCT_TYPE != ProductType::PRODUCT_NONE)
 	{
-		r.drawText(*FONT_BIG_BOLD, productDescription(SELECTED_PRODUCT_TYPE), position_x, DETAIL_PANEL.y() + 180, 0, 185, 0);
-		r.drawImage(*PRODUCT_IMAGE_ARRAY[static_cast<std::size_t>(SELECTED_PRODUCT_TYPE)], position_x, lstProducts.positionY());
+		renderer.drawText(*FONT_BIG_BOLD, productDescription(SELECTED_PRODUCT_TYPE), position_x, DETAIL_PANEL.y() + 180, 0, 185, 0);
+		renderer.drawImage(*PRODUCT_IMAGE_ARRAY[static_cast<std::size_t>(SELECTED_PRODUCT_TYPE)], position_x, lstProducts.positionY());
 		txtProductDescription.update();
 	}
 
 	if (SELECTED_FACTORY->productType() == ProductType::PRODUCT_NONE) { return; }
 	
-	r.drawText(*FONT_BIG_BOLD, "Progress", position_x, DETAIL_PANEL.y() + 358, 0, 185, 0);
-	r.drawText(*FONT_MED, "Building " + productDescription(SELECTED_FACTORY->productType()), position_x, DETAIL_PANEL.y() + 393, 0, 185, 0);
+	renderer.drawText(*FONT_BIG_BOLD, "Progress", position_x, DETAIL_PANEL.y() + 358, 0, 185, 0);
+	renderer.drawText(*FONT_MED, "Building " + productDescription(SELECTED_FACTORY->productType()), position_x, DETAIL_PANEL.y() + 393, 0, 185, 0);
 
 	float percent = 0.0f;
 	if (SELECTED_FACTORY->productType() != ProductType::PRODUCT_NONE)
@@ -628,8 +628,8 @@ void FactoryReport::drawProductPane(Renderer& r)
 	drawBasicProgressBar(position_x, DETAIL_PANEL.y() + 413, rect().width() - position_x - 10, 30, percent, 4);
 
 	const auto text = std::to_string(SELECTED_FACTORY->productionTurnsCompleted()) + " / " + std::to_string(SELECTED_FACTORY->productionTurnsToComplete());
-	r.drawText(*FONT_MED_BOLD, "Turns", position_x, DETAIL_PANEL.y() + 449, 0, 185, 0);
-	r.drawText(*FONT_MED, text, rect().width() - FONT_MED->width(text) - 10, DETAIL_PANEL.y() + 449, 0, 185, 0);
+	renderer.drawText(*FONT_MED_BOLD, "Turns", position_x, DETAIL_PANEL.y() + 449, 0, 185, 0);
+	renderer.drawText(*FONT_MED, text, rect().width() - FONT_MED->width(text) - 10, DETAIL_PANEL.y() + 449, 0, 185, 0);
 }
 
 
@@ -639,15 +639,15 @@ void FactoryReport::drawProductPane(Renderer& r)
 void FactoryReport::update()
 {
 	if (!visible()) { return; }
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.drawLine(cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 10, rect().y() + 10, cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 10, rect().y() + rect().height() - 10, 0, 185, 0);
-	r.drawText(*FONT, "Filter by Product", SORT_BY_PRODUCT_POSITION, rect().y() + 10, 0, 185, 0);
+	renderer.drawLine(cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 10, rect().y() + 10, cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 10, rect().y() + rect().height() - 10, 0, 185, 0);
+	renderer.drawText(*FONT, "Filter by Product", SORT_BY_PRODUCT_POSITION, rect().y() + 10, 0, 185, 0);
 
 	if (SELECTED_FACTORY)
 	{
-		drawDetailPane(r);
-		drawProductPane(r);
+		drawDetailPane(renderer);
+		drawProductPane(renderer);
 	}
 
 	UIContainer::update();

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -449,14 +449,14 @@ void WarehouseReport::lstStructuresSelectionChanged()
 /**
  * 
  */
-void WarehouseReport::drawLeftPanel(Renderer& r)
+void WarehouseReport::drawLeftPanel(Renderer& renderer)
 {
-	r.drawText(*FONT_MED_BOLD, "Warehouse Count", 10, positionY() + 40, 0, 185, 0);
-	r.drawText(*FONT_MED_BOLD, "Total Storage", 10, positionY() + 62, 0, 185, 0);
-	r.drawText(*FONT_MED_BOLD, "Capacity Used", 10, positionY() + 84, 0, 185, 0);
+	renderer.drawText(*FONT_MED_BOLD, "Warehouse Count", 10, positionY() + 40, 0, 185, 0);
+	renderer.drawText(*FONT_MED_BOLD, "Total Storage", 10, positionY() + 62, 0, 185, 0);
+	renderer.drawText(*FONT_MED_BOLD, "Capacity Used", 10, positionY() + 84, 0, 185, 0);
 
-	r.drawText(*FONT_MED, WH_COUNT, width() / 2 - 10 - COUNT_WIDTH, positionY() + 35, 0, 185, 0);
-	r.drawText(*FONT_MED, WH_CAPACITY, width() / 2 - 10 - CAPACITY_WIDTH, positionY() + 57, 0, 185, 0);
+	renderer.drawText(*FONT_MED, WH_COUNT, width() / 2 - 10 - COUNT_WIDTH, positionY() + 35, 0, 185, 0);
+	renderer.drawText(*FONT_MED, WH_CAPACITY, width() / 2 - 10 - CAPACITY_WIDTH, positionY() + 57, 0, 185, 0);
 
 	drawBasicProgressBar(static_cast<float>(CAPACITY_BAR_POSITION_X), positionY() + 84.0f, static_cast<float>(CAPACITY_BAR_WIDTH), 20.0f, CAPACITY_PERCENT);
 }
@@ -465,12 +465,12 @@ void WarehouseReport::drawLeftPanel(Renderer& r)
 /**
  * 
  */
-void WarehouseReport::drawRightPanel(Renderer& r)
+void WarehouseReport::drawRightPanel(Renderer& renderer)
 {
 	if (!SELECTED_WAREHOUSE) { return; }
 	
-	r.drawText(*FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), r.center_x() + 10, positionY() + 2, 0, 185, 0);
-	r.drawImage(*WAREHOUSE_IMG, r.center_x() + 10, positionY() + 35);
+	renderer.drawText(*FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), renderer.center_x() + 10, positionY() + 2, 0, 185, 0);
+	renderer.drawImage(*WAREHOUSE_IMG, renderer.center_x() + 10, positionY() + 35);
 }
 
 
@@ -480,12 +480,12 @@ void WarehouseReport::drawRightPanel(Renderer& r)
 void WarehouseReport::update()
 {
 	if (!visible()) { return; }
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
 	// Left Panel
-	drawLeftPanel(r);
-	r.drawLine(r.center_x(), positionY() + 10, r.center_x(), positionY() + height() - 10, 0, 185, 0);
-	drawRightPanel(r);
+	drawLeftPanel(renderer);
+	renderer.drawLine(renderer.center_x(), positionY() + 10, renderer.center_x(), positionY() + height() - 10, 0, 185, 0);
+	drawRightPanel(renderer);
 
 	UIContainer::update();
 }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -480,7 +480,7 @@ void WarehouseReport::drawRightPanel(Renderer& renderer)
 void WarehouseReport::update()
 {
 	if (!visible()) { return; }
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	// Left Panel
 	drawLeftPanel(renderer);

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -72,7 +72,7 @@ void ResourceBreakdownPanel::resourceCheck()
 
 void ResourceBreakdownPanel::update()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 	renderer.drawImageRect(rect(), mSkin);
 
 	static std::map<ResourceTrend, Point<int>> ICON_SLICE

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -91,7 +91,7 @@ void StructureInspector::btnCloseClicked()
 
 void StructureInspector::drawPopulationRequirements()
 {
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	auto position = rect().startPoint() + NAS2D::Vector{10, 85};
 	renderer.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
@@ -124,7 +124,7 @@ void StructureInspector::update()
 	if (!visible()) { return; }
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -17,7 +17,7 @@ static Font* MAIN_FONT = nullptr;
 static Font* MAIN_FONT_BOLD = nullptr;
 
 
-static void drawItem(Renderer& r, StructureListBox::StructureListBoxItem& item, float x, float y, float w, float offset, bool highlight)
+static void drawItem(Renderer& renderer, StructureListBox::StructureListBoxItem& item, float x, float y, float w, float offset, bool highlight)
 {
 	Structure* _st = item.structure;
 
@@ -25,13 +25,13 @@ static void drawItem(Renderer& r, StructureListBox::StructureListBoxItem& item, 
 	const auto& structureTextColor = structureTextColorFromIndex(_st->state());
 
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { r.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, structureColor.red, structureColor.green, structureColor.blue, 75); }
+	if (highlight) { renderer.drawBoxFilled(x, y - offset, w, LIST_ITEM_HEIGHT, structureColor.red, structureColor.green, structureColor.blue, 75); }
 
-	r.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, structureColor);
+	renderer.drawBox({x + 2, y + 2 - offset, w - 4, LIST_ITEM_HEIGHT - 4}, structureColor);
 
-	r.drawText(*MAIN_FONT_BOLD, item.Text, {x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
+	renderer.drawText(*MAIN_FONT_BOLD, item.Text, {x + 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
 
-	r.drawText(*MAIN_FONT, item.structureState, {x + w - MAIN_FONT->width(item.structureState) - 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
+	renderer.drawText(*MAIN_FONT, item.structureState, {x + w - MAIN_FONT->width(item.structureState) - 5, ((y + 15) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
 }
 
 
@@ -149,14 +149,14 @@ void StructureListBox::update()
 	if (!visible()) { return; }
 	ListBoxBase::update();
 
-	Renderer& r = Utility<Renderer>::get();
+	Renderer& renderer = Utility<Renderer>::get();
 
-	r.clipRect(rect());
+	renderer.clipRect(rect());
 
 	// ITEMS
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		drawItem(r, *static_cast<StructureListBoxItem*>(mItems[i]),
+		drawItem(renderer, *static_cast<StructureListBoxItem*>(mItems[i]),
 			positionX(),
 			positionY() + (i * LIST_ITEM_HEIGHT),
 			static_cast<float>(item_width()),
@@ -164,5 +164,5 @@ void StructureListBox::update()
 			i == ListBoxBase::currentSelection());
 	}
 
-	r.clipRectClear();
+	renderer.clipRectClear();
 }

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -149,7 +149,7 @@ void StructureListBox::update()
 	if (!visible()) { return; }
 	ListBoxBase::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	renderer.clipRect(rect());
 

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -51,7 +51,7 @@ void TileInspector::update()
 
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
 		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -82,7 +82,7 @@ void WarehouseInspector::update()
 
 	Window::update();
 
-	Renderer& renderer = Utility<Renderer>::get();
+	auto& renderer = Utility<Renderer>::get();
 
 	ProductPool& pool = mWarehouse->products();
 

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -112,17 +112,17 @@ int main(int /*argc*/, char *argv[])
 
 		WindowEventWrapper _wew;
 
-		Renderer& r = Utility<Renderer>::init<RendererOpenGL>("OutpostHD");
+		Renderer& renderer = Utility<Renderer>::init<RendererOpenGL>("OutpostHD");
 
 		std::cout << std::endl << "** GAME START **" << std::endl << std::endl;
 
-		r.minimum_size(1000, 700);
-		r.resizeable(true);
-		r.addCursor(constants::MOUSE_POINTER_NORMAL, PointerType::POINTER_NORMAL, 0, 0);
-		r.addCursor(constants::MOUSE_POINTER_PLACE_TILE, PointerType::POINTER_PLACE_TILE, 16, 16);
-		r.addCursor(constants::MOUSE_POINTER_INSPECT, PointerType::POINTER_INSPECT, 8, 8);
-		r.setCursor(PointerType::POINTER_NORMAL);
-		r.fadeOut(0.0f);
+		renderer.minimum_size(1000, 700);
+		renderer.resizeable(true);
+		renderer.addCursor(constants::MOUSE_POINTER_NORMAL, PointerType::POINTER_NORMAL, 0, 0);
+		renderer.addCursor(constants::MOUSE_POINTER_PLACE_TILE, PointerType::POINTER_PLACE_TILE, 16, 16);
+		renderer.addCursor(constants::MOUSE_POINTER_INSPECT, PointerType::POINTER_INSPECT, 8, 8);
+		renderer.setCursor(PointerType::POINTER_NORMAL);
+		renderer.fadeOut(0.0f);
 
 		if (cf.option("maximized") == "true")
 		{

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -112,7 +112,7 @@ int main(int /*argc*/, char *argv[])
 
 		WindowEventWrapper _wew;
 
-		Renderer& renderer = Utility<Renderer>::init<RendererOpenGL>("OutpostHD");
+		auto& renderer = Utility<Renderer>::init<RendererOpenGL>("OutpostHD");
 
 		std::cout << std::endl << "** GAME START **" << std::endl << std::endl;
 


### PR DESCRIPTION
Rename `r` to `renderer`, and catch references with `auto&`.

Prefer more explicit name. Helps differentiate from when `r` means `robot` or `resourcePool`.

Prefer using `auto` over naming a type multiple times.
