### PR TITLE
Unconditionally create saved game folder

### DIFF
--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -75,10 +75,7 @@ int main(int /*argc*/, char *argv[])
 		fs.mountSoftFail(fs.basePath() + "data");
 		fs.mountReadWrite(fs.prefPath());
 
-		if (!fs.exists(constants::SAVE_GAME_PATH))
-		{
-			fs.makeDirectory(constants::SAVE_GAME_PATH);
-		}
+		fs.makeDirectory(constants::SAVE_GAME_PATH);
 
 		Configuration& cf = Utility<Configuration>::init(
 			std::map<std::string, Dictionary>{


### PR DESCRIPTION
Fixes #432.

Before the code would skip creation of the saved games folder if a folder of that name existed within one of the mounted read folders. That was a problem if the folder didn't also exist within the write folder. That would lead to (directory) "not found" errors when attempting to save a game.

On Linux it doesn't appear to be an error to create a directory that already exists. Could someone please confirm this works on Windows? It may help to delete the user folder when testing (or at least any `"savedgames/"` subfolder):
- `"C:\\Users\\<user>\\AppData\\Roaming\\LairWorks\\OutpostHD"`

It may also help to create a `"savegames/"` folder within the static `"data/"` folder when testing this.
