### PR TITLE
Remove empty Thing constructor

### DIFF
--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -22,9 +22,6 @@ public:
 		mSprite(spritePath)
 	{}
 
-	Thing(): mName("Unknown")
-	{}
-
 	virtual ~Thing()
 	{
 		#ifdef _DEBUG


### PR DESCRIPTION
If an actual `Thing` is not being constructed, then don't construct one.
