### PR TITLE
Use packed parameter Renderer overloads

### DIFF
--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -102,11 +102,11 @@ static void setPanelRects(int width)
  */
 static void drawPanel(Renderer& _r, Panel& _p)
 {
-	if (_p.Rect.contains(MOUSE_COORDS)) { _r.drawBoxFilled(_p.Rect, 0, 185, 185, 100); }
+	if (_p.Rect.contains(MOUSE_COORDS)) { _r.drawBoxFilled(_p.Rect, NAS2D::Color{0, 185, 185, 100}); }
 
 	if (_p.Selected())
 	{
-		_r.drawBoxFilled(_p.Rect, 0, 85, 0);
+		_r.drawBoxFilled(_p.Rect, NAS2D::Color{0, 85, 0});
 
 		if (_p.UiPanel) { _p.UiPanel->update(); }
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -100,23 +100,23 @@ static void setPanelRects(int width)
 /**
  * Draws a UI panel.
  */
-static void drawPanel(Renderer& _r, Panel& _p)
+static void drawPanel(Renderer& renderer, Panel& panel)
 {
-	if (_p.Rect.contains(MOUSE_COORDS)) { _r.drawBoxFilled(_p.Rect, NAS2D::Color{0, 185, 185, 100}); }
+	if (panel.Rect.contains(MOUSE_COORDS)) { renderer.drawBoxFilled(panel.Rect, NAS2D::Color{0, 185, 185, 100}); }
 
-	if (_p.Selected())
+	if (panel.Selected())
 	{
-		_r.drawBoxFilled(_p.Rect, NAS2D::Color{0, 85, 0});
+		renderer.drawBoxFilled(panel.Rect, NAS2D::Color{0, 85, 0});
 
-		if (_p.UiPanel) { _p.UiPanel->update(); }
+		if (panel.UiPanel) { panel.UiPanel->update(); }
 
-		_r.drawText(*BIG_FONT_BOLD, _p.Name, _p.TextPosition, NAS2D::Color{185, 185, 0});
-		_r.drawImage(*_p.Img, _p.IconPosition, 1.0f, NAS2D::Color{185, 185, 0});
+		renderer.drawText(*BIG_FONT_BOLD, panel.Name, panel.TextPosition, NAS2D::Color{185, 185, 0});
+		renderer.drawImage(*panel.Img, panel.IconPosition, 1.0f, NAS2D::Color{185, 185, 0});
 	}
 	else
 	{
-		_r.drawText(*BIG_FONT_BOLD, _p.Name, _p.TextPosition, NAS2D::Color{0, 185, 0});
-		_r.drawImage(*_p.Img, _p.IconPosition, 1.0f, NAS2D::Color{0, 185, 0});
+		renderer.drawText(*BIG_FONT_BOLD, panel.Name, panel.TextPosition, NAS2D::Color{0, 185, 0});
+		renderer.drawImage(*panel.Img, panel.IconPosition, 1.0f, NAS2D::Color{0, 185, 0});
 	}
 }
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -48,7 +48,7 @@ extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 void MapViewState::save(const std::string& filePath)
 {
 	auto& renderer = Utility<Renderer>::get();
-	renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 100);
+	renderer.drawBoxFilled(NAS2D::Rectangle{0, 0, renderer.width(), renderer.height()}, NAS2D::Color{0, 0, 0, 100});
 	renderer.drawImage(*IMG_SAVING, renderer.center() - IMG_SAVING->size() / 2);
 	renderer.update();
 
@@ -100,7 +100,7 @@ void MapViewState::load(const std::string& filePath)
 	resetUi();
 
 	auto& renderer = Utility<Renderer>::get();
-	renderer.drawBoxFilled(0, 0, renderer.width(), renderer.height(), 0, 0, 0, 100);
+	renderer.drawBoxFilled(NAS2D::Rectangle{0, 0, renderer.width(), renderer.height()}, NAS2D::Color{0, 0, 0, 100});
 	renderer.drawImage(*IMG_LOADING, renderer.center() - IMG_LOADING->size() / 2);
 	renderer.update();
 

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -66,5 +66,5 @@ void Planet::update()
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto spriteFrameOffset = NAS2D::Point{mTick % 8 * PlanetSize.x, ((mTick % 64) / 8) * PlanetSize.y};
-	renderer.drawSubImage(mImage, mPosition, spriteFrameOffset, PlanetSize);
+	renderer.drawSubImage(mImage, mPosition, NAS2D::Rectangle<int>::Create(spriteFrameOffset, PlanetSize));
 }

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -164,7 +164,7 @@ State* PlanetSelectState::update()
 	auto& renderer = Utility<Renderer>::get();
 
 	const auto size = renderer.size();
-	renderer.drawImageStretched(mBg, {0, 0}, size);
+	renderer.drawImageStretched(mBg, NAS2D::Rectangle<int>::Create({0, 0}, size));
 
 	float rotation = mTimer.tick() / 1200.0f;
 	renderer.drawImageRotated(mCloud1, {-256, -256}, rotation, NAS2D::Color{100, 255, 0, 135});

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -133,7 +133,10 @@ NAS2D::State* SplashState::update()
 		BYLINE_ALPHA += tick * BYLINE_ALPHA_FADE_STEP;
 		BYLINE_ALPHA = std::clamp(BYLINE_ALPHA, -3000.0f, 255.0f);
 
-		if(BYLINE_ALPHA > 0.0f) { renderer.drawImage(mByline, renderer.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), renderer.center_y() + 25, BYLINE_SCALE, 255, 255, 255, static_cast<uint8_t>(BYLINE_ALPHA)); }
+		if (BYLINE_ALPHA > 0.0f)
+		{
+			renderer.drawImage(mByline, renderer.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), renderer.center_y() + 25, BYLINE_SCALE, 255, 255, 255, static_cast<uint8_t>(BYLINE_ALPHA));
+		}
 	}
 	
 	if (renderer.isFading()) { return this; }

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -124,15 +124,15 @@ NAS2D::State* SplashState::update()
 		renderer.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);
 		renderer.drawImage(mLogoOutpostHd, logoPosition);
 
