### PR TITLE
AppVeyor auto release on tag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,3 +43,13 @@ after_build:
 artifacts:
   - path: "*.zip"
     name: BuildArtifacts
+deploy:
+  on:
+    branch: master
+    APPVEYOR_REPO_TAG: true
+    CONFIGURATION: Release
+  artifact: BuildArtifacts
+  description: ''
+  provider: GitHub
+  auth_token:
+    secure: TmV7XiO84JvSaLJnbrRrtoOugcFLSogA4I55yBZ1Y+QAmv28EOgO1M8lX+NSJWA/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,3 +25,21 @@ install:
   - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
 build:
   project: OPHD.sln
+after_build:
+  # Set version/build tag
+  - set Version=Build%APPVEYOR_BUILD_VERSION%
+  - if defined APPVEYOR_REPO_TAG_NAME set Version=%APPVEYOR_REPO_TAG_NAME%
+  # Set platform/configuration tag
+  - set Config=%CONFIGURATION%
+  - if defined PLATFORM set Config=%PLATFORM%-%Config%
+  # Set overall build tag
+  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%Config%"
+  # Determine output folder
+  - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
+  - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
+  # Package artifacts
+  - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.exe" "%OutputFolder%*.dll"
+  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
+artifacts:
+  - path: "*.zip"
+    name: BuildArtifacts


### PR DESCRIPTION
AppVeyor will now package EXE and DLL files, and store them as artifacts associated with the build. This happens for every build.

If the build is for a new Git tag, the artifacts will also be uploaded to GitHub as a new release. This happens only for tagged builds.

----

Would appreciate someone testing the release artifacts package to make sure it runs. It will need a copy of the `data/` folder to run with.
