### PR TITLE
Set initial animation action in Things constructor

### DIFF
--- a/OPHD/Things/Robots/Robodigger.h
+++ b/OPHD/Things/Robots/Robodigger.h
@@ -10,10 +10,9 @@ class Robodigger: public Robot
 {
 public:
 	Robodigger() :
-		Robot(constants::ROBODIGGER, "robots/robodigger.sprite"),
+		Robot(constants::ROBODIGGER, "robots/robodigger.sprite", "running"),
 		mDirection(Direction::Down)
 	{
-		sprite().play("running");
 	}
 
 	void direction(Direction dir) { mDirection = dir; }

--- a/OPHD/Things/Robots/Robodigger.h
+++ b/OPHD/Things/Robots/Robodigger.h
@@ -10,7 +10,7 @@ class Robodigger: public Robot
 {
 public:
 	Robodigger() :
-		Robot(constants::ROBODIGGER, "robots/robodigger.sprite", "running"),
+		Robot(constants::ROBODIGGER, "robots/robodigger.sprite"),
 		mDirection(Direction::Down)
 	{
 	}

--- a/OPHD/Things/Robots/Robodozer.h
+++ b/OPHD/Things/Robots/Robodozer.h
@@ -7,7 +7,7 @@
 class Robodozer: public Robot
 {
 public:
-	Robodozer(): Robot(constants::ROBODOZER, "robots/robodozer.sprite", "running")
+	Robodozer(): Robot(constants::ROBODOZER, "robots/robodozer.sprite")
 	{
 	}
 

--- a/OPHD/Things/Robots/Robodozer.h
+++ b/OPHD/Things/Robots/Robodozer.h
@@ -7,9 +7,8 @@
 class Robodozer: public Robot
 {
 public:
-	Robodozer(): Robot(constants::ROBODOZER, "robots/robodozer.sprite")
+	Robodozer(): Robot(constants::ROBODOZER, "robots/robodozer.sprite", "running")
 	{
-		sprite().play("running");
 	}
 
 	void tileIndex(std::size_t index) { mTileIndex = index; }

--- a/OPHD/Things/Robots/Robominer.h
+++ b/OPHD/Things/Robots/Robominer.h
@@ -7,9 +7,8 @@
 class Robominer: public Robot
 {
 public:
-	Robominer(): Robot(constants::ROBOMINER, "robots/robominer.sprite")
+	Robominer(): Robot(constants::ROBOMINER, "robots/robominer.sprite", "running")
 	{
-		sprite().play("running");
 	}
 
 	void update() override { updateTask(); }

--- a/OPHD/Things/Robots/Robominer.h
+++ b/OPHD/Things/Robots/Robominer.h
@@ -7,7 +7,7 @@
 class Robominer: public Robot
 {
 public:
-	Robominer(): Robot(constants::ROBOMINER, "robots/robominer.sprite", "running")
+	Robominer(): Robot(constants::ROBOMINER, "robots/robominer.sprite")
 	{
 	}
 

--- a/OPHD/Things/Robots/Robot.cpp
+++ b/OPHD/Things/Robots/Robot.cpp
@@ -8,6 +8,11 @@ Robot::Robot(const std::string& name, const std::string& sprite_path) :
 {}
 
 
+Robot::Robot(const std::string& name, const std::string& sprite_path, const std::string& initialAction) :
+	Thing(name, sprite_path, initialAction)
+{}
+
+
 void Robot::startTask(int turns)
 {
 	if (turns < 1) { throw std::runtime_error("Robot::startTask() called with a value less than 1."); }

--- a/OPHD/Things/Robots/Robot.cpp
+++ b/OPHD/Things/Robots/Robot.cpp
@@ -4,7 +4,7 @@
 #include "Robot.h"
 
 Robot::Robot(const std::string& name, const std::string& sprite_path) :
-	Thing(name, sprite_path)
+	Thing(name, sprite_path, "running")
 {}
 
 

--- a/OPHD/Things/Robots/Robot.h
+++ b/OPHD/Things/Robots/Robot.h
@@ -11,6 +11,7 @@ public:
 
 public:
 	Robot(const std::string& name, const std::string& sprite_path);
+	Robot(const std::string& name, const std::string& sprite_path, const std::string& initialAction);
 
 	void startTask(int turns);
 

--- a/OPHD/Things/Structures/Agridome.h
+++ b/OPHD/Things/Structures/Agridome.h
@@ -11,7 +11,6 @@ class Agridome : public Structure
 public:
 	Agridome() : Structure(constants::AGRIDOME, "structures/agridome.sprite", StructureClass::FoodProduction)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(600);
 		turnsToBuild(3);
 

--- a/OPHD/Things/Structures/AirShaft.h
+++ b/OPHD/Things/Structures/AirShaft.h
@@ -6,9 +6,8 @@
 class AirShaft: public Structure
 {
 public:
-	AirShaft() : Structure(constants::AIR_SHAFT, "structures/air_shaft.sprite", StructureClass::Tube)
+	AirShaft() : Structure(constants::AIR_SHAFT, "structures/air_shaft.sprite", constants::STRUCTURE_STATE_OPERATIONAL, StructureClass::Tube)
 	{
-		sprite().play(constants::STRUCTURE_STATE_OPERATIONAL);
 		maxAge(400);
 
 		connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);

--- a/OPHD/Things/Structures/CHAP.h
+++ b/OPHD/Things/Structures/CHAP.h
@@ -7,7 +7,6 @@ class CHAP : public Structure
 public:
 	CHAP() : Structure(constants::CHAP, "structures/chap.sprite", StructureClass::LifeSupport)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(600);
 		turnsToBuild(5);
 

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -13,7 +13,6 @@ public:
 
 	CargoLander(Tile* t) : Structure(constants::CARGO_LANDER, "structures/lander_0.sprite", StructureClass::Lander), mTile(t)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(50);
 		turnsToBuild(1);
 		repairable(false);

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -14,7 +14,6 @@ public:
 
 	ColonistLander(Tile* t) : Structure(constants::COLONIST_LANDER, "structures/lander_1.sprite", StructureClass::Lander), mTile(t)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(50);
 		turnsToBuild(1);
 		repairable(false);

--- a/OPHD/Things/Structures/CommTower.h
+++ b/OPHD/Things/Structures/CommTower.h
@@ -11,7 +11,6 @@ public:
 
 	CommTower() : Structure(constants::COMM_TOWER, "structures/communications_tower.sprite", StructureClass::Communication)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(600);
 		turnsToBuild(2);
 

--- a/OPHD/Things/Structures/CommandCenter.h
+++ b/OPHD/Things/Structures/CommandCenter.h
@@ -10,7 +10,6 @@ class CommandCenter: public Structure
 public:
 	CommandCenter(): Structure(constants::COMMAND_CENTER, "structures/command_center.sprite", StructureClass::Command)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/Commercial.h
+++ b/OPHD/Things/Structures/Commercial.h
@@ -9,7 +9,6 @@ class Commercial : public Structure
 public:
 	Commercial() : Structure(constants::COMMERCIAL, "structures/commercial.sprite", StructureClass::Commercial)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(3);
 

--- a/OPHD/Things/Structures/FusionReactor.h
+++ b/OPHD/Things/Structures/FusionReactor.h
@@ -12,7 +12,6 @@ class FusionReactor : public PowerStructure
 public:
 	FusionReactor() : PowerStructure(constants::FUSION_REACTOR, "structures/fusion_reactor.sprite", StructureClass::EnergyProduction)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(1000);
 		turnsToBuild(10);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/HotLaboratory.h
+++ b/OPHD/Things/Structures/HotLaboratory.h
@@ -7,7 +7,6 @@ class HotLaboratory : public Structure
 public:
 	HotLaboratory() : Structure(constants::HOT_LABORATORY, "structures/labo_surface.sprite", StructureClass::Laboratory)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(5);
 

--- a/OPHD/Things/Structures/Laboratory.h
+++ b/OPHD/Things/Structures/Laboratory.h
@@ -7,7 +7,6 @@ class Laboratory : public Structure
 public:
 	Laboratory() : Structure(constants::LABORATORY, "structures/laboratory_underground.sprite", StructureClass::Laboratory)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/MedicalCenter.h
+++ b/OPHD/Things/Structures/MedicalCenter.h
@@ -9,7 +9,6 @@ class MedicalCenter : public Structure
 public:
 	MedicalCenter() : Structure(constants::MEDICAL_CENTER, "structures/medical.sprite", StructureClass::MedicalCenter)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/MineShaft.h
+++ b/OPHD/Things/Structures/MineShaft.h
@@ -11,7 +11,6 @@ class MineShaft : public Structure
 public:
 	MineShaft() : Structure(constants::MINE_SHAFT, "structures/mine_shaft.sprite", StructureClass::Undefined)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(1200);
 		turnsToBuild(2);
 

--- a/OPHD/Things/Structures/Nursery.h
+++ b/OPHD/Things/Structures/Nursery.h
@@ -9,7 +9,6 @@ class Nursery : public Structure
 public:
 	Nursery() : Structure(constants::NURSERY, "structures/nursery_01.sprite", StructureClass::Nursery)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/Park.h
+++ b/OPHD/Things/Structures/Park.h
@@ -9,7 +9,6 @@ class Park : public Structure
 public:
 	Park() : Structure(constants::PARK, "structures/park.sprite", StructureClass::Park)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(3);
 

--- a/OPHD/Things/Structures/RecreationCenter.h
+++ b/OPHD/Things/Structures/RecreationCenter.h
@@ -9,7 +9,6 @@ class RecreationCenter : public Structure
 public:
 	RecreationCenter() : Structure(constants::RECREATION_CENTER, "structures/recreation_center.sprite", StructureClass::RecreationCenter)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/RedLightDistrict.h
+++ b/OPHD/Things/Structures/RedLightDistrict.h
@@ -9,7 +9,6 @@ class RedLightDistrict : public Structure
 public:
 	RedLightDistrict() : Structure(constants::RED_LIGHT_DISTRICT, "structures/red_light_district.sprite", StructureClass::Residence)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/Residence.h
+++ b/OPHD/Things/Structures/Residence.h
@@ -15,7 +15,6 @@ class Residence : public Structure
 public:
 	Residence() : Structure(constants::RESIDENCE, "structures/residential_1.sprite", StructureClass::Residence)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(2);
 

--- a/OPHD/Things/Structures/RobotCommand.h
+++ b/OPHD/Things/Structures/RobotCommand.h
@@ -17,7 +17,6 @@ class RobotCommand : public Structure
 public:
 	RobotCommand() : Structure(constants::ROBOT_COMMAND, "structures/robot_control.sprite", StructureClass::RobotCommand)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(3);
 

--- a/OPHD/Things/Structures/SeedFactory.h
+++ b/OPHD/Things/Structures/SeedFactory.h
@@ -8,7 +8,6 @@ class SeedFactory: public Factory
 public:
 	SeedFactory(): Factory(constants::SEED_FACTORY, "structures/seed_1.sprite")
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(150);
 		turnsToBuild(8);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -16,7 +16,6 @@ public:
 		Structure{constants::SEED_LANDER, "structures/seed_0.sprite", StructureClass::Lander},
 		mPosition{position}
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(50);
 		turnsToBuild(1);
 		repairable(false);

--- a/OPHD/Things/Structures/SeedPower.h
+++ b/OPHD/Things/Structures/SeedPower.h
@@ -11,7 +11,6 @@ class SeedPower: public PowerStructure
 public:
 	SeedPower() : PowerStructure(constants::SEED_POWER, "structures/seed_1.sprite", StructureClass::EnergyProduction)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(150);
 		turnsToBuild(5);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/SeedSmelter.h
+++ b/OPHD/Things/Structures/SeedSmelter.h
@@ -8,7 +8,6 @@ class SeedSmelter : public Structure
 public:
 	SeedSmelter() : Structure(constants::SEED_SMELTER, "structures/seed_1.sprite", StructureClass::Smelter)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(150);
 		turnsToBuild(6);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/Smelter.h
+++ b/OPHD/Things/Structures/Smelter.h
@@ -8,7 +8,6 @@ class Smelter : public Structure
 public:
 	Smelter() : Structure(constants::SMELTER, "structures/smelter.sprite", StructureClass::Smelter)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(600);
 		turnsToBuild(9);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -12,7 +12,6 @@ public:
 	SolarPanelArray(float meanSolarDistance) : PowerStructure(constants::SOLAR_PANEL1, "structures/solar_array1.sprite", StructureClass::EnergyProduction), 
 		mMeanSolarDistance(meanSolarDistance)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(1000);
 		turnsToBuild(4);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -12,7 +12,6 @@ public:
 	SolarPlant(float meanSolarDistance) : PowerStructure(constants::SOLAR_PLANT, "structures/solar_plant.sprite", StructureClass::EnergyProduction),
 		mMeanSolarDistance(meanSolarDistance)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(1000);
 		turnsToBuild(4);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/StorageTanks.h
+++ b/OPHD/Things/Structures/StorageTanks.h
@@ -7,7 +7,6 @@ class StorageTanks : public Structure
 public:
 	StorageTanks() : Structure(constants::STORAGE_TANKS, "structures/storage_tanks.sprite", StructureClass::Storage)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(2);
 

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -72,6 +72,15 @@ Structure::Structure(const std::string& name, const std::string& spritePath, Str
 }
 
 
+Structure::Structure(const std::string& name, const std::string& spritePath, const std::string& initialAction, StructureClass structureClass) :
+	Thing(name, spritePath, initialAction),
+	mStructureClass(structureClass)
+{
+	mPopulationRequirements.fill(0);
+	mPopulationAvailable.fill(0);
+}
+
+
 /**
  * Sets a Disabled state for the Structure.
  */

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -64,7 +64,7 @@ const std::string& structureClassDescription(Structure::StructureClass _class)
  * C'tor
  */
 Structure::Structure(const std::string& name, const std::string& spritePath, StructureClass structureClass) :
-	Thing(name, spritePath),
+	Thing(name, spritePath, constants::STRUCTURE_STATE_CONSTRUCTION),
 	mStructureClass(structureClass)
 {
 	mPopulationRequirements.fill(0);

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -64,6 +64,7 @@ public:
 
 public:
 	Structure(const std::string& name, const std::string& spritePath, StructureClass structureClass);
+	Structure(const std::string& name, const std::string& spritePath, const std::string& initialAction, StructureClass structureClass);
 
 	// STATES & STATE MANAGEMENT
 	StructureState state() const { return mStructureState; }

--- a/OPHD/Things/Structures/SurfaceFactory.h
+++ b/OPHD/Things/Structures/SurfaceFactory.h
@@ -8,7 +8,6 @@ class SurfaceFactory: public Factory
 public:
 	SurfaceFactory(): Factory(constants::SURFACE_FACTORY, "structures/factory_surface.sprite")
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(600);
 		turnsToBuild(7);
 		requiresCHAP(false);

--- a/OPHD/Things/Structures/SurfacePolice.h
+++ b/OPHD/Things/Structures/SurfacePolice.h
@@ -9,7 +9,6 @@ class SurfacePolice : public Structure
 public:
 	SurfacePolice() : Structure(constants::SURFACE_POLICE, "structures/police_surface.sprite", StructureClass::SurfacePolice)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -23,13 +23,13 @@ private:
 
 	static const std::string& getAnimationName(ConnectorDir dir, bool underground)
 	{
-		return
+		return *(
 			(dir == ConnectorDir::CONNECTOR_INTERSECTION) ?
-				(underground ? constants::UG_TUBE_INTERSECTION : constants::AG_TUBE_INTERSECTION) :
+				(underground ? &constants::UG_TUBE_INTERSECTION : &constants::AG_TUBE_INTERSECTION) :
 			(dir == ConnectorDir::CONNECTOR_RIGHT) ?
-				(underground ? constants::UG_TUBE_RIGHT : constants::AG_TUBE_RIGHT) :
+				(underground ? &constants::UG_TUBE_RIGHT : &constants::AG_TUBE_RIGHT) :
 			(dir == ConnectorDir::CONNECTOR_LEFT) ?
-				(underground ? constants::UG_TUBE_LEFT : constants::AG_TUBE_LEFT) :
-			throw std::runtime_error("Tried to create a Tube structure with invalid connector direction paramter.");
+				(underground ? &constants::UG_TUBE_LEFT : &constants::AG_TUBE_LEFT) :
+			throw std::runtime_error("Tried to create a Tube structure with invalid connector direction paramter."));
 	}
 };

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -19,26 +19,26 @@ public:
 
 		maxAge(400);
 
-		setAnimationState();
+		sprite().play(getAnimationName());
 	}
 
 private:
 
-	void setAnimationState()
+	const std::string& getAnimationName()
 	{
 		if (mUnderground)
 		{
 			if (connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION)
 			{
-				sprite().play(constants::UG_TUBE_INTERSECTION);
+				return constants::UG_TUBE_INTERSECTION;
 			}
 			else if (connectorDirection() == ConnectorDir::CONNECTOR_RIGHT)
 			{
-				sprite().play(constants::UG_TUBE_RIGHT);
+				return constants::UG_TUBE_RIGHT;
 			}
 			else if (connectorDirection() == ConnectorDir::CONNECTOR_LEFT)
 			{
-				sprite().play(constants::UG_TUBE_LEFT);
+				return constants::UG_TUBE_LEFT;
 			}
 			else
 			{
@@ -49,15 +49,15 @@ private:
 		{
 			if (connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION)
 			{
-				sprite().play(constants::AG_TUBE_INTERSECTION);
+				return constants::AG_TUBE_INTERSECTION;
 			}
 			else if (connectorDirection() == ConnectorDir::CONNECTOR_RIGHT)
 			{
-				sprite().play(constants::AG_TUBE_RIGHT);
+				return constants::AG_TUBE_RIGHT;
 			}
 			else if (connectorDirection() == ConnectorDir::CONNECTOR_LEFT)
 			{
-				sprite().play(constants::AG_TUBE_LEFT);
+				return constants::AG_TUBE_LEFT;
 			}
 			else
 			{

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -11,14 +11,12 @@ class Tube : public Structure
 {
 public:
 	Tube(ConnectorDir dir, bool underground) :
-		Structure(constants::TUBE, "structures/tubes.sprite", StructureClass::Tube)
+		Structure(constants::TUBE, "structures/tubes.sprite", getAnimationName(dir, underground), StructureClass::Tube)
 	{
 		connectorDirection(dir);
 		requiresCHAP(false);
 
 		maxAge(400);
-
-		sprite().play(getAnimationName(dir, underground));
 	}
 
 private:

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -11,32 +11,31 @@ class Tube : public Structure
 {
 public:
 	Tube(ConnectorDir dir, bool underground) :
-		Structure(constants::TUBE, "structures/tubes.sprite", StructureClass::Tube),
-		mUnderground(underground)
+		Structure(constants::TUBE, "structures/tubes.sprite", StructureClass::Tube)
 	{
 		connectorDirection(dir);
 		requiresCHAP(false);
 
 		maxAge(400);
 
-		sprite().play(getAnimationName());
+		sprite().play(getAnimationName(dir, underground));
 	}
 
 private:
 
-	const std::string& getAnimationName()
+	static const std::string& getAnimationName(ConnectorDir dir, bool underground)
 	{
-		if (mUnderground)
+		if (underground)
 		{
-			if (connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION)
+			if (dir == ConnectorDir::CONNECTOR_INTERSECTION)
 			{
 				return constants::UG_TUBE_INTERSECTION;
 			}
-			else if (connectorDirection() == ConnectorDir::CONNECTOR_RIGHT)
+			else if (dir == ConnectorDir::CONNECTOR_RIGHT)
 			{
 				return constants::UG_TUBE_RIGHT;
 			}
-			else if (connectorDirection() == ConnectorDir::CONNECTOR_LEFT)
+			else if (dir == ConnectorDir::CONNECTOR_LEFT)
 			{
 				return constants::UG_TUBE_LEFT;
 			}
@@ -47,15 +46,15 @@ private:
 		}
 		else
 		{
-			if (connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION)
+			if (dir == ConnectorDir::CONNECTOR_INTERSECTION)
 			{
 				return constants::AG_TUBE_INTERSECTION;
 			}
-			else if (connectorDirection() == ConnectorDir::CONNECTOR_RIGHT)
+			else if (dir == ConnectorDir::CONNECTOR_RIGHT)
 			{
 				return constants::AG_TUBE_RIGHT;
 			}
-			else if (connectorDirection() == ConnectorDir::CONNECTOR_LEFT)
+			else if (dir == ConnectorDir::CONNECTOR_LEFT)
 			{
 				return constants::AG_TUBE_LEFT;
 			}
@@ -65,7 +64,4 @@ private:
 			}
 		}
 	}
-
-private:
-	bool mUnderground;
 };

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -23,43 +23,13 @@ private:
 
 	static const std::string& getAnimationName(ConnectorDir dir, bool underground)
 	{
-		if (underground)
-		{
-			if (dir == ConnectorDir::CONNECTOR_INTERSECTION)
-			{
-				return constants::UG_TUBE_INTERSECTION;
-			}
-			else if (dir == ConnectorDir::CONNECTOR_RIGHT)
-			{
-				return constants::UG_TUBE_RIGHT;
-			}
-			else if (dir == ConnectorDir::CONNECTOR_LEFT)
-			{
-				return constants::UG_TUBE_LEFT;
-			}
-			else
-			{
-				throw std::runtime_error("Tried to create a Tube structure with invalid connector direction paramter.");
-			}
-		}
-		else
-		{
-			if (dir == ConnectorDir::CONNECTOR_INTERSECTION)
-			{
-				return constants::AG_TUBE_INTERSECTION;
-			}
-			else if (dir == ConnectorDir::CONNECTOR_RIGHT)
-			{
-				return constants::AG_TUBE_RIGHT;
-			}
-			else if (dir == ConnectorDir::CONNECTOR_LEFT)
-			{
-				return constants::AG_TUBE_LEFT;
-			}
-			else
-			{
-				throw std::runtime_error("Tried to create a Tube structure with invalid connector direction paramter.");
-			}
-		}
+		return
+			(dir == ConnectorDir::CONNECTOR_INTERSECTION) ?
+				(underground ? constants::UG_TUBE_INTERSECTION : constants::AG_TUBE_INTERSECTION) :
+			(dir == ConnectorDir::CONNECTOR_RIGHT) ?
+				(underground ? constants::UG_TUBE_RIGHT : constants::AG_TUBE_RIGHT) :
+			(dir == ConnectorDir::CONNECTOR_LEFT) ?
+				(underground ? constants::UG_TUBE_LEFT : constants::AG_TUBE_LEFT) :
+			throw std::runtime_error("Tried to create a Tube structure with invalid connector direction paramter.");
 	}
 };

--- a/OPHD/Things/Structures/UndergroundFactory.h
+++ b/OPHD/Things/Structures/UndergroundFactory.h
@@ -8,7 +8,6 @@ class UndergroundFactory: public Factory
 public:
 	UndergroundFactory(): Factory(constants::UNDERGROUND_FACTORY, "structures/factory_underground.sprite")
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(600);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/UndergroundPolice.h
+++ b/OPHD/Things/Structures/UndergroundPolice.h
@@ -9,7 +9,6 @@ class UndergroundPolice : public Structure
 public:
 	UndergroundPolice() : Structure(constants::UNDERGROUND_POLICE, "structures/police_underground.sprite", StructureClass::UndergroundPolice)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(3);
 

--- a/OPHD/Things/Structures/University.h
+++ b/OPHD/Things/Structures/University.h
@@ -9,7 +9,6 @@ class University : public Structure
 public:
 	University() : Structure(constants::UNIVERSITY, "structures/university.sprite", StructureClass::University)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(4);
 

--- a/OPHD/Things/Structures/Warehouse.h
+++ b/OPHD/Things/Structures/Warehouse.h
@@ -9,7 +9,6 @@ class Warehouse : public Structure
 public:
 	Warehouse() : Structure(constants::WAREHOUSE, "structures/warehouse.sprite", StructureClass::Warehouse)
 	{
-		sprite().play(constants::STRUCTURE_STATE_CONSTRUCTION);
 		maxAge(500);
 		turnsToBuild(2);
 

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -17,11 +17,6 @@ public:
 	using DieCallback = NAS2D::Signals::Signal<Thing*>;
 
 public:
-	Thing(const std::string& name, const std::string& spritePath) :
-		mName(name),
-		mSprite(spritePath)
-	{}
-
 	Thing(const std::string& name, const std::string& spritePath, const std::string& initialAction) :
 		mName(name),
 		mSprite(spritePath, initialAction)

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -22,6 +22,11 @@ public:
 		mSprite(spritePath)
 	{}
 
+	Thing(const std::string& name, const std::string& spritePath, const std::string& initialAction) :
+		mName(name),
+		mSprite(spritePath, initialAction)
+	{}
+
 	virtual ~Thing()
 	{
 		#ifdef _DEBUG


### PR DESCRIPTION
This paves the way for closing the upstream issue: https://github.com/lairworks/nas2d-core/issues/525

By removing all uses of the older `Sprite` constructor that doesn't set an initial animation state, we can then remove that older constructor, and close the issue that was caused by having an invalid initial animation action.
