### PR TITLE
Planet hostility scoped enum

### DIFF
--- a/OPHD/Constants/Numbers.h
+++ b/OPHD/Constants/Numbers.h
@@ -44,13 +44,4 @@ namespace constants
 	const int ROBOT_COM_RANGE = 15;
 	const int COMM_TOWER_BASE_RANGE = 10;
 	const int LANDER_COM_RANGE = 5;
-
-	enum class PlanetHostility
-	{
-		None,
-
-		Low,
-		Medium,
-		High
-	};
 }

--- a/OPHD/Constants/Numbers.h
+++ b/OPHD/Constants/Numbers.h
@@ -47,10 +47,10 @@ namespace constants
 
 	enum class PlanetHostility
 	{
-		HOSTILITY_NONE,
+		None,
 
-		HOSTILITY_LOW,
-		HOSTILITY_MEDIUM,
-		HOSTILITY_HIGH
+		Low,
+		Medium,
+		High
 	};
 }

--- a/OPHD/Constants/Numbers.h
+++ b/OPHD/Constants/Numbers.h
@@ -45,7 +45,7 @@ namespace constants
 	const int COMM_TOWER_BASE_RANGE = 10;
 	const int LANDER_COM_RANGE = 5;
 
-	enum PlanetHostility
+	enum class PlanetHostility
 	{
 		HOSTILITY_NONE,
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -39,9 +39,9 @@ const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 /** Tuple indicates percent of mines that should be of yields LOW, MED, HIGH */
 const std::map<constants::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
 {
-	{ constants::PlanetHostility::HOSTILITY_LOW, {0.30f, 0.50f, 0.20f} },
-	{ constants::PlanetHostility::HOSTILITY_MEDIUM, {0.45f, 0.35f, 0.20f} },
-	{ constants::PlanetHostility::HOSTILITY_HIGH, {0.35f, 0.20f, 0.45f} },
+	{ constants::PlanetHostility::Low, {0.30f, 0.50f, 0.20f} },
+	{ constants::PlanetHostility::Medium, {0.45f, 0.35f, 0.20f} },
+	{ constants::PlanetHostility::High, {0.35f, 0.20f, 0.45f} },
 };
 
 
@@ -187,7 +187,7 @@ void TileMap::buildTerrainMap(const std::string& path)
  */
 void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
 {
-	if (hostility == constants::PlanetHostility::HOSTILITY_NONE) { return; }
+	if (hostility == constants::PlanetHostility::None) { return; }
 
 	int yieldLow = mineCount * HostilityMineYieldTable.at(hostility)[0];
 	int yieldMedium = mineCount * HostilityMineYieldTable.at(hostility)[1];

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -37,11 +37,11 @@ const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
 
 /** Tuple indicates percent of mines that should be of yields LOW, MED, HIGH */
-const std::map<Planet::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
+const std::map<Planet::Hostility, std::array<float, 3>> HostilityMineYieldTable =
 {
-	{ Planet::PlanetHostility::Low, {0.30f, 0.50f, 0.20f} },
-	{ Planet::PlanetHostility::Medium, {0.45f, 0.35f, 0.20f} },
-	{ Planet::PlanetHostility::High, {0.35f, 0.20f, 0.45f} },
+	{ Planet::Hostility::Low, {0.30f, 0.50f, 0.20f} },
+	{ Planet::Hostility::Medium, {0.45f, 0.35f, 0.20f} },
+	{ Planet::Hostility::High, {0.35f, 0.20f, 0.45f} },
 };
 
 
@@ -89,7 +89,7 @@ static void addMineSet(Point<int> suggestedMineLocation, Point2dList& plist, Til
 /**
  * C'tor
  */
-TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::PlanetHostility hostility, bool shouldSetupMines) :
+TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
 	mWidth(MAP_WIDTH),
 	mHeight(MAP_HEIGHT),
 	mMaxDepth(maxDepth),
@@ -185,9 +185,9 @@ void TileMap::buildTerrainMap(const std::string& path)
 /**
  * Creates mining locations around the map area.
  */
-void TileMap::setupMines(int mineCount, Planet::PlanetHostility hostility)
+void TileMap::setupMines(int mineCount, Planet::Hostility hostility)
 {
-	if (hostility == Planet::PlanetHostility::None) { return; }
+	if (hostility == Planet::Hostility::None) { return; }
 
 	int yieldLow = mineCount * HostilityMineYieldTable.at(hostility)[0];
 	int yieldMedium = mineCount * HostilityMineYieldTable.at(hostility)[1];

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -37,11 +37,11 @@ const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
 
 /** Tuple indicates percent of mines that should be of yields LOW, MED, HIGH */
-const std::map<constants::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
+const std::map<Planet::PlanetHostility, std::array<float, 3>> HostilityMineYieldTable =
 {
-	{ constants::PlanetHostility::Low, {0.30f, 0.50f, 0.20f} },
-	{ constants::PlanetHostility::Medium, {0.45f, 0.35f, 0.20f} },
-	{ constants::PlanetHostility::High, {0.35f, 0.20f, 0.45f} },
+	{ Planet::PlanetHostility::Low, {0.30f, 0.50f, 0.20f} },
+	{ Planet::PlanetHostility::Medium, {0.45f, 0.35f, 0.20f} },
+	{ Planet::PlanetHostility::High, {0.35f, 0.20f, 0.45f} },
 };
 
 
@@ -89,7 +89,7 @@ static void addMineSet(Point<int> suggestedMineLocation, Point2dList& plist, Til
 /**
  * C'tor
  */
-TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, constants::PlanetHostility hostility, bool shouldSetupMines) :
+TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::PlanetHostility hostility, bool shouldSetupMines) :
 	mWidth(MAP_WIDTH),
 	mHeight(MAP_HEIGHT),
 	mMaxDepth(maxDepth),
@@ -185,9 +185,9 @@ void TileMap::buildTerrainMap(const std::string& path)
 /**
  * Creates mining locations around the map area.
  */
-void TileMap::setupMines(int mineCount, constants::PlanetHostility hostility)
+void TileMap::setupMines(int mineCount, Planet::PlanetHostility hostility)
 {
-	if (hostility == constants::PlanetHostility::None) { return; }
+	if (hostility == Planet::PlanetHostility::None) { return; }
 
 	int yieldLow = mineCount * HostilityMineYieldTable.at(hostility)[0];
 	int yieldMedium = mineCount * HostilityMineYieldTable.at(hostility)[1];

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -29,7 +29,7 @@ public:
 	};
 
 public:
-	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::PlanetHostility hostility /*= constants::PlanetHostility::None*/, bool setupMines = true);
+	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility /*= constants::Hostility::None*/, bool setupMines = true);
 	~TileMap() override;
 
 	Tile* getTile(NAS2D::Point<int> position, int level);
