### PR TITLE
Allow loading art assets independent of environment variable settings

### DIFF
--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -70,7 +70,8 @@ int main(int /*argc*/, char *argv[])
 	try
 	{
 		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
-		f.mount("data");
+		// Use executable's absolute directory in case environment path is not pointing to expected directory
+		f.mount(f.basePath() + "data");
 		f.mountReadWrite(f.prefPath());
 
 		if (!f.exists(constants::SAVE_GAME_PATH))

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -69,7 +69,7 @@ int main(int /*argc*/, char *argv[])
 
 	try
 	{
-		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
+		auto& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
 		// Prioritize data from working directory, fallback on data from executable path
 		f.mountSoftFail("data");
 		f.mountSoftFail(f.basePath() + "data");

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -69,15 +69,15 @@ int main(int /*argc*/, char *argv[])
 
 	try
 	{
-		auto& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
+		auto& fs = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
 		// Prioritize data from working directory, fallback on data from executable path
-		f.mountSoftFail("data");
-		f.mountSoftFail(f.basePath() + "data");
-		f.mountReadWrite(f.prefPath());
+		fs.mountSoftFail("data");
+		fs.mountSoftFail(fs.basePath() + "data");
+		fs.mountReadWrite(fs.prefPath());
 
-		if (!f.exists(constants::SAVE_GAME_PATH))
+		if (!fs.exists(constants::SAVE_GAME_PATH))
 		{
-			f.makeDirectory(constants::SAVE_GAME_PATH);
+			fs.makeDirectory(constants::SAVE_GAME_PATH);
 		}
 
 		Configuration& cf = Utility<Configuration>::init(
@@ -147,8 +147,8 @@ int main(int /*argc*/, char *argv[])
 
 		std::cout << "Loading packed assets... ";
 
-		f.mountSoftFail("fonts.dat");
-		f.mountSoftFail("planets.dat");
+		fs.mountSoftFail("fonts.dat");
+		fs.mountSoftFail("planets.dat");
 
 		std::cout << "done." << std::endl;
 

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -70,8 +70,9 @@ int main(int /*argc*/, char *argv[])
 	try
 	{
 		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
-		// Use executable's absolute directory in case environment path is not pointing to expected directory
-		f.mount(f.basePath() + "data");
+		// Prioritize data from working directory, fallback on data from executable path
+		f.mountSoftFail("data");
+		f.mountSoftFail(f.basePath() + "data");
 		f.mountReadWrite(f.prefPath());
 
 		if (!f.exists(constants::SAVE_GAME_PATH))


### PR DESCRIPTION
When using Visual Studio to debug, the environment path stays with the project file instead of using the executable being debugged.

I think this makes it possible (easier) to debug from within Visual Studio.