### PR TITLE
Unhide base class overload ListBoxBase::currentSelection

### DIFF
--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -140,7 +140,7 @@ void FactoryListBox::currentSelection(Factory* f)
 
 Factory* FactoryListBox::selectedFactory()
 {
-	return (ListBoxBase::currentSelection() == constants::NO_SELECTION) ? nullptr : static_cast<FactoryListBoxItem*>(mItems[ListBoxBase::currentSelection()])->factory;
+	return (currentSelection() == constants::NO_SELECTION) ? nullptr : static_cast<FactoryListBoxItem*>(mItems[currentSelection()])->factory;
 }
 
 
@@ -164,7 +164,7 @@ void FactoryListBox::update()
 			positionY() + (i * LIST_ITEM_HEIGHT),
 			static_cast<float>(item_width()),
 			static_cast<float>(draw_offset()),
-			i == ListBoxBase::currentSelection());
+			i == currentSelection());
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -41,6 +41,7 @@ public:
 	void addItem(Factory* factory);
 	void removeItem(Factory* factory);
 	void currentSelection(Factory*);
+	using ListBoxBase::currentSelection;
 
 	Factory* selectedFactory();
 

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -112,7 +112,7 @@ void ProductListBox::update()
 			positionY() + (i * LIST_ITEM_HEIGHT),
 			static_cast<float>(item_width()),
 			static_cast<float>(draw_offset()),
-			i == ListBoxBase::currentSelection());
+			i == currentSelection());
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -128,7 +128,7 @@ void StructureListBox::currentSelection(Structure* structure)
 
 Structure* StructureListBox::selectedStructure()
 {
-	return (ListBoxBase::currentSelection() == constants::NO_SELECTION) ? nullptr : static_cast<StructureListBoxItem*>(mItems[ListBoxBase::currentSelection()])->structure;
+	return (currentSelection() == constants::NO_SELECTION) ? nullptr : static_cast<StructureListBoxItem*>(mItems[currentSelection()])->structure;
 }
 
 
@@ -161,7 +161,7 @@ void StructureListBox::update()
 			positionY() + (i * LIST_ITEM_HEIGHT),
 			static_cast<float>(item_width()),
 			static_cast<float>(draw_offset()),
-			i == ListBoxBase::currentSelection());
+			i == currentSelection());
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -34,6 +34,7 @@ public:
 	void addItem(Structure*);
 	void removeItem(Structure*);
 	void currentSelection(Structure*);
+	using ListBoxBase::currentSelection;
 
 	Structure* selectedStructure();
 


### PR DESCRIPTION
Reference: #479

When adding a new overload in a derived class, base class methods of the same name become hidden. A `using` clause can be used to unhide those names. Assuming method signatures are different, usual overload resolution can then distinguish between them.