@@ -107,7 +107,7 @@ private:
 private:
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
-	void setupMines(int, Planet::PlanetHostility);
+	void setupMines(int, Planet::Hostility);
 
 	void updateTileHighlight();
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -28,7 +28,7 @@ public:
 	};
 
 public:
-	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, constants::PlanetHostility hostility /*= constants::PlanetHostility::HOSTILITY_NONE*/, bool setupMines = true);
+	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, constants::PlanetHostility hostility /*= constants::PlanetHostility::None*/, bool setupMines = true);
 	~TileMap() override;
 
 	Tile* getTile(NAS2D::Point<int> position, int level);

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -2,6 +2,7 @@
 
 #include "Tile.h"
 
+#include "../States/Planet.h"
 #include "../Things/Structures/Structure.h"
 #include "../MicroPather/micropather.h"
 
@@ -28,7 +29,7 @@ public:
 	};
 
 public:
-	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, constants::PlanetHostility hostility /*= constants::PlanetHostility::None*/, bool setupMines = true);
+	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::PlanetHostility hostility /*= constants::PlanetHostility::None*/, bool setupMines = true);
 	~TileMap() override;
 
 	Tile* getTile(NAS2D::Point<int> position, int level);
@@ -106,7 +107,7 @@ private:
 private:
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
-	void setupMines(int, constants::PlanetHostility);
+	void setupMines(int, Planet::PlanetHostility);
 
 	void updateTileHighlight();
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -93,7 +93,7 @@ MapViewState::MapViewState(const std::string& savegame) :
  * \param	d	Depth of the site map.
  * \param	mc	Mine Count - Number of mines to generate.
  */
