### PR TITLE
String table

### DIFF
--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -213,7 +213,7 @@ void FactoryProduction::update()
 	Window::update();
 
 	StringTable stringTable(2, 5);
-	stringTable.setPosition({ mRect.x() + constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), mRect.y() + 25 });
+	stringTable.setPosition(mRect.startPoint() + NAS2D::Vector<float>{ constants::MARGIN * 2 + mProductGrid.width(), 25 });
 	stringTable.setColumnJustification(1, StringTable::Justification::Right);
 
 	stringTable.setCellText(0, 0, "Turns Completed:");

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -213,7 +213,7 @@ void FactoryProduction::update()
 	Window::update();
 
 	StringTable stringTable(2, 5);
-	stringTable.setPosition(mRect.startPoint() + NAS2D::Vector{constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), 25});
+	stringTable.setPosition({ mRect.x() + constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), mRect.y() + 25 });
 	stringTable.setColumnJustification(1, StringTable::Justification::Right);
 
 	stringTable.setCellText(0, 0, "Turns Completed:");

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -3,7 +3,7 @@
 
 #include "FactoryProduction.h"
 
-#include "TextRender.h"
+#include "StringTable.h"
 #include "../Constants.h"
 
 using namespace NAS2D;

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -212,19 +212,25 @@ void FactoryProduction::update()
 
 	Window::update();
 
-	const int labelWidth = 120;
-	auto position = mRect.startPoint() + NAS2D::Vector{constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), 25};
-	drawLabelAndValueRightJustify(position, labelWidth, "Turns Completed:", std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild()));
+	StringTable stringTable(2, 5);
+	stringTable.setPosition(mRect.startPoint() + NAS2D::Vector{constants::MARGIN * 2 + static_cast<int>(mProductGrid.width()), 25});
+	stringTable.setColumnJustification(1, StringTable::Justification::Right);
 
-	position.y() += 20;
-	drawLabelAndValueRightJustify(position, labelWidth, "Common Metals:", std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()));
+	stringTable.setCellText(0, 0, "Turns Completed:");
+	stringTable.setCellText(1, 0, std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild()));
 
-	position.y() += 10;
-	drawLabelAndValueRightJustify(position, labelWidth, "Common Minerals:", std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild()));
+	stringTable.setCellText(0, 1, "Common Metals:");
+	stringTable.setCellText(1, 1, std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()));
 
-	position.y() += 10;
-	drawLabelAndValueRightJustify(position, labelWidth, "Rare Metals:", std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild()));
+	stringTable.setCellText(0, 2, "Common Minerals:");
+	stringTable.setCellText(1, 2, std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild()));
 
-	position.y() += 10;
-	drawLabelAndValueRightJustify(position, labelWidth, "Rare Minerals:", std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild()));
+	stringTable.setCellText(0, 3, "Rare Metals:");
+	stringTable.setCellText(1, 3, std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild()));
+
+	stringTable.setCellText(0, 4, "Rare Minerals:");
+	stringTable.setCellText(1, 4, std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild()));
+
+	stringTable.computeRelativeCellPositions();
+	stringTable.draw(Utility<Renderer>::get());
 }

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -216,20 +216,20 @@ void FactoryProduction::update()
 	stringTable.setPosition(mRect.startPoint() + NAS2D::Vector<float>{ constants::MARGIN * 2 + mProductGrid.width(), 25 });
 	stringTable.setColumnJustification(1, StringTable::Justification::Right);
 
-	stringTable.setCellText(0, 0, "Turns Completed:");
-	stringTable.setCellText(1, 0, std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild()));
+	stringTable.at(0, 0).text = "Turns Completed:";
+	stringTable.at(1, 0).text = std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild());
 
-	stringTable.setCellText(0, 1, "Common Metals:");
-	stringTable.setCellText(1, 1, std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild()));
+	stringTable.at(0, 1).text = "Common Metals:";
+	stringTable.at(1, 1).text = std::to_string(mProductCost.commonMetals() * mProductCost.turnsToBuild());
 
-	stringTable.setCellText(0, 2, "Common Minerals:");
-	stringTable.setCellText(1, 2, std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild()));
+	stringTable.at(0, 2).text = "Common Minerals:";
+	stringTable.at(1, 2).text = std::to_string(mProductCost.commonMinerals() * mProductCost.turnsToBuild());
 
-	stringTable.setCellText(0, 3, "Rare Metals:");
-	stringTable.setCellText(1, 3, std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild()));
+	stringTable.at(0, 3).text = "Rare Metals:";
+	stringTable.at(1, 3).text = std::to_string(mProductCost.rareMetals() * mProductCost.turnsToBuild());
 
