### PR TITLE
Refactor TileMap::initMapDrawParams

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -270,6 +270,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	const auto lengthY = size.y / TILE_HEIGHT_ABSOLUTE;
 	mEdgeLength = std::max(3, std::min(lengthX, lengthY));
 
+	// Find top left corner of rectangle containing top tile of diamond
 	mMapPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
 	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -266,7 +266,9 @@ void TileMap::buildMouseMap()
 void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 {
 	// Set up map draw position
-	mEdgeLength = size.x / TILE_WIDTH;
+	const auto lengthX = size.x / TILE_WIDTH;
+	const auto lengthY = size.y / TILE_HEIGHT_ABSOLUTE;
+	mEdgeLength = std::min(lengthX, lengthY);
 
 	mMapPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
 	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -268,7 +268,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	// Set up map draw position
 	mEdgeLength = size.x / TILE_WIDTH;
 
-	mMapPosition = {static_cast<float>(size.x / 2 - (TILE_WIDTH / 2)), ((size.y - constants::BOTTOM_UI_HEIGHT) / 2) - ((static_cast<float>(mEdgeLength) / 2) * TILE_HEIGHT_ABSOLUTE)};
+	mMapPosition = {static_cast<float>((size.x - TILE_WIDTH) / 2), static_cast<float>((size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2)};
 	mMapBoundingBox = {(size.x / 2) - ((TILE_WIDTH * mEdgeLength) / 2), static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 
 	int transform = (mMapPosition.x() - mMapBoundingBox.x()) / TILE_WIDTH;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -269,7 +269,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	mEdgeLength = size.x / TILE_WIDTH;
 
 	mMapPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
-	mMapBoundingBox = {(size.x / 2) - ((TILE_WIDTH * mEdgeLength) / 2), static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
+	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 
 	int transform = (mMapPosition.x() - mMapBoundingBox.x()) / TILE_WIDTH;
 	TRANSFORM = {-transform, transform};

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -268,7 +268,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	// Set up map draw position
 	mEdgeLength = size.x / TILE_WIDTH;
 
-	mMapPosition = {static_cast<float>((size.x - TILE_WIDTH) / 2), static_cast<float>((size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2)};
+	mMapPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
 	mMapBoundingBox = {(size.x / 2) - ((TILE_WIDTH * mEdgeLength) / 2), static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 
 	int transform = (mMapPosition.x() - mMapBoundingBox.x()) / TILE_WIDTH;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -268,7 +268,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	// Set up map draw position
 	const auto lengthX = size.x / TILE_WIDTH;
 	const auto lengthY = size.y / TILE_HEIGHT_ABSOLUTE;
-	mEdgeLength = std::min(lengthX, lengthY);
+	mEdgeLength = std::max(3, std::min(lengthX, lengthY));
 
 	mMapPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
 	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};


### PR DESCRIPTION
A bit of cleanup to the formulas being used to calculate map position, and some extra bounds checking in the `y` direction, in case the user uses a really wide window. The bounds checking isn't perfect, though that seems to be because the entire display area is considered the map area, with the UI drawn on top of it, rather than clipping the map area to the non-UI-covered area.

In the future, I may look into splitting the `TileMap` class into an abstract concept representing the map, and a UI control to handle detailed display of it. That may make the bounds and clipping more obvious to deal with, as well as make the code organization a little more strict.
