### PR TITLE
Replace double static_cast with std::floor

### DIFF
--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -12,6 +12,7 @@
 #include <NAS2D/MathUtils.h>
 
 #include <algorithm>
+#include <cmath>
 
 
 using namespace NAS2D;
@@ -332,9 +333,9 @@ void ListBox::slideChanged(float newPosition)
 {
 	_updateItemDisplay();
 	// Intentional truncation of fractional value
-	int pos = static_cast<int>(newPosition);
-	if (static_cast<float>(pos) != newPosition)
+	const auto pos = std::floor(newPosition);
+	if (pos != newPosition)
 	{
-		mSlider.thumbPosition(static_cast<float>(pos));
+		mSlider.thumbPosition(pos);
 	}
 }


### PR DESCRIPTION
Replace double `static_cast` rounding code with `std::floor`.

This function is a bit odd, and may require closer scrutiny. It seems it only calls `mSlider.thumbPosition` if the `float` parameter is non-integer equivalent.
