### PR TITLE
Use explicit filePath when calling Configuration::save

### DIFF
--- a/OPHD/UI/MainMenuOptions.cpp
+++ b/OPHD/UI/MainMenuOptions.cpp
@@ -238,7 +238,7 @@ void MainMenuOptions::btnApplyClicked()
 void MainMenuOptions::saveOptions()
 {
 	auto& cf = NAS2D::Utility<NAS2D::Configuration>::get();
-	cf.save();
+	cf.save("config.xml");
 }
 
 void MainMenuOptions::loadOptions()

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -163,7 +163,7 @@ int main(int /*argc*/, char *argv[])
 			Utility<Renderer>::get().update();
 		}
 
-		cf.save(); // force configuration to save any changes.
+		cf.save("config.xml"); // force configuration to save any changes.
 	}
 	catch(const std::exception& e)
 	{


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/666

Use explicit `filePath` when calling `Configuration::save`.

This clears the way to remove the `Configuration::save` overload that does not have a parameter. It also means the `mConfigPath` member variable can be removed in future updates.

----

Also relevant, `Configuration::save` is explicitly called before shutdown, so there is no dependence on the `Configuration` destructor to save the config data.