-MapViewState::MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, Planet::PlanetHostility hostility) :
+MapViewState::MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, Planet::Hostility hostility) :
 	mTileMap(new TileMap(siteMap, tileSet, depth, mineCount, hostility)),
 	mBackground("sys/bg1.png"),
 	mMapDisplay(siteMap + MAP_DISPLAY_EXTENSION),

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -93,7 +93,7 @@ MapViewState::MapViewState(const std::string& savegame) :
  * \param	d	Depth of the site map.
  * \param	mc	Mine Count - Number of mines to generate.
  */
-MapViewState::MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, constants::PlanetHostility hostility) :
+MapViewState::MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, Planet::PlanetHostility hostility) :
 	mTileMap(new TileMap(siteMap, tileSet, depth, mineCount, hostility)),
 	mBackground("sys/bg1.png"),
 	mMapDisplay(siteMap + MAP_DISPLAY_EXTENSION),

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -7,6 +7,7 @@
 #include "MainReportsUiState.h"
 #include "Wrapper.h"
 
+#include "Planet.h"
 #include "../Common.h"
 #include "../Constants.h"
 
@@ -61,7 +62,7 @@ public:
 
 public:
 	MapViewState(const std::string& savegame);
-	MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, constants::PlanetHostility hostility);
+	MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, Planet::PlanetHostility hostility);
 	~MapViewState() override;
 
 	void setPopulationLevel(PopulationLevel popLevel);

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -62,7 +62,7 @@ public:
 
 public:
 	MapViewState(const std::string& savegame);
-	MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, Planet::PlanetHostility hostility);
+	MapViewState(const std::string& siteMap, const std::string& tileSet, int depth, int mineCount, Planet::Hostility hostility);
 	~MapViewState() override;
 
 	void setPopulationLevel(PopulationLevel popLevel);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -157,7 +157,7 @@ void MapViewState::load(const std::string& filePath)
 
 	mMapDisplay = Image(sitemap + MAP_DISPLAY_EXTENSION);
 	mHeightMap = Image(sitemap + MAP_TERRAIN_EXTENSION);
-	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, constants::PlanetHostility::HOSTILITY_NONE, false);
+	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, constants::PlanetHostility::None, false);
 	mTileMap->deserialize(root);
 
 	delete pather;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -157,7 +157,7 @@ void MapViewState::load(const std::string& filePath)
 
 	mMapDisplay = Image(sitemap + MAP_DISPLAY_EXTENSION);
 	mHeightMap = Image(sitemap + MAP_TERRAIN_EXTENSION);
-	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, Planet::PlanetHostility::None, false);
+	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 
 	delete pather;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -157,7 +157,7 @@ void MapViewState::load(const std::string& filePath)
 
 	mMapDisplay = Image(sitemap + MAP_DISPLAY_EXTENSION);
 	mHeightMap = Image(sitemap + MAP_TERRAIN_EXTENSION);
-	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, constants::PlanetHostility::None, false);
+	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, Planet::PlanetHostility::None, false);
 	mTileMap->deserialize(root);
 
 	delete pather;

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -3,6 +3,8 @@
 
 #include "Planet.h"
 
+#include "../Constants.h"
+
 #include "NAS2D/Utility.h"
 #include "NAS2D/EventHandler.h"
 #include "NAS2D/Renderer/Renderer.h"

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -5,9 +5,9 @@
 
 #include "../Constants.h"
 
-#include "NAS2D/Utility.h"
-#include "NAS2D/EventHandler.h"
-#include "NAS2D/Renderer/Renderer.h"
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
+#include <NAS2D/Renderer/Renderer.h>
 
 #include <array>
 

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -26,6 +26,15 @@ public:
 		Count
 	};
 
+	enum class PlanetHostility
+	{
+		None,
+
+		Low,
+		Medium,
+		High
+	};
+
 public:
 	using MouseCallback = NAS2D::Signals::Signal<>;
 

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -7,10 +7,6 @@
 #include <NAS2D/Renderer/Point.h>
 #include <NAS2D/Resources/Image.h>
 
-#include "../Constants.h"
-
-
-
 
 class Planet
 {

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -26,7 +26,7 @@ public:
 		Count
 	};
 