-	stringTable.setCellText(0, 4, "Rare Minerals:");
-	stringTable.setCellText(1, 4, std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild()));
+	stringTable.at(0, 4).text = "Rare Minerals:";
+	stringTable.at(1, 4).text = std::to_string(mProductCost.rareMinerals() * mProductCost.turnsToBuild());
 
 	stringTable.computeRelativeCellPositions();
 	stringTable.draw(Utility<Renderer>::get());

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -89,7 +89,7 @@ void StringTable::setCellJustification(const CellCoordinate& cellCoordinate, Jus
 
 void StringTable::setColumnJustification(std::size_t column, Justification justification)
 {
-	for (int row = 0; row < rows; ++row)
+	for (std::size_t row = 0; row < rows; ++row)
 	{
 		setCellJustification(CellCoordinate(column, row), justification);
 	}

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -216,7 +216,7 @@ void StringTable::checkCellIndex(const CellCoordinate& cellCoordinate) const
 
 NAS2D::Font* StringTable::getCellFont(std::size_t index) const
 {
-	NAS2D::Font* font = cells[index].font;// = index % columns == 0 ? defaultTitleFont : defaultFont;
+	NAS2D::Font* font = cells[index].font;
 
 	if (font == nullptr) {
 		font = isFirstColumn(index) ? defaultTitleFont : defaultFont;

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -21,18 +21,18 @@ void StringTable::draw(NAS2D::Renderer& renderer) const
 		const Cell& cell = cells.at(i);
 
 		NAS2D::Color textColor = cell.textColor != Cell::ColorEmpty ? cell.textColor : defaultTextColor;
-		NAS2D::Point<float> drawPosition = { position.x() + cell.textRelativePosition.x(), position.y() + cell.textRelativePosition.y() };
+		const auto drawPosition = position + cell.textRelativePosition;
 
-		renderer.drawText(*getCellFont(i), cell.text, drawPosition, textColor);
+		renderer.drawText(*getCellFont(i), cell.text, NAS2D::Point<float>(drawPosition.x, drawPosition.y), textColor);
 	}
 }
 
-void StringTable::setPosition(NAS2D::Point<float> tablePosition)
+void StringTable::setPosition(NAS2D::Vector<float> tablePosition)
 {
 	this->position = tablePosition;
 }
 
-NAS2D::Point<float> StringTable::getPosition() const
+NAS2D::Vector<float> StringTable::getPosition() const
 {
 	return position;
 }
@@ -137,7 +137,7 @@ void StringTable::accountForCellJustification(std::size_t index, float columnWid
 	case (Justification::Left):
 		return; // No modification required for left justifited
 	case (Justification::Right):
-		cell.textRelativePosition.x() += columnWidth - getCellFont(index)->width(cell.text);
+		cell.textRelativePosition.x += columnWidth - getCellFont(index)->width(cell.text);
 		return;
 	default:
 		return;

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -18,7 +18,7 @@ void StringTable::draw(NAS2D::Renderer& renderer) const
 {
 	for (std::size_t i = 0; i < cells.size(); ++i)
 	{
-		const Cell& cell = cells.at(i);
+		const auto& cell = cells.at(i);
 
 		NAS2D::Color textColor = cell.textColor != Cell::ColorEmpty ? cell.textColor : defaultTextColor;
 
@@ -124,7 +124,7 @@ void StringTable::computeRelativeCellPositions()
 
 void StringTable::accountForCellJustification(std::size_t index, float columnWidth)
 {
-	Cell& cell = cells[index];
+	auto& cell = cells[index];
 
 	switch (cell.justification)
 	{

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -6,6 +6,16 @@
 
 const NAS2D::Color StringTable::Cell::ColorEmpty = NAS2D::Color::NoAlpha;
 
+StringTable::Cell& StringTable::operator[](const CellCoordinate& coordinate)
+{
+	return cells[getCellIndex(coordinate)];
+}
+
+StringTable::Cell& StringTable::at(std::size_t column, std::size_t row)
+{
+	return cells[getCellIndex(CellCoordinate(column, row))];
+}
+
 StringTable::StringTable(std::size_t columns, std::size_t rows) : columnCount(columns), rowCount(rows)
 {
 	cells.resize(columns * rows);
@@ -61,37 +71,12 @@ void StringTable::setVerticalPadding(float padding)
 	verticalPadding = padding;
 }
 
-void StringTable::setCellText(std::size_t column, std::size_t row, std::string text)
-{
-	setCellText(CellCoordinate(column, row), text);
-}
-
-void StringTable::setCellText(const CellCoordinate& cellCoordinate, std::string text)
-{
-	cells[getCellIndex(cellCoordinate)].text = text;
-}
-
-void StringTable::setCellFont(const CellCoordinate& cellCoordinate, NAS2D::Font* font)
-{
-	cells[getCellIndex(cellCoordinate)].font = font;
-}
-
-void StringTable::setCellJustification(const CellCoordinate& cellCoordinate, Justification justification)
-{
-	cells[getCellIndex(cellCoordinate)].justification = justification;
-}
-
 void StringTable::setColumnJustification(std::size_t column, Justification justification)
 {
 	for (std::size_t row = 0; row < rowCount; ++row)
 	{
-		setCellJustification(CellCoordinate(column, row), justification);
+		this->at(column, row).justification = justification;
 	}
-}
-
-void StringTable::setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::Color color)
-{
-	cells[getCellIndex(cellCoordinate)].textColor = color;
 }
 
 void StringTable::computeRelativeCellPositions()

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -6,7 +6,7 @@
 
 const NAS2D::Color StringTable::Cell::ColorEmpty = NAS2D::Color::NoAlpha;
 
-StringTable::StringTable(std::size_t columns, std::size_t rows) : columns(columns), rows(rows)
+StringTable::StringTable(std::size_t columns, std::size_t rows) : columnCount(columns), rowCount(rows)
 {
 	cells.resize(columns * rows);
 
@@ -84,7 +84,7 @@ void StringTable::setCellJustification(const CellCoordinate& cellCoordinate, Jus
 
 void StringTable::setColumnJustification(std::size_t column, Justification justification)
 {
-	for (std::size_t row = 0; row < rows; ++row)
+	for (std::size_t row = 0; row < rowCount; ++row)
 	{
 		setCellJustification(CellCoordinate(column, row), justification);
 	}
@@ -98,7 +98,7 @@ void StringTable::setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::
 void StringTable::computeRelativeCellPositions()
 {
 	// Must be at least 1 row and 1 column to compute position values
-	if (columns == 0 || rows == 0)
+	if (columnCount == 0 || rowCount == 0)
 	{
 		return;
 	}
@@ -107,10 +107,10 @@ void StringTable::computeRelativeCellPositions()
 	auto rowHeights = computeRowHeights();
 
 	float columnOffset = 0;
-	for (std::size_t column = 0; column < columns; ++column)
+	for (std::size_t column = 0; column < columnCount; ++column)
 	{
 		float rowOffset = 0;
-		for (std::size_t row = 0; row < rows; ++row)
+		for (std::size_t row = 0; row < rowCount; ++row)
 		{
 			auto cellIndex = getCellIndex(CellCoordinate(column, row));
 			cells[cellIndex].textRelativePosition = { columnOffset, rowOffset };
@@ -143,11 +143,11 @@ std::vector<float> StringTable::computeColumnWidths() const
 {
 	std::vector<float> columnWidths;
 
-	for (std::size_t column = 0; column < columns; ++column)
+	for (std::size_t column = 0; column < columnCount; ++column)
 	{
 		float columnWidth = 0;
 
-		for (std::size_t row = 0; row < rows; ++row)
+		for (std::size_t row = 0; row < rowCount; ++row)
 		{
 			auto index = getCellIndex(CellCoordinate(column, row));
 			auto cellWidth = static_cast<float>(getCellFont(index)->width(cells[index].text));
@@ -168,11 +168,11 @@ std::vector<float> StringTable::computeRowHeights() const
 {
 	std::vector<float> rowHeights;
 
-	for (std::size_t row = 0; row < rows; ++row)
+	for (std::size_t row = 0; row < rowCount; ++row)
 	{
 		float rowHeight = 0;
 
-		for (std::size_t column = 0; column < columns; ++column)
+		for (std::size_t column = 0; column < columnCount; ++column)
 		{
 			auto index = getCellIndex(CellCoordinate(column, row));
 			float cellHeight = static_cast<float>(getCellFont(index)->height());
@@ -193,22 +193,22 @@ std::size_t StringTable::getCellIndex(const CellCoordinate& cellCoordinate) cons
 {
 	checkCellIndex(cellCoordinate);
 
-	return columns * cellCoordinate.y() + cellCoordinate.x();
+	return columnCount * cellCoordinate.y() + cellCoordinate.x();
 }
 
 StringTable::CellCoordinate StringTable::getCellCoordinate(std::size_t index) const
 {
-	return CellCoordinate{ index % columns, index / columns };
+	return CellCoordinate{ index % columnCount, index / columnCount };
 }
 
 void StringTable::checkCellIndex(const CellCoordinate& cellCoordinate) const
 {
-	if (cellCoordinate.x() >= columns)
+	if (cellCoordinate.x() >= columnCount)
 	{
 		throw std::runtime_error("Index is outside column bounds");
 	}
 
-	if (cellCoordinate.y() >= rows)
+	if (cellCoordinate.y() >= rowCount)
 	{
 		throw std::runtime_error("Index is outside row bounds");
 	}
@@ -233,5 +233,5 @@ NAS2D::Font* StringTable::getCellFont(std::size_t index) const
 
 bool StringTable::isFirstColumn(std::size_t index) const
 {
-	return index % columns == 0;
+	return index % columnCount == 0;
 }

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -37,14 +37,9 @@ NAS2D::Vector<float> StringTable::getPosition() const
 	return position;
 }
 
-void StringTable::setDefaultFont(NAS2D::Font* font)
+void StringTable::setDefaultFont(NAS2D::Font& font)
 {
-	if (font == nullptr)
-	{
-		throw std::runtime_error("Default font may not be a nullptr");
-	}
-
-	defaultFont = font;
+	defaultFont = &font;
 }
 
 void StringTable::setDefaultTitleFont(NAS2D::Font* font)

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -219,7 +219,13 @@ NAS2D::Font* StringTable::getCellFont(std::size_t index) const
 	NAS2D::Font* font = cells[index].font;
 
 	if (font == nullptr) {
-		font = isFirstColumn(index) ? defaultTitleFont : defaultFont;
+		// If a different title font is not desired, it is set to nullptr
+		if (defaultTitleFont == nullptr) {
+			font = defaultFont;
+		}
+		else {
+			font = isFirstColumn(index) ? defaultTitleFont : defaultFont;
+		}
 	}
 
 	return font;

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -21,18 +21,17 @@ void StringTable::draw(NAS2D::Renderer& renderer) const
 		const Cell& cell = cells.at(i);
 
 		NAS2D::Color textColor = cell.textColor != Cell::ColorEmpty ? cell.textColor : defaultTextColor;
-		const auto drawPosition = position + cell.textRelativePosition;
 
-		renderer.drawText(*getCellFont(i), cell.text, NAS2D::Point<float>(drawPosition.x, drawPosition.y), textColor);
+		renderer.drawText(*getCellFont(i), cell.text, position + cell.textRelativePosition, textColor);
 	}
 }
 
-void StringTable::setPosition(NAS2D::Vector<float> tablePosition)
+void StringTable::setPosition(NAS2D::Point<float> tablePosition)
 {
 	this->position = tablePosition;
 }
 
-NAS2D::Vector<float> StringTable::getPosition() const
+NAS2D::Point<float> StringTable::getPosition() const
 {
 	return position;
 }

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -1,0 +1,236 @@
+#include "StringTable.h"
+#include "../FontManager.h"
+#include "../Constants/UiConstants.h"
+#include <NAS2D/Utility.h>
+#include <stdexcept>
+
+const NAS2D::Color StringTable::Cell::ColorEmpty = NAS2D::Color::NoAlpha;
+
+StringTable::StringTable(std::size_t columns, std::size_t rows) : columns(columns), rows(rows)
+{
+	cells.resize(columns * rows);
+
+	defaultFont = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	defaultTitleFont = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+}
+
+void StringTable::draw(NAS2D::Renderer& renderer) const
+{
+	for (std::size_t i = 0; i < cells.size(); ++i)
+	{
+		const Cell& cell = cells.at(i);
+
+		NAS2D::Color textColor = cell.textColor != Cell::ColorEmpty ? cell.textColor : defaultTextColor;
+		NAS2D::Point<float> drawPosition = { position.x() + cell.textRelativePosition.x(), position.y() + cell.textRelativePosition.y() };
+
+		renderer.drawText(*getCellFont(i), cell.text, drawPosition, textColor);
+	}
+}
+
+void StringTable::setPosition(NAS2D::Point<float> tablePosition)
+{
+	this->position = tablePosition;
+}
+
+NAS2D::Point<float> StringTable::getPosition() const
+{
+	return position;
+}
+
+void StringTable::setDefaultFont(NAS2D::Font* font)
+{
+	if (font == nullptr)
+	{
+		throw std::runtime_error("Default font may not be a nullptr");
+	}
+
+	defaultFont = font;
+}
+
+void StringTable::setDefaultTitleFont(NAS2D::Font* font)
+{
+	defaultTitleFont = font;
+}
+
+void StringTable::setDefaultTextColor(NAS2D::Color color)
+{
+	defaultTextColor = color;
+}
+
+void StringTable::setHorizontalPadding(float padding)
+{
+	horizontalPadding = padding;
+}
+
+void StringTable::setVerticalPadding(float padding)
+{
+	verticalPadding = padding;
+}
+
+void StringTable::setCellText(std::size_t column, std::size_t row, std::string text)
+{
+	setCellText(CellCoordinate(column, row), text);
+}
+
+void StringTable::setCellText(const CellCoordinate& cellCoordinate, std::string text)
+{
+	cells[getCellIndex(cellCoordinate)].text = text;
+}
+
+void StringTable::setCellFont(const CellCoordinate& cellCoordinate, NAS2D::Font* font)
+{
+	cells[getCellIndex(cellCoordinate)].font = font;
+}
+
+void StringTable::setCellJustification(const CellCoordinate& cellCoordinate, Justification justification)
+{
+	cells[getCellIndex(cellCoordinate)].justification = justification;
+}
+
+void StringTable::setColumnJustification(std::size_t column, Justification justification)
+{
+	for (int row = 0; row < rows; ++row)
+	{
+		setCellJustification(CellCoordinate(column, row), justification);
+	}
+}
+
+void StringTable::setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::Color color)
+{
+	cells[getCellIndex(cellCoordinate)].textColor = color;
+}
+
+void StringTable::computeRelativeCellPositions()
+{
+	// Must be at least 1 row and 1 column to compute position values
+	if (columns == 0 || rows == 0)
+	{
+		return;
+	}
+
+	auto columnWidths = computeColumnWidths();
+	auto rowHeights = computeRowHeights();
+
+	float columnOffset = 0;
+	for (std::size_t column = 0; column < columns; ++column)
+	{
+		float rowOffset = 0;
+		for (std::size_t row = 0; row < rows; ++row)
+		{
+			auto cellIndex = getCellIndex(CellCoordinate(column, row));
+			cells[cellIndex].textRelativePosition = { columnOffset, rowOffset };
+			accountForCellJustification(cellIndex, columnWidths[column]);
+
+			rowOffset += rowHeights[row] + verticalPadding;
+		}
+
+		columnOffset += columnWidths[column] + horizontalPadding;
+	}
+}
+
+void StringTable::accountForCellJustification(std::size_t index, float columnWidth)
+{
+	Cell& cell = cells[index];
+
+	switch (cell.justification)
+	{
+	case (Justification::Left):
+		return; // No modification required for left justifited
+	case (Justification::Right):
+		cell.textRelativePosition.x() += columnWidth - getCellFont(index)->width(cell.text);
+		return;
+	default:
+		return;
+	}
+}
+
+std::vector<float> StringTable::computeColumnWidths() const
+{
+	std::vector<float> columnWidths;
+
+	for (std::size_t column = 0; column < columns; ++column)
+	{
+		float columnWidth = 0;
+
+		for (std::size_t row = 0; row < rows; ++row)
+		{
+			auto index = getCellIndex(CellCoordinate(column, row));
+			auto cellWidth = static_cast<float>(getCellFont(index)->width(cells[index].text));
+
+			if (cellWidth > columnWidth)
+			{
+				columnWidth = cellWidth;
+			}
+		}
+
+		columnWidths.push_back(columnWidth);
+	}
+
+	return columnWidths;
+}
+
+std::vector<float> StringTable::computeRowHeights() const
+{
+	std::vector<float> rowHeights;
+
+	for (std::size_t row = 0; row < rows; ++row)
+	{
+		float rowHeight = 0;
+
+		for (std::size_t column = 0; column < columns; ++column)
+		{
+			auto index = getCellIndex(CellCoordinate(column, row));
+			float cellHeight = static_cast<float>(getCellFont(index)->height());
+
+			if (cellHeight > rowHeight)
+			{
+				rowHeight = cellHeight;
+			}
+		}
+
+		rowHeights.push_back(rowHeight);
+	}
+
+	return rowHeights;
+}
+
+std::size_t StringTable::getCellIndex(const CellCoordinate& cellCoordinate) const
+{
+	checkCellIndex(cellCoordinate);
+
+	return columns * cellCoordinate.y() + cellCoordinate.x();
+}
+
+StringTable::CellCoordinate StringTable::getCellCoordinate(std::size_t index) const
+{
+	return CellCoordinate{ index % columns, index / columns };
+}
+
+void StringTable::checkCellIndex(const CellCoordinate& cellCoordinate) const
+{
+	if (cellCoordinate.x() >= columns)
+	{
+		throw std::runtime_error("Index is outside column bounds");
+	}
+
+	if (cellCoordinate.y() >= rows)
+	{
+		throw std::runtime_error("Index is outside row bounds");
+	}
+}
+
+NAS2D::Font* StringTable::getCellFont(std::size_t index) const
+{
+	NAS2D::Font* font = cells[index].font;// = index % columns == 0 ? defaultTitleFont : defaultFont;
+
+	if (font == nullptr) {
+		font = isFirstColumn(index) ? defaultTitleFont : defaultFont;
+	}
+
+	return font;
+}
+
+bool StringTable::isFirstColumn(std::size_t index) const
+{
+	return index % columns == 0;
+}

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -20,6 +20,18 @@ public:
 		Right
 	};
 
+	struct Cell
+	{
+		// Set textColor to ColorEmpty to indicate cell should use default StringTable color
+		static const NAS2D::Color ColorEmpty;
+
+		// Use defaultFont if not set
+		NAS2D::Font* font = nullptr;
+		std::string text;
+		Justification justification = Justification::Left;
+		NAS2D::Color textColor = ColorEmpty;
+	};
+
 	// Set default fonts in constructor
 	StringTable(std::size_t columns, std::size_t rows);
 
@@ -48,21 +60,14 @@ public:
 	void computeRelativeCellPositions();
 
 private:
-	struct Cell
+	// Purposely hide textRelativePosition from public access
+	struct CellWithPosition : Cell
 	{
-		// Set textColor to ColorEmpty to indicate cell should use default StringTable color
-		static const NAS2D::Color ColorEmpty;
-
-		// Use defaultFont if not set
-		NAS2D::Font* font = nullptr;
-		std::string text;
-		Justification justification = Justification::Left;
-		NAS2D::Color textColor = ColorEmpty;
 		// Position relative to the StringTable's position
 		NAS2D::Vector<float> textRelativePosition;
 	};
 
-	std::vector<Cell> cells;
+	std::vector<CellWithPosition> cells;
 	const std::size_t columnCount;
 	const std::size_t rowCount;
 	NAS2D::Point<float> position;

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -12,74 +12,74 @@
 class StringTable
 {
 public:
-    using CellCoordinate = NAS2D::Point<std::size_t>;
+	using CellCoordinate = NAS2D::Point<std::size_t>;
 
-    enum class Justification
-    {
-        Left,
-        Right
-    };
+	enum class Justification
+	{
+		Left,
+		Right
+	};
 
-    // Set default fonts in constructor
-    StringTable(std::size_t columns, std::size_t rows);
+	// Set default fonts in constructor
+	StringTable(std::size_t columns, std::size_t rows);
 
-    void draw(NAS2D::Renderer& renderer) const;
+	void draw(NAS2D::Renderer& renderer) const;
 
-    void setPosition(NAS2D::Vector<float> position);
-    NAS2D::Vector<float> getPosition() const;
+	void setPosition(NAS2D::Vector<float> position);
+	NAS2D::Vector<float> getPosition() const;
 
-    void setDefaultFont(NAS2D::Font& font);
-    void setDefaultTitleFont(NAS2D::Font* font);
-    void setDefaultTextColor(NAS2D::Color textColor);
+	void setDefaultFont(NAS2D::Font& font);
+	void setDefaultTitleFont(NAS2D::Font* font);
+	void setDefaultTextColor(NAS2D::Color textColor);
 
-    void setHorizontalPadding(float horizontalPadding);
-    void setVerticalPadding(float verticalPadding);
+	void setHorizontalPadding(float horizontalPadding);
+	void setVerticalPadding(float verticalPadding);
 
-    void setCellText(std::size_t column, std::size_t row, std::string text);
-    void setCellText(const CellCoordinate& cellCoordinate, std::string text);
-    // Override default font settings
-    void setCellFont(const CellCoordinate& cellCoordinate, NAS2D::Font* font);
-    void setCellJustification(const CellCoordinate& cellCoordinate, Justification justification);
-    void setColumnJustification(std::size_t column, Justification justification);
-    // Override default Color setting
-    void setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::Color textColor);
+	void setCellText(std::size_t column, std::size_t row, std::string text);
+	void setCellText(const CellCoordinate& cellCoordinate, std::string text);
+	// Override default font settings
+	void setCellFont(const CellCoordinate& cellCoordinate, NAS2D::Font* font);
+	void setCellJustification(const CellCoordinate& cellCoordinate, Justification justification);
+	void setColumnJustification(std::size_t column, Justification justification);
+	// Override default Color setting
+	void setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::Color textColor);
 
-    // Call after updating table properties to recompute cell positions
-    void computeRelativeCellPositions();
+	// Call after updating table properties to recompute cell positions
+	void computeRelativeCellPositions();
 
 private:
-    struct Cell
-    {
-        // Set textColor to ColorEmpty to indicate cell should use default StringTable color
-        static const NAS2D::Color ColorEmpty;
+	struct Cell
+	{
+		// Set textColor to ColorEmpty to indicate cell should use default StringTable color
+		static const NAS2D::Color ColorEmpty;
 
-        // Use defaultFont if not set
-        NAS2D::Font* font = nullptr;
-        std::string text;
-        Justification justification = Justification::Left;
-        NAS2D::Color textColor = ColorEmpty;
-        // Position relative to the StringTable's position
-        NAS2D::Vector<float> textRelativePosition;
-    };
+		// Use defaultFont if not set
+		NAS2D::Font* font = nullptr;
+		std::string text;
+		Justification justification = Justification::Left;
+		NAS2D::Color textColor = ColorEmpty;
+		// Position relative to the StringTable's position
+		NAS2D::Vector<float> textRelativePosition;
+	};
 
-    std::vector<Cell> cells;
-    const std::size_t columnCount;
-    const std::size_t rowCount;
-    NAS2D::Vector<float> position;
-    NAS2D::Font* defaultFont;
-    NAS2D::Font* defaultTitleFont;
-    NAS2D::Color defaultTextColor = NAS2D::Color::White;
-    float horizontalPadding = 5;
-    float verticalPadding = 0;
+	std::vector<Cell> cells;
+	const std::size_t columnCount;
+	const std::size_t rowCount;
+	NAS2D::Vector<float> position;
+	NAS2D::Font* defaultFont;
+	NAS2D::Font* defaultTitleFont;
+	NAS2D::Color defaultTextColor = NAS2D::Color::White;
+	float horizontalPadding = 5;
+	float verticalPadding = 0;
 
-    void accountForCellJustification(std::size_t index, float columnWidth);
-    std::vector<float> computeColumnWidths() const;
-    std::vector<float> computeRowHeights() const;
+	void accountForCellJustification(std::size_t index, float columnWidth);
+	std::vector<float> computeColumnWidths() const;
+	std::vector<float> computeRowHeights() const;
 
-    std::size_t getCellIndex(const CellCoordinate& cellCoordinate) const;
-    CellCoordinate getCellCoordinate(std::size_t index) const;
-    void checkCellIndex(const CellCoordinate& cellCoordinate) const;
+	std::size_t getCellIndex(const CellCoordinate& cellCoordinate) const;
+	CellCoordinate getCellCoordinate(std::size_t index) const;
+	void checkCellIndex(const CellCoordinate& cellCoordinate) const;
 
-    NAS2D::Font* getCellFont(std::size_t index) const;
-    bool isFirstColumn(std::size_t index) const;
+	NAS2D::Font* getCellFont(std::size_t index) const;
+	bool isFirstColumn(std::size_t index) const;
 };

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -25,8 +25,8 @@ public:
 
 	void draw(NAS2D::Renderer& renderer) const;
 
-	void setPosition(NAS2D::Vector<float> position);
-	NAS2D::Vector<float> getPosition() const;
+	void setPosition(NAS2D::Point<float> position);
+	NAS2D::Point<float> getPosition() const;
 
 	void setDefaultFont(NAS2D::Font& font);
 	void setDefaultTitleFont(NAS2D::Font* font);
@@ -65,7 +65,7 @@ private:
 	std::vector<Cell> cells;
 	const std::size_t columnCount;
 	const std::size_t rowCount;
-	NAS2D::Vector<float> position;
+	NAS2D::Point<float> position;
 	NAS2D::Font* defaultFont;
 	NAS2D::Font* defaultTitleFont;
 	NAS2D::Color defaultTextColor = NAS2D::Color::White;

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <NAS2D/Renderer/Renderer.h>
+#include <NAS2D/Renderer/Color.h>
+#include <NAS2D/Renderer/Point.h>
+#include <string>
+#include <vector>
+#include <cstddef>
+
+// Draw a 2 dimensional table of text. Determine cell size based on inserted text, font, and padding. Only allows one line of text per cell.
+class StringTable
+{
+public:
+    using CellCoordinate = NAS2D::Point<std::size_t>;
+
+    enum class Justification
+    {
+        Left,
+        Right
+    };
+
+    // Set default fonts in constructor
+    StringTable(std::size_t columns, std::size_t rows);
+
+    void draw(NAS2D::Renderer& renderer) const;
+
+    void setPosition(NAS2D::Point<float> position);
+    NAS2D::Point<float> getPosition() const;
+
+    void setDefaultFont(NAS2D::Font* font);
+    void setDefaultTitleFont(NAS2D::Font* font);
+    void setDefaultTextColor(NAS2D::Color textColor);
+
+    void setHorizontalPadding(float horizontalPadding);
+    void setVerticalPadding(float verticalPadding);
+
+    void setCellText(std::size_t column, std::size_t row, std::string text);
+    void setCellText(const CellCoordinate& cellCoordinate, std::string text);
+    // Override default font settings
+    void setCellFont(const CellCoordinate& cellCoordinate, NAS2D::Font* font);
+    void setCellJustification(const CellCoordinate& cellCoordinate, Justification justification);
+    void setColumnJustification(std::size_t column, Justification justification);
+    // Override default Color setting
+    void setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::Color textColor);
+
+    // Call after updating table properties to recompute cell positions
+    void computeRelativeCellPositions();
+
+private:
+    struct Cell
+    {
+        // Set textColor to ColorEmpty to indicate cell should use default StringTable color
+        static const NAS2D::Color ColorEmpty;
+
+        // Use defaultFont if not set
+        NAS2D::Font* font = nullptr;
+        std::string text;
+        Justification justification = Justification::Left;
+        NAS2D::Color textColor = ColorEmpty;
+        // Position relative to the StringTable's position
+        NAS2D::Point<float> textRelativePosition;
+    };
+
+    std::vector<Cell> cells;
+    const std::size_t columns;
+    const std::size_t rows;
+    NAS2D::Point<float> position;
+    NAS2D::Font* defaultFont;
+    NAS2D::Font* defaultTitleFont;
+    NAS2D::Color defaultTextColor = NAS2D::Color::White;
+    float horizontalPadding = 5;
+    float verticalPadding = 0;
+
+    void accountForCellJustification(std::size_t index, float columnWidth);
+    std::vector<float> computeColumnWidths() const;
+    std::vector<float> computeRowHeights() const;
+
+    std::size_t getCellIndex(const CellCoordinate& cellCoordinate) const;
+    CellCoordinate getCellCoordinate(std::size_t index) const;
+    void checkCellIndex(const CellCoordinate& cellCoordinate) const;
+
+    NAS2D::Font* getCellFont(std::size_t index) const;
+    bool isFirstColumn(std::size_t index) const;
+};

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -63,8 +63,8 @@ private:
     };
 
     std::vector<Cell> cells;
-    const std::size_t columns;
-    const std::size_t rows;
+    const std::size_t columnCount;
+    const std::size_t rowCount;
     NAS2D::Vector<float> position;
     NAS2D::Font* defaultFont;
     NAS2D::Font* defaultTitleFont;

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -28,7 +28,7 @@ public:
     void setPosition(NAS2D::Vector<float> position);
     NAS2D::Vector<float> getPosition() const;
 
-    void setDefaultFont(NAS2D::Font* font);
+    void setDefaultFont(NAS2D::Font& font);
     void setDefaultTitleFont(NAS2D::Font* font);
     void setDefaultTextColor(NAS2D::Color textColor);
 

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -32,6 +32,9 @@ public:
 		NAS2D::Color textColor = ColorEmpty;
 	};
 
+	Cell& operator[](const CellCoordinate& coordinate);
+	Cell& at(std::size_t column, std::size_t row);
+
 	// Set default fonts in constructor
 	StringTable(std::size_t columns, std::size_t rows);
 
@@ -47,14 +50,7 @@ public:
 	void setHorizontalPadding(float horizontalPadding);
 	void setVerticalPadding(float verticalPadding);
 
-	void setCellText(std::size_t column, std::size_t row, std::string text);
-	void setCellText(const CellCoordinate& cellCoordinate, std::string text);
-	// Override default font settings
-	void setCellFont(const CellCoordinate& cellCoordinate, NAS2D::Font* font);
-	void setCellJustification(const CellCoordinate& cellCoordinate, Justification justification);
 	void setColumnJustification(std::size_t column, Justification justification);
-	// Override default Color setting
-	void setCellTextColor(const CellCoordinate& cellCoordinate, NAS2D::Color textColor);
 
 	// Call after updating table properties to recompute cell positions
 	void computeRelativeCellPositions();

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -3,6 +3,7 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Point.h>
+#include <NAS2D/Renderer/Vector.h>
 #include <string>
 #include <vector>
 #include <cstddef>
@@ -24,8 +25,8 @@ public:
 
     void draw(NAS2D::Renderer& renderer) const;
 
-    void setPosition(NAS2D::Point<float> position);
-    NAS2D::Point<float> getPosition() const;
+    void setPosition(NAS2D::Vector<float> position);
+    NAS2D::Vector<float> getPosition() const;
 
     void setDefaultFont(NAS2D::Font* font);
     void setDefaultTitleFont(NAS2D::Font* font);
@@ -58,13 +59,13 @@ private:
         Justification justification = Justification::Left;
         NAS2D::Color textColor = ColorEmpty;
         // Position relative to the StringTable's position
-        NAS2D::Point<float> textRelativePosition;
+        NAS2D::Vector<float> textRelativePosition;
     };
 
     std::vector<Cell> cells;
     const std::size_t columns;
     const std::size_t rows;
-    NAS2D::Point<float> position;
+    NAS2D::Vector<float> position;
     NAS2D::Font* defaultFont;
     NAS2D::Font* defaultTitleFont;
     NAS2D::Color defaultTextColor = NAS2D::Color::White;

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -243,6 +243,7 @@
     <ClCompile Include="UI\Reports\FactoryReport.cpp" />
     <ClCompile Include="UI\Reports\WarehouseReport.cpp" />
     <ClCompile Include="UI\ResourceBreakdownPanel.cpp" />
+    <ClCompile Include="UI\StringTable.cpp" />
     <ClCompile Include="UI\StructureInspector.cpp" />
     <ClCompile Include="UI\StructureListBox.cpp" />
     <ClCompile Include="UI\TextRender.cpp" />
@@ -357,6 +358,7 @@
     <ClInclude Include="UI\Reports\ReportInterface.h" />
     <ClInclude Include="UI\Reports\WarehouseReport.h" />
     <ClInclude Include="UI\ResourceBreakdownPanel.h" />
+    <ClInclude Include="UI\StringTable.h" />
     <ClInclude Include="UI\StructureInspector.h" />
     <ClInclude Include="UI\FactoryListBox.h" />
     <ClInclude Include="UI\StructureListBox.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClCompile Include="UI\TextRender.cpp">
       <Filter>Header Files\UI</Filter>
     </ClCompile>
+    <ClCompile Include="UI\StringTable.cpp">
+      <Filter>Header Files\UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common.h">
@@ -633,6 +636,9 @@
       <Filter>Header Files\Things\Structures</Filter>
     </ClInclude>
     <ClInclude Include="UI\TextRender.h">
+      <Filter>Header Files\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\StringTable.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
   </ItemGroup>

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -292,7 +292,7 @@
       <Filter>Header Files\UI</Filter>
     </ClCompile>
     <ClCompile Include="UI\StringTable.cpp">
-      <Filter>Header Files\UI</Filter>
+      <Filter>Source Files\UI</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Looking for feedback if I'm close enough to the mark on code style in addition to the logic of StringTable.

Included FactoryProduction window as a sample for how StringTable would be used. 

The idea of StringTable is that you can initialize all the data and then just call the Draw function many times. This would reduce CPU time recalculating the layout of each cell. The underlying game framework tends to call update and draw code from same function, so at this state doesn't buy anything.

Actual dimensions are not calculated until the function computeRelativeCellPositions is called. This allows for manipulation of the data without forcing recalculation of the dimensions on every call to a function in StringTable that could change layout. This call could be moved inside the draw function to encapsulate the logic, but may make a performance hit long term. Since there isn't currently a performance problem, I would be completely fine encapsulating it this way.

I standardized to (row, column) because that seems to match up with (x,y) type logic on a graph. However, intuitively, it might be better to insert data in (column, row) format since I tend to fill one row at a time. 

The cells are stored in a 1D array. There may be some sort of bit twiddling or better math to optimize some of the calls? Maybe best to leave alone unless performance is needed though if it harms readability.

Closes #458 

<img width="238" alt="FactoryProductionSample" src="https://user-images.githubusercontent.com/15183337/86503602-b694fb00-bd7d-11ea-934d-52f09c9a8c5b.png">
Screenshot showing I think it looks close to the same as before

---

PS: How do I access the FactoryReport UI from in game? I'm having trouble finding it for some reason...