### PR TITLE
Pixel aligned Controls

### DIFF
--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -134,7 +134,7 @@ private:
 	NAS2D::Point<int> mMapHighlight; /**< Tile the mouse is pointing to. */
 	NAS2D::Point<int> mMapViewLocation;
 
-	NAS2D::Point<float> mMapPosition; /** Where to start drawing the TileMap on the screen. */
+	NAS2D::Point<int> mMapPosition; /** Where to start drawing the TileMap on the screen. */
 
 	Point2dList mMineLocations; /**< Location of all mines on the map. */
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -205,8 +205,8 @@ void MainReportsUiState::initialize()
 	Panels[NavigationPanel::PANEL_SPACEPORT].Name = "Space Ports";
 
 	auto& renderer = Utility<Renderer>::get();
-	const auto size = renderer.size();
-	setPanelRects(static_cast<int>(size.x));
+	const auto size = renderer.size().to<int>();
+	setPanelRects(size.x);
 
 	// INIT UI REPORT PANELS
 	ReportInterface* factory_report = new FactoryReport();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -61,7 +61,7 @@ void MapViewState::initUi()
 	mStructureInspector.position(renderer.center() - NAS2D::Vector{mStructureInspector.width() / 2.0f, 175.0f});
 	mStructureInspector.hide();
 
-	mFactoryProduction.position({renderer.center_x() - mFactoryProduction.width() / 2.0f, 175.0f});
+	mFactoryProduction.position(NAS2D::Point{renderer.center_x() - mFactoryProduction.width() / 2.0f, 175.0f});
 	mFactoryProduction.hide();
 
 	mFileIoDialog.setMode(FileIo::FileOperation::FILE_SAVE);
@@ -104,22 +104,22 @@ void MapViewState::initUi()
 	// BUTTONS
 	mBtnTurns.image("ui/icons/turns.png");
 	mBtnTurns.position(NAS2D::Point{mMiniMapBoundingBox.x - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT, size.y - constants::MARGIN - MAIN_BUTTON_SIZE});
-	mBtnTurns.size(static_cast<float>(constants::MAIN_BUTTON_SIZE));
+	mBtnTurns.size(constants::MAIN_BUTTON_SIZE);
 	mBtnTurns.click().connect(this, &MapViewState::btnTurnsClicked);
 	mBtnTurns.enabled(false);
 
 	mBtnToggleHeightmap.image("ui/icons/height.png");
-	mBtnToggleHeightmap.size(static_cast<float>(constants::MAIN_BUTTON_SIZE));
+	mBtnToggleHeightmap.size(constants::MAIN_BUTTON_SIZE);
 	mBtnToggleHeightmap.type(Button::Type::BUTTON_TOGGLE);
 
 	mBtnToggleConnectedness.image("ui/icons/connection.png");
-	mBtnToggleConnectedness.size(static_cast<float>(constants::MAIN_BUTTON_SIZE));
+	mBtnToggleConnectedness.size(constants::MAIN_BUTTON_SIZE);
 	mBtnToggleConnectedness.type(Button::Type::BUTTON_TOGGLE);
 	mBtnToggleConnectedness.click().connect(this, &MapViewState::btnToggleConnectednessClicked);
 
 	// Menus
 	mRobots.sheetPath("ui/robots.png");
-	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, static_cast<float>(BOTTOM_UI_AREA.y + MARGIN)});
+	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mRobots.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 	mRobots.iconSize(46);
 	mRobots.iconMargin(constants::MARGIN_TIGHT);
@@ -127,7 +127,7 @@ void MapViewState::initUi()
 	mRobots.selectionChanged().connect(this, &MapViewState::robotsSelectionChanged);
 
 	mConnections.sheetPath("ui/structures.png");
-	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, static_cast<float>(BOTTOM_UI_AREA.y + MARGIN)});
+	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mConnections.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 	mConnections.iconSize(46);
 	mConnections.iconMargin(constants::MARGIN_TIGHT);
@@ -175,12 +175,12 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	// Position UI Buttons
 	mBtnTurns.position(NAS2D::Point{mMiniMapBoundingBox.x - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT, size.y - constants::MARGIN - MAIN_BUTTON_SIZE});
