### PR TITLE
Remove IconGrid sorted property

### DIFF
--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -126,7 +126,6 @@ void MapViewState::initUi()
 	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
 	mConnections.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 	mConnections.selectionChanged().connect(this, &MapViewState::connectionsSelectionChanged);
-	mConnections.sorted(false);
 
 	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
@@ -319,7 +318,6 @@ void MapViewState::populateStructureMenu()
 	updateStructuresAvailability();
 
 	mStructures.sort();
-	mConnections.sort();
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -433,8 +433,5 @@ bool iconItemCompare(const IconGrid::IconGridItem& left, const IconGrid::IconGri
 
 void IconGrid::sort()
 {
-	if (sorted())
-	{
-		std::sort(mIconItemList.begin(), mIconItemList.end(), &iconItemCompare);
-	}
+	std::sort(mIconItemList.begin(), mIconItemList.end(), &iconItemCompare);
 }

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -54,9 +54,6 @@ public:
 
 	bool empty() const { return mIconItemList.empty(); }
 
-	bool sorted() const { return mSorted; }
-	void sorted(bool isSorted) { mSorted = isSorted; }
-
 	void addItemSorted(const std::string& name, int sheetIndex, int meta);
 	void addItem(const std::string& name, int sheetIndex, int meta);
 	void removeItem(const std::string& item);
@@ -110,7 +107,6 @@ private:
 	int mIconMargin = 0; /**< Spacing between icons and edges of the IconGrid. */
 
 	bool mShowTooltip = false; /**< Flag indicating that we want a tooltip drawn near an icon when hovering over it. */
-	bool mSorted = true; /**< Flag indicating that the IconGrid should be sorted. */
 
 	NAS2D::Image mIconSheet; /**< Image containing the icons. */
 


### PR DESCRIPTION
Calling `IcongGrid::sort()` will now unconditionally sort the contents.

Recent `IconGrid` refactoring: #559, #558, #557
