### PR TITLE
Make min size checks consistent

### DIFF
--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -110,8 +110,7 @@ void CheckBox::onTextChanged()
  */
 void CheckBox::onSizeChanged()
 {
-	mRect.height = 13;
-	if (width() < 13) { mRect.width = 13; }
+	mRect.size({std::max(mRect.width, 13), 13});
 }
 
 

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -101,7 +101,8 @@ void CheckBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
  */
 void CheckBox::onTextChanged()
 {
-	width(16 + CBOX_FONT->width(text()));
+	const auto textWidth = CBOX_FONT->width(text());
+	width((textWidth > 0) ? 20 + textWidth : 13);
 }
 
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -6,6 +6,9 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/MathUtils.h>
 
+#include <algorithm>
+
+
 using namespace NAS2D;
 
 /**
@@ -58,8 +61,11 @@ void ComboBox::init()
  */
 void ComboBox::resizedHandler(Control* /*control*/)
 {
-	if (height() < 20) { height(20); } // enforce minimum height;
-	if (width() < 50) { width(50); } // enforce mininum width;
+	// Enforce minimum size
+	if (mRect.width < 50 || mRect.height < 20)
+	{
+		size({std::max(mRect.width, 50), std::max(mRect.height, 20)});
+	}
 
 	txtField.size(size() - NAS2D::Vector{20, 0});
 	btnDown.position(txtField.rect().crossXPoint());

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -62,7 +62,6 @@ void RadioButton::parentContainer(UIContainer* parent)
 void RadioButton::text(const std::string& text)
 {
 	mLabel.text(text);
-	width(20 + CBOX_FONT->width(text));
 	onTextChanged();
 }
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -11,6 +11,8 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/MathUtils.h>
 
+#include <algorithm>
+
 
 using namespace NAS2D;
 
@@ -115,8 +117,7 @@ void RadioButton::onTextChanged()
  */
 void RadioButton::onSizeChanged()
 {
-	mRect.height = 13;
-	if (width() < 13) { mRect.width = 13; }
+	mRect.size({std::max(mRect.width, 13), 13});
 }
 
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -108,7 +108,8 @@ void RadioButton::onMouseDown(EventHandler::MouseButton button, int x, int y)
  */
 void RadioButton::onTextChanged()
 {
-	width(16 + CBOX_FONT->width(text()));
+	const auto textWidth = CBOX_FONT->width(text());
+	width((textWidth > 0) ? 20 + textWidth : 13);
 }
 
 


### PR DESCRIPTION
Closes #503

Use consistent checks for minimum `Control` sizes for:
- `CheckBox`
- `RadioButton`

Also updates `ComboBox` in a similar manner so it emits fewer events when both dimensions need to be updated.