-	mBtnToggleHeightmap.position({mBtnTurns.positionX(), static_cast<float>(mMiniMapBoundingBox.y)});
-	mBtnToggleConnectedness.position({mBtnTurns.positionX(), static_cast<float>(mMiniMapBoundingBox.y + constants::MAIN_BUTTON_SIZE + constants::MARGIN_TIGHT)});
+	mBtnToggleHeightmap.position({mBtnTurns.positionX(), mMiniMapBoundingBox.y});
+	mBtnToggleConnectedness.position({mBtnTurns.positionX(), mMiniMapBoundingBox.y + constants::MAIN_BUTTON_SIZE + constants::MARGIN_TIGHT});
 
 	// UI Panels
-	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, static_cast<float>(BOTTOM_UI_AREA.y + MARGIN)});
-	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, static_cast<float>(BOTTOM_UI_AREA.y + MARGIN)});
+	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
+	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
 
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -115,13 +115,13 @@ void PlanetSelectState::initialize()
 	PLANET_TYPE_SELECTION = Planet::PlanetType::PLANET_TYPE_NONE;
 
 	mQuit.size({100, 20});
-	mQuit.position({renderer.width() - 105, 30});
+	mQuit.position({static_cast<int>(renderer.width()) - 105, 30});
 	mQuit.click().connect(this, &PlanetSelectState::btnQuitClicked);
 
 	mPlanetDescription.text("");
 	mPlanetDescription.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
 	mPlanetDescription.size({550, 200});
-	mPlanetDescription.position({renderer.center_x() - 275, renderer.height() - 225});
+	mPlanetDescription.position(NAS2D::Point{renderer.center_x() - 275, renderer.height() - 225});
 
 	renderer.showSystemPointer(true);
 	renderer.fadeIn(constants::FADE_SPEED);

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -67,20 +67,20 @@ void ComboBox::resizedHandler(Control* /*control*/)
 	lstItems.width(width());
 	lstItems.position(rect().crossYPoint());
 
-	mBaseArea = Rectangle<float>::Create(position(), NAS2D::Vector{width(), btnDown.height()});
+	mBaseArea = Rectangle<int>::Create(position(), NAS2D::Vector{width(), btnDown.height()});
 }
 
 
 /**
  * Position changed event handler.
  */
-void ComboBox::repositioned(float, float)
+void ComboBox::repositioned(int, int)
 {
 	txtField.position(position());
 	btnDown.position(txtField.rect().crossXPoint());
 	lstItems.position(rect().crossYPoint());
 
-	mBaseArea = Rectangle<float>::Create(position(), NAS2D::Vector{width(), btnDown.height()});
+	mBaseArea = Rectangle<int>::Create(position(), NAS2D::Vector{width(), btnDown.height()});
 }
 
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -43,7 +43,7 @@ private:
 	void init();
 
 	void resizedHandler(Control* control);
-	void repositioned(float, float);
+	void repositioned(int, int);
 	void lstItemsSelectionChanged();
 
 	void onMouseWheel(int x, int y);
@@ -54,7 +54,7 @@ private:
 	ListBox lstItems;
 	TextField txtField;
 
-	NAS2D::Rectangle<float> mBaseArea;
+	NAS2D::Rectangle<int> mBaseArea;
 
 	SelectionChanged mSelectionChanged;
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -11,7 +11,7 @@ using namespace NAS2D;
  * 
  * \param pos	2D Coordinate to position the Control at.
  */
