### PR TITLE
Refactor ListBox access

### DIFF
--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -35,7 +35,7 @@ public:
 
 	using ListBoxItems = std::vector<ListBoxItem>;
 
-public:
+
 	ListBox();
 	~ListBox() override;
 	
@@ -86,7 +86,7 @@ private:
 	void _updateItemDisplay();
 	void _init();
 
-private:
+
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	std::size_t mCurrentSelection = 0; /**< Current selection index. */
 	std::size_t mCurrentOffset = 0; /**< Current selection index. */

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -44,7 +44,6 @@ public:
 
 	public:
 		std::string Text;
-		NAS2D::Point<int> Size;
 	};
 
 public:

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -30,7 +30,6 @@ public:
 	 */
 	using SelectionChangedCallback = NAS2D::Signals::Signal<>;
 
-public:
 	/**
 	 * Derived SpecialListBox types can inherit from this struct
 	 * for specialized information needed for derived types.
@@ -42,11 +41,10 @@ public:
 		ListBoxItem(std::string text) : Text(text) {}
 		virtual ~ListBoxItem() = default;
 
-	public:
 		std::string Text;
 	};
 
-public:
+
 	ListBoxBase();
 	~ListBoxBase() override;
 
@@ -69,6 +67,7 @@ public:
 
 	void update() override = 0;
 
+
 protected:
 	/**
 	 * List of ListBoxItem's.
@@ -80,7 +79,7 @@ protected:
 	 */
 	using ItemList = std::vector<ListBoxItem*>;
 
-protected:
+
 	void _update_item_display();
 
 	unsigned int item_width() const { return mItemWidth; }
@@ -92,7 +91,6 @@ protected:
 	void visibilityChanged(bool) override;
 
 
-protected:
 	ItemList mItems; /**< List of Items. */
 
 private:
@@ -105,7 +103,7 @@ private:
 
 	void onSizeChanged() override;
 
-private:
+
 	unsigned int mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	unsigned int mCurrentSelection = constants::NO_SELECTION; /**< Current selection index. */
 	unsigned int mCurrentOffset = 0; /**< Draw Offset. */

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -34,9 +34,8 @@ public:
 	 * Derived SpecialListBox types can inherit from this struct
 	 * for specialized information needed for derived types.
 	 */
-	class ListBoxItem
+	struct ListBoxItem
 	{
-	public:
 		ListBoxItem() = default;
 		ListBoxItem(std::string text) : Text(text) {}
 		virtual ~ListBoxItem() = default;


### PR DESCRIPTION
Reference: #479

Remove duplicate access specifiers. Mark `ListBoxItem` as a `struct`. Remove unused `Size` field.
