### PR TITLE
Rename `rp` to `resourcePool`

### DIFF
--- a/OPHD/ResourcePool.cpp
+++ b/OPHD/ResourcePool.cpp
@@ -292,7 +292,7 @@ void ResourcePool::pushResources(ResourcePool& rp)
  *
  * \param rp The ResourcePool to pull resources to.
  */
-void ResourcePool::pullResources(ResourcePool& _rp)
+void ResourcePool::pullResources(ResourcePool& resourcePool)
 {
 	if (_capacity == 0)
 	{
@@ -301,23 +301,23 @@ void ResourcePool::pullResources(ResourcePool& _rp)
 	}
 
 	// Energy is not part of the capacity check and needs to be transfered first.
-	_rp.energy(_rp.energy() + pullResource(ResourceType::RESOURCE_ENERGY, energy()));
+	resourcePool.energy(resourcePool.energy() + pullResource(ResourceType::RESOURCE_ENERGY, energy()));
 
 	// sanity checks
-	if (_rp.atCapacity() || empty())
+	if (resourcePool.atCapacity() || empty())
 		return;
 
-	_rp.pushResource(ResourceType::RESOURCE_COMMON_METALS_ORE, pullResource(ResourceType::RESOURCE_COMMON_METALS_ORE, commonMetalsOre()), false);
-	_rp.pushResource(ResourceType::RESOURCE_COMMON_MINERALS_ORE, pullResource(ResourceType::RESOURCE_COMMON_MINERALS_ORE, commonMineralsOre()), false);
-	_rp.pushResource(ResourceType::RESOURCE_RARE_METALS_ORE, pullResource(ResourceType::RESOURCE_RARE_METALS_ORE, rareMetalsOre()), false);
-	_rp.pushResource(ResourceType::RESOURCE_RARE_MINERALS_ORE, pullResource(ResourceType::RESOURCE_RARE_MINERALS_ORE, rareMineralsOre()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_COMMON_METALS_ORE, pullResource(ResourceType::RESOURCE_COMMON_METALS_ORE, commonMetalsOre()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_COMMON_MINERALS_ORE, pullResource(ResourceType::RESOURCE_COMMON_MINERALS_ORE, commonMineralsOre()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_RARE_METALS_ORE, pullResource(ResourceType::RESOURCE_RARE_METALS_ORE, rareMetalsOre()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_RARE_MINERALS_ORE, pullResource(ResourceType::RESOURCE_RARE_MINERALS_ORE, rareMineralsOre()), false);
 
-	_rp.pushResource(ResourceType::RESOURCE_COMMON_METALS, pullResource(ResourceType::RESOURCE_COMMON_METALS, commonMetals()), false);
-	_rp.pushResource(ResourceType::RESOURCE_COMMON_MINERALS, pullResource(ResourceType::RESOURCE_COMMON_MINERALS, commonMinerals()), false);
-	_rp.pushResource(ResourceType::RESOURCE_RARE_METALS, pullResource(ResourceType::RESOURCE_RARE_METALS, rareMetals()), false);
-	_rp.pushResource(ResourceType::RESOURCE_RARE_MINERALS, pullResource(ResourceType::RESOURCE_RARE_MINERALS, rareMinerals()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_COMMON_METALS, pullResource(ResourceType::RESOURCE_COMMON_METALS, commonMetals()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_COMMON_MINERALS, pullResource(ResourceType::RESOURCE_COMMON_MINERALS, commonMinerals()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_RARE_METALS, pullResource(ResourceType::RESOURCE_RARE_METALS, rareMetals()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_RARE_MINERALS, pullResource(ResourceType::RESOURCE_RARE_MINERALS, rareMinerals()), false);
 
-	_rp.pushResource(ResourceType::RESOURCE_FOOD, pullResource(ResourceType::RESOURCE_FOOD, food()), false);
+	resourcePool.pushResource(ResourceType::RESOURCE_FOOD, pullResource(ResourceType::RESOURCE_FOOD, food()), false);
 }
 
 /**

--- a/OPHD/ResourcePool.cpp
+++ b/OPHD/ResourcePool.cpp
@@ -260,12 +260,12 @@ int ResourcePool::pullResource(ResourceType type, int amount)
 /**
  * Attempts to push all available resources into a ResourcePool.
  *
- * \param rp The ResourcePool to push resources from.
+ * \param resourcePool The ResourcePool to push resources from.
  *
  * \note	Any resources that can't be fit in ResourcePool are left in
  *			the source ResourcePool.
  */
-void ResourcePool::pushResources(ResourcePool& rp)
+void ResourcePool::pushResources(ResourcePool& resourcePool)
 {
 	if (_capacity == 0)
 	{
@@ -273,24 +273,24 @@ void ResourcePool::pushResources(ResourcePool& rp)
 		return;
 	}
 
-	rp.commonMetalsOre(pushResource(ResourceType::RESOURCE_COMMON_METALS_ORE, rp.commonMetalsOre(), false));
-	rp.commonMineralsOre(pushResource(ResourceType::RESOURCE_COMMON_MINERALS_ORE, rp.commonMineralsOre(), false));
-	rp.rareMetalsOre(pushResource(ResourceType::RESOURCE_RARE_METALS_ORE, rp.rareMetalsOre(), false));
-	rp.rareMineralsOre(pushResource(ResourceType::RESOURCE_RARE_MINERALS_ORE, rp.rareMineralsOre(), false));
+	resourcePool.commonMetalsOre(pushResource(ResourceType::RESOURCE_COMMON_METALS_ORE, resourcePool.commonMetalsOre(), false));
+	resourcePool.commonMineralsOre(pushResource(ResourceType::RESOURCE_COMMON_MINERALS_ORE, resourcePool.commonMineralsOre(), false));
+	resourcePool.rareMetalsOre(pushResource(ResourceType::RESOURCE_RARE_METALS_ORE, resourcePool.rareMetalsOre(), false));
+	resourcePool.rareMineralsOre(pushResource(ResourceType::RESOURCE_RARE_MINERALS_ORE, resourcePool.rareMineralsOre(), false));
 
-	rp.commonMetals(pushResource(ResourceType::RESOURCE_COMMON_METALS, rp.commonMetals(), false));
-	rp.commonMinerals(pushResource(ResourceType::RESOURCE_COMMON_MINERALS, rp.commonMinerals(), false));
-	rp.rareMetals(pushResource(ResourceType::RESOURCE_RARE_METALS, rp.rareMetals(), false));
-	rp.rareMinerals(pushResource(ResourceType::RESOURCE_RARE_MINERALS, rp.rareMinerals(), false));
+	resourcePool.commonMetals(pushResource(ResourceType::RESOURCE_COMMON_METALS, resourcePool.commonMetals(), false));
+	resourcePool.commonMinerals(pushResource(ResourceType::RESOURCE_COMMON_MINERALS, resourcePool.commonMinerals(), false));
+	resourcePool.rareMetals(pushResource(ResourceType::RESOURCE_RARE_METALS, resourcePool.rareMetals(), false));
+	resourcePool.rareMinerals(pushResource(ResourceType::RESOURCE_RARE_MINERALS, resourcePool.rareMinerals(), false));
 
-	rp.food(pushResource(ResourceType::RESOURCE_FOOD, rp.food(), false));
-	rp.energy(pushResource(ResourceType::RESOURCE_ENERGY, rp.energy(), false));
+	resourcePool.food(pushResource(ResourceType::RESOURCE_FOOD, resourcePool.food(), false));
+	resourcePool.energy(pushResource(ResourceType::RESOURCE_ENERGY, resourcePool.energy(), false));
 }
 
 /**
  * Attempts to pull all available resources from a ResourcePool.
  *
- * \param rp The ResourcePool to pull resources to.
+ * \param resourcePool The ResourcePool to pull resources to.
  */
 void ResourcePool::pullResources(ResourcePool& resourcePool)
 {

--- a/OPHD/ResourcePool.h
+++ b/OPHD/ResourcePool.h
@@ -89,8 +89,8 @@ public:
 	int pushResource(ResourceType, int, bool);
 	int pullResource(ResourceType, int);
 
-	void pushResources(ResourcePool& rp);
-	void pullResources(ResourcePool& rp);
+	void pushResources(ResourcePool& resourcePool);
+	void pullResources(ResourcePool& resourcePool);
 
 	int capacity() const { return _capacity; }
 	void capacity(int newCapacity);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -480,16 +480,16 @@ void moveProducts(Warehouse* wh)
  * Displays a message indicating that there are not enough resources to build
  * a structure and what the missing resources are.
  */
-void resourceShortageMessage(ResourcePool& _rp, StructureID sid)
+void resourceShortageMessage(ResourcePool& resourcePool, StructureID sid)
 {
 	const ResourcePool& cost = StructureCatalogue::costToBuild(sid);
 
 	ResourcePool missing;
 	
-	if (_rp.commonMetals() < cost.commonMetals()) { missing.commonMetals(cost.commonMetals() - _rp.commonMetals()); }
-	if (_rp.commonMinerals() < cost.commonMinerals()) { missing.commonMinerals(cost.commonMinerals() - _rp.commonMinerals()); }
-	if (_rp.rareMetals() < cost.rareMetals()) { missing.rareMetals(cost.rareMetals() - _rp.rareMetals()); }
-	if (_rp.rareMinerals() < cost.rareMinerals()) { missing.rareMinerals(cost.rareMinerals() - _rp.rareMinerals()); }
+	if (resourcePool.commonMetals() < cost.commonMetals()) { missing.commonMetals(cost.commonMetals() - resourcePool.commonMetals()); }
+	if (resourcePool.commonMinerals() < cost.commonMinerals()) { missing.commonMinerals(cost.commonMinerals() - resourcePool.commonMinerals()); }
+	if (resourcePool.rareMetals() < cost.rareMetals()) { missing.rareMetals(cost.rareMetals() - resourcePool.rareMetals()); }
+	if (resourcePool.rareMinerals() < cost.rareMinerals()) { missing.rareMinerals(cost.rareMinerals() - resourcePool.rareMinerals()); }
 
 	std::string message = constants::ALERT_STRUCTURE_INSUFFICIENT_RESORUCES;
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -20,17 +20,17 @@ extern NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
 /**
  * 
  */
-static int pullFood(ResourcePool& _rp, int amount)
+static int pullFood(ResourcePool& resourcePool, int amount)
 {
-	if (amount <= _rp.food())
+	if (amount <= resourcePool.food())
 	{
-		_rp.food(_rp.food() - amount);
+		resourcePool.food(resourcePool.food() - amount);
 		return amount;
 	}
 	else
 	{
-		int ret = _rp.food();
-		_rp.food(0);
+		int ret = resourcePool.food();
+		resourcePool.food(0);
 		return ret;
 	}
 }
@@ -180,12 +180,12 @@ void MapViewState::updateResources()
 
 		if (!mine->operational()) { continue; } // consider a different control path.
 
-		ResourcePool& _rp = mine->storage();
+		ResourcePool& resourcePool = mine->storage();
 
-		truck.commonMetalsOre(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_METALS_ORE, 25));
-		truck.commonMineralsOre(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_MINERALS_ORE, 25));
-		truck.rareMetalsOre(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_METALS_ORE, 25));
-		truck.rareMineralsOre(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_MINERALS_ORE, 25));
+		truck.commonMetalsOre(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_METALS_ORE, 25));
+		truck.commonMineralsOre(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_MINERALS_ORE, 25));
+		truck.rareMetalsOre(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_METALS_ORE, 25));
+		truck.rareMineralsOre(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_MINERALS_ORE, 25));
 
 		for (auto smelter : NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::CLASS_SMELTER))
 		{
@@ -206,11 +206,11 @@ void MapViewState::updateResources()
 	{
 		if (!smelter->operational()) { continue; } // consider a different control path.
 
-		ResourcePool& _rp = smelter->storage();
-		truck.commonMetals(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_METALS, 25));
-		truck.commonMinerals(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_MINERALS, 25));
-		truck.rareMetals(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_METALS, 25));
-		truck.rareMinerals(_rp.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_MINERALS, 25));
+		ResourcePool& resourcePool = smelter->storage();
+		truck.commonMetals(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_METALS, 25));
+		truck.commonMinerals(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_COMMON_MINERALS, 25));
+		truck.rareMetals(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_METALS, 25));
+		truck.rareMinerals(resourcePool.pullResource(ResourcePool::ResourceType::RESOURCE_RARE_MINERALS, 25));
 
 		mPlayerResources.pushResources(truck);
 

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -234,10 +234,10 @@ void StructureCatalogue::init()
  */
 bool StructureCatalogue::canBuild(const ResourcePool& source, StructureID type)
 {
-	ResourcePool _rp = StructureCatalogue::costToBuild(type);
+	ResourcePool resourcePool = StructureCatalogue::costToBuild(type);
 
-	if (source.commonMetals() < _rp.commonMetals() || source.commonMinerals() < _rp.commonMinerals() ||
-		source.rareMetals() < _rp.rareMetals() || source.rareMinerals() < _rp.rareMinerals())
+	if (source.commonMetals() < resourcePool.commonMetals() || source.commonMinerals() < resourcePool.commonMinerals() ||
+		source.rareMetals() < resourcePool.rareMetals() || source.rareMinerals() < resourcePool.rareMinerals())
 	{
 		return false;
 	}
@@ -347,17 +347,17 @@ ResourcePool StructureCatalogue::recycleValue(StructureID type, float percent)
 		throw std::runtime_error("StructureCatalogue::recycleValue() called before StructureCatalogue::buildCostTable().");
 	}
 
