### PR TITLE
Planet type to scoped enum

### DIFF
--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -21,19 +21,19 @@ Planet::Planet(PlanetType type) : mType(type)
 	// Fixme: This should be in a table vs. a giant switch statement.
 	switch (mType)
 	{
-	case PlanetType::PLANET_TYPE_MERCURY:
+	case PlanetType::Mercury:
 		mImage = NAS2D::Image(constants::PLANET_TYPE_MERCURY_PATH);
 		mMaxMines = 10;
 		mMaxDigDepth = 1;
 		break;
 
-	case PlanetType::PLANET_TYPE_MARS:
+	case PlanetType::Mars:
 		mImage = NAS2D::Image(constants::PLANET_TYPE_MARS_PATH);
 		mMaxMines = 30;
 		mMaxDigDepth = 4;
 		break;
 
-	case PlanetType::PLANET_TYPE_GANYMEDE:
+	case PlanetType::Ganymede:
 		mMaxMines = 15;
 		mMaxDigDepth = 2;
 		mImage = NAS2D::Image(constants::PLANET_TYPE_GANYMEDE_PATH);

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -17,13 +17,13 @@ class Planet
 public:
 	enum class PlanetType
 	{
-		PLANET_TYPE_NONE,
+		None,
 
-		PLANET_TYPE_MERCURY,
-		PLANET_TYPE_MARS,
-		PLANET_TYPE_GANYMEDE,
+		Mercury,
+		Mars,
+		Ganymede,
 
-		PLANET_TYPE_COUNT
+		Count
 	};
 
 public:
@@ -67,7 +67,7 @@ private:
 	NAS2D::Image mImage;
 	NAS2D::Point<int> mPosition;
 
-	PlanetType mType = PlanetType::PLANET_TYPE_NONE;
+	PlanetType mType = PlanetType::None;
 
 	MouseCallback mMouseEnterCallback;
 	MouseCallback mMouseExitCallback;

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -15,7 +15,7 @@
 class Planet
 {
 public:
-	enum PlanetType
+	enum class PlanetType
 	{
 		PLANET_TYPE_NONE,
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -15,7 +15,7 @@
 
 using namespace NAS2D;
 
-Planet::PlanetType PLANET_TYPE_SELECTION = Planet::PlanetType::PLANET_TYPE_NONE;
+Planet::PlanetType PLANET_TYPE_SELECTION = Planet::PlanetType::None;
 
 static Font* FONT = nullptr;
 static Font* FONT_BOLD = nullptr;
@@ -94,9 +94,9 @@ void PlanetSelectState::initialize()
 	e.mouseMotion().connect(this, &PlanetSelectState::onMouseMove);
 	e.windowResized().connect(this, &PlanetSelectState::onWindowResized);
 
-	mPlanets.push_back(new Planet(Planet::PlanetType::PLANET_TYPE_MERCURY));
-	mPlanets.push_back(new Planet(Planet::PlanetType::PLANET_TYPE_MARS));
-	mPlanets.push_back(new Planet(Planet::PlanetType::PLANET_TYPE_GANYMEDE));
+	mPlanets.push_back(new Planet(Planet::PlanetType::Mercury));
+	mPlanets.push_back(new Planet(Planet::PlanetType::Mars));
+	mPlanets.push_back(new Planet(Planet::PlanetType::Ganymede));
 
 	auto& renderer = Utility<Renderer>::get();
 	const auto viewportSize = renderer.size().to<int>();
@@ -112,7 +112,7 @@ void PlanetSelectState::initialize()
 	mPlanets[2]->mouseEnter().connect(this, &PlanetSelectState::onMousePlanetEnter);
 	mPlanets[2]->mouseExit().connect(this, &PlanetSelectState::onMousePlanetExit);
 
-	PLANET_TYPE_SELECTION = Planet::PlanetType::PLANET_TYPE_NONE;
+	PLANET_TYPE_SELECTION = Planet::PlanetType::None;
 
 	mQuit.size({100, 20});
 	mQuit.position({renderer.width() - 105, 30});
@@ -182,7 +182,7 @@ State* PlanetSelectState::update()
 	{
 		return this;
 	}
-	else if (PLANET_TYPE_SELECTION != Planet::PlanetType::PLANET_TYPE_NONE)
+	else if (PLANET_TYPE_SELECTION != Planet::PlanetType::None)
 	{
 		std::string map, tileset;
 		int dig_depth = 0, max_mines = 0;
@@ -190,7 +190,7 @@ State* PlanetSelectState::update()
 
 		switch (PLANET_TYPE_SELECTION)
 		{
-		case Planet::PlanetType::PLANET_TYPE_MERCURY:
+		case Planet::PlanetType::Mercury:
 			map = "maps/merc_01";
 			tileset = "tsets/mercury.png";
 			dig_depth = mPlanets[0]->digDepth();
@@ -198,7 +198,7 @@ State* PlanetSelectState::update()
 			hostility = constants::PlanetHostility::HOSTILITY_HIGH;
 			break;
 
-		case Planet::PlanetType::PLANET_TYPE_MARS:
+		case Planet::PlanetType::Mars:
 			map = "maps/mars_04";
 			tileset = "tsets/mars.png";
 			dig_depth = mPlanets[1]->digDepth();
@@ -206,7 +206,7 @@ State* PlanetSelectState::update()
 			hostility = constants::PlanetHostility::HOSTILITY_LOW;
 			break;
 
-		case Planet::PlanetType::PLANET_TYPE_GANYMEDE:
+		case Planet::PlanetType::Ganymede:
 			map = "maps/ganymede_01";
 			tileset = "tsets/ganymede.png";
 			dig_depth = mPlanets[2]->digDepth();
@@ -265,9 +265,9 @@ void PlanetSelectState::onMousePlanetEnter()
 		// FIXME: Ugly, will be difficult to maintain in the future.
 		if (mPlanets[i]->mouseHovering())
 		{
-			if (mPlanets[i]->type() == Planet::PlanetType::PLANET_TYPE_GANYMEDE) { mPlanetDescription.text(constants::PLANET_DESCRIPTION_GANYMEDE); }
-			if (mPlanets[i]->type() == Planet::PlanetType::PLANET_TYPE_MARS) { mPlanetDescription.text(constants::PLANET_DESCRIPTION_MARS); }
-			if (mPlanets[i]->type() == Planet::PlanetType::PLANET_TYPE_MERCURY) { mPlanetDescription.text(constants::PLANET_DESCRIPTION_MERCURY); }
+			if (mPlanets[i]->type() == Planet::PlanetType::Ganymede) { mPlanetDescription.text(constants::PLANET_DESCRIPTION_GANYMEDE); }
+			if (mPlanets[i]->type() == Planet::PlanetType::Mars) { mPlanetDescription.text(constants::PLANET_DESCRIPTION_MARS); }
+			if (mPlanets[i]->type() == Planet::PlanetType::Mercury) { mPlanetDescription.text(constants::PLANET_DESCRIPTION_MERCURY); }
 		}
 	}
 }


### PR DESCRIPTION
Since PlanetType is a member of Planet, I thought about renaming it just Type, but thought that might be too generic. IE you would call `Planet::Type::Ganymede`.

There are a couple of variables with PLANET_TYPE still in their names, but I didn't change them out as it looked like the changeset would start growing and I wasn't sure it was appropriate at this refactor.