### PR TITLE
Show Residence Capacity in Structure Info Window

### DIFF
--- a/OPHD/Things/Structures/Residence.h
+++ b/OPHD/Things/Structures/Residence.h
@@ -2,7 +2,10 @@
 
 #include "Structure.h"
 
+#include "../../FontManager.h"
 #include "../../Constants.h"
+#include <NAS2D/Resources/Font.h>
+#include <NAS2D/Utility.h>
 
 
 /**
@@ -25,6 +28,21 @@ public:
 	}
 
 	int capacity() const { return mCapacity; }
+
+	void drawInspectorView(NAS2D::Renderer& renderer, const NAS2D::Rectangle<float>& windowRect) override
+	{
+		const auto drawLabelAndValue = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
+			NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+			NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+			
+			renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
+			position.x() += FONT_BOLD->width(title);
+			renderer.drawText(*FONT, text, position, NAS2D::Color::White);
+		};
+
+		auto position = windowRect.startPoint() + NAS2D::Vector{ 10, 135 };
+		drawLabelAndValue(position, "Colonist Capacity: ", std::to_string(capacity()));
+	}
 
 protected:
 	void defineResourceInput() override

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -5,6 +5,9 @@
 #include "../../Common.h"
 #include "../../PopulationPool.h"
 #include "../../ResourcePool.h"
+#include <NAS2D/Renderer/Rectangle.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 
 class Structure: public Thing
 {
@@ -133,6 +136,12 @@ public:
 
 	void update() override;
 	virtual void think() {}
+
+	/**
+	* Pass limited structure specific details for drawing. Use a custom UI window if needed.
+	*/
+	#pragma warning(suppress: 4100) // Unreferenced formal parameter
+	virtual void drawInspectorView(NAS2D::Renderer& renderer, const NAS2D::Rectangle<float>& windowRect) {}
 
 protected:
 	friend class StructureCatalogue;

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -140,8 +140,7 @@ public:
 	/**
 	* Pass limited structure specific details for drawing. Use a custom UI window if needed.
 	*/
-	#pragma warning(suppress: 4100) // Unreferenced formal parameter
-	virtual void drawInspectorView(NAS2D::Renderer& renderer, const NAS2D::Rectangle<float>& windowRect) {}
+	virtual void drawInspectorView([[maybe_unused]] NAS2D::Renderer& renderer, [[maybe_unused]] const NAS2D::Rectangle<float>& windowRect) {}
 
 protected:
 	friend class StructureCatalogue;

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -101,7 +101,7 @@ void StructureInspector::drawLabelAndValue(NAS2D::Point<int> position, const std
 	renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
 	position.x() += FONT_BOLD->width(title);
 	renderer.drawText(*FONT, text, position, NAS2D::Color::White);
-};
+}
 
 
 void StructureInspector::drawPopulationRequirements()

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -6,6 +6,7 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "../Things/Structures/Residence.h"
 #include "../Things/Structures/Structure.h"
 
 #include <map>
@@ -161,7 +162,34 @@ void StructureInspector::update()
 	}
 
 	drawPopulationRequirements();
+	drawStructureTypeSpecific();
 
-	position = mRect.startPoint() + NAS2D::Vector{5, static_cast<int>(mRect.height()) - FONT->height() - 5};
+	position = mRect.startPoint() + NAS2D::Vector{ 5, static_cast<int>(mRect.height()) - FONT->height() - 5 };
 	renderer.drawText(*FONT, "This window is a work in progress", position, NAS2D::Color::White);
+}
+
+
+void StructureInspector::drawStructureTypeSpecific()
+{
+	switch (mStructure->structureClass())
+	{
+	case Structure::CLASS_RESIDENCE:
+		drawResidenceText();
+		return;
+	}
+}
+
+void StructureInspector::drawResidenceText()
+{
+	auto& renderer = Utility<Renderer>::get();
+
+	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
+		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
+		position.x() += FONT_BOLD->width(title);
+		renderer.drawText(*FONT, text, position, NAS2D::Color::White);
+	};
+
+	auto position = rect().startPoint() + NAS2D::Vector{ 10, 135 };
+	drawTitleText(position, "Colonist Capacity: ", std::to_string(dynamic_cast<Residence*>(mStructure)->capacity()));
+	return;
 }

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -94,6 +94,16 @@ void StructureInspector::btnCloseClicked()
 }
 
 
