### PR TITLE
Refactor comm tower range check

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -851,7 +851,7 @@ void MapViewState::placeRobot()
 	if (!tile) { return; }
 	if (!mRobotPool.robotCtrlAvailable()) { return; }
 	
-	if (outOfCommRange(tile->position()))
+	if (!inCommRange(tile->position()))
 	{
 		doAlertMessage(constants::ALERT_INVALID_ROBOT_PLACEMENT, constants::ALERT_OUT_OF_COMM_RANGE);
 		return;

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -851,7 +851,7 @@ void MapViewState::placeRobot()
 	if (!tile) { return; }
 	if (!mRobotPool.robotCtrlAvailable()) { return; }
 	
-	if (outOfCommRange(ccLocation(), mTileMap, tile))
+	if (outOfCommRange(tile->position()))
 	{
 		doAlertMessage(constants::ALERT_INVALID_ROBOT_PLACEMENT, constants::ALERT_OUT_OF_COMM_RANGE);
 		return;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -316,8 +316,7 @@ bool selfSustained(StructureID id)
 bool outOfCommRange(Point<int>& ccLocation, TileMap* tileMap, Tile* currentTile)
 {
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
-	const auto tile = tileMap->getVisibleTile();
-	const auto ccDistance = tile->position() - tileMap->getTile(ccLocation, 0)->position();
+	const auto ccDistance = currentTile->position() - tileMap->getTile(ccLocation, 0)->position();
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
 		return false;
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -320,7 +320,6 @@ bool outOfCommRange(Point<int>& cc_location, TileMap* tile_map, Tile* current_ti
 	if (tile->distanceTo(tile_map->getTile(cc_location, 0)) <= constants::ROBOT_COM_RANGE)
 		return false;
 
-	Tile* _comm_t = nullptr;
 	for (auto _tower : Utility<StructureManager>::get().structureList(Structure::StructureClass::CLASS_COMM))
 	{
 		if (!_tower->operational())
@@ -328,7 +327,7 @@ bool outOfCommRange(Point<int>& cc_location, TileMap* tile_map, Tile* current_ti
 			continue;
 		}
 
-		_comm_t = Utility<StructureManager>::get().tileFromStructure(_tower);
+		const auto _comm_t = Utility<StructureManager>::get().tileFromStructure(_tower);
 		if (_comm_t->distanceTo(current_tile) <= constants::COMM_TOWER_BASE_RANGE)
 		{
 			return false;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -315,8 +315,7 @@ bool selfSustained(StructureID id)
  */
 bool outOfCommRange(Point<int>& ccLocation, TileMap* tileMap, Tile* currentTile)
 {
-	Tile* tile = tileMap->getVisibleTile();
-
+	const auto tile = tileMap->getVisibleTile();
 	if (tile->distanceTo(tileMap->getTile(ccLocation, 0)) <= constants::ROBOT_COM_RANGE)
 		return false;
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -315,12 +315,12 @@ bool selfSustained(StructureID id)
  */
 bool outOfCommRange(Point<int>& ccLocation, TileMap* /*tileMap*/, Tile* currentTile)
 {
+	const auto currentPosition = currentTile->position();
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
-	const auto ccDistance = currentTile->position() - ccLocation;
+	const auto ccDistance = currentPosition - ccLocation;
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
 		return false;
 
-	const auto currentPosition = currentTile->position();
 	const auto maxTowerRangeSquared = constants::COMM_TOWER_BASE_RANGE * constants::COMM_TOWER_BASE_RANGE;
 	auto structureManager = Utility<StructureManager>::get();
 	for (auto tower : structureManager.structureList(Structure::StructureClass::CLASS_COMM))

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -315,9 +315,9 @@ bool selfSustained(StructureID id)
  */
 bool inCommRange(NAS2D::Point<int> position)
 {
-	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
+	const auto maxCCRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
 	const auto ccDistance = position - ccLocation();
-	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
+	if (ccDistance.lengthSquared() <= maxCCRangeSquared)
 	{
 		return true;
 	}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -320,14 +320,15 @@ bool outOfCommRange(Point<int>& cc_location, TileMap* tile_map, Tile* current_ti
 	if (tile->distanceTo(tile_map->getTile(cc_location, 0)) <= constants::ROBOT_COM_RANGE)
 		return false;
 
-	for (auto _tower : Utility<StructureManager>::get().structureList(Structure::StructureClass::CLASS_COMM))
+	auto structureManager = Utility<StructureManager>::get();
+	for (auto _tower : structureManager.structureList(Structure::StructureClass::CLASS_COMM))
 	{
 		if (!_tower->operational())
 		{
 			continue;
 		}
 
-		const auto _comm_t = Utility<StructureManager>::get().tileFromStructure(_tower);
+		const auto _comm_t = structureManager.tileFromStructure(_tower);
 		if (_comm_t->distanceTo(current_tile) <= constants::COMM_TOWER_BASE_RANGE)
 		{
 			return false;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -315,10 +315,14 @@ bool selfSustained(StructureID id)
  */
 bool outOfCommRange(Point<int>& ccLocation, TileMap* tileMap, Tile* currentTile)
 {
+	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
 	const auto tile = tileMap->getVisibleTile();
-	if (tile->distanceTo(tileMap->getTile(ccLocation, 0)) <= constants::ROBOT_COM_RANGE)
+	const auto ccDistance = tile->position() - tileMap->getTile(ccLocation, 0)->position();
+	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
 		return false;
 
+	const auto currentPosition = currentTile->position();
+	const auto maxTowerRangeSquared = constants::COMM_TOWER_BASE_RANGE * constants::COMM_TOWER_BASE_RANGE;
 	auto structureManager = Utility<StructureManager>::get();
 	for (auto tower : structureManager.structureList(Structure::StructureClass::CLASS_COMM))
 	{
@@ -328,7 +332,8 @@ bool outOfCommRange(Point<int>& ccLocation, TileMap* tileMap, Tile* currentTile)
 		}
 
 		const auto commTowerTile = structureManager.tileFromStructure(tower);
-		if (commTowerTile->distanceTo(currentTile) <= constants::COMM_TOWER_BASE_RANGE)
+		const auto towerDistance = currentPosition - commTowerTile->position();
+		if (towerDistance.lengthSquared() <= maxTowerRangeSquared)
 		{
 			return false;
 		}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -313,10 +313,10 @@ bool selfSustained(StructureID id)
 /** 
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool outOfCommRange(Point<int>& ccLocation, TileMap* tileMap, Tile* currentTile)
+bool outOfCommRange(Point<int>& ccLocation, TileMap* /*tileMap*/, Tile* currentTile)
 {
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
-	const auto ccDistance = currentTile->position() - tileMap->getTile(ccLocation, 0)->position();
+	const auto ccDistance = currentTile->position() - ccLocation;
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
 		return false;
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -313,12 +313,12 @@ bool selfSustained(StructureID id)
 /** 
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool outOfCommRange(NAS2D::Point<int> position)
+bool inCommRange(NAS2D::Point<int> position)
 {
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
 	const auto ccDistance = position - ccLocation();
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
-		return false;
+		return true;
 
 	const auto maxTowerRangeSquared = constants::COMM_TOWER_BASE_RANGE * constants::COMM_TOWER_BASE_RANGE;
 	auto structureManager = Utility<StructureManager>::get();
@@ -333,11 +333,11 @@ bool outOfCommRange(NAS2D::Point<int> position)
 		const auto towerDistance = position - commTowerTile->position();
 		if (towerDistance.lengthSquared() <= maxTowerRangeSquared)
 		{
-			return false;
+			return true;
 		}
 	}
 
-	return true;
+	return false;
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -313,23 +313,23 @@ bool selfSustained(StructureID id)
 /** 
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool outOfCommRange(Point<int>& cc_location, TileMap* tile_map, Tile* current_tile)
+bool outOfCommRange(Point<int>& ccLocation, TileMap* tileMap, Tile* currentTile)
 {
-	Tile* tile = tile_map->getVisibleTile();
+	Tile* tile = tileMap->getVisibleTile();
 
-	if (tile->distanceTo(tile_map->getTile(cc_location, 0)) <= constants::ROBOT_COM_RANGE)
+	if (tile->distanceTo(tileMap->getTile(ccLocation, 0)) <= constants::ROBOT_COM_RANGE)
 		return false;
 
 	auto structureManager = Utility<StructureManager>::get();
-	for (auto _tower : structureManager.structureList(Structure::StructureClass::CLASS_COMM))
+	for (auto tower : structureManager.structureList(Structure::StructureClass::CLASS_COMM))
 	{
-		if (!_tower->operational())
+		if (!tower->operational())
 		{
 			continue;
 		}
 
-		const auto _comm_t = structureManager.tileFromStructure(_tower);
-		if (_comm_t->distanceTo(current_tile) <= constants::COMM_TOWER_BASE_RANGE)
+		const auto commTowerTile = structureManager.tileFromStructure(tower);
+		if (commTowerTile->distanceTo(currentTile) <= constants::COMM_TOWER_BASE_RANGE)
 		{
 			return false;
 		}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -313,11 +313,10 @@ bool selfSustained(StructureID id)
 /** 
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool outOfCommRange(Point<int>& /*ccLocation*/, TileMap* /*tileMap*/, Tile* currentTile)
+bool outOfCommRange(NAS2D::Point<int> position)
 {
-	const auto currentPosition = currentTile->position();
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
-	const auto ccDistance = currentPosition - ccLocation();
+	const auto ccDistance = position - ccLocation();
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
 		return false;
 
@@ -331,7 +330,7 @@ bool outOfCommRange(Point<int>& /*ccLocation*/, TileMap* /*tileMap*/, Tile* curr
 		}
 
 		const auto commTowerTile = structureManager.tileFromStructure(tower);
-		const auto towerDistance = currentPosition - commTowerTile->position();
+		const auto towerDistance = position - commTowerTile->position();
 		if (towerDistance.lengthSquared() <= maxTowerRangeSquared)
 		{
 			return false;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -318,7 +318,9 @@ bool inCommRange(NAS2D::Point<int> position)
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
 	const auto ccDistance = position - ccLocation();
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
+	{
 		return true;
+	}
 
 	const auto maxTowerRangeSquared = constants::COMM_TOWER_BASE_RANGE * constants::COMM_TOWER_BASE_RANGE;
 	auto structureManager = Utility<StructureManager>::get();

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -313,11 +313,11 @@ bool selfSustained(StructureID id)
 /** 
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool outOfCommRange(Point<int>& ccLocation, TileMap* /*tileMap*/, Tile* currentTile)
+bool outOfCommRange(Point<int>& /*ccLocation*/, TileMap* /*tileMap*/, Tile* currentTile)
 {
 	const auto currentPosition = currentTile->position();
 	const auto maxCcRangeSquared = constants::ROBOT_COM_RANGE * constants::ROBOT_COM_RANGE;
-	const auto ccDistance = currentPosition - ccLocation;
+	const auto ccDistance = currentPosition - ccLocation();
 	if (ccDistance.lengthSquared() <= maxCcRangeSquared)
 		return false;
 

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -30,7 +30,7 @@ bool validStructurePlacement(TileMap* tilemap, NAS2D::Point<int> point);
 bool validLanderSite(Tile* t);
 bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position);
 bool structureIsLander(StructureID id);
-bool outOfCommRange(NAS2D::Point<int> position);
+bool inCommRange(NAS2D::Point<int> position);
 bool selfSustained(StructureID id);
 
 int totalStorage(StructureList& structures);

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -30,7 +30,7 @@ bool validStructurePlacement(TileMap* tilemap, NAS2D::Point<int> point);
 bool validLanderSite(Tile* t);
 bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position);
 bool structureIsLander(StructureID id);
-bool outOfCommRange(NAS2D::Point<int>& cc_location, TileMap* tile_map, Tile* current_tile);
+bool outOfCommRange(NAS2D::Point<int> position);
 bool selfSustained(StructureID id);
 
 int totalStorage(StructureList& structures);


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/pull/495#discussion_r452380541

Refactor `outOfCommRange` to use more efficient distance squared check, simplify the parameter list, and rename to `inCommRange` to represent a positive sounding boolean expression.

The distance squared check avoids calling an expensive square root function, and also managed to work entirely with `int`, thus avoiding conversion to `float`.
