### PR TITLE
Fix config defaults

### DIFF
--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -85,7 +85,9 @@ int main(int /*argc*/, char *argv[])
 					{{
 						{"screenwidth", constants::MINIMUM_WINDOW_WIDTH},
 						{"screenheight", constants::MINIMUM_WINDOW_HEIGHT},
-						{"fullscreen", false}
+						{"bitdepth", 32},
+						{"fullscreen", false},
+						{"vsync", true}
 					}}
 				},
 				{

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -91,6 +91,17 @@ int main(int /*argc*/, char *argv[])
 					}}
 				},
 				{
+					"audio",
+					{{
+						{"mixer", "SDL"},
+						{"musicvolume", 100},
+						{"sfxvolume", 128},
+						{"channels", 2},
+						{"mixrate", 22050},
+						{"bufferlength", 1024}
+					}}
+				},
+				{
 					"options",
 					{{
 						{"skip-splash", false},


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/issues/422
Reference: https://github.com/lairworks/nas2d-core/pull/668

Allows default `Configuration` values to be usable before data is loaded, and if data fails to load.

Specifies a full set of default values for all required sections and all required keys.

----

This fixes the odd behaviour where fullscreen behaviour would change depending on if the config file was pre-existing or not. It does not fix the bug where changes to fullscreen are not remembered.
