### PR TITLE
Remove ListBox sort during add

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -46,7 +46,6 @@ void ComboBox::init()
 	txtField.editable(false);
 	lstItems.visible(false);
 	lstItems.height(300);
-	lstItems.sorted(false);
 
 	resized().connect(this, &ComboBox::resizedHandler);
 	moved().connect(this, &ComboBox::repositioned);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -165,7 +165,6 @@ void ListBox::removeItem(const std::string& item)
 	{
 		mItems.erase(it);
 		mCurrentSelection = constants::NO_SELECTION;
-		sort();
 		_updateItemDisplay();
 	}
 }

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -11,6 +11,9 @@
 #include "NAS2D/Renderer/Point.h"
 #include "NAS2D/MathUtils.h"
 
+#include <algorithm>
+
+
 using namespace NAS2D;
 
 
@@ -195,6 +198,12 @@ void ListBox::dropAllItems()
 	mItems.clear();
 	mCurrentSelection = 0;
 	_updateItemDisplay();
+}
+
+
+void ListBox::sort()
+{
+	std::sort(mItems.begin(), mItems.end());
 }
 
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -143,7 +143,6 @@ int ListBox::selectionTag() const
 void ListBox::addItem(const std::string& item, int tag)
 {
 	mItems.push_back(ListBoxItem(item, tag));
-	sort();
 	_updateItemDisplay();
 }
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -10,7 +10,6 @@
 
 #include <string>
 #include <vector>
-#include <algorithm>
 #include <cstddef>
 
 
@@ -39,8 +38,6 @@ public:
 	ListBox();
 	~ListBox() override;
 
-	void sort() { std::sort(mItems.begin(), mItems.end()); }
-
 	void textColor(const NAS2D::Color& color) { mText = color; }
 	void selectColor(const NAS2D::Color& color) { mHighlightBg = color; }
 
@@ -48,6 +45,7 @@ public:
 	void removeItem(const std::string& item);
 	bool itemExists(const std::string& item);
 	void dropAllItems();
+	void sort();
 
 	std::size_t count() const { return mItems.size(); }
 	unsigned int lineHeight() const { return mLineHeight; }

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -38,11 +38,8 @@ public:
 
 	ListBox();
 	~ListBox() override;
-	
-	void sorted(bool isSorted) { mSorted = isSorted; }
-	bool sorted(bool) const { return mSorted; }
 
-	void sort() { if (mSorted) { std::sort(mItems.begin(), mItems.end()); } }
+	void sort() { std::sort(mItems.begin(), mItems.end()); }
 
 	void textColor(const NAS2D::Color& color) { mText = color; }
 	void selectColor(const NAS2D::Color& color) { mHighlightBg = color; }
@@ -103,6 +100,4 @@ private:
 
 	SelectionChangedCallback mSelectionChanged; /**< Callback for selection changed callback. */
 	Slider mSlider;
-	
-	bool mSorted = false; /**< Flag indicating that all Items should be sorted. */
 };


### PR DESCRIPTION
Reference: #479

Remove feature where `ListBox` tries to resort the list when new items are added. This is a rather inefficient way to keep the list sorted. Instead, items should be pre-sorted before being added, or should all be added at once, and then sorted.

Curiously, removing most of this feature means the `FileIo` list box will now be sorted, where it wasn't sorted before. This is because it manually called `sort()`, which previously did nothing if the `sorted` property wasn't set to `true` first.
