### PR TITLE
Remove Planet x/y read methods

### DIFF
--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -39,9 +39,6 @@ public:
 	void position(const NAS2D::Point<int>& point) { mPosition = point; }
 	void position(int x, int y) { mPosition = {x, y}; }
 
-	int x() const { return mPosition.x(); }
-	int y() const { return mPosition.y(); }
-
 	int digDepth() const { return mMaxDigDepth; }
 	int maxMines() const { return mMaxMines; }
 


### PR DESCRIPTION
Methods are no longer in use.

Use `position()` instead.
