### PR TITLE
Set more required attributes in IconGrid constructor

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -64,11 +64,6 @@ std::map <int, std::string> LEVEL_STRING_TABLE =
 Font* MAIN_FONT = nullptr;
 
 
-/**
- * C'Tor
- *
- * \param	savegame	Save game filename to load.
- */
 MapViewState::MapViewState(const std::string& savegame) :
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
@@ -78,14 +73,6 @@ MapViewState::MapViewState(const std::string& savegame) :
 }
 
 
-/**
- * C'Tor
- * 
- * \param	sm	Site map to load.
- * \param	t	Tileset to use.
- * \param	d	Depth of the site map.
- * \param	mc	Mine Count - Number of mines to generate.
- */
 MapViewState::MapViewState(const Planet::Attributes& planetAttributes) :
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
 	mPlanetAttributes(planetAttributes),
@@ -97,9 +84,6 @@ MapViewState::MapViewState(const Planet::Attributes& planetAttributes) :
 }
 
 
-/**
- * D'Tor
- */
 MapViewState::~MapViewState()
 {
 	scrubRobotList();
@@ -121,9 +105,6 @@ MapViewState::~MapViewState()
 }
 
 
-/**
- * 
- */
 void MapViewState::setPopulationLevel(PopulationLevel popLevel)
 {
 	mLandersColonist = static_cast<int>(popLevel);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -70,8 +70,6 @@ Font* MAIN_FONT = nullptr;
  * \param	savegame	Save game filename to load.
  */
 MapViewState::MapViewState(const std::string& savegame) :
-	mBackground("sys/bg1.png"),
-	mUiIcons("ui/icons.png"),
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
 {
@@ -91,10 +89,8 @@ MapViewState::MapViewState(const std::string& savegame) :
 MapViewState::MapViewState(const Planet::Attributes& planetAttributes) :
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
 	mPlanetAttributes(planetAttributes),
-	mBackground("sys/bg1.png"),
 	mMapDisplay(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION),
-	mHeightMap(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION),
-	mUiIcons("ui/icons.png")
+	mHeightMap(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION)
 {
 	ccLocation() = CcNotPlaced;
 	Utility<EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -231,9 +231,9 @@ private:
 	Button mBtnToggleHeightmap;
 	Button mBtnToggleConnectedness;
 
-	IconGrid mStructures;
-	IconGrid mRobots;
-	IconGrid mConnections;
+	IconGrid mStructures{"ui/structures.png", 46};
+	IconGrid mRobots{"ui/robots.png", 46};
+	IconGrid mConnections{"ui/structures.png", 46};
 
 	DiggerDirection mDiggerDirection;
 	FactoryProduction mFactoryProduction;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -231,9 +231,9 @@ private:
 	Button mBtnToggleHeightmap;
 	Button mBtnToggleConnectedness;
 
-	IconGrid mStructures{"ui/structures.png", 46};
-	IconGrid mRobots{"ui/robots.png", 46};
-	IconGrid mConnections{"ui/structures.png", 46};
+	IconGrid mStructures{"ui/structures.png", 46, constants::MARGIN_TIGHT};
+	IconGrid mRobots{"ui/robots.png", 46, constants::MARGIN_TIGHT};
+	IconGrid mConnections{"ui/structures.png", 46, constants::MARGIN_TIGHT};
 
 	DiggerDirection mDiggerDirection;
 	FactoryProduction mFactoryProduction;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -202,10 +202,10 @@ private:
 
 	Planet::Attributes mPlanetAttributes;
 
-	NAS2D::Image mBackground; /**< Background image drawn behind the tile map. */
+	NAS2D::Image mBackground{"sys/bg1.png"}; /**< Background image drawn behind the tile map. */
 	NAS2D::Image mMapDisplay; /**< Satellite view of the Site Map. */
 	NAS2D::Image mHeightMap; /**< Height view of the Site Map. */
-	NAS2D::Image mUiIcons; /**< User interface icons. */
+	NAS2D::Image mUiIcons{"ui/icons.png"}; /**< User interface icons. */
 
 	NAS2D::Point<int> mTileMapMouseHover; /**< Tile position the mouse is currently hovering over. */
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -120,19 +120,16 @@ void MapViewState::initUi()
 	// Menus
 	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mRobots.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mRobots.iconMargin(constants::MARGIN_TIGHT);
 	mRobots.showTooltip(true);
 	mRobots.selectionChanged().connect(this, &MapViewState::robotsSelectionChanged);
 
 	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mConnections.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mConnections.iconMargin(constants::MARGIN_TIGHT);
 	mConnections.selectionChanged().connect(this, &MapViewState::connectionsSelectionChanged);
 	mConnections.sorted(false);
 
 	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mStructures.iconMargin(constants::MARGIN_TIGHT);
 	mStructures.showTooltip(true);
 	mStructures.selectionChanged().connect(this, &MapViewState::structuresSelectionChanged);
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -118,26 +118,20 @@ void MapViewState::initUi()
 	mBtnToggleConnectedness.click().connect(this, &MapViewState::btnToggleConnectednessClicked);
 
 	// Menus
-	mRobots.sheetPath("ui/robots.png");
 	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mRobots.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mRobots.iconSize(46);
 	mRobots.iconMargin(constants::MARGIN_TIGHT);
 	mRobots.showTooltip(true);
 	mRobots.selectionChanged().connect(this, &MapViewState::robotsSelectionChanged);
 
-	mConnections.sheetPath("ui/structures.png");
 	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mConnections.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mConnections.iconSize(46);
 	mConnections.iconMargin(constants::MARGIN_TIGHT);
 	mConnections.selectionChanged().connect(this, &MapViewState::connectionsSelectionChanged);
 	mConnections.sorted(false);
 
-	mStructures.sheetPath("ui/structures.png");
 	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
-	mStructures.iconSize(46);
 	mStructures.iconMargin(constants::MARGIN_TIGHT);
 	mStructures.showTooltip(true);
 	mStructures.selectionChanged().connect(this, &MapViewState::structuresSelectionChanged);

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -41,7 +41,6 @@ void FactoryProduction::init()
 	// Set up GUI Layout
 	add(&mProductGrid, constants::MARGIN, 25);
 	mProductGrid.size({140, 110});
-	mProductGrid.iconMargin(constants::MARGIN_TIGHT);
 	mProductGrid.showTooltip(true);
 	mProductGrid.hide();
 	mProductGrid.selectionChanged().connect(this, &FactoryProduction::productSelectionChanged);

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -40,9 +40,7 @@ void FactoryProduction::init()
 
 	// Set up GUI Layout
 	add(&mProductGrid, constants::MARGIN, 25);
-	mProductGrid.sheetPath("ui/factory.png");
 	mProductGrid.size({140, 110});
-	mProductGrid.iconSize(32);
 	mProductGrid.iconMargin(constants::MARGIN_TIGHT);
 	mProductGrid.showTooltip(true);
 	mProductGrid.hide();

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -12,12 +12,7 @@ using namespace NAS2D;
 /**
  * 
  */
-FactoryProduction::FactoryProduction() :
-	btnOkay{"Okay"},
-	btnCancel{"Cancel"},
-	btnClearSelection{"Clear Selection"},
-	btnApply{"Apply"},
-	chkIdle{"Idle"}
+FactoryProduction::FactoryProduction()
 {
 	text(constants::WINDOW_FACTORY_PRODUCTION);
 	init();

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -3,6 +3,7 @@
 #include "UI.h"
 #include "IconGrid.h"
 
+#include "../Constants.h"
 #include "../Things/Structures/Factory.h"
 
 /**
@@ -45,7 +46,7 @@ private:
 	ProductType mProduct = ProductType::PRODUCT_NONE;
 	ProductionCost mProductCost;
 
-	IconGrid mProductGrid{"ui/factory.png", 32};
+	IconGrid mProductGrid{"ui/factory.png", 32, constants::MARGIN_TIGHT};
 
 	Button btnOkay;
 	Button btnCancel;

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -45,7 +45,7 @@ private:
 	ProductType mProduct = ProductType::PRODUCT_NONE;
 	ProductionCost mProductCost;
 
-	IconGrid mProductGrid;
+	IconGrid mProductGrid{"ui/factory.png", 32};
 
 	Button btnOkay;
 	Button btnCancel;

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -48,10 +48,10 @@ private:
 
 	IconGrid mProductGrid{"ui/factory.png", 32, constants::MARGIN_TIGHT};
 
-	Button btnOkay;
-	Button btnCancel;
-	Button btnClearSelection;
-	Button btnApply;
+	Button btnOkay{"Okay"};
+	Button btnCancel{"Cancel"};
+	Button btnClearSelection{"Clear Selection"};
+	Button btnApply{"Apply"};
 
-	CheckBox chkIdle;
+	CheckBox chkIdle{"Idle"};
 };

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -66,45 +66,6 @@ IconGrid::~IconGrid()
 
 
 /**
- * Sets the icon sheet path and loads an Image.
- */
-void IconGrid::sheetPath(const std::string& filePath)
-{
-	mIconSheet = Image(filePath);
-}
-
-
-/**
- * Sets the icon dimensions.
- */
-void IconGrid::iconSize(int newSize)
-{
-	if (newSize <= 0)
-	{
-		throw std::runtime_error("IconGrid::iconSize must be positive: " + std::to_string(newSize));
-	}
-
-	mIconSize = newSize;
-	updateGrid();
-}
-
-
-/**
- * Sets the margin used between the edges of the IconGrid and other icons.
- */
-void IconGrid::iconMargin(int newMargin)
-{
-	if (newMargin < 0)
-	{
-		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(newMargin));
-	}
-
-	mIconMargin = newMargin;
-	updateGrid();
-}
-
-
-/**
  * Updates the icon grid.
  */
 void IconGrid::updateGrid()

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -22,8 +22,20 @@ static Font* FONT = nullptr;
 /**
  * C'tor
  */
-IconGrid::IconGrid()
+IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
+	mIconSize{iconEdgeSize},
+	mIconMargin{margin},
+	mIconSheet{filePath}
 {
+	if (iconEdgeSize <= 0)
+	{
+		throw std::runtime_error("IconGrid::iconSize must be positive: " + std::to_string(iconEdgeSize));
+	}
+	if (margin < 0)
+	{
+		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(margin));
+	}
+
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &IconGrid::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMove);
 	resized().connect(this, &IconGrid::sizeChanged);
@@ -40,23 +52,6 @@ IconGrid::IconGrid()
 	mSkin.push_back(Image("ui/skin/textbox_bottom_right.png"));
 
 	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-}
-
-
-IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) : IconGrid()
-{
-	if (iconEdgeSize <= 0)
-	{
-		throw std::runtime_error("IconGrid::iconSize must be positive: " + std::to_string(iconEdgeSize));
-	}
-	if (margin < 0)
-	{
-		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(margin));
-	}
-
-	sheetPath(filePath);
-	mIconSize = iconEdgeSize;
-	mIconMargin = margin;
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -45,9 +45,18 @@ IconGrid::IconGrid()
 
 IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) : IconGrid()
 {
+	if (iconEdgeSize <= 0)
+	{
+		throw std::runtime_error("IconGrid::iconSize must be positive: " + std::to_string(iconEdgeSize));
+	}
+	if (margin < 0)
+	{
+		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(margin));
+	}
+
 	sheetPath(filePath);
