### PR TITLE
Remove unpacked TileMap::injectMouse

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -279,12 +279,6 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 }
 
 
-void TileMap::injectMouse(int x, int y)
-{
-	mMousePosition = {x, y};
-}
-
-
 void TileMap::mapViewLocation(NAS2D::Point<int> point)
 {
 	mMapViewLocation = {

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -65,7 +65,6 @@ public:
 
 	int maxDepth() const { return mMaxDepth; }
 
-	void injectMouse(int x, int y);
 	void injectMouse(NAS2D::Point<int> position) { mMousePosition = position; }
 
 	void initMapDrawParams(NAS2D::Vector<int>);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -229,7 +229,7 @@ State* MapViewState::update()
 	
 	if (!modalUiElementDisplayed())
 	{
-		mTileMap->injectMouse(MOUSE_COORDS.x(), MOUSE_COORDS.y());
+		mTileMap->injectMouse(MOUSE_COORDS);
 	}
 
 	mTileMap->draw();


### PR DESCRIPTION
Remove unpacked overload:
```cpp
void TileMap::injectMouse(int x, int y)
```

Reference: #217
