### PR TITLE
TileMap random mine placement refactor

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <functional>
 #include <random>
-#include <tuple>
+#include <array>
 
 using namespace NAS2D;
 using namespace NAS2D::Xml;
@@ -37,7 +37,7 @@ const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
 
 /** Tuple indicates percent of mines that should be of yields LOW, MED, HIGH */
-std::map<constants::PlanetHostility, std::tuple<float, float, float>> HostilityMineYieldTable =
+std::map<constants::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
 {
 	{ constants::PlanetHostility::HOSTILITY_LOW, {0.30f, 0.50f, 0.20f} },
 	{ constants::PlanetHostility::HOSTILITY_MEDIUM, {0.45f, 0.35f, 0.20f} },
@@ -189,9 +189,9 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 {
 	if (hostility == constants::PlanetHostility::HOSTILITY_NONE) { return; }
 
-	int yield_low = mineCount * std::get<0>(HostilityMineYieldTable[hostility]);
-	int yield_medium = mineCount * std::get<1>(HostilityMineYieldTable[hostility]);
-	int yield_high = mineCount * std::get<2>(HostilityMineYieldTable[hostility]);
+	int yield_low = mineCount * HostilityMineYieldTable[hostility][0];
+	int yield_medium = mineCount * HostilityMineYieldTable[hostility][1];
+	int yield_high = mineCount * HostilityMineYieldTable[hostility][2];
 
 	// There will inevitably be cases where the total yield count will not match
 	// the required mine count. In these cases just tack on the difference to the

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -205,11 +205,11 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 
 	std::random_device rd;
 	std::mt19937 generator(rd());
-	std::uniform_int_distribution<int> map_width(5, MAP_WIDTH - 5);
-	std::uniform_int_distribution<int> map_height(5, MAP_HEIGHT - 5);
+	std::uniform_int_distribution<int> distributionWidth(5, MAP_WIDTH - 5);
+	std::uniform_int_distribution<int> distributionHeight(5, MAP_HEIGHT - 5);
 
-	auto mwidth = std::bind(map_width, std::ref(generator));
-	auto mheight = std::bind(map_height, std::ref(generator));
+	auto mwidth = std::bind(distributionWidth, std::ref(generator));
+	auto mheight = std::bind(distributionHeight, std::ref(generator));
 	auto randPoint = [&mwidth, &mheight]() { return NAS2D::Point{mwidth(), mheight()}; };
 
 	// \fixme Inelegant solution but may not be worth refactoring out into its own function.

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -37,7 +37,7 @@ const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
 
 /** Tuple indicates percent of mines that should be of yields LOW, MED, HIGH */
-std::map<constants::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
+const std::map<constants::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
 {
 	{ constants::PlanetHostility::HOSTILITY_LOW, {0.30f, 0.50f, 0.20f} },
 	{ constants::PlanetHostility::HOSTILITY_MEDIUM, {0.45f, 0.35f, 0.20f} },
@@ -189,9 +189,9 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 {
 	if (hostility == constants::PlanetHostility::HOSTILITY_NONE) { return; }
 
-	int yield_low = mineCount * HostilityMineYieldTable[hostility][0];
-	int yield_medium = mineCount * HostilityMineYieldTable[hostility][1];
-	int yield_high = mineCount * HostilityMineYieldTable[hostility][2];
+	int yield_low = mineCount * HostilityMineYieldTable.at(hostility)[0];
+	int yield_medium = mineCount * HostilityMineYieldTable.at(hostility)[1];
+	int yield_high = mineCount * HostilityMineYieldTable.at(hostility)[2];
 
 	// There will inevitably be cases where the total yield count will not match
 	// the required mine count. In these cases just tack on the difference to the

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -58,11 +58,9 @@ std::random_device rd;
 std::mt19937 generator(rd());
 std::uniform_int_distribution<int> map_width(5, MAP_WIDTH - 5);
 std::uniform_int_distribution<int> map_height(5, MAP_HEIGHT - 5);
-std::uniform_int_distribution<int> mine_yield(0, 100);
 
 auto mwidth = std::bind(map_width, std::ref(generator));
 auto mheight = std::bind(map_height, std::ref(generator));
-auto myield = std::bind(mine_yield, std::ref(generator));
 
 
 // ===============================================================================

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -210,24 +210,22 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 
 	auto mwidth = std::bind(map_width, std::ref(generator));
 	auto mheight = std::bind(map_height, std::ref(generator));
+	auto randPoint = [&mwidth, &mheight]() { return NAS2D::Point{mwidth(), mheight()}; };
 
 	// \fixme Inelegant solution but may not be worth refactoring out into its own function.
 	for (int i = 0; i < yield_low; ++i)
 	{
-		Point<int> pt{mwidth(), mheight()};
-		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_LOW);
+		addMineSet(randPoint(), mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_LOW);
 	}
 
 	for (int i = 0; i < yield_medium; ++i)
 	{
-		Point<int> pt{mwidth(), mheight()};
-		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_MEDIUM);
+		addMineSet(randPoint(), mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_MEDIUM);
 	}
 
 	for (int i = 0; i < yield_high; ++i)
 	{
-		Point<int> pt{mwidth(), mheight()};
-		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_HIGH);
+		addMineSet(randPoint(), mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_HIGH);
 	}
 
 }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -52,18 +52,6 @@ Point<int> TRANSFORM; /**< Used to adjust mouse and screen spaces based on posit
 
 
 // ===============================================================================
-// = RANDOM NUMBER GENERATION
-// ===============================================================================
-std::random_device rd;
-std::mt19937 generator(rd());
-std::uniform_int_distribution<int> map_width(5, MAP_WIDTH - 5);
-std::uniform_int_distribution<int> map_height(5, MAP_HEIGHT - 5);
-
-auto mwidth = std::bind(map_width, std::ref(generator));
-auto mheight = std::bind(map_height, std::ref(generator));
-
-
-// ===============================================================================
 // = STATIC/LOCAL FUNCTIONS
 // ===============================================================================
 using TileArray = std::vector<std::vector<std::vector<Tile> > >;
@@ -214,6 +202,14 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 	// no check for overflows here because of the nature of division operations
 	// on int types. Yield totals should only ever equate to mineCount or less
 	// than mineCount.
+
+	std::random_device rd;
+	std::mt19937 generator(rd());
+	std::uniform_int_distribution<int> map_width(5, MAP_WIDTH - 5);
+	std::uniform_int_distribution<int> map_height(5, MAP_HEIGHT - 5);
+
+	auto mwidth = std::bind(map_width, std::ref(generator));
+	auto mheight = std::bind(map_height, std::ref(generator));
 
 	// \fixme Inelegant solution but may not be worth refactoring out into its own function.
 	for (int i = 0; i < yield_low; ++i)

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -199,10 +199,6 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 	int yieldTotal = yieldLow + yieldMedium + yieldHigh;
 	if (yieldTotal < mineCount) { yieldLow += mineCount - yieldTotal; }
 
-	// no check for overflows here because of the nature of division operations
-	// on int types. Yield totals should only ever equate to mineCount or less
-	// than mineCount.
-
 	std::random_device rd;
 	std::mt19937 generator(rd());
 	std::uniform_int_distribution<int> distributionWidth(5, MAP_WIDTH - 5);

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -212,22 +212,15 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 	auto mheight = std::bind(distributionHeight, std::ref(generator));
 	auto randPoint = [&mwidth, &mheight]() { return NAS2D::Point{mwidth(), mheight()}; };
 
-	// \fixme Inelegant solution but may not be worth refactoring out into its own function.
-	for (int i = 0; i < yield_low; ++i)
-	{
-		addMineSet(randPoint(), mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_LOW);
-	}
+	auto generateMines = [&](int mineCountAtYield, MineProductionRate yield) {
+		for (int i = 0; i < mineCountAtYield; ++i) {
+			addMineSet(randPoint(), mMineLocations, mTileMap, yield);
+		}
+	};
 
-	for (int i = 0; i < yield_medium; ++i)
-	{
-		addMineSet(randPoint(), mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_MEDIUM);
-	}
-
-	for (int i = 0; i < yield_high; ++i)
-	{
-		addMineSet(randPoint(), mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_HIGH);
-	}
-
+	generateMines(yield_low, MineProductionRate::PRODUCTION_RATE_LOW);
+	generateMines(yield_medium, MineProductionRate::PRODUCTION_RATE_MEDIUM);
+	generateMines(yield_high, MineProductionRate::PRODUCTION_RATE_HIGH);
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -214,19 +214,19 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 	// \fixme Inelegant solution but may not be worth refactoring out into its own function.
 	for (int i = 0; i < yield_low; ++i)
 	{
-		Point<int> pt{std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8)};
+		Point<int> pt{mwidth(), mheight()};
 		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_LOW);
 	}
 
 	for (int i = 0; i < yield_medium; ++i)
 	{
-		Point<int> pt{std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8)};
+		Point<int> pt{mwidth(), mheight()};
 		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_MEDIUM);
 	}
 
 	for (int i = 0; i < yield_high; ++i)
 	{
-		Point<int> pt{std::clamp(mwidth(), 4, mWidth - 8), std::clamp(mheight(), 4, mWidth - 8)};
+		Point<int> pt{mwidth(), mheight()};
 		addMineSet(pt, mMineLocations, mTileMap, MineProductionRate::PRODUCTION_RATE_HIGH);
 	}
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -189,15 +189,15 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 {
 	if (hostility == constants::PlanetHostility::HOSTILITY_NONE) { return; }
 
-	int yield_low = mineCount * HostilityMineYieldTable.at(hostility)[0];
-	int yield_medium = mineCount * HostilityMineYieldTable.at(hostility)[1];
-	int yield_high = mineCount * HostilityMineYieldTable.at(hostility)[2];
+	int yieldLow = mineCount * HostilityMineYieldTable.at(hostility)[0];
+	int yieldMedium = mineCount * HostilityMineYieldTable.at(hostility)[1];
+	int yieldHigh = mineCount * HostilityMineYieldTable.at(hostility)[2];
 
 	// There will inevitably be cases where the total yield count will not match
 	// the required mine count. In these cases just tack on the difference to the
 	// low yield mines. Difficulty settings could shift this to other yields.
-	int yield_total = yield_low + yield_medium + yield_high;
-	if (yield_total < mineCount) { yield_low += mineCount - yield_total; }
+	int yieldTotal = yieldLow + yieldMedium + yieldHigh;
+	if (yieldTotal < mineCount) { yieldLow += mineCount - yieldTotal; }
 
 	// no check for overflows here because of the nature of division operations
 	// on int types. Yield totals should only ever equate to mineCount or less
@@ -218,9 +218,9 @@ void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 		}
 	};
 
-	generateMines(yield_low, MineProductionRate::PRODUCTION_RATE_LOW);
-	generateMines(yield_medium, MineProductionRate::PRODUCTION_RATE_MEDIUM);
-	generateMines(yield_high, MineProductionRate::PRODUCTION_RATE_HIGH);
+	generateMines(yieldLow, MineProductionRate::PRODUCTION_RATE_LOW);
+	generateMines(yieldMedium, MineProductionRate::PRODUCTION_RATE_MEDIUM);
+	generateMines(yieldHigh, MineProductionRate::PRODUCTION_RATE_HIGH);
 }
 
 


### PR DESCRIPTION
Moves random number objects from global to function local. These are used once per map generation.
