### PR TITLE
Remove control position static cast

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -272,7 +272,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 
 	// Find top left corner of rectangle containing top tile of diamond
 	mMapPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BOTTOM_UI_HEIGHT - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
-	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, static_cast<int>(mMapPosition.y), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
+	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, mMapPosition.y, TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 
 	int transform = (mMapPosition.x - mMapBoundingBox.x) / TILE_WIDTH;
 	TRANSFORM = {-transform, transform};

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -246,7 +246,7 @@ void MainReportsUiState::onMouseDown(EventHandler::MouseButton button, int x, in
 {
 	if (!active()) { return; }
 
-	if (!NAS2D::Rectangle{0, 0, static_cast<int>(Utility<Renderer>::get().width()), 40}.contains(Point{x, y})) { return; } // ignore clicks in the UI area.
+	if (!NAS2D::Rectangle{0, 0, Utility<Renderer>::get().width(), 40}.contains(Point{x, y})) { return; } // ignore clicks in the UI area.
 
 	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1024,7 +1024,7 @@ void MapViewState::placeRobot()
 			if (position.x + mDiggerDirection.width() > Utility<Renderer>::get().width())
 			{
 				// Popup to the left of the mouse
-				position = MOUSE_COORDS + NAS2D::Vector{-20 - static_cast<int>(mDiggerDirection.width()), -32};
+				position = MOUSE_COORDS + NAS2D::Vector{-20 - mDiggerDirection.width(), -32};
 			}
 			mDiggerDirection.position(position);
 		}

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -203,12 +203,12 @@ void MapViewState::drawResourceInfo()
 	bool shouldShowPopPanel = mPinPopulationPanel || isMouseInPopPanel;
 	if(shouldShowPopPanel) { mPopulationPanel.update(); }
 
-	bool isMouseInResourcePanel = NAS2D::Rectangle{0, 1, static_cast<int>(mResourceBreakdownPanel.width()), 19}.contains(MOUSE_COORDS);
+	bool isMouseInResourcePanel = NAS2D::Rectangle{0, 1, mResourceBreakdownPanel.width(), 19}.contains(MOUSE_COORDS);
 	bool shouldShowResourcePanel = mPinResourcePanel || isMouseInResourcePanel;
 	if (shouldShowResourcePanel) { mResourceBreakdownPanel.update(); }
 
 	// Turns
-	position.x = static_cast<int>(renderer.width() - 80);
+	position.x = renderer.width() - 80;
 	const auto turnImageRect = NAS2D::Rectangle{128, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, turnImageRect);
 	renderer.drawText(*MAIN_FONT, std::to_string(mTurnCount), position + textOffset, NAS2D::Color::White);
@@ -232,7 +232,7 @@ void MapViewState::drawRobotInfo()
 
 	// Robots: Miner (last one), Dozer (middle one), Digger (first one)
 	// Start from the bottom - The bottom UI Height - Icons Height - 8 (1 offset to avoid the last to be glued with at the border)
-	auto position = NAS2D::Point{8, static_cast<int>(renderer.height()) - constants::BOTTOM_UI_HEIGHT - 25 - 8};
+	auto position = NAS2D::Point{8, renderer.height() - constants::BOTTOM_UI_HEIGHT - 25 - 8};
 	constexpr auto textOffset = NAS2D::Vector{30, 7};
 
 	const auto minerImageRect = NAS2D::Rectangle{231, 18, 25, 25};
@@ -279,7 +279,7 @@ void MapViewState::drawNavInfo()
 
 	// Display the levels "bar"
 	const auto stepSizeWidth = MAIN_FONT->width("IX");
-	auto position = NAS2D::Point{static_cast<int>(renderer.width()) - 5, mMiniMapBoundingBox.y - 30};
+	auto position = NAS2D::Point{renderer.width() - 5, mMiniMapBoundingBox.y - 30};
 	for (int i = mTileMap->maxDepth(); i >= 0; i--)
 	{
 		const auto levelString = (i == 0) ? std::string{"S"} : std::to_string(i);

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -127,7 +127,7 @@ void PlanetSelectState::initialize()
 	planetSelection = planetSelectionInvalid;
 
 	mQuit.size({100, 20});
-	mQuit.position({static_cast<int>(renderer.width()) - 105, 30});
+	mQuit.position({renderer.width() - 105, 30});
 	mQuit.click().connect(this, &PlanetSelectState::btnQuitClicked);
 
 	mPlanetDescription.text("");

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -254,7 +254,7 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 	
-	mCurrentHighlight = (y - static_cast<int>(mRect.y) + mCurrentOffset) / (LST_FONT->height() + 2);
+	mCurrentHighlight = (y - mRect.y + mCurrentOffset) / (LST_FONT->height() + 2);
 
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -157,7 +157,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 
-	mCurrentHighlight = (y - static_cast<int>(positionY()) + mCurrentOffset) / mItemHeight;
+	mCurrentHighlight = (y - positionY() + mCurrentOffset) / mItemHeight;
 
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -105,7 +105,7 @@ void TextField::maxCharacters(std::size_t count)
 
 int TextField::textAreaWidth() const
 {
-	return static_cast<int>(mRect.width) - FIELD_PADDING * 2;
+	return mRect.width - FIELD_PADDING * 2;
 }
 
 
@@ -228,7 +228,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 
-	int relativePosition = static_cast<int>(x - mRect.x);
+	int relativePosition = x - mRect.x;
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
@@ -304,7 +304,7 @@ void TextField::updateCursor()
 		mScrollOffset = 0;
 	}
 
-	mCursorX = static_cast<int>(mRect.x + FIELD_PADDING + cursorX - mScrollOffset);
+	mCursorX = mRect.x + FIELD_PADDING + cursorX - mScrollOffset;
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -81,9 +81,8 @@ void IconGrid::iconMargin(int newMargin)
  */
 void IconGrid::updateGrid()
 {
-	// explicit cast, intentional trunctation of floating point data.
-	int cols = static_cast<int>((mRect.width - (mIconMargin * 2)) / (mIconSize + mIconMargin));
-	int rows = static_cast<int>((mRect.height - (mIconMargin * 2)) / (mIconSize + mIconMargin));
+	int cols = (mRect.width - (mIconMargin * 2)) / (mIconSize + mIconMargin);
+	int rows = (mRect.height - (mIconMargin * 2)) / (mIconSize + mIconMargin);
 
 	mGridSize = {cols, rows};
 }

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -214,7 +214,7 @@ void MineOperationsWindow::update()
 	drawLabelAndValue(origin + NAS2D::Vector{300, 30}, "Depth: ", mineDepth);
 
 	// REMAINING ORE PANEL
-	const auto width = static_cast<int>(mRect.width);
+	const auto width = mRect.width;
 	renderer.drawText(*FONT_BOLD, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
 	renderer.drawImageRect(NAS2D::Rectangle<int>::Create(origin + NAS2D::Vector{10, 180}, NAS2D::Vector{width - 20, 40}), mPanel);

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -145,7 +145,7 @@ void FactoryReport::init()
 	btnShowDisabled.type(Button::Type::BUTTON_TOGGLE);
 	btnShowDisabled.click().connect(this, &FactoryReport::btnShowDisabledClicked);
 
-	int position_x = static_cast<int>(Utility<Renderer>::get().width()) - 110;
+	int position_x = Utility<Renderer>::get().width() - 110;
 	add(&btnIdle, position_x, 35);
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({140, 30});

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -149,7 +149,7 @@ void WarehouseReport::init()
 	add(&lstStructures, 10, mRect.y + 115);
 	lstStructures.selectionChanged().connect(this, &WarehouseReport::lstStructuresSelectionChanged);
 
-	add(&lstProducts, static_cast<int>(Utility<Renderer>::get().center_x()) + 10, mRect.y + 173);
+	add(&lstProducts, Utility<Renderer>::get().center_x() + 10, mRect.y + 173);
 
 	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &WarehouseReport::doubleClicked);
 
@@ -338,11 +338,11 @@ void WarehouseReport::_resized(Control*)
 {
 	lstStructures.size({(width() / 2) - 20, height() - 126});
 	lstProducts.size({(width() / 2) - 20, height() - 184});
-	lstProducts.position({static_cast<int>(Utility<Renderer>::get().center_x()) + 10, lstProducts.positionY()});
+	lstProducts.position({Utility<Renderer>::get().center_x() + 10, lstProducts.positionY()});
 
-	btnTakeMeThere.position({static_cast<int>(Utility<Renderer>::get().width()) - 150, positionY() + 35});
+	btnTakeMeThere.position({Utility<Renderer>::get().width() - 150, positionY() + 35});
 
-	CAPACITY_BAR_WIDTH = static_cast<int>(width() / 2) - 30 - FONT_MED_BOLD->width("Capacity Used");
+	CAPACITY_BAR_WIDTH = width() / 2 - 30 - FONT_MED_BOLD->width("Capacity Used");
 	CAPACITY_BAR_POSITION_X = 20 + FONT_MED_BOLD->width("Capacity Used");
 }
 
@@ -469,7 +469,7 @@ void WarehouseReport::drawRightPanel(Renderer& renderer)
 {
 	if (!SELECTED_WAREHOUSE) { return; }
 
-	const auto positionX = static_cast<int>(renderer.center_x()) + 10;
+	const auto positionX = renderer.center_x() + 10;
 	renderer.drawText(*FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
 	renderer.drawImage(*WAREHOUSE_IMG, NAS2D::Point{positionX, positionY() + 35});
 }
@@ -485,7 +485,7 @@ void WarehouseReport::update()
 
 	// Left Panel
 	drawLeftPanel(renderer);
-	const auto positionX = static_cast<int>(renderer.center_x());
+	const auto positionX = renderer.center_x();
 	renderer.drawLine(NAS2D::Point{positionX, positionY() + 10}, NAS2D::Point{positionX, positionY() + height() - 10}, NAS2D::Color{0, 185, 0});
 	drawRightPanel(renderer);
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -162,6 +162,6 @@ void StructureInspector::update()
 	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{10, 135});
 	stringTable.draw(renderer);
 
-	position = mRect.startPoint() + NAS2D::Vector{5, static_cast<int>(mRect.height) - FONT->height() - 5};
+	position = mRect.startPoint() + NAS2D::Vector{5, mRect.height - FONT->height() - 5};
 	renderer.drawText(*FONT, "This window is a work in progress", position, NAS2D::Color::White);
 }


### PR DESCRIPTION
Reference: #504

Remove `static_cast<int>` conversions for `Control` positioning as they are now no longer needed with pixel aligned Controls.