-	ResourcePool _rp = mStructureCostTable[type];
+	ResourcePool resourcePool = mStructureCostTable[type];
 
 	/** Truncation of value from float to int cast is intended and desired behavior. */
-	return ResourcePool(static_cast<int>(_rp.commonMetalsOre() * percent),
-						static_cast<int>(_rp.commonMineralsOre() * percent),
-						static_cast<int>(_rp.rareMetalsOre() * percent),
-						static_cast<int>(_rp.rareMineralsOre() * percent),
-						static_cast<int>(_rp.commonMetals() * percent),
-						static_cast<int>(_rp.commonMinerals() * percent),
-						static_cast<int>(_rp.rareMetals() * percent),
-						static_cast<int>(_rp.rareMinerals() * percent),
-						static_cast<int>(_rp.food() * percent),
-						static_cast<int>(_rp.energy() * percent));
+	return ResourcePool(static_cast<int>(resourcePool.commonMetalsOre() * percent),
+						static_cast<int>(resourcePool.commonMineralsOre() * percent),
+						static_cast<int>(resourcePool.rareMetalsOre() * percent),
+						static_cast<int>(resourcePool.rareMineralsOre() * percent),
+						static_cast<int>(resourcePool.commonMetals() * percent),
+						static_cast<int>(resourcePool.commonMinerals() * percent),
+						static_cast<int>(resourcePool.rareMetals() * percent),
+						static_cast<int>(resourcePool.rareMinerals() * percent),
+						static_cast<int>(resourcePool.food() * percent),
+						static_cast<int>(resourcePool.energy() * percent));
 }