-void Control::position(const Point<float>& pos)
+void Control::position(const Point<int>& pos)
 {
 	const auto displacement = pos - mRect.startPoint();
 	mRect.startPoint(pos);
@@ -22,7 +22,7 @@ void Control::position(const Point<float>& pos)
 /**
  * Gets the X Position of the Control.
  */
-float Control::positionX()
+int Control::positionX()
 {
 	return mRect.x;
 }
@@ -31,7 +31,7 @@ float Control::positionX()
 /**
  * Gets the Y Position of the Control.
  */
-float Control::positionY()
+int Control::positionY()
 {
 	return mRect.y;
 }
@@ -49,7 +49,7 @@ Control::PositionChangedCallback& Control::moved()
 /**
  * Gets the width of the Control
  */
-float Control::width() const
+int Control::width() const
 {
 	return mRect.width;
 }
@@ -58,20 +58,20 @@ float Control::width() const
 /**
  * Gets the height of the Control.
  */
-float Control::height() const
+int Control::height() const
 {
 	return mRect.height;
 }
 
 
-void Control::size(NAS2D::Vector<float> newSize)
+void Control::size(NAS2D::Vector<int> newSize)
 {
 	mRect.size(newSize);
 	onSizeChanged();
 }
 
 
-void Control::size(float newSize)
+void Control::size(int newSize)
 {
 	size({newSize, newSize});
 }
@@ -83,7 +83,7 @@ void Control::size(float newSize)
  * \note	This is an internal function and may not be
  *			called outside of the Control class.
  */
-void Control::width(float w)
+void Control::width(int w)
 {
 	mRect.width = w;
 	onSizeChanged();
@@ -96,7 +96,7 @@ void Control::width(float w)
  * \note	This is an internal function and may not be
  *			called outside of the Control class.
  */
-void Control::height(float h)
+void Control::height(int h)
 {
 	mRect.height = h;
 	onSizeChanged();
@@ -114,7 +114,7 @@ Control::ResizeCallback& Control::resized()
  * 
  * \return	A const reference to a Rectangle<int> object.
  */
-const Rectangle<float>& Control::rect() const
+const Rectangle<int>& Control::rect() const
 {
 	return mRect;
 }

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -19,17 +19,17 @@ class Control
 public:
 	using ResizeCallback = NAS2D::Signals::Signal<Control*>;
 	using TextChangedCallback = NAS2D::Signals::Signal<Control*>;
-	using PositionChangedCallback = NAS2D::Signals::Signal<float, float>;
+	using PositionChangedCallback = NAS2D::Signals::Signal<int, int>;
 
 public:
 	Control() = default;
 	virtual ~Control() = default;
 
-	NAS2D::Point<float> position() const { return mRect.startPoint(); }
-	void position(const NAS2D::Point<float>& pos);
+	NAS2D::Point<int> position() const { return mRect.startPoint(); }
+	void position(const NAS2D::Point<int>& pos);
 
-	float positionX();
-	float positionY();
+	int positionX();
+	int positionY();
 
 	PositionChangedCallback& moved();
 
@@ -45,7 +45,7 @@ public:
 	virtual void hide() { visible(false); }
 	virtual void show() { visible(true); }
 
-	const NAS2D::Rectangle<float>& rect() const;
+	const NAS2D::Rectangle<int>& rect() const;
 
 	virtual void hasFocus(bool focus);
 	bool hasFocus() const;
@@ -54,15 +54,15 @@ public:
 	const std::string& text() const { return mText; }
 	TextChangedCallback& textChanged() { return mTextChanged; }
 
-	NAS2D::Vector<float> size() const { return mRect.size(); }
-	void size(NAS2D::Vector<float> newSize);
-	void size(float newSize);
+	NAS2D::Vector<int> size() const { return mRect.size(); }
+	void size(NAS2D::Vector<int> newSize);
+	void size(int newSize);
 
-	void width(float w);
-	void height(float h);
+	void width(int w);
+	void height(int h);
 
-	float width() const;
-	float height() const;
+	int width() const;
+	int height() const;
 
 	ResizeCallback& resized();
 
@@ -75,8 +75,8 @@ protected:
 	 * \param	dX	Difference in X Position.
 	 * \param	dY	Difference in Y Position.
 	 */
-	virtual void positionChanged(float dX, float dY) { mPositionChanged(dX, dY); }
-	void positionChanged(NAS2D::Vector<float> displacement) { positionChanged(displacement.x, displacement.y); }
+	virtual void positionChanged(int dX, int dY) { mPositionChanged(dX, dY); }
+	void positionChanged(NAS2D::Vector<int> displacement) { positionChanged(displacement.x, displacement.y); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}
 
@@ -92,7 +92,7 @@ protected:
 	ResizeCallback mResized;
 	TextChangedCallback mTextChanged;
 
-	NAS2D::Rectangle<float> mRect; /**< Area of the Control. */
+	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */
 
 private:
 	virtual void draw() {}

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -72,7 +72,7 @@ void ListBoxBase::visibilityChanged(bool)
  */
 void ListBoxBase::_update_item_display()
 {
-	mItemWidth = static_cast<unsigned int>(width());
+	mItemWidth = width();
 
 	if ((mItemHeight * mItems.size()) > static_cast<std::size_t>(height()))
 	{
@@ -175,7 +175,7 @@ void ListBoxBase::onMouseWheel(int /*x*/, int y)
 	if (!visible()) { return; }
 	if (!mHasFocus) { return; }
 
-	float change = static_cast<float>(mItemHeight);
+	float change = mItemHeight;
 
 	mSlider.changeThumbPosition((y < 0 ? change : -change));
 }
@@ -189,9 +189,9 @@ void ListBoxBase::slideChanged(float newPosition)
 	_update_item_display();
 	// Intentional truncation of fractional value
 	int pos = static_cast<int>(newPosition);
-	if (static_cast<float>(pos) != newPosition)
+	if (pos != newPosition)
 	{
-		mSlider.thumbPosition(static_cast<float>(pos));
+		mSlider.thumbPosition(pos);
 	}
 }
 
@@ -322,15 +322,15 @@ void ListBoxBase::update()
 	auto& renderer = Utility<Renderer>::get();
 
 	// CONTROL EXTENTS
-	const auto backgroundRect = NAS2D::Rectangle{mRect.x, mRect.y, static_cast<float>(mItemWidth), mRect.height};
+	const auto backgroundRect = NAS2D::Rectangle{mRect.x, mRect.y, mItemWidth, mRect.height};
 	renderer.drawBoxFilled(backgroundRect, NAS2D::Color::Black);
 	renderer.drawBox(backgroundRect, (hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75}));
 
 	renderer.clipRect(mRect);
 
 	// MOUSE HIGHLIGHT
-	float highlight_y = positionY() + static_cast<float>((mCurrentHighlight * mItemHeight) - mCurrentOffset);
-	renderer.drawBoxFilled({positionX(), highlight_y, static_cast<float>(mItemWidth), static_cast<float>(mItemHeight)}, NAS2D::Color{0, 185, 0, 50});
+	int highlight_y = positionY() + (mCurrentHighlight * mItemHeight) - mCurrentOffset;
+	renderer.drawBoxFilled(NAS2D::Rectangle{positionX(), highlight_y, mItemWidth, mItemHeight}, NAS2D::Color{0, 185, 0, 50});
 
 	mSlider.update();
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -76,9 +76,9 @@ void ListBoxBase::_update_item_display()
 
 	if ((mItemHeight * mItems.size()) > static_cast<std::size_t>(height()))
 	{
-		mLineCount = static_cast<int>(height() / mItemHeight);
+		mLineCount = height() / mItemHeight;
 
-		if (mLineCount < mItems.size())
+		if (static_cast<std::size_t>(mLineCount) < mItems.size())
 		{
 			mSlider.position({rect().x + mRect.width - 14, mRect.y});
 			mSlider.size({14, mRect.height});

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -106,9 +106,9 @@ private:
 	unsigned int mCurrentSelection = constants::NO_SELECTION; /**< Current selection index. */
 	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
 
-	unsigned int mItemHeight = 1; /**< Height of a ListBoxItem. */
-	unsigned int mItemWidth = 0; /**< Width of a ListBoxItem. */
-	unsigned int mLineCount = 0; /**< Number of lines that can be displayed. */
+	int mItemHeight = 1; /**< Height of a ListBoxItem. */
+	int mItemWidth = 0; /**< Width of a ListBoxItem. */
+	int mLineCount = 0; /**< Number of lines that can be displayed. */
 
 	bool mHasFocus = false;
 

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -160,7 +160,7 @@ void Slider::positionInternal(float newPosition)
 }
 
 
-void Slider::_buttonCheck(bool& buttonFlag, Rectangle<float>& rect, float value)
+void Slider::_buttonCheck(bool& buttonFlag, Rectangle<int>& rect, float value)
 {
 	if (rect.to<int>().contains(mMousePosition))
 	{
@@ -334,20 +334,20 @@ void Slider::draw()
 	if (mSliderType == SliderType::Vertical)
 	{
 		// Fractional value can be dropped to avoid 'fuzzy' rendering due to texture filtering
-		const auto i = std::floor(mSlideBar.height / mLength);
+		const auto i = static_cast<int>(mSlideBar.height / mLength);
 		const auto newSize = std::max(i, mSlider.width);
 
-		const auto relativeThumbPosition = (mSlideBar.height - mSlider.height) * (mPosition / mLength); //relative width
+		const auto relativeThumbPosition = static_cast<int>((mSlideBar.height - mSlider.height) * (mPosition / mLength)); //relative width
 
 		mSlider = {mSlideBar.x, mSlideBar.y + relativeThumbPosition, mSlideBar.width, newSize};
 	}
 	else
 	{
 		// Fractional value can be dropped to avoid 'fuzzy' rendering due to texture filtering
-		const auto i = std::floor(mSlideBar.width / (mLength + 1.0f));
+		const auto i = static_cast<int>(mSlideBar.width / (mLength + 1.0f));
 		const auto newSize = std::max(i, mSlider.height);
 
-		const auto relativeThumbPosition = (mSlideBar.width - mSlider.width) * (mPosition / mLength); //relative width
+		const auto relativeThumbPosition = static_cast<int>((mSlideBar.width - mSlider.width) * (mPosition / mLength)); //relative width
 
 		mSlider = {mSlideBar.x + relativeThumbPosition, mSlideBar.y, newSize, mSlideBar.height};
 	}

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -71,7 +71,7 @@ private:
 	void draw() override; /*!< Draw the widget on screen. */
 	void logic(); /*!< Compute some values before drawing the control. */
 
-	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle<float>& rect, float value);
+	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle<int>& rect, float value);
 
 private:
 	NAS2D::Timer mTimer;
@@ -106,8 +106,8 @@ private:
 	NAS2D::ImageList mSkinSlider; /*!< Skin for the slider. */
 	bool mDisplayPosition = false; /*!< Indicate if the slider display the value on mouse over. */
 	
-	NAS2D::Rectangle<float> mButton1; /*!< Area on screen where the second button is displayed. (Down/Left) */
-	NAS2D::Rectangle<float> mButton2; /*!< Area on screen where the first button is displayed. (Up/Right)*/
-	NAS2D::Rectangle<float> mSlideBar; /*!< Area on screen where the slide area is displayed. */
-	NAS2D::Rectangle<float> mSlider; /*!< Area on screen where the slider is displayed. */
+	NAS2D::Rectangle<int> mButton1; /*!< Area on screen where the second button is displayed. (Down/Left) */
+	NAS2D::Rectangle<int> mButton2; /*!< Area on screen where the first button is displayed. (Up/Right)*/
+	NAS2D::Rectangle<int> mSlideBar; /*!< Area on screen where the slide area is displayed. */
+	NAS2D::Rectangle<int> mSlider; /*!< Area on screen where the slider is displayed. */
 };

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -26,8 +26,9 @@ void TextArea::processString()
 	if (width() < 10 || !mFont || text().empty()) { return; }
 
 	StringList tokenList = split_string(text().c_str(), ' ');
-	
-	std::size_t w = 0, i = 0;
+
+	std::size_t i = 0;
+	int w = 0;
 	while (i < tokenList.size())
 	{
 		std::string line;

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -268,8 +268,8 @@ void TextField::drawCursor()
 			// updateCursor() should be called only on events relating to the cursor so this is temporary.
 			updateCursor();
 			auto& renderer = Utility<Renderer>::get();
-			const auto startPosition = NAS2D::Point{static_cast<float>(mCursorX), mRect.y + FIELD_PADDING};
-			const auto endPosition = NAS2D::Point{static_cast<float>(mCursorX), mRect.y + mRect.height - FIELD_PADDING - 1};
+			const auto startPosition = NAS2D::Point{mCursorX, mRect.y + FIELD_PADDING};
+			const auto endPosition = NAS2D::Point{mCursorX, mRect.y + mRect.height - FIELD_PADDING - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);
 			renderer.drawLine(startPosition, endPosition, NAS2D::Color::White);
 		}

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -105,7 +105,7 @@ void UIContainer::visibilityChanged(bool visible)
 /**
  * 
  */
-void UIContainer::positionChanged(float dX, float dY)
+void UIContainer::positionChanged(int dX, int dY)
 {
 	Control::positionChanged(dX, dY);
 

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -27,7 +27,7 @@ public:
 	std::vector<Control*> controls() const;
 protected:
 	void visibilityChanged(bool visible) override;
-	void positionChanged(float dX, float dY) override;
+	void positionChanged(int dX, int dY) override;
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -23,7 +23,7 @@ protected:
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseMove(int x, int y, int dX, int dY);
 
-	static inline constexpr float sWindowTitleBarHeight = 20.0f;
+	static inline constexpr int sWindowTitleBarHeight = 20;
 
 private:
 	void _init();

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -213,7 +213,7 @@ void FactoryProduction::update()
 	Window::update();
 
 	StringTable stringTable(2, 5);
-	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{ constants::MARGIN * 2 + mProductGrid.width(), 25 });
+	stringTable.position(mRect.startPoint() + NAS2D::Vector{constants::MARGIN * 2 + mProductGrid.width(), 25});
 	stringTable.setColumnJustification(1, StringTable::Justification::Right);
 
 	stringTable.setColumnText(0,

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -204,7 +204,7 @@ void IconGrid::addItem(const std::string& name, int sheetIndex, int meta)
 	IconGrid::IconGridItem& _item = mIconItemList.back();
 
 	_item.name = name;
-	_item.pos = {static_cast<float>(x_pos), static_cast<float>(y_pos)};
+	_item.pos = {x_pos, y_pos};
 	_item.meta = meta;
 }
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -39,7 +39,7 @@ public:
 	protected:
 		friend class IconGrid;
 
-		NAS2D::Point<float> pos;
+		NAS2D::Point<int> pos;
 	};
 
 	using Callback = NAS2D::Signals::Signal<const IconGridItem*>;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -18,8 +18,8 @@ using namespace NAS2D;
 
 static float SORT_BY_PRODUCT_POSITION = 0;
 
-static Rectangle<float> FACTORY_LISTBOX;
-static Rectangle<float> DETAIL_PANEL;
+static Rectangle<int> FACTORY_LISTBOX;
+static Rectangle<int> DETAIL_PANEL;
 
 static Font* FONT = nullptr;
 static Font* FONT_BOLD = nullptr;
@@ -339,7 +339,7 @@ void FactoryReport::resized(Control* /*c*/)
 		rect().y + mRect.height - 69
 	};
 