-		const float BYLINE_SCALE_STEP = 0.000025f;
-		const float BYLINE_ALPHA_FADE_STEP = 0.30f;
-		const float BYLINE_SCALE = 0.50f + tick * BYLINE_SCALE_STEP;
-		const float BYLINE_ALPHA = -800.0f + tick * BYLINE_ALPHA_FADE_STEP;
-		const auto clampedBylineAlpha = static_cast<uint8_t>(std::clamp(BYLINE_ALPHA, 0.0f, 255.0f));
+		const float bylineScaleStep = 0.000025f;
+		const float bylineAlphaFadeStep = 0.30f;
+		const float bylineScale = 0.50f + tick * bylineScaleStep;
+		const float bylineAlpha = -800.0f + tick * bylineAlphaFadeStep;
+		const auto clampedBylineAlpha = static_cast<uint8_t>(std::clamp(bylineAlpha, 0.0f, 255.0f));
 
 		if (clampedBylineAlpha > 0)
 		{
-			renderer.drawImage(mByline, renderer.center().to<float>() + NAS2D::Vector<float>{-mByline.width() * BYLINE_SCALE / 2, 25}, BYLINE_SCALE, NAS2D::Color::White.alphaFade(clampedBylineAlpha));
+			renderer.drawImage(mByline, renderer.center().to<float>() + NAS2D::Vector<float>{-mByline.width() * bylineScale / 2, 25}, bylineScale, NAS2D::Color::White.alphaFade(clampedBylineAlpha));
 		}
 	}
 	

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -135,7 +135,7 @@ NAS2D::State* SplashState::update()
 
 		if (BYLINE_ALPHA > 0.0f)
 		{
-			renderer.drawImage(mByline, renderer.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), renderer.center_y() + 25, BYLINE_SCALE, 255, 255, 255, static_cast<uint8_t>(BYLINE_ALPHA));
+			renderer.drawImage(mByline, renderer.center().to<float>() + NAS2D::Vector<float>{-mByline.width() * BYLINE_SCALE / 2, 25}, BYLINE_SCALE, NAS2D::Color::White.alphaFade(static_cast<uint8_t>(BYLINE_ALPHA)));
 		}
 	}
 	

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -118,19 +118,16 @@ NAS2D::State* SplashState::update()
 	}
 	if (CURRENT_STATE == LogoState::LOGO_OUTPOSTHD)
 	{
-		const unsigned int tick = BYLINE_TIMER.delta();
+		const unsigned int tick = BYLINE_TIMER.accumulator();
 		const auto logoPosition = renderer.center() - mLogoOutpostHd.size() / 2 - NAS2D::Vector{100, 0};
 
 		renderer.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);
 		renderer.drawImage(mLogoOutpostHd, logoPosition);
 
-		static float BYLINE_SCALE = 0.50f;
-		static float BYLINE_SCALE_STEP = 0.000025f;
-		static float BYLINE_ALPHA = -800.0f;
-		static float BYLINE_ALPHA_FADE_STEP = 0.30f;
-
-		BYLINE_SCALE += tick * BYLINE_SCALE_STEP;
-		BYLINE_ALPHA += tick * BYLINE_ALPHA_FADE_STEP;
+		const float BYLINE_SCALE_STEP = 0.000025f;
+		const float BYLINE_ALPHA_FADE_STEP = 0.30f;
+		const float BYLINE_SCALE = 0.50f + tick * BYLINE_SCALE_STEP;
+		float BYLINE_ALPHA = -800.0f + tick * BYLINE_ALPHA_FADE_STEP;
 		BYLINE_ALPHA = std::clamp(BYLINE_ALPHA, -3000.0f, 255.0f);
 
 		if (BYLINE_ALPHA > 0.0f)

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -16,11 +16,6 @@ unsigned int FADE_PAUSE_TIME = 5000;
 
 const float FADE_LENGTH = 800;
 
