### PR TITLE
Use brace init

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -219,19 +219,19 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 	// \fixme Inelegant solution but may not be worth refactoring out into its own function.
 	for (int i = 0; i < yield_low; ++i)
 	{
-		Point<int> pt(std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8));
+		Point<int> pt{std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8)};
 		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_LOW);
 	}
 
 	for (int i = 0; i < yield_medium; ++i)
 	{
-		Point<int> pt(std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8));
+		Point<int> pt{std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8)};
 		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_MEDIUM);
 	}
 
 	for (int i = 0; i < yield_high; ++i)
 	{
-		Point<int> pt(std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8));
+		Point<int> pt{std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8)};
 		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_HIGH);
 	}
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -38,8 +38,8 @@ extern MainReportsUiState* MAIN_REPORTS_UI;
 int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
 
 Rectangle<int> MENU_ICON;
-Rectangle<int> RESOURCE_PANEL_PIN(0, 1, 8, 19);
-Rectangle<int> POPULATION_PANEL_PIN(675, 1, 8, 19);
+Rectangle<int> RESOURCE_PANEL_PIN{0, 1, 8, 19};
+Rectangle<int> POPULATION_PANEL_PIN{675, 1, 8, 19};
 
 Rectangle<int> MOVE_NORTH_ICON;
 Rectangle<int> MOVE_SOUTH_ICON;

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -109,9 +109,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point<int> click{x, y};
-
-		if(mRect.contains(click))
+		if(mRect.contains(Point<int>{x, y}))
 		{
 			if(mType == Type::BUTTON_NORMAL)
 			{
@@ -133,13 +131,11 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point<int> click{x, y};
-		
 		if(mType == Type::BUTTON_NORMAL)
 		{
 			mState = State::STATE_NORMAL;
 
-			if (mRect.contains(click))
+			if (mRect.contains(Point<int>{x, y}))
 			{
 				mCallback();
 			}

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -109,7 +109,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point<int> click(x, y);
+		Point<int> click{x, y};
 
 		if(mRect.contains(click))
 		{
@@ -133,7 +133,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point<int> click(x, y);
+		Point<int> click{x, y};
 		
 		if(mType == Type::BUTTON_NORMAL)
 		{


### PR DESCRIPTION
Use brace initialization for `Point` and `Rectangle`. Brace initialization can be used for either constructor calls or struct public member field initialization. This will be important for when `Point` and `Rectangle` switch to public member fields.

Reference: https://github.com/lairworks/nas2d-core/issues/302