+void StructureInspector::drawTitleText(NAS2D::Point<int> position, const std::string& title, const std::string& text)
+{
+	auto& renderer = Utility<Renderer>::get();
+
+	renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
+	position.x() += FONT_BOLD->width(title);
+	renderer.drawText(*FONT, text, position, NAS2D::Color::White);
+};
+
+
 void StructureInspector::drawPopulationRequirements()
 {
 	auto& renderer = Utility<Renderer>::get();
@@ -129,14 +139,6 @@ void StructureInspector::update()
 	if (!visible()) { return; }
 	Window::update();
 
-	auto& renderer = Utility<Renderer>::get();
-
-	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
-		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
-		position.x() += FONT_BOLD->width(title);
-		renderer.drawText(*FONT, text, position, NAS2D::Color::White);
-	};
-
 	auto position = mRect.startPoint() + NAS2D::Vector{5, 25};
 	if (mStructure == nullptr)
 	{
@@ -164,6 +166,7 @@ void StructureInspector::update()
 	drawPopulationRequirements();
 	drawStructureTypeSpecific();
 
+	auto& renderer = Utility<Renderer>::get();
 	position = mRect.startPoint() + NAS2D::Vector{ 5, static_cast<int>(mRect.height()) - FONT->height() - 5 };
 	renderer.drawText(*FONT, "This window is a work in progress", position, NAS2D::Color::White);
 }
@@ -181,14 +184,6 @@ void StructureInspector::drawStructureTypeSpecific()
 
 void StructureInspector::drawResidenceText()
 {
-	auto& renderer = Utility<Renderer>::get();
-
-	const auto drawTitleText = [&renderer](NAS2D::Point<int> position, const std::string& title, const std::string& text) {
-		renderer.drawText(*FONT_BOLD, title, position, NAS2D::Color::White);
-		position.x() += FONT_BOLD->width(title);
-		renderer.drawText(*FONT, text, position, NAS2D::Color::White);
-	};
-
 	auto position = rect().startPoint() + NAS2D::Vector{ 10, 135 };
 	drawTitleText(position, "Colonist Capacity: ", std::to_string(dynamic_cast<Residence*>(mStructure)->capacity()));
 	return;

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -94,7 +94,7 @@ void StructureInspector::btnCloseClicked()
 }
 
 
-void StructureInspector::drawTitleText(NAS2D::Point<int> position, const std::string& title, const std::string& text)
+void StructureInspector::drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, const std::string& text)
 {
 	auto& renderer = Utility<Renderer>::get();
 
@@ -142,25 +142,25 @@ void StructureInspector::update()
 	auto position = mRect.startPoint() + NAS2D::Vector{5, 25};
 	if (mStructure == nullptr)
 	{
-		drawTitleText(position, "NULLPTR!", "");
+		drawLabelAndValue(position, "NULLPTR!", "");
 		return;
 	}
-	drawTitleText(position, mStructure->name(), "");
+	drawLabelAndValue(position, mStructure->name(), "");
 
 	position.y() += 20;
-	drawTitleText(position,"Type: ", mStructureClass);
+	drawLabelAndValue(position,"Type: ", mStructureClass);
 
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};
-	drawTitleText(position,"State: ", structureStateDescription(mStructure->state()));
+	drawLabelAndValue(position,"State: ", structureStateDescription(mStructure->state()));
 
 	position.y() += 20;
 	if (mStructure->underConstruction())
 	{
-		drawTitleText(position,"Turns Remaining: ", std::to_string(mStructure->turnsToBuild() - mStructure->age()));
+		drawLabelAndValue(position,"Turns Remaining: ", std::to_string(mStructure->turnsToBuild() - mStructure->age()));
 	}
 	else
 	{
-		drawTitleText(position,"Age: ", std::to_string(mStructure->age()) + " of " + std::to_string(mStructure->maxAge()));
+		drawLabelAndValue(position,"Age: ", std::to_string(mStructure->age()) + " of " + std::to_string(mStructure->maxAge()));
 	}
 
 	drawPopulationRequirements();
