### PR TITLE
Refactor RadioButton resize

### DIFF
--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -12,8 +12,6 @@
 
 #include "UIContainer.h"
 
-#include <algorithm>
-
 
 using namespace NAS2D;
 
@@ -118,7 +116,7 @@ void RadioButton::onTextChanged()
  */
 void RadioButton::onSizeChanged()
 {
-	mRect.height(std::clamp(height(), 13.0f, 13.0f));
+	mRect.height(13.0f);
 	if (width() < 13.0f) { mRect.width(13.0f); }
 }
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -116,8 +116,8 @@ void RadioButton::onTextChanged()
  */
 void RadioButton::onSizeChanged()
 {
-	mRect.height(13.0f);
-	if (width() < 13.0f) { mRect.width(13.0f); }
+	mRect.height(13);
+	if (width() < 13) { mRect.width(13); }
 }
 
 


### PR DESCRIPTION
Noticed an odd `std::clamp` call that didn't appear to do anything. Figured it was better to remove it.