-float BYLINE_SCALE = 0.50f;
-float BYLINE_SCALE_STEP = 0.000025f;
-float BYLINE_ALPHA = -800.0f;
-float BYLINE_ALPHA_FADE_STEP = 0.30f;
-
 NAS2D::Timer BYLINE_TIMER;
 
 enum LogoState
@@ -128,6 +123,11 @@ NAS2D::State* SplashState::update()
 
 		renderer.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, BYLINE_TIMER.tick() / 600.0f);
 		renderer.drawImage(mLogoOutpostHd, logoPosition);
+
+		static float BYLINE_SCALE = 0.50f;
+		static float BYLINE_SCALE_STEP = 0.000025f;
+		static float BYLINE_ALPHA = -800.0f;
+		static float BYLINE_ALPHA_FADE_STEP = 0.30f;
 
 		BYLINE_SCALE += tick * BYLINE_SCALE_STEP;
 		BYLINE_ALPHA += tick * BYLINE_ALPHA_FADE_STEP;

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -10,13 +10,6 @@
 
 #include <algorithm>
 
-const int PAUSE_TIME = 5800;
-
-unsigned int FADE_PAUSE_TIME = 5000;
-
-const float FADE_LENGTH = 800;
-
-NAS2D::Timer BYLINE_TIMER;
 
 enum LogoState
 {
@@ -26,7 +19,14 @@ enum LogoState
 	LOGO_OUTPOSTHD
 };
 
+
 LogoState CURRENT_STATE = LogoState::LOGO_NONE;
+
+const int PAUSE_TIME = 5800;
+unsigned int FADE_PAUSE_TIME = 5000;
+const float FADE_LENGTH = 800;
+
+NAS2D::Timer BYLINE_TIMER;
 
 
 SplashState::SplashState() :

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -127,12 +127,12 @@ NAS2D::State* SplashState::update()
 		const float BYLINE_SCALE_STEP = 0.000025f;
 		const float BYLINE_ALPHA_FADE_STEP = 0.30f;
 		const float BYLINE_SCALE = 0.50f + tick * BYLINE_SCALE_STEP;
-		float BYLINE_ALPHA = -800.0f + tick * BYLINE_ALPHA_FADE_STEP;
-		BYLINE_ALPHA = std::clamp(BYLINE_ALPHA, -3000.0f, 255.0f);
+		const float BYLINE_ALPHA = -800.0f + tick * BYLINE_ALPHA_FADE_STEP;
+		const auto clampedBylineAlpha = static_cast<uint8_t>(std::clamp(BYLINE_ALPHA, 0.0f, 255.0f));
 
-		if (BYLINE_ALPHA > 0.0f)
+		if (clampedBylineAlpha > 0)
 		{
-			renderer.drawImage(mByline, renderer.center().to<float>() + NAS2D::Vector<float>{-mByline.width() * BYLINE_SCALE / 2, 25}, BYLINE_SCALE, NAS2D::Color::White.alphaFade(static_cast<uint8_t>(BYLINE_ALPHA)));
+			renderer.drawImage(mByline, renderer.center().to<float>() + NAS2D::Vector<float>{-mByline.width() * BYLINE_SCALE / 2, 25}, BYLINE_SCALE, NAS2D::Color::White.alphaFade(clampedBylineAlpha));
 		}
 	}
 	

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -301,7 +301,7 @@ void ListBox::update()
 	auto itemBounds = listBounds;
 	itemBounds.height = mLineHeight;
 	itemBounds.y += static_cast<int>((mCurrentSelection * mLineHeight) - mCurrentOffset);
-	renderer.drawBoxFilled(itemBounds, mHighlightBg.red, mHighlightBg.green, mHighlightBg.blue, 80);
+	renderer.drawBoxFilled(itemBounds, mHighlightBg.alphaFade(80));
 
 	// Highlight On mouse Over
 	if (mCurrentHighlight != constants::NO_SELECTION)

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -126,7 +126,7 @@ int main(int /*argc*/, char *argv[])
 
 		std::cout << std::endl << "** GAME START **" << std::endl << std::endl;
 
-		renderer.minimum_size(1000, 700);
+		renderer.minimumSize({1000, 700});
 		renderer.resizeable(true);
 		renderer.addCursor(constants::MOUSE_POINTER_NORMAL, PointerType::POINTER_NORMAL, 0, 0);
 		renderer.addCursor(constants::MOUSE_POINTER_PLACE_TILE, PointerType::POINTER_PLACE_TILE, 16, 16);


### PR DESCRIPTION
Update `Renderer` calls to use the packed parameter overloads.

Contains a bit of refactoring to rename variables, or to replace global variables with local variables.

References:
https://github.com/lairworks/nas2d-core/pull/699
https://github.com/lairworks/nas2d-core/pull/697
https://github.com/lairworks/nas2d-core/pull/700
