### PR TITLE
Fix Slider orientation for MainMenuOptions

### DIFF
--- a/OPHD/UI/MainMenuOptions.h
+++ b/OPHD/UI/MainMenuOptions.h
@@ -54,8 +54,8 @@ private:
 	CheckBox cbxVSync;
 	CheckBox cbxSkipSplash;
 	CheckBox cbxStartMaximized;
-	Slider sldrMusicVolume;
-	Slider sldrSoundVolume;
+	Slider sldrMusicVolume{Slider::SliderType::Horizontal};
+	Slider sldrSoundVolume{Slider::SliderType::Horizontal};
 
 	UIContainer pnlButtons;
 	Button btnOk;


### PR DESCRIPTION
Fix for MainMenuOptions Slider orientation, accidentally left out of #468.
