### PR TITLE
Refactor tile highlight

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -352,7 +352,7 @@ void TileMap::draw()
 			{
 				const auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
-				const bool isTileHighlighted = row == mMapHighlight.y() && col == mMapHighlight.x();
+				const bool isTileHighlighted = NAS2D::Point{col, row} == mMapHighlight;
 				const bool isConnectionHighlighted = mShowConnections && tile.connected();
 				const NAS2D::Color highlightColor =
 					isTileHighlighted ?

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -332,7 +332,7 @@ void TileMap::centerMapOnTile(Tile* _t)
  */
 bool TileMap::tileHighlightVisible() const
 {
-	return NAS2D::Rectangle{0, 0, mEdgeLength - 1, mEdgeLength - 1}.contains(mMapHighlight);
+	return NAS2D::Rectangle{0, 0, mEdgeLength - 1, mEdgeLength - 1}.contains(NAS2D::Point{0, 0} + mMapHighlight);
 }
 
 
@@ -352,7 +352,7 @@ void TileMap::draw()
 			{
 				const auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
-				const bool isTileHighlighted = NAS2D::Point{col, row} == mMapHighlight;
+				const bool isTileHighlighted = NAS2D::Vector{col, row} == mMapHighlight;
 				const bool isConnectionHighlighted = mShowConnections && tile.connected();
 				const NAS2D::Color highlightColor =
 					isTileHighlighted ?
@@ -406,19 +406,19 @@ void TileMap::updateTileHighlight()
 	switch (mmr)
 	{
 	case MouseMapRegion::MMR_TOP_RIGHT:
-		mMapHighlight.y(--mMapHighlight.y());
+		--mMapHighlight.y;
 		break;
 
 	case MouseMapRegion::MMR_TOP_LEFT:
-		mMapHighlight.x(--mMapHighlight.x());
+		--mMapHighlight.x;
 		break;
 
 	case MouseMapRegion::MMR_BOTTOM_RIGHT:
-		mMapHighlight.x(++mMapHighlight.x());
+		++mMapHighlight.x;
 		break;
 
 	case MouseMapRegion::MMR_BOTTOM_LEFT:
-		mMapHighlight.y(++mMapHighlight.y());
+		++mMapHighlight.y;
 		break;
 
 	default:

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -332,7 +332,7 @@ void TileMap::centerMapOnTile(Tile* _t)
  */
 bool TileMap::tileHighlightVisible() const
 {
-	return NAS2D::Rectangle{0, 0, mEdgeLength - 1, mEdgeLength - 1}.contains(NAS2D::Point{0, 0} + mMapHighlight);
+	return NAS2D::Rectangle<int>::Create(mMapViewLocation, NAS2D::Vector{mEdgeLength - 1, mEdgeLength - 1}).contains(mMapHighlight);
 }
 
 
@@ -341,6 +341,7 @@ void TileMap::draw()
 	auto& renderer = Utility<Renderer>::get();
 
 	int tsetOffset = mCurrentDepth > 0 ? TILE_HEIGHT : 0;
+	const auto highlightOffset = mMapHighlight - mMapViewLocation;
 
 	for (int row = 0; row < mEdgeLength; row++)
 	{
@@ -352,7 +353,7 @@ void TileMap::draw()
 			{
 				const auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
-				const bool isTileHighlighted = NAS2D::Vector{col, row} == mMapHighlight;
+				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 				const bool isConnectionHighlighted = mShowConnections && tile.connected();
 				const NAS2D::Color highlightColor =
 					isTileHighlighted ?
@@ -396,7 +397,7 @@ void TileMap::updateTileHighlight()
 
 	int offsetX = ((mMousePosition.x() - mMapBoundingBox.x() - even_edge_length_adjust) / TILE_WIDTH);
 	int offsetY = ((mMousePosition.y() - mMapBoundingBox.y()) / TILE_HEIGHT_ABSOLUTE);
-	mMapHighlight = {TRANSFORM.x() + offsetY + offsetX, TRANSFORM.y() + offsetY - offsetX};
+	NAS2D::Vector<int> highlightOffset = {TRANSFORM.x() + offsetY + offsetX, TRANSFORM.y() + offsetY - offsetX};
 
 	int mmOffsetX = std::clamp((mMousePosition.x() - mMapBoundingBox.x() - even_edge_length_adjust) % TILE_WIDTH, 0, TILE_WIDTH);
 	int mmOffsetY = (mMousePosition.y() - mMapBoundingBox.y()) % TILE_HEIGHT_ABSOLUTE;
@@ -406,24 +407,26 @@ void TileMap::updateTileHighlight()
 	switch (mmr)
 	{
 	case MouseMapRegion::MMR_TOP_RIGHT:
-		--mMapHighlight.y;
+		--highlightOffset.y;
 		break;
 
 	case MouseMapRegion::MMR_TOP_LEFT:
-		--mMapHighlight.x;
+		--highlightOffset.x;
 		break;
 
 	case MouseMapRegion::MMR_BOTTOM_RIGHT:
-		++mMapHighlight.x;
+		++highlightOffset.x;
 		break;
 
 	case MouseMapRegion::MMR_BOTTOM_LEFT:
-		++mMapHighlight.y;
+		++highlightOffset.y;
 		break;
 
 	default:
 		break;
 	}
+
+	mMapHighlight = mMapViewLocation + highlightOffset;
 }
 
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -49,7 +49,6 @@ public:
 	void mapViewLocation(NAS2D::Point<int> point);
 	void centerMapOnTile(Tile*);
 
-	const NAS2D::Point<int>& tileHighlight() const { return mMapHighlight; }
 	bool tileHighlightVisible() const;
 
 	int tileMouseHoverX() const { return mMapHighlight.x() + mMapViewLocation.x(); }

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -50,10 +50,7 @@ public:
 	void centerMapOnTile(Tile*);
 
 	bool tileHighlightVisible() const;
-
-	int tileMouseHoverX() const { return mMapHighlight.x + mMapViewLocation.x(); }
-	int tileMouseHoverY() const { return mMapHighlight.y + mMapViewLocation.y(); }
-	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point{tileMouseHoverX(), tileMouseHoverY()}; }
+	NAS2D::Point<int> tileMouseHover() const { return mMapViewLocation + mMapHighlight; }
 
 	const Point2dList& mineLocations() const { return mMineLocations; }
 	void removeMineLocation(const NAS2D::Point<int>& pt);

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -51,8 +51,8 @@ public:
 
 	bool tileHighlightVisible() const;
 
-	int tileMouseHoverX() const { return mMapHighlight.x() + mMapViewLocation.x(); }
-	int tileMouseHoverY() const { return mMapHighlight.y() + mMapViewLocation.y(); }
+	int tileMouseHoverX() const { return mMapHighlight.x + mMapViewLocation.x(); }
+	int tileMouseHoverY() const { return mMapHighlight.y + mMapViewLocation.y(); }
 	NAS2D::Point<int> tileMouseHover() const { return NAS2D::Point{tileMouseHoverX(), tileMouseHoverY()}; }
 
 	const Point2dList& mineLocations() const { return mMineLocations; }
@@ -137,7 +137,7 @@ private:
 	NAS2D::Timer mTimer;
 
 	NAS2D::Point<int> mMousePosition; /**< Current mouse position. */
-	NAS2D::Point<int> mMapHighlight; /**< Tile the mouse is pointing to. */
+	NAS2D::Vector<int> mMapHighlight; /**< Tile the mouse is pointing to. */
 	NAS2D::Point<int> mMapViewLocation;
 
 	NAS2D::Point<float> mMapPosition; /** Where to start drawing the TileMap on the screen. */

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -50,7 +50,7 @@ public:
 	void centerMapOnTile(Tile*);
 
 	bool tileHighlightVisible() const;
-	NAS2D::Point<int> tileMouseHover() const { return mMapViewLocation + mMapHighlight; }
+	NAS2D::Point<int> tileMouseHover() const { return mMapHighlight; }
 
 	const Point2dList& mineLocations() const { return mMineLocations; }
 	void removeMineLocation(const NAS2D::Point<int>& pt);
@@ -134,7 +134,7 @@ private:
 	NAS2D::Timer mTimer;
 
 	NAS2D::Point<int> mMousePosition; /**< Current mouse position. */
-	NAS2D::Vector<int> mMapHighlight; /**< Tile the mouse is pointing to. */
+	NAS2D::Point<int> mMapHighlight; /**< Tile the mouse is pointing to. */
 	NAS2D::Point<int> mMapViewLocation;
 
 	NAS2D::Point<float> mMapPosition; /** Where to start drawing the TileMap on the screen. */

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -475,7 +475,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 
 		if (!mTileMap->tileHighlightVisible()) { return; }
 
-		Tile* _t = mTileMap->getTile(mTileMap->tileHighlight().x() + mTileMap->mapViewLocation().x(), mTileMap->tileHighlight().y() + mTileMap->mapViewLocation().y());
+		Tile* _t = mTileMap->getTile(mTileMap->tileMouseHover());
 		if (!_t)
 		{
 			return;
@@ -598,7 +598,7 @@ void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int /*x*
 		if (mWindowStack.pointInWindow(MOUSE_COORDS)) { return; }
 		if (!mTileMap->tileHighlightVisible()) { return; }
 
-		Tile* _t = mTileMap->getTile(mTileMap->tileHighlight().x() + mTileMap->mapViewLocation().x(), mTileMap->tileHighlight().y() + mTileMap->mapViewLocation().y());
+		Tile* _t = mTileMap->getTile(mTileMap->tileMouseHover());
 		if (_t && _t->thingIsStructure())
 		{
 			Structure* structure = _t->structure();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -647,7 +647,7 @@ void MapViewState::onMouseMove(int /*x*/, int /*y*/, int /*rX*/, int /*rY*/)
 		}
 	}
 
-	mTileMapMouseHover = {mTileMap->tileMouseHoverX(), mTileMap->tileMouseHoverY()};
+	mTileMapMouseHover = mTileMap->tileMouseHover();
 }
 
 


### PR DESCRIPTION
Represent highlight position internally as an absolute coordinate `Point`, rather than an offset relative to `mMapViewLocation`.
