### PR TITLE
Add Git submodule check for NAS2D with auto download

### DIFF
--- a/makefile
+++ b/makefile
@@ -42,8 +42,18 @@ intermediate: $(OBJS)
 $(NAS2DLIB): nas2d
 
 .PHONY: nas2d
-nas2d:
+nas2d: $(NAS2DDIR)makefile
 	$(MAKE) -C nas2d-core
+
+$(NAS2DDIR)makefile:
+	@echo "\nWARNING: NAS2D dependency not found. Install as Git submodule or download manually."
+	@if test -d ".git"; then \
+		echo "Git detected. Attempting to download submodules.\n"; \
+		git submodule update --init --recursive; \
+	else \
+		echo "You don't seem to be using Git. Consider using Git clone.\n"; \
+		false; \
+	fi
 
 $(OBJS): $(OBJDIR)%.o : $(SRCDIR)%.cpp $(OBJDIR)%.d | build-folder
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<


### PR DESCRIPTION
This should make first time checkout and build a little easier. If a non-recursive git clone is used, it will be detected, with a meaningful warning message displayed to the user, and an automatic submodule initialization and download will be performed.

Inspired by feedback:
https://forum.outpost2.net/index.php/topic,6321.msg88995.html#msg88995
