### PR TITLE
TileMap::getTile packed primary

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -141,7 +141,7 @@ void TileMap::removeMineLocation(const NAS2D::Point<int>& pt)
 
 Tile* TileMap::getTile(int x, int y, int level)
 {
-	if (x >= 0 && x < width() && y >= 0 && y < height() && level >= 0 && level <= mMaxDepth)
+	if (NAS2D::Rectangle{0, 0, mWidth, mHeight}.contains({x, y}) && level >= 0 && level <= mMaxDepth)
 	{
 		return &mTileMap[level][y][x];
 	}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -139,11 +139,11 @@ void TileMap::removeMineLocation(const NAS2D::Point<int>& pt)
 }
 
 
-Tile* TileMap::getTile(int x, int y, int level)
+Tile* TileMap::getTile(NAS2D::Point<int> position, int level)
 {
-	if (NAS2D::Rectangle{0, 0, mWidth, mHeight}.contains({x, y}) && level >= 0 && level <= mMaxDepth)
+	if (NAS2D::Rectangle{0, 0, mWidth, mHeight}.contains(position) && level >= 0 && level <= mMaxDepth)
 	{
-		return &mTileMap[level][y][x];
+		return &mTileMap[level][position.y()][position.x()];
 	}
 
 	return nullptr;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -506,7 +506,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 		{
 			for (int y = 0; y < height(); ++y)
 			{
-				tile = getTile(x, y, depth);
+				tile = getTile({x, y}, depth);
 				if (depth > 0 && tile->excavated() && tile->empty() && tile->mine() == nullptr)
 				{
 					serializeTile(tiles, x, y, depth, tile->index());

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -31,9 +31,9 @@ public:
 	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, constants::PlanetHostility hostility /*= constants::PlanetHostility::HOSTILITY_NONE*/, bool setupMines = true);
 	~TileMap() override;
 
-	Tile* getTile(int x, int y, int level);
-	Tile* getTile(int x, int y) { return getTile(x, y, mCurrentDepth); }
-	Tile* getTile(NAS2D::Point<int> position, int level) { return getTile(position.x(), position.y(), level); }
+	Tile* getTile(int x, int y, int level) { return getTile({x, y}, level); }
+	Tile* getTile(int x, int y) { return getTile({x, y}, mCurrentDepth); }
+	Tile* getTile(NAS2D::Point<int> position, int level);
 	Tile* getTile(NAS2D::Point<int> position) { return getTile(position, mCurrentDepth); }
 
 	Tile* getVisibleTile(NAS2D::Point<int> position, int level);

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -31,8 +31,6 @@ public:
 	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, constants::PlanetHostility hostility /*= constants::PlanetHostility::HOSTILITY_NONE*/, bool setupMines = true);
 	~TileMap() override;
 
-	Tile* getTile(int x, int y, int level) { return getTile({x, y}, level); }
-	Tile* getTile(int x, int y) { return getTile({x, y}, mCurrentDepth); }
 	Tile* getTile(NAS2D::Point<int> position, int level);
 	Tile* getTile(NAS2D::Point<int> position) { return getTile(position, mCurrentDepth); }
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -843,7 +843,7 @@ void MapViewState::placeTubeEnd()
 		}else if (!validTubeConnection(mTileMap, x, y, cd)){
 			endReach = true;
 		}else{
-			insertTube(cd, mTileMap->currentDepth(), mTileMap->getTile(x, y));
+			insertTube(cd, mTileMap->currentDepth(), mTileMap->getTile({x, y}));
 			
 			// FIXME: Naive approach -- will be slow with larger colonies.
 			Utility<StructureManager>::get().disconnectAll();
@@ -1214,7 +1214,7 @@ void MapViewState::insertSeedLander(int x, int y)
 
 		SeedLander* s = new SeedLander(x, y);
 		s->deployCallback().connect(this, &MapViewState::deploySeedLander);
-		Utility<StructureManager>::get().addStructure(s, mTileMap->getTile(x, y)); // Can only ever be placed on depth level 0
+		Utility<StructureManager>::get().addStructure(s, mTileMap->getTile({x, y})); // Can only ever be placed on depth level 0
 
 		clearMode();
 		resetUi();

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -255,7 +255,7 @@ void MapViewState::diggerTaskFinished(Robot* robot)
 	{
 		for(int x = originX - 1; x <= originX + 1; ++x)
 		{
-			mTileMap->getTile(x, y, t->depth() + depthAdjust)->excavated(true);
+			mTileMap->getTile({x, y}, t->depth() + depthAdjust)->excavated(true);
 		}
 	}
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -221,7 +221,7 @@ bool landingSiteSuitable(TileMap* tilemap, int x, int y)
 	{
 		for (int offX = x - 1; offX <= x + 1; ++offX)
 		{
-			Tile* tile = tilemap->getTile(offX, offY);
+			Tile* tile = tilemap->getTile({offX, offY});
 
 			if (tile->index() == TerrainType::TERRAIN_IMPASSABLE)
 			{

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -298,7 +298,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 		if (production_time > 0)
 		{
 			robot->startTask(production_time);
-			mRobotPool.insertRobotIntoTable(mRobotList, robot, mTileMap->getTile(x, y, depth));
+			mRobotPool.insertRobotIntoTable(mRobotList, robot, mTileMap->getTile({x, y}, depth));
 			mRobotList[robot]->index(0);
 		}
 
@@ -346,7 +346,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			attribute = attribute->next();
 		}
 
-		Tile* t = mTileMap->getTile(x, y, depth);
+		Tile* t = mTileMap->getTile({x, y}, depth);
 		t->index(0);
 		t->excavated(true);
 
@@ -355,7 +355,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 		if (type == constants::TUBE)
 		{
 			ConnectorDir cd = static_cast<ConnectorDir>(direction);
-			insertTube(cd, depth, mTileMap->getTile(x, y, depth));
+			insertTube(cd, depth, mTileMap->getTile({x, y}, depth));
 			continue; // FIXME: ugly
 		}
 
@@ -369,7 +369,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 
 		if (type_id == StructureID::SID_MINE_FACILITY)
 		{
-			Mine* m = mTileMap->getTile(x, y, 0)->mine();
+			Mine* m = mTileMap->getTile({x, y}, 0)->mine();
 			if (m == nullptr)
 			{
 				throw std::runtime_error("Mine Facility is located on a Tile with no Mine.");


### PR DESCRIPTION
Make packed parameter version of `TileMap::getTile` the primary overload. Remove unpacked overloads.