-	float position_x = mRect.width - 150.0f;
+	int position_x = mRect.width - 150;
 	btnIdle.position({position_x, btnIdle.positionY()});
 	btnClearProduction.position({position_x, btnClearProduction.positionY()});
 	btnTakeMeThere.position({position_x, btnTakeMeThere.positionY()});

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -338,9 +338,9 @@ void WarehouseReport::_resized(Control*)
 {
 	lstStructures.size({(width() / 2) - 20, height() - 126});
 	lstProducts.size({(width() / 2) - 20, height() - 184});
-	lstProducts.position({Utility<Renderer>::get().center_x() + 10, lstProducts.positionY()});
+	lstProducts.position({static_cast<int>(Utility<Renderer>::get().center_x()) + 10, lstProducts.positionY()});
 
-	btnTakeMeThere.position({Utility<Renderer>::get().width() - 150, positionY() + 35});
+	btnTakeMeThere.position({static_cast<int>(Utility<Renderer>::get().width()) - 150, positionY() + 35});
 
 	CAPACITY_BAR_WIDTH = static_cast<int>(width() / 2) - 30 - FONT_MED_BOLD->width("Capacity Used");
 	CAPACITY_BAR_POSITION_X = 20 + FONT_MED_BOLD->width("Capacity Used");

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -32,12 +32,12 @@ void StringTable::draw(NAS2D::Renderer& renderer) const
 	}
 }
 
