### PR TITLE
Add dependency install rule

### DIFF
--- a/makefile
+++ b/makefile
@@ -89,6 +89,11 @@ clean-all:
 	-rm -f $(EXE)
 
 
+.PHONY: install-dependencies
+install-dependencies:
+	$(MAKE) -C nas2d-core install-dependencies
+
+
 .PHONY: lint
 lint: cppcheck cppclean
 


### PR DESCRIPTION
Closes #427

This should allow dependencies to be installed by running:
```
make install-dependencies
```

The command may need **root** privilege to run.
