### PR TITLE
Prevent undefined behaviour when serializing robots to Xml

### DIFF
--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -516,6 +516,10 @@ void checkRobotDeployment(XmlElement* _ti, RobotTileTable& _rm, Robot* _r, Robot
 	_ti->attribute("age", _r->fuelCellAge());
 	_ti->attribute("production", _r->turnsToCompleteTask());
 
+	if (_rm.empty()) {
+		return;
+	}
+
 	const auto it = _rm.find(_r);
 	if (it->first == _r)
 	{
@@ -525,7 +529,6 @@ void checkRobotDeployment(XmlElement* _ti, RobotTileTable& _rm, Robot* _r, Robot
 		_ti->attribute("y", position.y);
 		_ti->attribute("depth", tile.depth());
 	}
-
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -516,12 +516,8 @@ void checkRobotDeployment(XmlElement* _ti, RobotTileTable& _rm, Robot* _r, Robot
 	_ti->attribute("age", _r->fuelCellAge());
 	_ti->attribute("production", _r->turnsToCompleteTask());
 
-	if (_rm.empty()) {
-		return;
-	}
-
 	const auto it = _rm.find(_r);
-	if (it->first == _r)
+	if (it != _rm.end())
 	{
 		const auto& tile = *it->second;
 		const auto position = tile.position();


### PR DESCRIPTION
Using an iterator within an empty std::map leads to undefined behaviour as caught by Visual Studio when running code in debug mode. Reference http://www.cplusplus.com/reference/map/map/begin/.

Resolves issue noted in PR #544 but unrelated to changes in that PR.