### PR TITLE
Have Control::size for squares delegate to rectangle method

### DIFF
--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -89,9 +89,7 @@ void Control::size(NAS2D::Vector<float> newSize)
 
 void Control::size(float newSize)
 {
-	width(newSize);
-	height(newSize);
-	onSizeChanged();
+	size({newSize, newSize});
 }
 
 


### PR DESCRIPTION
This prevents raising `onSizeChanged` events multiple times. Previously the code would set `width` and `height` separately, which would each raise an `onSizeChanged` event, followed by a manual `onSizeChanged` event, resulting in 3 total `onSizeChanged` events. This update reduces that to a single `onSizeChanged` event.