--- a/OPHD/StructureCatalogue.h
+++ b/OPHD/StructureCatalogue.h
@@ -17,7 +17,7 @@
  * \note	StructureCatalogue::init() must be called prior to use.
  * 
  * \code{.cpp}
- * ResourcePool _rp = StructureCatalogue::costToBuild(StructureID::SID_AGRIDOME);
+ * ResourcePool resourcePool = StructureCatalogue::costToBuild(StructureID::SID_AGRIDOME);
  * PopulationRequirements _pr = StructureCatalogue::populationRequirements(StructureID::SID_AGRIDOME);
  * \endcode
  */

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -392,10 +392,10 @@ Tile* StructureManager::tileFromStructure(Structure* st)
 /**
  * 
  */
-void serializeResourcePool(XmlElement* _ti, ResourcePool& _rp, const std::string& name)
+void serializeResourcePool(XmlElement* _ti, ResourcePool& resourcePool, const std::string& name)
 {
 	XmlElement* pool = new XmlElement(name);
-	_rp.serialize(pool);
+	resourcePool.serialize(pool);
 	_ti->linkEndChild(pool);
 }
 

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -10,7 +10,7 @@ class ResourceBreakdownPanel : public Control
 public:
 	ResourceBreakdownPanel();
 
-	void playerResources(ResourcePool* rp) { mPlayerResources = rp; }
+	void playerResources(ResourcePool* resourcePool) { mPlayerResources = resourcePool; }
 	ResourcePool& previousResources() { return mPreviousResources; }
 
 	void resourceCheck();


### PR DESCRIPTION
Rename:
- `_rp` => `resourcePool`
- `rp` => `resourcePool`

Prefer being explicit. Not be to confused with `rp` for `robotPool`.
