### PR TITLE
Mean solar distance

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -427,7 +427,7 @@ static void serializeTile(XmlElement* _ti, int x, int y, int depth, int index)
 }
 
 
-void TileMap::serialize(NAS2D::Xml::XmlElement* element)
+void TileMap::serialize(NAS2D::Xml::XmlElement* element, const Planet::Attributes& planetAttributes)
 {
 	// ==========================================
 	// MAP PROPERTIES
@@ -435,10 +435,10 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 	XmlElement *properties = new XmlElement("properties");
 	element->linkEndChild(properties);
 
-	properties->attribute("sitemap", mMapPath);
-	properties->attribute("tset", mTsetPath);
-	properties->attribute("diggingdepth", mMaxDepth);
-
+	properties->attribute("sitemap", planetAttributes.mapImagePath);
+	properties->attribute("tset", planetAttributes.tilesetPath);
+	properties->attribute("diggingdepth", planetAttributes.maxDepth);
+	properties->attribute("meansolardistance", planetAttributes.meanSolarDistance);
 	// ==========================================
 	// VIEW PARAMETERS
 	// ==========================================

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -438,7 +438,8 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element, const Planet::Attribute
 	properties->attribute("sitemap", planetAttributes.mapImagePath);
 	properties->attribute("tset", planetAttributes.tilesetPath);
 	properties->attribute("diggingdepth", planetAttributes.maxDepth);
-	properties->attribute("meansolardistance", planetAttributes.meanSolarDistance);
+	// NAS2D only supports double for floating point conversions as of 26July2020
+	properties->attribute("meansolardistance", static_cast<double>(planetAttributes.meanSolarDistance));
 	// ==========================================
 	// VIEW PARAMETERS
 	// ==========================================

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -70,7 +70,7 @@ public:
 	
 	void draw();
 
-	void serialize(NAS2D::Xml::XmlElement* element);
+	void serialize(NAS2D::Xml::XmlElement* element, const Planet::Attributes& planetAttributes);
 	void deserialize(NAS2D::Xml::XmlElement* element);
 
 public:

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -95,6 +95,7 @@ MapViewState::MapViewState(const std::string& savegame) :
  */
 MapViewState::MapViewState(const Planet::Attributes& planetAttributes) :
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
+	mPlanetAttributes(planetAttributes),
 	mBackground("sys/bg1.png"),
 	mMapDisplay(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION),
 	mHeightMap(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION),
@@ -165,7 +166,7 @@ void MapViewState::initialize()
 	else 
 	{ 
 		// StructureCatalogue is initialized in load routine if saved game present to load existing structures
-		StructureCatalogue::init(); 
+		StructureCatalogue::init(mPlanetAttributes.meanSolarDistance); 
 	}
 
 	//Utility<Mixer>::get().fadeInMusic(mBgMusic);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -158,7 +158,15 @@ void MapViewState::initialize()
 
 	mPopulationPool.population(&mPopulation);
 
-	if (mLoadingExisting) { load(mExistingToLoad); }
+	if (mLoadingExisting) 
+	{ 
+		load(mExistingToLoad); 
+	}
+	else 
+	{ 
+		// StructureCatalogue is initialized in load routine if saved game present to load existing structures
+		StructureCatalogue::init(); 
+	}
 
 	//Utility<Mixer>::get().fadeInMusic(mBgMusic);
 	Utility<Renderer>::get().fadeIn(constants::FADE_SPEED);

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -198,6 +198,8 @@ private:
 private:
 	TileMap* mTileMap = nullptr;
 
+	Planet::Attributes mPlanetAttributes;
+
 	NAS2D::Image mBackground; /**< Background image drawn behind the tile map. */
 	NAS2D::Image mMapDisplay; /**< Satellite view of the Site Map. */
 	NAS2D::Image mHeightMap; /**< Height view of the Site Map. */

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -147,17 +147,19 @@ void MapViewState::load(const std::string& filePath)
 	XmlElement* map = root->firstChildElement("properties");
 	int depth = 0;
 	std::string sitemap;
+	std::string tilesetPath;
 	XmlAttribute* attribute = map->firstAttribute();
 	while (attribute)
 	{
 		if (attribute->name() == "diggingdepth") { attribute->queryIntValue(depth); }
 		else if (attribute->name() == "sitemap") { sitemap = attribute->value(); }
+		else if (attribute->name() == "tset") { tilesetPath = attribute->value(); }
 		attribute = attribute->next();
 	}
 
 	mMapDisplay = Image(sitemap + MAP_DISPLAY_EXTENSION);
 	mHeightMap = Image(sitemap + MAP_TERRAIN_EXTENSION);
-	mTileMap = new TileMap(sitemap, map->attribute("tset"), depth, 0, Planet::Hostility::None, false);
+	mTileMap = new TileMap(sitemap, tilesetPath, depth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 
 	delete pather;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -157,6 +157,7 @@ void MapViewState::load(const std::string& filePath)
 		attribute = attribute->next();
 	}
 
+	StructureCatalogue::init();
 	mMapDisplay = Image(sitemap + MAP_DISPLAY_EXTENSION);
 	mHeightMap = Image(sitemap + MAP_TERRAIN_EXTENSION);
 	mTileMap = new TileMap(sitemap, tilesetPath, depth, 0, Planet::Hostility::None, false);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -97,6 +97,7 @@ extern std::vector<void*> path;
  */
 void MapViewState::load(const std::string& filePath)
 {
+	mPlanetAttributes = Planet::Attributes();
 	resetUi();
 
 	auto& renderer = Utility<Renderer>::get();
@@ -145,22 +146,20 @@ void MapViewState::load(const std::string& filePath)
 	mTileMap = nullptr;
 
 	XmlElement* map = root->firstChildElement("properties");
-	int depth = 0;
-	std::string sitemap;
-	std::string tilesetPath;
 	XmlAttribute* attribute = map->firstAttribute();
 	while (attribute)
 	{
-		if (attribute->name() == "diggingdepth") { attribute->queryIntValue(depth); }
-		else if (attribute->name() == "sitemap") { sitemap = attribute->value(); }
-		else if (attribute->name() == "tset") { tilesetPath = attribute->value(); }
+		if (attribute->name() == "diggingdepth") { attribute->queryIntValue(mPlanetAttributes.maxDepth); }
+		else if (attribute->name() == "sitemap") { mPlanetAttributes.mapImagePath = attribute->value(); }
+		else if (attribute->name() == "tset") { mPlanetAttributes.tilesetPath = attribute->value(); }
+		else if (attribute->name() == "meansolardistance") { mPlanetAttributes.meanSolarDistance = std::stof(attribute->value()); }
 		attribute = attribute->next();
 	}
 
-	StructureCatalogue::init();
-	mMapDisplay = Image(sitemap + MAP_DISPLAY_EXTENSION);
-	mHeightMap = Image(sitemap + MAP_TERRAIN_EXTENSION);
-	mTileMap = new TileMap(sitemap, tilesetPath, depth, 0, Planet::Hostility::None, false);
+	StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
+	mMapDisplay = Image(mPlanetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION);
+	mHeightMap = Image(mPlanetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION);
+	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.tilesetPath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 
 	delete pather;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -58,7 +58,7 @@ void MapViewState::save(const std::string& filePath)
 	root->attribute("version", constants::SAVE_GAME_VERSION);
 	doc.linkEndChild(root);
 
-	mTileMap->serialize(root);
+	mTileMap->serialize(root, mPlanetAttributes);
 	Utility<StructureManager>::get().serialize(root);
 	writeRobots(root, mRobotPool, mRobotList);
 	writeResources(root, mPlayerResources, "resources");

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -36,7 +36,7 @@ public:
 	{
 		PlanetType type = PlanetType::None;
 		std::string imagePath;
-		Hostility hostility;
+		Hostility hostility = Hostility::None;
 		int maxDepth = 0;
 		int maxMines = 0;
 		std::string mapImagePath;
@@ -45,7 +45,7 @@ public:
 		/**
 		 * Mean distance from star in astronomical units (AU)
 		 */
-		float meanSolarDistance;
+		float meanSolarDistance = 0;
 	};
 
 public:

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -41,6 +41,11 @@ public:
 		int maxMines = 0;
 		std::string mapImagePath;
 		std::string tilesetPath;
+
+		/**
+		 * Mean distance from star in astronomical units (AU)
+		 */
+		float meanSolarDistance;
 	};
 
 public:

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -92,9 +92,9 @@ PlanetSelectState::~PlanetSelectState()
 
 namespace {
 	std::vector<Planet::Attributes> planetAttributes = {
-		{ Planet::Attributes{Planet::PlanetType::Mercury, "planets/planet_d.png", Planet::Hostility::High, 1, 10, "maps/merc_01", "tsets/mercury.png"} },
-		{ Planet::Attributes{Planet::PlanetType::Mars, "planets/planet_c.png", Planet::Hostility::Low, 4, 30, "maps/mars_04", "tsets/mars.png"} },
-		{ Planet::Attributes{Planet::PlanetType::Ganymede, "planets/planet_e.png", Planet::Hostility::Medium, 2, 15, "maps/ganymede_01", "tsets/ganymede.png"} }
+		{ Planet::Attributes{Planet::PlanetType::Mercury, "planets/planet_d.png", Planet::Hostility::High, 1, 10, "maps/merc_01", "tsets/mercury.png", 0.4f} },
+		{ Planet::Attributes{Planet::PlanetType::Mars, "planets/planet_c.png", Planet::Hostility::Low, 4, 30, "maps/mars_04", "tsets/mars.png", 1.524f} },
+		{ Planet::Attributes{Planet::PlanetType::Ganymede, "planets/planet_e.png", Planet::Hostility::Medium, 2, 15, "maps/ganymede_01", "tsets/ganymede.png", 5.2f} }
 	};
 }
 

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -8,6 +8,7 @@
 std::array<ResourcePool, StructureID::SID_COUNT> StructureCatalogue::mStructureCostTable;
 std::array<ResourcePool, StructureID::SID_COUNT> StructureCatalogue::mStructureRecycleValueTable;
 std::array<PopulationRequirements, StructureID::SID_COUNT> StructureCatalogue::mPopulationRequirementsTable = {};
+float StructureCatalogue::mMeanSolarDistance = 0;
 
 /**	Default recycle value. Currently set at 90% but this should probably be
  *	lowered for actual gameplay with modifiers to improve efficiency. */
@@ -220,8 +221,9 @@ const ResourcePool& StructureCatalogue::recyclingValue(StructureID type)
 /**
  * Initializes StructureCatalogue and builds the requirements tables.
  */
-void StructureCatalogue::init()
+void StructureCatalogue::init(float meanSolarDistance)
 {
+	mMeanSolarDistance = meanSolarDistance;
 	buildCostTable();
 	buildRecycleValueTable();
 	buildPopulationRequirementsTable();

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -144,11 +144,11 @@ Structure* StructureCatalogue::get(StructureID type)
 			break;
 
 		case StructureID::SID_SOLAR_PANEL1:
-			structure = new SolarPanelArray();
+			structure = new SolarPanelArray(mMeanSolarDistance);
 			break;
 
 		case StructureID::SID_SOLAR_PLANT:
-			structure = new SolarPlant();
+			structure = new SolarPlant(mMeanSolarDistance);
 			break;
 
 		case StructureID::SID_STORAGE_TANKS:

--- a/OPHD/StructureCatalogue.h
+++ b/OPHD/StructureCatalogue.h
@@ -24,7 +24,7 @@
 class StructureCatalogue
 {
 public:
-	static void init();
+	static void init(float meanSolarDistance);
 
 	static Structure* get(StructureID type);
 
@@ -49,4 +49,5 @@ private:
 	static std::array<ResourcePool, StructureID::SID_COUNT> mStructureCostTable;
 	static std::array<ResourcePool, StructureID::SID_COUNT> mStructureRecycleValueTable;
 	static std::array<PopulationRequirements, StructureID::SID_COUNT> mPopulationRequirementsTable;
+	static float mMeanSolarDistance;
 };

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -4,12 +4,13 @@
 
 #include "../../Constants.h"
 
-const int SOLAR_PANEL_BASE_PRODUCUCTION = 25;
+const int SOLAR_PANEL_BASE_PRODUCUCTION = 50;
 
 class SolarPanelArray : public PowerStructure
 {
 public:
-	SolarPanelArray() : PowerStructure(constants::SOLAR_PANEL1, "structures/solar_array1.sprite", StructureClass::EnergyProduction)
+	SolarPanelArray(float meanSolarDistance) : PowerStructure(constants::SOLAR_PANEL1, "structures/solar_array1.sprite", StructureClass::EnergyProduction), 
+		mMeanSolarDistance(meanSolarDistance)
 	{
 		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(1000);
@@ -23,9 +24,11 @@ protected:
 		resourcesOut().energy(calculateEnergyProduced());
 	}
 
-private:
 	int calculateMaxEnergyProduction() override
 	{
-		return SOLAR_PANEL_BASE_PRODUCUCTION;
+		return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / mMeanSolarDistance);
 	}
+
+private:
+	const float mMeanSolarDistance;
 };

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -26,7 +26,10 @@ protected:
 
 	int calculateMaxEnergyProduction() override
 	{
-		return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / mMeanSolarDistance);
+		// Prevent possible dividing by zero
+		float solarDistance = mMeanSolarDistance != 0 ? mMeanSolarDistance : 1;
+
+		return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / solarDistance);
 	}
 
 private:

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -9,7 +9,8 @@ const int SOLAR_PLANT_BASE_PRODUCUCTION = 2000;
 class SolarPlant : public PowerStructure
 {
 public:
-	SolarPlant() : PowerStructure(constants::SOLAR_PLANT, "structures/solar_plant.sprite", StructureClass::EnergyProduction)
+	SolarPlant(float meanSolarDistance) : PowerStructure(constants::SOLAR_PLANT, "structures/solar_plant.sprite", StructureClass::EnergyProduction),
+		mMeanSolarDistance(meanSolarDistance)
 	{
 		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(1000);
@@ -25,6 +26,9 @@ protected:
 
 	int calculateMaxEnergyProduction() override
 	{
-		return SOLAR_PLANT_BASE_PRODUCUCTION;
+		return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / mMeanSolarDistance);
 	}
+
+private:
+	const float mMeanSolarDistance;
 };

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -26,7 +26,10 @@ protected:
 
 	int calculateMaxEnergyProduction() override
 	{
-		return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / mMeanSolarDistance);
+		// Prevent possible dividing by zero
+		float solarDistance = mMeanSolarDistance != 0 ? mMeanSolarDistance : 1;
+
+		return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / solarDistance);
 	}
 
 private:

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -3,7 +3,6 @@
 
 #include "Common.h"
 #include "Constants.h"
-#include "StructureCatalogue.h"
 #include "StructureTranslator.h"
 #include "WindowEventWrapper.h"
 
@@ -63,7 +62,6 @@ int main(int /*argc*/, char *argv[])
 
 	std::cout << "OutpostHD " << constants::VERSION << std::endl << std::endl;
 
-	StructureCatalogue::init(); // only needs to be done once at the start of the program.
 	StructureTranslator::init(); // only needs to be done once at the start of the program.
 
 	try


### PR DESCRIPTION
This was a tough refactor.

I used actual meanSolarDistance values for Mars, Mercury, and Jupiter.

I standardized at 1 AU (Earth) producing 50 solar power. This puts Mars around 35 power, Mercury around 125, and Ganymede at about 9.

This is a bit different value for Mars but I don't think it was really balanced to start with. 

Nothing scientific about the formula, but it seemed to produce a reasonable curve with Mercury being a lot better than Mars and Ganymede likely useless. Please feel free to adjust.

MapViewState is probably not the right place for a lot of the loading and game settings to exist, but didn't really address that with this branch.