### PR TITLE
Replace Renderer::center_x/_y

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -304,7 +304,7 @@ NAS2D::State* MainMenuState::update()
 {
 	auto& renderer = Utility<Renderer>::get();
 
-	renderer.clearScreen(0, 0, 0);
+	renderer.clearScreen();
 	renderer.drawImage(mBgImage, renderer.center() - mBgImage.size() / 2);
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -61,7 +61,7 @@ void MapViewState::initUi()
 	mStructureInspector.position(renderer.center() - NAS2D::Vector{mStructureInspector.size().x / 2.0f, 175.0f});
 	mStructureInspector.hide();
 
-	mFactoryProduction.position(NAS2D::Point{renderer.center_x() - mFactoryProduction.size().x / 2.0f, 175.0f});
+	mFactoryProduction.position(NAS2D::Point{renderer.center().x - mFactoryProduction.size().x / 2.0f, 175.0f});
 	mFactoryProduction.hide();
 
 	mFileIoDialog.setMode(FileIo::FileOperation::FILE_SAVE);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -149,7 +149,7 @@ void WarehouseReport::init()
 	add(&lstStructures, 10, mRect.y + 115);
 	lstStructures.selectionChanged().connect(this, &WarehouseReport::lstStructuresSelectionChanged);
 
-	add(&lstProducts, Utility<Renderer>::get().center_x() + 10, mRect.y + 173);
+	add(&lstProducts, Utility<Renderer>::get().center().x + 10, mRect.y + 173);
 
 	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &WarehouseReport::doubleClicked);
 
@@ -338,7 +338,7 @@ void WarehouseReport::_resized(Control*)
 {
 	lstStructures.size({(mRect.width / 2) - 20, mRect.height - 126});
 	lstProducts.size({(mRect.width / 2) - 20, mRect.height - 184});
-	lstProducts.position({Utility<Renderer>::get().center_x() + 10, lstProducts.positionY()});
+	lstProducts.position({Utility<Renderer>::get().center().x + 10, lstProducts.positionY()});
 
 	btnTakeMeThere.position({Utility<Renderer>::get().size().x - 150, positionY() + 35});
 
@@ -469,7 +469,7 @@ void WarehouseReport::drawRightPanel(Renderer& renderer)
 {
 	if (!SELECTED_WAREHOUSE) { return; }
 
-	const auto positionX = renderer.center_x() + 10;
+	const auto positionX = renderer.center().x + 10;
 	renderer.drawText(*FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
 	renderer.drawImage(*WAREHOUSE_IMG, NAS2D::Point{positionX, positionY() + 35});
 }
@@ -485,7 +485,7 @@ void WarehouseReport::update()
 
 	// Left Panel
 	drawLeftPanel(renderer);
-	const auto positionX = renderer.center_x();
+	const auto positionX = renderer.center().x;
 	renderer.drawLine(NAS2D::Point{positionX, positionY() + 10}, NAS2D::Point{positionX, positionY() + mRect.height - 10}, NAS2D::Color{0, 185, 0});
 	drawRightPanel(renderer);
 


### PR DESCRIPTION
Replace `Renderer::center_x()`/`Renderer::center_y()` with `Renderer::center().x`/`Renderer::center().y`.

Removes explicit parameters for `Color::Black` default to `Renderer::clearScreen` call. Seems this was missed in #535.
