### PR TITLE
Hook up IconGrid::sizeChanged event

### DIFF
--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -184,7 +184,6 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
 
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mStructures.iconMargin(constants::MARGIN_TIGHT);
 
 	// Allow for centering with rounding to integer values
 	const auto rendererCenter = NAS2D::Utility<NAS2D::Renderer>::get().center().to<int>();

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -11,6 +11,8 @@
 #include <NAS2D/MathUtils.h>
 
 #include <algorithm>
+#include <stdexcept>
+#include <string>
 
 
 using namespace NAS2D;
@@ -65,6 +67,11 @@ void IconGrid::sheetPath(const std::string& filePath)
  */
 void IconGrid::iconSize(int newSize)
 {
+	if (newSize <= 0)
+	{
+		throw std::runtime_error("IconGrid::iconSize must be positive: " + std::to_string(newSize));
+	}
+
 	mIconSize = newSize;
 	updateGrid();
 }
@@ -75,6 +82,11 @@ void IconGrid::iconSize(int newSize)
  */
 void IconGrid::iconMargin(int newMargin)
 {
+	if (newMargin < 0)
+	{
+		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(newMargin));
+	}
+
 	mIconMargin = newMargin;
 	updateGrid();
 }

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -63,9 +63,9 @@ void IconGrid::sheetPath(const std::string& filePath)
 /**
  * Sets the icon dimensions.
  */
-void IconGrid::iconSize(int newSsize)
+void IconGrid::iconSize(int newSize)
 {
-	mIconSize = newSsize;
+	mIconSize = newSize;
 	updateGrid();
 }
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -24,6 +24,7 @@ IconGrid::IconGrid()
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &IconGrid::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMove);
+	resized().connect(this, &IconGrid::sizeChanged);
 	hasFocus(true);
 
 	mSkin.push_back(Image("ui/skin/textbox_top_left.png"));
@@ -169,7 +170,7 @@ std::size_t IconGrid::translateCoordsToIndex(NAS2D::Vector<int> relativeOffset)
 /**
  * Called whenever the size of the IconGrid is changed.
  */
-void IconGrid::sizeChanged()
+void IconGrid::sizeChanged(Control*)
 {
 	updateGrid();
 }

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -85,10 +85,7 @@ void IconGrid::iconMargin(int newMargin)
  */
 void IconGrid::updateGrid()
 {
-	int cols = (mRect.width - (mIconMargin * 2)) / (mIconSize + mIconMargin);
-	int rows = (mRect.height - (mIconMargin * 2)) / (mIconSize + mIconMargin);
-
-	mGridSize = {cols, rows};
+	mGridSize = (mRect.size() - NAS2D::Vector{mIconMargin, mIconMargin} * 2) / (mIconSize + mIconMargin);
 }
 
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -110,7 +110,7 @@ private:
 	Index mHighlightIndex = constants::NO_SELECTION; /**< Current highlight index. */
 	Index mCurrentSelection = constants::NO_SELECTION; /**< Currently selected item index. */
 
-	int mIconSize = 0; /**< Size of the icons. */
+	int mIconSize = 1; /**< Size of the icons. */
 	int mIconMargin = 0; /**< Spacing between icons and edges of the IconGrid. */
 
 	bool mShowTooltip = false; /**< Flag indicating that we want a tooltip drawn near an icon when hovering over it. */

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -94,7 +94,7 @@ protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	virtual void onMouseMove(int x, int y, int dX, int dY);
 
-	virtual void sizeChanged();
+	virtual void sizeChanged(Control*);
 
 private:
 	using IconItemList = std::vector<IconGridItem>;


### PR DESCRIPTION
Hook up previously unused `IconGrid::sizeChanged` event.

Previously, the grid tile size was not being recalculated when the control size changed. It only recalculated size after an icon or margin size change (which should probably be static).

Add error checks to ensure negative margins or zero sized tiles are not possible.

Related: #557
