### PR TITLE
Update NAS2D submodule for Resource updates

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -99,7 +99,7 @@ void Button::image(const std::string& path)
 
 bool Button::hasImage() const
 {
-	return mImage->loaded();
+	return mImage != nullptr;
 }
 
 


### PR DESCRIPTION
Update NAS2D submodule for `Resource` updates, where objects are either fully constructed and loaded, or abort construction by throwing an exception from the constructor.

Remove uses of the now no longer useful `Resource::loaded()` property.

Consequently, this fixes a potential crash bug in `Button::hasImage()`, which previously could dereference `nullptr` when an `Image` was not set.
