### PR TITLE
Rename `r` to `resourcePool` and `rate`

### DIFF
--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -33,7 +33,7 @@ public:
 
 	int update(int morale, int food, int residences, int universities, int nurseries, int hospitals);
 
-	void starveRate(float r) { mStarveRate = r; }
+	void starveRate(float rate) { mStarveRate = rate; }
 
 protected:
 

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -146,9 +146,9 @@ void Structure::forceIdle(bool force)
 }
 
 
-bool Structure::enoughResourcesAvailable(ResourcePool& r)
+bool Structure::enoughResourcesAvailable(ResourcePool& resourcePool)
 {
-	return r >= resourcesIn();
+	return resourcePool >= resourcesIn();
 }
 
 

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -93,7 +93,7 @@ public:
 	ResourcePool& production() { return mProductionPool; }
 
 	virtual void input(ResourcePool& /*pool*/) {}
-	bool enoughResourcesAvailable(ResourcePool& r);
+	bool enoughResourcesAvailable(ResourcePool& resourcePool);
 
 	const PopulationRequirements& populationRequirements() const { return mPopulationRequirements; }
 	PopulationRequirements& populationAvailable() { return mPopulationAvailable; }


### PR DESCRIPTION
Rename `r` to `resourcePool` and `rate`.

Prefer more explicit name. Helps differentiate from variables that were named `r` for `renderer` or `robot`.
