### PR TITLE
Refactor ListBox Point

### DIFF
--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -205,12 +205,14 @@ void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 	// Ignore if menu is empty or invisible
 	if (empty() || !visible()) { return; }
 
-	if (!rect().contains(Point{x, y}) || mCurrentHighlight == constants::NO_SELECTION)
+	const auto point = NAS2D::Point{x, y};
+
+	if (!rect().contains(point) || mCurrentHighlight == constants::NO_SELECTION)
 	{
 		return;
 	}
 
-	if (mSlider.visible() && mSlider.rect().contains(Point{x, y}))
+	if (mSlider.visible() && mSlider.rect().contains(point))
 	{
 		return; // if the mouse is on the slider then the slider should handle that
 	}
@@ -229,15 +231,17 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 	// Ignore if menu is empty or invisible
 	if (empty() || !visible()) { return; }
 
+	const auto point = NAS2D::Point{x, y};
+
 	// Ignore mouse motion events if the pointer isn't within the menu rect.
-	if (!rect().contains(Point{x, y}))
+	if (!rect().contains(point))
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 		return;
 	}
 
 	// if the mouse is on the slider then the slider should handle that
-	if (mSlider.visible() && mSlider.rect().contains(Point{x, y}))
+	if (mSlider.visible() && mSlider.rect().contains(point))
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 		return;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -8,6 +8,7 @@
 
 #include "NAS2D/Utility.h"
 #include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/Renderer/Point.h"
 #include "NAS2D/MathUtils.h"
 
 using namespace NAS2D;

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -7,6 +7,7 @@
 
 #include "NAS2D/Utility.h"
 #include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/Renderer/Point.h"
 #include "NAS2D/MathUtils.h"
 
 #include <algorithm>

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -123,7 +123,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	}
 
 	// A few basic checks
-	if (!rect().contains(mMousePosition) || mCurrentHighlight == constants::NO_SELECTION) { return; }
+	if (!rect().contains(point) || mCurrentHighlight == constants::NO_SELECTION) { return; }
 	if (mSlider.visible() && mSlider.rect().contains(point)) { return; }
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size()) { return; }
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -139,9 +139,10 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 	if (!visible() || empty()) { return; }
 
 	mMousePosition = {x, y};
+	mHasFocus = rect().contains(mMousePosition);
 
 	// Ignore mouse motion events if the pointer isn't within the menu rect.
-	if (!rect().contains(mMousePosition))
+	if (!mHasFocus)
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 		return;
@@ -171,7 +172,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 void ListBoxBase::onMouseWheel(int /*x*/, int y)
 {
 	if (!visible()) { return; }
-	if (!rect().contains(mMousePosition)) { return; }
+	if (!mHasFocus) { return; }
 
 	float change = static_cast<float>(mItemHeight);
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -138,8 +138,8 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
 	if (!visible() || empty()) { return; }
 
-	mMousePosition = {x, y};
-	mHasFocus = rect().contains(mMousePosition);
+	const auto mousePosition = NAS2D::Point{x, y};
+	mHasFocus = rect().contains(mousePosition);
 
 	// Ignore mouse motion events if the pointer isn't within the menu rect.
 	if (!mHasFocus)
@@ -149,7 +149,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 	}
 
 	// if the mouse is on the slider then the slider should handle that
-	if (mSlider.visible() && mSlider.rect().contains(mMousePosition))
+	if (mSlider.visible() && mSlider.rect().contains(mousePosition))
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 		return;

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -110,11 +110,13 @@ void ListBoxBase::onSizeChanged()
  */
 void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	const auto point = NAS2D::Point{x, y};
+
 	if (!visible() || !hasFocus()) { return; }
 
 	if (empty() || button == EventHandler::MouseButton::BUTTON_MIDDLE) { return; }
 
-	if (button == EventHandler::MouseButton::BUTTON_RIGHT && mRect.to<int>().contains(Point{x, y}))
+	if (button == EventHandler::MouseButton::BUTTON_RIGHT && mRect.to<int>().contains(point))
 	{
 		setSelection(constants::NO_SELECTION);
 		return;
@@ -122,7 +124,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	// A few basic checks
 	if (!rect().contains(mMousePosition) || mCurrentHighlight == constants::NO_SELECTION) { return; }
-	if (mSlider.visible() && mSlider.rect().contains(Point{x, y})) { return; }
+	if (mSlider.visible() && mSlider.rect().contains(point)) { return; }
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size()) { return; }
 
 	setSelection(mCurrentHighlight);

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -6,7 +6,6 @@
 
 #include "NAS2D/Signal.h"
 #include "NAS2D/EventHandler.h"
-#include "NAS2D/Renderer/Point.h"
 #include "NAS2D/Renderer/Color.h"
 
 #include <string>

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -111,7 +111,6 @@ private:
 	unsigned int mItemWidth = 0; /**< Width of a ListBoxItem. */
 	unsigned int mLineCount = 0; /**< Number of lines that can be displayed. */
 
-	NAS2D::Point<int> mMousePosition; /**< Mouse coordinates. */
 	bool mHasFocus = false;
 
 	NAS2D::Color mText = NAS2D::Color::White; /**< Text Color */

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -112,6 +112,7 @@ private:
 	unsigned int mLineCount = 0; /**< Number of lines that can be displayed. */
 
 	NAS2D::Point<int> mMousePosition; /**< Mouse coordinates. */
+	bool mHasFocus = false;
 
 	NAS2D::Color mText = NAS2D::Color::White; /**< Text Color */
 	NAS2D::Color mHighlightBg = NAS2D::Color::DarkGreen; /**< Highlight Background color. */


### PR DESCRIPTION
Reference: #479
Reference: #217

Refactor use of `Point` in `ListBox` and `ListBoxBase`. Construct from local parameters where possible, rather than using stored values.

The `onMouseWheel` method takes scroll wheel delta values for the `x` and `y` parameters, not absolute mouse pointer coordinates. Hence that method needed to use a stored value to determine if the mouse was within the region of the control.