@@ -185,6 +185,6 @@ void StructureInspector::drawStructureTypeSpecific()
 void StructureInspector::drawResidenceText()
 {
 	auto position = rect().startPoint() + NAS2D::Vector{ 10, 135 };
-	drawTitleText(position, "Colonist Capacity: ", std::to_string(dynamic_cast<Residence*>(mStructure)->capacity()));
+	drawLabelAndValue(position, "Colonist Capacity: ", std::to_string(dynamic_cast<Residence*>(mStructure)->capacity()));
 	return;
 }

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -164,29 +164,10 @@ void StructureInspector::update()
 	}
 
 	drawPopulationRequirements();
-	drawStructureTypeSpecific();
 
 	auto& renderer = Utility<Renderer>::get();
+	mStructure->drawInspectorView(renderer, mRect);
+
 	position = mRect.startPoint() + NAS2D::Vector{ 5, static_cast<int>(mRect.height()) - FONT->height() - 5 };
 	renderer.drawText(*FONT, "This window is a work in progress", position, NAS2D::Color::White);
-}
-
-
-void StructureInspector::drawStructureTypeSpecific()
-{
-	switch (mStructure->structureClass())
-	{
-	case Structure::CLASS_RESIDENCE:
-		drawResidenceText();
-		return;
-	default:
-		return;
-	}
-}
-
-void StructureInspector::drawResidenceText()
-{
-	auto position = rect().startPoint() + NAS2D::Vector{ 10, 135 };
-	drawLabelAndValue(position, "Colonist Capacity: ", std::to_string(dynamic_cast<Residence*>(mStructure)->capacity()));
-	return;
 }

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -179,6 +179,8 @@ void StructureInspector::drawStructureTypeSpecific()
 	case Structure::CLASS_RESIDENCE:
 		drawResidenceText();
 		return;
+	default:
+		return;
 	}
 }
 

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -23,6 +23,7 @@ protected:
 private:
 	void btnCloseClicked();
 
+	void drawTitleText(NAS2D::Point<int> position, const std::string& title, const std::string& text);
 	void drawPopulationRequirements();
 	void drawStructureTypeSpecific();
 	void drawResidenceText();

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -24,6 +24,8 @@ private:
 	void btnCloseClicked();
 
 	void drawPopulationRequirements();
+	void drawStructureTypeSpecific();
+	void drawResidenceText();
 
 private:
 	StructureInspector(const StructureInspector&) = delete;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -25,8 +25,6 @@ private:
 
 	void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, const std::string& text);
 	void drawPopulationRequirements();
-	void drawStructureTypeSpecific();
-	void drawResidenceText();
 
 private:
 	StructureInspector(const StructureInspector&) = delete;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -23,7 +23,7 @@ protected:
 private:
 	void btnCloseClicked();
 
-	void drawTitleText(NAS2D::Point<int> position, const std::string& title, const std::string& text);
+	void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, const std::string& text);
 	void drawPopulationRequirements();
 	void drawStructureTypeSpecific();
 	void drawResidenceText();


### PR DESCRIPTION
What are thoughts on how to show all the small bits of information for each structure that doesn't require specialized UI?

I took a stab at doing it procedurally here. Wasn't sure how to handle the lamda expression that I copied from the main function. If procedural seems ok, we should probably clean that up before merging.

It could also be solved with inheritance by making many structures as child classes. Maybe there is a way to give a view pane over for each structure to populate with data. Or maybe it can just be procedural for now until a better solution is designed?

-Brett

<img width="381" alt="ColonistCapacity" src="https://user-images.githubusercontent.com/15183337/85816538-a2c41600-b739-11ea-9055-6c198a2de245.png">