### PR TITLE
Rename `r` to `robot`

### DIFF
--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -44,13 +44,13 @@ void RobotPool::clear()
 }
 
 
-void RobotPool::erase(Robot* r)
+void RobotPool::erase(Robot* robot)
 {
-	mRobots.erase(find(mRobots.begin(), mRobots.end(), r));
+	mRobots.erase(find(mRobots.begin(), mRobots.end(), robot));
 
-	eraseRobot(mDiggers, r);
-	eraseRobot(mDozers, r);
-	eraseRobot(mMiners, r);
+	eraseRobot(mDiggers, robot);
+	eraseRobot(mDozers, robot);
+	eraseRobot(mMiners, robot);
 }
 
 

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -36,7 +36,7 @@ public:
 	MinerList& miners() { return mMiners; }
 
 	void clear();
-	void erase(Robot* r);
+	void erase(Robot* robot);
 	bool insertRobotIntoTable(RobotTileTable& robotMap, Robot* robot, Tile* tile);
 
 	uint32_t robotControlMax() { return mRobotControlMax; }

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -54,9 +54,9 @@ void updateRobotControlCount(const T& t, uint32_t& controlCounter)
 
 
 template <class T>
-void eraseRobot(T& t, Robot* r)
+void eraseRobot(T& t, Robot* robot)
 {
-	auto it = find(t.begin(), t.end(), r);
+	auto it = find(t.begin(), t.end(), robot);
 	if (it != t.end())
 	{
 		t.erase(it);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -906,7 +906,7 @@ void MapViewState::placeRobot()
 	// Robodozer has been selected.
 	if(mCurrentRobot == RobotType::ROBOT_DOZER)
 	{
-		Robot* r = mRobotPool.getDozer();
+		Robot* robot = mRobotPool.getDozer();
 
 		if (!tile->excavated() || (tile->thing() && !tile->thingIsStructure()))
 		{
@@ -955,7 +955,7 @@ void MapViewState::placeRobot()
 				return;
 			}
 
-			if (_s->isRobotCommand()) { deleteRobotsInRCC(r, static_cast<RobotCommand*>(_s), mRobotPool, mRobotList, tile); }
+			if (_s->isRobotCommand()) { deleteRobotsInRCC(robot, static_cast<RobotCommand*>(_s), mRobotPool, mRobotList, tile); }
 			if (_s->isFactory() && static_cast<Factory*>(_s) == mFactoryProduction.factory()) { mFactoryProduction.hide(); }
 			if (_s->isWarehouse())
 			{
@@ -975,7 +975,7 @@ void MapViewState::placeRobot()
 			Utility<StructureManager>::get().removeStructure(_s);
 			tile->deleteThing();
 			Utility<StructureManager>::get().disconnectAll();
-			static_cast<Robodozer*>(r)->tileIndex(static_cast<std::size_t>(TerrainType::TERRAIN_DOZED));
+			static_cast<Robodozer*>(robot)->tileIndex(static_cast<std::size_t>(TerrainType::TERRAIN_DOZED));
 			checkConnectedness();
 		}
 		else if (tile->index() == TerrainType::TERRAIN_DOZED)
@@ -984,9 +984,9 @@ void MapViewState::placeRobot()
 			return;
 		}
 
-		r->startTask(tile->index());
-		mRobotPool.insertRobotIntoTable(mRobotList, r, tile);
-		static_cast<Robodozer*>(r)->tileIndex(static_cast<std::size_t>(tile->index()));
+		robot->startTask(tile->index());
+		mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
+		static_cast<Robodozer*>(robot)->tileIndex(static_cast<std::size_t>(tile->index()));
 		tile->index(TerrainType::TERRAIN_DOZED);
 
 		if(!mRobotPool.robotAvailable(RobotType::ROBOT_DOZER))
@@ -1080,9 +1080,9 @@ void MapViewState::placeRobot()
 		if (mTileMap->currentDepth() != constants::DEPTH_SURFACE) { doAlertMessage(constants::ALERT_INVALID_ROBOT_PLACEMENT, constants::ALERT_MINER_SURFACE_ONLY); return; }
 		if (!tile->mine()) { doAlertMessage(constants::ALERT_INVALID_ROBOT_PLACEMENT, constants::ALERT_MINER_NOT_ON_MINE); return; }
 
-		Robot* r = mRobotPool.getMiner();
-		r->startTask(constants::MINER_TASK_TIME);
-		mRobotPool.insertRobotIntoTable(mRobotList, r, tile);
+		Robot* robot = mRobotPool.getMiner();
+		robot->startTask(constants::MINER_TASK_TIME);
+		mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 		tile->index(TerrainType::TERRAIN_DOZED);
 
 		if (!mRobotPool.robotAvailable(RobotType::ROBOT_MINER))

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -94,9 +94,9 @@ private:
 	void onWindowResized(int w, int h);
 
 	// ROBOT EVENT HANDLERS
-	void dozerTaskFinished(Robot* r);
-	void diggerTaskFinished(Robot* r);
-	void minerTaskFinished(Robot* r);
+	void dozerTaskFinished(Robot* robot);
+	void diggerTaskFinished(Robot* robot);
+	void minerTaskFinished(Robot* robot);
 
 	// DRAWING FUNCTIONS
 	void drawUI();

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -20,27 +20,27 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 
 	if ((_rc != nullptr) || mRobotPool.commandCapacityAvailable())
 	{
-		Robot* r = nullptr;
+		Robot* robot = nullptr;
 		
 		switch (pt)
 		{
 		case ProductType::PRODUCT_DIGGER:
-			r = mRobotPool.addRobot(RobotType::ROBOT_DIGGER);
-			r->taskComplete().connect(this, &MapViewState::diggerTaskFinished);
+			robot = mRobotPool.addRobot(RobotType::ROBOT_DIGGER);
+			robot->taskComplete().connect(this, &MapViewState::diggerTaskFinished);
 			factory.pullProduct();
 			checkRobotSelectionInterface(constants::ROBODIGGER, constants::ROBODIGGER_SHEET_ID, RobotType::ROBOT_DIGGER);
 			break;
 
 		case ProductType::PRODUCT_DOZER:
-			r = mRobotPool.addRobot(RobotType::ROBOT_DOZER);
-			r->taskComplete().connect(this, &MapViewState::dozerTaskFinished);
+			robot = mRobotPool.addRobot(RobotType::ROBOT_DOZER);
+			robot->taskComplete().connect(this, &MapViewState::dozerTaskFinished);
 			factory.pullProduct();
 			checkRobotSelectionInterface(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, RobotType::ROBOT_DOZER);
 			break;
 
 		case ProductType::PRODUCT_MINER:
-			r = mRobotPool.addRobot(RobotType::ROBOT_MINER);
-			r->taskComplete().connect(this, &MapViewState::minerTaskFinished);
+			robot = mRobotPool.addRobot(RobotType::ROBOT_MINER);
+			robot->taskComplete().connect(this, &MapViewState::minerTaskFinished);
 			factory.pullProduct();
 			checkRobotSelectionInterface(constants::ROBOMINER, constants::ROBOMINER_SHEET_ID, RobotType::ROBOT_MINER);
 			break;
@@ -49,7 +49,7 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 			throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
 		}
 
-		if (_rc != nullptr) { _rc->addRobot(r); }
+		if (_rc != nullptr) { _rc->addRobot(robot); }
 	}
 	else
 	{
@@ -180,7 +180,7 @@ void MapViewState::deploySeedLander(int x, int y)
 /**
  * Called whenever a RoboDozer completes its task.
  */
-void MapViewState::dozerTaskFinished(Robot* /*r*/)
+void MapViewState::dozerTaskFinished(Robot* /*robot*/)
 {
 	checkRobotSelectionInterface(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, RobotType::ROBOT_DOZER);
 }
@@ -189,18 +189,18 @@ void MapViewState::dozerTaskFinished(Robot* /*r*/)
 /**
  * Called whenever a RoboDigger completes its task.
  */
-void MapViewState::diggerTaskFinished(Robot* r)
+void MapViewState::diggerTaskFinished(Robot* robot)
 {
-	if (mRobotList.find(r) == mRobotList.end()) { throw std::runtime_error("MapViewState::diggerTaskFinished() called with a Robot not in the Robot List!"); }
+	if (mRobotList.find(robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::diggerTaskFinished() called with a Robot not in the Robot List!"); }
 
-	Tile* t = mRobotList[r];
+	Tile* t = mRobotList[robot];
 
 	if (t->depth() > mTileMap->maxDepth())
 	{
 		throw std::runtime_error("Digger defines a depth that exceeds the maximum digging depth!");
 	}
 
-	Direction dir = static_cast<Robodigger*>(r)->direction(); // fugly
+	Direction dir = static_cast<Robodigger*>(robot)->direction(); // fugly
 
 	int originX = 0, originY = 0, depthAdjust = 0;
 
@@ -266,11 +266,11 @@ void MapViewState::diggerTaskFinished(Robot* r)
 /**
  * Called whenever a RoboMiner completes its task.
  */
-void MapViewState::minerTaskFinished(Robot* r)
+void MapViewState::minerTaskFinished(Robot* robot)
 {
-	if (mRobotList.find(r) == mRobotList.end()) { throw std::runtime_error("MapViewState::minerTaskFinished() called with a Robot not in the Robot List!"); }
+	if (mRobotList.find(robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::minerTaskFinished() called with a Robot not in the Robot List!"); }
 
-	Tile* t = mRobotList[r];
+	Tile* t = mRobotList[robot];
 
 	// Surface structure
 	MineFacility* _mf = new MineFacility(t->mine());
@@ -286,7 +286,7 @@ void MapViewState::minerTaskFinished(Robot* r)
 	t2->index(0);
 	t2->excavated(true);
 
-	r->die();
+	robot->die();
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -248,9 +248,9 @@ bool landingSiteSuitable(TileMap* tilemap, int x, int y)
 /**
  * Document me!
  */
-void deleteRobotsInRCC(Robot* r, RobotCommand* rcc, RobotPool& rp, RobotTileTable& rtt, Tile* /*tile*/)
+void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& rp, RobotTileTable& rtt, Tile* /*tile*/)
 {
-	if (rcc->commandedByThis(r))
+	if (rcc->commandedByThis(robotToDelete))
 	{
 		std::cout << "Cannot bulldoze Robot Command Center by a Robot under its command." << std::endl;
 		return;

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -50,4 +50,4 @@ void writeResources(NAS2D::Xml::XmlElement* element, ResourcePool& resourcePool,
 void readResources(NAS2D::Xml::XmlElement* element, ResourcePool& resourcePool);
 
 void updateRobotControl(RobotPool& robotPool);
-void deleteRobotsInRCC(Robot* r, RobotCommand* rcc, RobotPool& rp, RobotTileTable& rtt, Tile* tile);
+void deleteRobotsInRCC(Robot* robot, RobotCommand* rcc, RobotPool& rp, RobotTileTable& rtt, Tile* tile);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -266,23 +266,23 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 			attribute = attribute->next();
 		}
 
-		Robot* r = nullptr;
+		Robot* robot = nullptr;
 		switch (static_cast<RobotType>(type))
 		{
 		case RobotType::ROBOT_DIGGER:
-			r = mRobotPool.addRobot(RobotType::ROBOT_DIGGER, id);
-			r->taskComplete().connect(this, &MapViewState::diggerTaskFinished);
-			static_cast<Robodigger*>(r)->direction(static_cast<Direction>(direction));
+			robot = mRobotPool.addRobot(RobotType::ROBOT_DIGGER, id);
+			robot->taskComplete().connect(this, &MapViewState::diggerTaskFinished);
+			static_cast<Robodigger*>(robot)->direction(static_cast<Direction>(direction));
 			break;
 
 		case RobotType::ROBOT_DOZER:
-			r = mRobotPool.addRobot(RobotType::ROBOT_DOZER, id);
-			r->taskComplete().connect(this, &MapViewState::dozerTaskFinished);
+			robot = mRobotPool.addRobot(RobotType::ROBOT_DOZER, id);
+			robot->taskComplete().connect(this, &MapViewState::dozerTaskFinished);
 			break;
 
 		case RobotType::ROBOT_MINER:
-			r = mRobotPool.addRobot(RobotType::ROBOT_MINER, id);
-			r->taskComplete().connect(this, &MapViewState::minerTaskFinished);
+			robot = mRobotPool.addRobot(RobotType::ROBOT_MINER, id);
+			robot->taskComplete().connect(this, &MapViewState::minerTaskFinished);
 			break;
 
 		default:
@@ -290,21 +290,21 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 			break;
 		}
 
-		if (!r) { continue; } // Could be done in the default handler in the above switch
+		if (!robot) { continue; } // Could be done in the default handler in the above switch
 								// but may be better here as an explicit statement.
 
-		r->fuelCellAge(age);
+		robot->fuelCellAge(age);
 
 		if (production_time > 0)
 		{
-			r->startTask(production_time);
-			mRobotPool.insertRobotIntoTable(mRobotList, r, mTileMap->getTile(x, y, depth));
-			mRobotList[r]->index(0);
+			robot->startTask(production_time);
+			mRobotPool.insertRobotIntoTable(mRobotList, robot, mTileMap->getTile(x, y, depth));
+			mRobotList[robot]->index(0);
 		}
 
 		if (depth > 0)
 		{
-			mRobotList[r]->excavated(true);
+			mRobotList[robot]->excavated(true);
 		}
 	}
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -248,10 +248,10 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 
 	int id = 0, type = 0, age = 0, production_time = 0, x = 0, y = 0, depth = 0, direction = 0;
 	XmlAttribute* attribute = nullptr;
-	for (XmlNode* robot = element->firstChild(); robot; robot = robot->nextSibling())
+	for (XmlNode* robotNode = element->firstChild(); robotNode; robotNode = robotNode->nextSibling())
 	{
 		id = type = age = production_time = x = y = depth = direction = 0;
-		attribute = robot->toElement()->firstAttribute();
+		attribute = robotNode->toElement()->firstAttribute();
 		while (attribute)
 		{
 			if (attribute->name() == "id") { attribute->queryIntValue(id); }

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -470,33 +470,33 @@ void MapViewState::diggerSelectionDialog(DiggerDirection::DiggerSelection select
 	}
 
 	// Assumes a digger is available.
-	Robodigger* r = mRobotPool.getDigger();
-	r->startTask(tile->index() + 5); // FIXME: Magic Number
-	mRobotPool.insertRobotIntoTable(mRobotList, r, tile);
+	Robodigger* robot = mRobotPool.getDigger();
+	robot->startTask(tile->index() + 5); // FIXME: Magic Number
+	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
 
 	if (selection == DiggerDirection::DiggerSelection::SEL_DOWN)
 	{
-		r->direction(Direction::DIR_DOWN);
+		robot->direction(Direction::DIR_DOWN);
 	}
 	else if (selection == DiggerDirection::DiggerSelection::SEL_NORTH)
 	{
-		r->direction(Direction::DIR_NORTH);
+		robot->direction(Direction::DIR_NORTH);
 		mTileMap->getTile(tile->x(), tile->y() - 1, tile->depth())->excavated(true);
 	}
 	else if (selection == DiggerDirection::DiggerSelection::SEL_SOUTH)
 	{
-		r->direction(Direction::DIR_SOUTH);
+		robot->direction(Direction::DIR_SOUTH);
 		mTileMap->getTile(tile->x(), tile->y() + 1, tile->depth())->excavated(true);
 	}
 	else if (selection == DiggerDirection::DiggerSelection::SEL_EAST)
 	{
-		r->direction(Direction::DIR_EAST);
+		robot->direction(Direction::DIR_EAST);
 		mTileMap->getTile(tile->x() + 1, tile->y(), tile->depth())->excavated(true);
 	}
 	else if (selection == DiggerDirection::DiggerSelection::SEL_WEST)
 	{
-		r->direction(Direction::DIR_WEST);
+		robot->direction(Direction::DIR_WEST);
 		mTileMap->getTile(tile->x() - 1, tile->y(), tile->depth())->excavated(true);
 	}
 


### PR DESCRIPTION
Rename `r` to `robot`.

Prefer more explicit name. Helps differentiate from variables that were named `r` for `renderer` or `resourcePool`.