-void StringTable::position(NAS2D::Point<float> position)
+void StringTable::position(NAS2D::Point<int> position)
 {
 	this->mPosition = position;
 }
 
-NAS2D::Point<float> StringTable::position() const
+NAS2D::Point<int> StringTable::position() const
 {
 	return mPosition;
 }

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -40,8 +40,8 @@ public:
 
 	void draw(NAS2D::Renderer& renderer) const;
 
-	void position(NAS2D::Point<float> position);
-	NAS2D::Point<float> position() const;
+	void position(NAS2D::Point<int> position);
+	NAS2D::Point<int> position() const;
 
 	void setDefaultFont(NAS2D::Font& font);
 	void setDefaultTitleFont(NAS2D::Font* font);
@@ -68,7 +68,7 @@ private:
 	std::vector<CellWithPosition> mCells;
 	const std::size_t mColumnCount;
 	const std::size_t mRowCount;
-	NAS2D::Point<float> mPosition;
+	NAS2D::Point<int> mPosition;
 	NAS2D::Font* mDefaultFont;
 	NAS2D::Font* mDefaultTitleFont;
 	NAS2D::Color mDefaultTextColor = NAS2D::Color::White;


### PR DESCRIPTION
Closes #434

Convert `Control` `position` and `size` from `float` to `int`. This enforces pixel level alignment of controls, which should prevent fuzzing `Control` borders and text.