-	enum class PlanetHostility
+	enum class Hostility
 	{
 		None,
 

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <cmath>
-
 #include <NAS2D/Signal.h>
 #include <NAS2D/Timer.h>
 #include <NAS2D/Renderer/Point.h>
 #include <NAS2D/Resources/Image.h>
+
+#include <cmath>
 
 
 class Planet

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -186,7 +186,7 @@ State* PlanetSelectState::update()
 	{
 		std::string map, tileset;
 		int dig_depth = 0, max_mines = 0;
-		constants::PlanetHostility hostility = constants::PlanetHostility::HOSTILITY_NONE;
+		constants::PlanetHostility hostility = constants::PlanetHostility::None;
 
 		switch (PLANET_TYPE_SELECTION)
 		{
@@ -195,7 +195,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/mercury.png";
 			dig_depth = mPlanets[0]->digDepth();
 			max_mines = mPlanets[0]->maxMines();
-			hostility = constants::PlanetHostility::HOSTILITY_HIGH;
+			hostility = constants::PlanetHostility::High;
 			break;
 
 		case Planet::PlanetType::Mars:
@@ -203,7 +203,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/mars.png";
 			dig_depth = mPlanets[1]->digDepth();
 			max_mines = mPlanets[1]->maxMines();
-			hostility = constants::PlanetHostility::HOSTILITY_LOW;
+			hostility = constants::PlanetHostility::Low;
 			break;
 
 		case Planet::PlanetType::Ganymede:
@@ -211,7 +211,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/ganymede.png";
 			dig_depth = mPlanets[2]->digDepth();
 			max_mines = mPlanets[2]->maxMines();
-			hostility = constants::PlanetHostility::HOSTILITY_MEDIUM;
+			hostility = constants::PlanetHostility::Medium;
 			break;
 
 		default:

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -186,7 +186,7 @@ State* PlanetSelectState::update()
 	{
 		std::string map, tileset;
 		int dig_depth = 0, max_mines = 0;
-		Planet::PlanetHostility hostility = Planet::PlanetHostility::None;
+		Planet::Hostility hostility = Planet::Hostility::None;
 
 		switch (PLANET_TYPE_SELECTION)
 		{
@@ -195,7 +195,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/mercury.png";
 			dig_depth = mPlanets[0]->digDepth();
 			max_mines = mPlanets[0]->maxMines();
-			hostility = Planet::PlanetHostility::High;
+			hostility = Planet::Hostility::High;
 			break;
 
 		case Planet::PlanetType::Mars:
@@ -203,7 +203,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/mars.png";
 			dig_depth = mPlanets[1]->digDepth();
 			max_mines = mPlanets[1]->maxMines();
-			hostility = Planet::PlanetHostility::Low;
+			hostility = Planet::Hostility::Low;
 			break;
 
 		case Planet::PlanetType::Ganymede:
@@ -211,7 +211,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/ganymede.png";
 			dig_depth = mPlanets[2]->digDepth();
 			max_mines = mPlanets[2]->maxMines();
-			hostility = Planet::PlanetHostility::Medium;
+			hostility = Planet::Hostility::Medium;
 			break;
 
 		default:

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -186,7 +186,7 @@ State* PlanetSelectState::update()
 	{
 		std::string map, tileset;
 		int dig_depth = 0, max_mines = 0;
-		constants::PlanetHostility hostility = constants::PlanetHostility::None;
+		Planet::PlanetHostility hostility = Planet::PlanetHostility::None;
 
 		switch (PLANET_TYPE_SELECTION)
 		{
@@ -195,7 +195,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/mercury.png";
 			dig_depth = mPlanets[0]->digDepth();
 			max_mines = mPlanets[0]->maxMines();
-			hostility = constants::PlanetHostility::High;
+			hostility = Planet::PlanetHostility::High;
 			break;
 
 		case Planet::PlanetType::Mars:
@@ -203,7 +203,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/mars.png";
 			dig_depth = mPlanets[1]->digDepth();
 			max_mines = mPlanets[1]->maxMines();
-			hostility = constants::PlanetHostility::Low;
+			hostility = Planet::PlanetHostility::Low;
 			break;
 
 		case Planet::PlanetType::Ganymede:
@@ -211,7 +211,7 @@ State* PlanetSelectState::update()
 			tileset = "tsets/ganymede.png";
 			dig_depth = mPlanets[2]->digDepth();
 			max_mines = mPlanets[2]->maxMines();
-			hostility = constants::PlanetHostility::Medium;
+			hostility = Planet::PlanetHostility::Medium;
 			break;
 
 		default:


### PR DESCRIPTION
After moving PlanetHostility into the Planet class, I thought the word Planet became redundant in the enum name. Happy to switch it back to PlanetHostility if this isn't proferred by others.

Prep-work before starting on issue #506 