-	iconSize(iconEdgeSize);
-	iconMargin(margin);
+	mIconSize = iconEdgeSize;
+	mIconMargin = margin;
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -43,6 +43,13 @@ IconGrid::IconGrid()
 }
 
 
+IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize) : IconGrid()
+{
+	sheetPath(filePath);
+	iconSize(iconEdgeSize);
+}
+
+
 /**
  * D'tor
  */

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -43,10 +43,11 @@ IconGrid::IconGrid()
 }
 
 
-IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize) : IconGrid()
+IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) : IconGrid()
 {
 	sheetPath(filePath);
 	iconSize(iconEdgeSize);
+	iconMargin(margin);
 }
 
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -48,10 +48,6 @@ public:
 	IconGrid(const std::string& filePath, int iconSize, int margin);
 	~IconGrid() override;
 
-	void sheetPath(const std::string& filePath);
-	void iconSize(int newSsize);
-	void iconMargin(int newMargin);
-
 	const std::string& itemName(std::size_t index) const { return mIconItemList[index].name; }
 
 	int selectionIndex() const { return static_cast<int>(mCurrentSelection); }

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -46,6 +46,7 @@ public:
 
 public:
 	IconGrid();
+	IconGrid(const std::string& filePath, int iconSize);
 	~IconGrid() override;
 
 	void sheetPath(const std::string& filePath);

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -46,7 +46,7 @@ public:
 
 public:
 	IconGrid();
-	IconGrid(const std::string& filePath, int iconSize);
+	IconGrid(const std::string& filePath, int iconSize, int margin);
 	~IconGrid() override;
 
 	void sheetPath(const std::string& filePath);

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -45,7 +45,6 @@ public:
 	using Callback = NAS2D::Signals::Signal<const IconGridItem*>;
 
 public:
-	IconGrid();
 	IconGrid(const std::string& filePath, int iconSize, int margin);
 	~IconGrid() override;
 


### PR DESCRIPTION
The `IconGrid` needs several attributes to function correctly. As such, these values should all be supplied to the constructor. Further, these values once set are not expected to change for the lifetime of the control. If they need to change, reinitialize the control.

Related: #558, #557
