### PR TITLE
Fix Visual Studio filter mistake with TextRender.cpp

### DIFF
--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -289,7 +289,7 @@
       <Filter>Source Files\UI</Filter>
     </ClCompile>
     <ClCompile Include="UI\TextRender.cpp">
-      <Filter>Header Files\UI</Filter>
+      <Filter>Source Files\UI</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I made a mistake on TextRender (Visual Studio only, and just affects the folder hierarchy within Visual Studio)

I would actually prefer if the cpp and header files sat next to each other instead of being in separate folders, although that is not the normal convention by Visual Studio.