### PR TITLE
Fix CheckBox initialization order bug

### DIFF
--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -36,8 +36,8 @@ static Font* CBOX_FONT = nullptr;
  */
 CheckBox::CheckBox(std::string newText) : mSkin("ui/skin/checkbox.png")
 {
-	text(newText);
 	CBOX_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	text(newText);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &CheckBox::onMouseDown);
 }
 


### PR DESCRIPTION
The `Font` must be set before `text` is set, as the `text` setter uses the `Font` to calculate text size and set the `Control` size.

If the `text` was empty, the `Font::width` call would exit early and return 0, and so the `Font` member variables were never accessed, avoiding crashes. Hence why the bug wasn't caught earlier. A `CheckBox` control was being used in `MainMenuOptions` with no initial text set, and so `Font::width` was exiting before crashing and then the static `Font` variable was being initialized, preventing future possible crashes.
