### PR TITLE
Const correct resources

### DIFF
--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -44,7 +44,7 @@ public:
 	 * \warning	The pointer returned by font() is owned by FontManager. Do not dispose of the
 	 *			pointer manually.
 	 */
-	NAS2D::Font* font(const std::string& name, std::size_t size)
+	const NAS2D::Font* font(const std::string& name, std::size_t size)
 	{
 		auto it = mFontTable.find(FontId(name, size));
 		if (it != mFontTable.end())

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -145,7 +145,7 @@ void TileMap::buildTerrainMap(const std::string& path)
 		throw std::runtime_error("Given map file does not exist.");
 	}
 
-	Image heightmap(path + MAP_TERRAIN_EXTENSION);
+	const Image heightmap(path + MAP_TERRAIN_EXTENSION);
 
 	mTileMap.resize(static_cast<std::size_t>(mMaxDepth) + 1);
 	for(int level = 0; level <= mMaxDepth; level++)
@@ -230,7 +230,7 @@ void TileMap::buildMouseMap()
 		throw std::runtime_error("Unable to find the mouse map file.");
 	}
 
-	Image mousemap("ui/mouse_map.png");
+	const Image mousemap("ui/mouse_map.png");
 
 	// More sanity checks (mousemap should match dimensions of tile)
 	if (mousemap.size() != Vector{TILE_WIDTH, TILE_HEIGHT_ABSOLUTE})

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -127,8 +127,8 @@ private:
 
 	TileArray mTileMap;
 
-	NAS2D::Image mTileset;
-	NAS2D::Image mMineBeacon;
+	const NAS2D::Image mTileset;
+	const NAS2D::Image mMineBeacon;
 
 	NAS2D::Timer mTimer;
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -92,7 +92,7 @@ void MainMenuState::initialize()
 	Utility<Renderer>::get().fadeIn(constants::FADE_SPEED);
 	Utility<Renderer>::get().showSystemPointer(true);
 
-	extern Music* MARS; /// yuck
+	extern const Music* MARS; /// yuck
 	Mixer& mixer = Utility<Mixer>::get();
 	if (!mixer.musicPlaying()) { mixer.playMusic(*MARS); }
 }

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -81,7 +81,7 @@ void MainMenuState::initialize()
 	mFileIoDialog.anchored(false);
 	mFileIoDialog.hide();
 
-	Font* tiny_font = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const Font* tiny_font = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	lblVersion.font(tiny_font);
 	lblVersion.color(NAS2D::Color::White);
 

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -43,7 +43,7 @@ private:
 	void fileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
 private:
-	NAS2D::Image mBgImage;
+	const NAS2D::Image mBgImage;
 
 	FileIo mFileIoDialog; /**< File IO window. */
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -21,8 +21,8 @@ extern Point<int> MOUSE_COORDS;
 
 static Image* WINDOW_BACKGROUND = nullptr;
 
-Font* BIG_FONT = nullptr;
-Font* BIG_FONT_BOLD = nullptr;
+const Font* BIG_FONT = nullptr;
+const Font* BIG_FONT_BOLD = nullptr;
 
 
 /**

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -19,7 +19,7 @@ using namespace NAS2D;
 
 extern Point<int> MOUSE_COORDS;
 
-static Image* WINDOW_BACKGROUND = nullptr;
+static const Image* WINDOW_BACKGROUND = nullptr;
 
 const Font* BIG_FONT = nullptr;
 const Font* BIG_FONT_BOLD = nullptr;
@@ -58,7 +58,7 @@ public:
 public:
 	std::string Name;
 
-	Image* Img = nullptr;
+	const Image* Img = nullptr;
 
 	Point<int> TextPosition;
 	Point<int> IconPosition;

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -61,7 +61,7 @@ std::map <int, std::string> LEVEL_STRING_TABLE =
 };
 
 
-Font* MAIN_FONT = nullptr;
+const Font* MAIN_FONT = nullptr;
 
 
 MapViewState::MapViewState(const std::string& savegame) :
@@ -205,7 +205,7 @@ State* MapViewState::update()
 	renderer.drawImageStretched(mBackground, renderArea);
 
 	// explicit current level
-	Font* font = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
+	const Font* font = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
 	const auto currentLevelPosition = mMiniMapBoundingBox.crossXPoint() - font->size(CURRENT_LEVEL_STRING) - NAS2D::Vector{0, 12};
 	renderer.drawText(*font, CURRENT_LEVEL_STRING, currentLevelPosition, NAS2D::Color::White);
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -30,8 +30,8 @@ using namespace NAS2D;
 const std::string MAP_TERRAIN_EXTENSION = "_a.png";
 const std::string MAP_DISPLAY_EXTENSION = "_b.png";
 
-extern NAS2D::Image* IMG_LOADING; /// \fixme Find a sane place for this.
-extern NAS2D::Image* IMG_SAVING; /// \fixme Find a sane place for this.
+extern const NAS2D::Image* IMG_LOADING; /// \fixme Find a sane place for this.
+extern const NAS2D::Image* IMG_SAVING; /// \fixme Find a sane place for this.
 extern Point<int> MOUSE_COORDS;
 extern MainReportsUiState* MAIN_REPORTS_UI;
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -202,10 +202,10 @@ private:
 
 	Planet::Attributes mPlanetAttributes;
 
-	NAS2D::Image mBackground{"sys/bg1.png"}; /**< Background image drawn behind the tile map. */
+	const NAS2D::Image mBackground{"sys/bg1.png"}; /**< Background image drawn behind the tile map. */
 	NAS2D::Image mMapDisplay; /**< Satellite view of the Site Map. */
 	NAS2D::Image mHeightMap; /**< Height view of the Site Map. */
-	NAS2D::Image mUiIcons{"ui/icons.png"}; /**< User interface icons. */
+	const NAS2D::Image mUiIcons{"ui/icons.png"}; /**< User interface icons. */
 
 	NAS2D::Point<int> mTileMapMouseHover; /**< Tile position the mouse is currently hovering over. */
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -224,7 +224,7 @@ private:
 
 	Population mPopulation;
 
-	//Music mBgMusic;
+	//const Music mBgMusic;
 
 	// USER INTERFACE
 	Button mBtnTurns;

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -25,7 +25,7 @@ extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 extern NAS2D::Point<int> MOUSE_COORDS;
 
-extern NAS2D::Font* MAIN_FONT; /// yuck
+extern const NAS2D::Font* MAIN_FONT; /// yuck
 
 
 namespace {

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -35,8 +35,8 @@ extern std::string CURRENT_LEVEL_STRING;
 extern std::map <int, std::string> LEVEL_STRING_TABLE;
 
 
-extern NAS2D::Image* IMG_LOADING; /// \fixme	Hate having these as externs.
-extern NAS2D::Image* IMG_SAVING;
+extern const NAS2D::Image* IMG_LOADING; /// \fixme	Hate having these as externs.
+extern const NAS2D::Image* IMG_SAVING;
 
 
 extern int ROBOT_ID_COUNTER; /// \fixme Kludge

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 
 
-extern NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
+extern const NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
 
 
 /**

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -37,9 +37,9 @@ extern NAS2D::Rectangle<int> MOVE_UP_ICON;
 extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 
-extern NAS2D::Image* IMG_LOADING; /// \fixme Find a sane place for this.
-extern NAS2D::Image* IMG_SAVING; /// \fixme Find a sane place for this.
-extern NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
+extern const NAS2D::Image* IMG_LOADING; /// \fixme Find a sane place for this.
+extern const NAS2D::Image* IMG_SAVING; /// \fixme Find a sane place for this.
+extern const NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
 
 
 /**

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -82,7 +82,7 @@ private:
 
 	Attributes mAttributes;
 
-	NAS2D::Image mImage;
+	const NAS2D::Image mImage;
 	NAS2D::Point<int> mPosition;
 
 	MouseCallback mMouseEnterCallback;

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -52,7 +52,7 @@ public:
 	}
 
 private:
-	NAS2D::Image mSheet;
+	const NAS2D::Image mSheet;
 	NAS2D::Timer mTimer;
 
 	std::size_t mFrame = 0;

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -21,9 +21,9 @@ using namespace NAS2D;
 std::size_t planetSelection;
 constexpr std::size_t planetSelectionInvalid = std::numeric_limits<std::size_t>::max();
 
-static Font* FONT = nullptr;
-static Font* FONT_BOLD = nullptr;
-static Font* FONT_TINY = nullptr;
+static const Font* FONT = nullptr;
+static const Font* FONT_BOLD = nullptr;
+static const Font* FONT_TINY = nullptr;
 
 
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -51,10 +51,10 @@ private:
 	const NAS2D::Image mCloud1;
 	const NAS2D::Image mCloud2;
 
-	NAS2D::Music mBgMusic;
+	const NAS2D::Music mBgMusic;
 
-	NAS2D::Sound mSelect;
-	NAS2D::Sound mHover;
+	const NAS2D::Sound mSelect;
+	const NAS2D::Sound mHover;
 
 	NAS2D::Point<int> mMousePosition;
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -42,14 +42,14 @@ private:
 	void drawStar(NAS2D::Point<int> point);
 
 private:
-	NAS2D::Image mBg;
+	const NAS2D::Image mBg;
 
-	NAS2D::Image mStarFlare;
-	NAS2D::Image mDetailFlare;
-	NAS2D::Image mDetailFlare2;
+	const NAS2D::Image mStarFlare;
+	const NAS2D::Image mDetailFlare;
+	const NAS2D::Image mDetailFlare2;
 
-	NAS2D::Image mCloud1;
-	NAS2D::Image mCloud2;
+	const NAS2D::Image mCloud1;
+	const NAS2D::Image mCloud2;
 
 	NAS2D::Music mBgMusic;
 

--- a/OPHD/States/SplashState.h
+++ b/OPHD/States/SplashState.h
@@ -27,11 +27,11 @@ private:
 	void skipSplash();
 
 private:
-	NAS2D::Image mLogoLairworks;
-	NAS2D::Image mLogoNas2d;
-	NAS2D::Image mLogoOutpostHd;
-	NAS2D::Image mFlare;
-	NAS2D::Image mByline;
+	const NAS2D::Image mLogoLairworks;
+	const NAS2D::Image mLogoNas2d;
+	const NAS2D::Image mLogoOutpostHd;
+	const NAS2D::Image mFlare;
+	const NAS2D::Image mByline;
 
 	NAS2D::Point<int> mMousePosition;
 

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -65,7 +65,7 @@ private:
 	NAS2D::ImageList mSkinHover;
 	NAS2D::ImageList mSkinPressed;
 
-	NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
+	const NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 
 	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -59,7 +59,7 @@ private:
 	State mState = State::STATE_NORMAL; /**< Current state of the Button. */
 	Type mType = Type::BUTTON_NORMAL; /**< Modifies Button behavior. */
 
-	NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
+	const NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
 
 	NAS2D::ImageList mSkinNormal;
 	NAS2D::ImageList mSkinHover;

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -29,7 +29,7 @@
 
 using namespace NAS2D;
 
-static Font* CBOX_FONT = nullptr;
+static const Font* CBOX_FONT = nullptr;
 
 /**
  * C'tor

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -32,7 +32,7 @@ protected:
 	void onTextChanged() override;
 	
 private:
-	NAS2D::Image mSkin;
+	const NAS2D::Image mSkin;
 
 	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -9,7 +9,7 @@
 #include <NAS2D/Utility.h>
 
 static const int FIELD_PADDING = 2;
-static NAS2D::Font* TXT_FONT = nullptr;
+static const NAS2D::Font* TXT_FONT = nullptr;
 
 
 Label::Label(std::string newText)
@@ -26,7 +26,7 @@ void Label::autoSize()
 }
 
 
-void Label::font(NAS2D::Font* font)
+void Label::font(const NAS2D::Font* font)
 {
 	TXT_FONT = font;
 	autoSize();

--- a/OPHD/UI/Core/Label.h
+++ b/OPHD/UI/Core/Label.h
@@ -27,7 +27,7 @@ public:
 	Label(std::string newText = "");
 
 	void autoSize();
-	void font(NAS2D::Font* font);
+	void font(const NAS2D::Font* font);
 	bool empty() const { return text().empty(); }
 	void clear() { mText.clear(); }
 	void update() override;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -18,7 +18,7 @@
 using namespace NAS2D;
 
 
-static Font* LST_FONT = nullptr;
+static const Font* LST_FONT = nullptr;
 
 
 /**

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -16,7 +16,7 @@
 
 using namespace NAS2D;
 
-static Font* CBOX_FONT = nullptr;
+static const Font* CBOX_FONT = nullptr;
 
 /**
  * C'tor

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -41,7 +41,7 @@ protected:
 	void parentContainer(UIContainer* parent);
 
 private:
-	NAS2D::Image mSkin;
+	const NAS2D::Image mSkin;
 	Label mLabel;
 	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 	UIContainer* mParentContainer{nullptr};

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -20,7 +20,7 @@
 using namespace NAS2D;
 
 
-static Font* SLD_FONT = nullptr;
+static const Font* SLD_FONT = nullptr;
 
 /**
  * C'tor

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -37,5 +37,5 @@ private:
 
 	NAS2D::Color mTextColor = NAS2D::Color::White;
 
-	NAS2D::Font* mFont = nullptr;
+	const NAS2D::Font* mFont = nullptr;
 };

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -28,7 +28,7 @@ static const int CURSOR_BLINK_DELAY = 250;
 
 static std::locale LOC;
 
-static Font* TXT_FONT = nullptr;
+static const Font* TXT_FONT = nullptr;
 
 
 TextField::TextField()

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -12,7 +12,7 @@
 
 using namespace NAS2D;
 
-static Font* WINDOW_TITLE_FONT;
+static const Font* WINDOW_TITLE_FONT;
 
 Window::Window(std::string newTitle)
 {

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -13,8 +13,8 @@ using namespace NAS2D;
 const int LIST_ITEM_HEIGHT = 58;
 Image* STRUCTURE_ICONS = nullptr;
 
-static Font* MAIN_FONT = nullptr;
-static Font* MAIN_FONT_BOLD = nullptr;
+static const Font* MAIN_FONT = nullptr;
+static const Font* MAIN_FONT_BOLD = nullptr;
 
 
 static void drawItem(Renderer& renderer, FactoryListBox::FactoryListBoxItem& item, int x, int y, int w, int offset, bool highlight)

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -26,7 +26,7 @@ private:
 	void btnCloseClicked();
 
 private:
-	NAS2D::Image mHeader;
+	const NAS2D::Image mHeader;
 
 	Button btnClose;
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -17,7 +17,7 @@
 
 using namespace NAS2D;
 
-static Font* FONT = nullptr;
+static const Font* FONT = nullptr;
 
 /**
  * C'tor

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -108,7 +108,7 @@ private:
 
 	bool mShowTooltip = false; /**< Flag indicating that we want a tooltip drawn near an icon when hovering over it. */
 
-	NAS2D::Image mIconSheet; /**< Image containing the icons. */
+	const NAS2D::Image mIconSheet; /**< Image containing the icons. */
 
 	NAS2D::ImageList mSkin;
 

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -11,8 +11,7 @@
 
 using namespace NAS2D;
 
-MajorEventAnnouncement::MajorEventAnnouncement() :
-	btnClose{"Okay"}
+MajorEventAnnouncement::MajorEventAnnouncement()
 {
 	init();
 }
@@ -46,11 +45,9 @@ void MajorEventAnnouncement::announcement(AnnouncementType a)
 	switch (a)
 	{
 	case AnnouncementType::ANNOUNCEMENT_COLONY_SHIP_CRASH:
-		mHeader = Image("ui/interface/colony_ship_crash.png");
 		mMessage = "Colony ship deorbited and crashed on the surface.";
 		break;
 	case AnnouncementType::ANNOUNCEMENT_COLONY_SHIP_CRASH_WITH_COLONISTS:
-		mHeader = Image("ui/interface/colony_ship_crash.png");
 		mMessage = "Colony ship deorbited and crashed on the surface but you left colonists on board!";
 		break;
 	default:

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -33,9 +33,9 @@ private:
 	MajorEventAnnouncement& operator=(const MajorEventAnnouncement&) = delete;
 
 private:
-	NAS2D::Image mHeader;
+	NAS2D::Image mHeader{"ui/interface/colony_ship_crash.png"};
 
 	std::string mMessage;
 
-	Button btnClose;
+	Button btnClose{"Okay"};
 };

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -33,7 +33,7 @@ private:
 	MajorEventAnnouncement& operator=(const MajorEventAnnouncement&) = delete;
 
 private:
-	NAS2D::Image mHeader{"ui/interface/colony_ship_crash.png"};
+	const NAS2D::Image mHeader{"ui/interface/colony_ship_crash.png"};
 
 	std::string mMessage;
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -10,8 +10,8 @@
 
 using namespace NAS2D;
 
-static Font* FONT = nullptr;
-static Font* FONT_BOLD = nullptr;
+static const Font* FONT = nullptr;
+static const Font* FONT_BOLD = nullptr;
 
 
 /**

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -41,8 +41,8 @@ private:
 private:
 	MineFacility* mFacility = nullptr;
 
-	NAS2D::Image mUiIcon;
-	NAS2D::Image mIcons;
+	const NAS2D::Image mUiIcon;
+	const NAS2D::Image mIcons;
 
 	NAS2D::ImageList mPanel;
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -11,7 +11,7 @@
 
 using namespace NAS2D;
 
-static Font* FONT = nullptr;
+static const Font* FONT = nullptr;
 
 PopulationPanel::PopulationPanel() : mIcons("ui/icons.png")
 {

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -26,7 +26,7 @@ public:
 protected:
 
 private:
-	NAS2D::Image mIcons;
+	const NAS2D::Image mIcons;
 	NAS2D::ImageList mSkin;
 
 	Population* mPopulation = nullptr;

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -16,8 +16,8 @@ using namespace NAS2D;
 
 const int LIST_ITEM_HEIGHT = 30;
 
-static Font* MAIN_FONT = nullptr;
-static Font* MAIN_FONT_BOLD = nullptr;
+static const Font* MAIN_FONT = nullptr;
+static const Font* MAIN_FONT_BOLD = nullptr;
 
 
 static Color ITEM_COLOR{0, 185, 0};

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -21,12 +21,12 @@ static int SORT_BY_PRODUCT_POSITION = 0;
 static Rectangle<int> FACTORY_LISTBOX;
 static Rectangle<int> DETAIL_PANEL;
 
-static Font* FONT = nullptr;
-static Font* FONT_BOLD = nullptr;
-static Font* FONT_MED = nullptr;
-static Font* FONT_MED_BOLD = nullptr;
-static Font* FONT_BIG = nullptr;
-static Font* FONT_BIG_BOLD = nullptr;
+static const Font* FONT = nullptr;
+static const Font* FONT_BOLD = nullptr;
+static const Font* FONT_MED = nullptr;
+static const Font* FONT_MED_BOLD = nullptr;
+static const Font* FONT_BIG = nullptr;
+static const Font* FONT_BIG_BOLD = nullptr;
 
 static Factory* SELECTED_FACTORY = nullptr;
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -30,13 +30,13 @@ static const Font* FONT_BIG_BOLD = nullptr;
 
 static Factory* SELECTED_FACTORY = nullptr;
 
-static Image* FACTORY_SEED = nullptr;
-static Image* FACTORY_AG = nullptr;
-static Image* FACTORY_UG = nullptr;
-static Image* FACTORY_IMAGE = nullptr;
+static const Image* FACTORY_SEED = nullptr;
+static const Image* FACTORY_AG = nullptr;
+static const Image* FACTORY_UG = nullptr;
+static const Image* FACTORY_IMAGE = nullptr;
 
 std::array<Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
-static Image* _PRODUCT_NONE = nullptr;
+static const Image* _PRODUCT_NONE = nullptr;
 
 static std::string FACTORY_STATUS;
 static const std::string RESOURCES_REQUIRED = "Resources Required";

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -18,7 +18,7 @@ static const Font* FONT_MED = nullptr;
 static const Font* FONT_MED_BOLD = nullptr;
 static const Font* FONT_BIG_BOLD = nullptr;
 
-static Image* WAREHOUSE_IMG = nullptr;
+static const Image* WAREHOUSE_IMG = nullptr;
 
 static int COUNT_WIDTH = 0;
 static int CAPACITY_WIDTH = 0;

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -13,10 +13,10 @@
 using namespace NAS2D;
 
 
-static Font* FONT_BOLD = nullptr;
-static Font* FONT_MED = nullptr;
-static Font* FONT_MED_BOLD = nullptr;
-static Font* FONT_BIG_BOLD = nullptr;
+static const Font* FONT_BOLD = nullptr;
+static const Font* FONT_MED = nullptr;
+static const Font* FONT_MED_BOLD = nullptr;
+static const Font* FONT_BIG_BOLD = nullptr;
 
 static Image* WAREHOUSE_IMG = nullptr;
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -12,7 +12,7 @@
 
 using namespace NAS2D;
 
-static Font* FONT = nullptr;
+static const Font* FONT = nullptr;
 
 
 enum ResourceTrend

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -19,7 +19,7 @@ public:
 	void update() override;
 
 private:
-	NAS2D::Image mIcons;
+	const NAS2D::Image mIcons;
 	NAS2D::ImageList mSkin;
 
 	ResourcePool mPreviousResources;

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -47,7 +47,7 @@ void StringTable::setDefaultFont(NAS2D::Font& font)
 	mDefaultFont = &font;
 }
 
-void StringTable::setDefaultTitleFont(NAS2D::Font* font)
+void StringTable::setDefaultTitleFont(const NAS2D::Font* font)
 {
 	mDefaultTitleFont = font;
 }
@@ -198,9 +198,9 @@ void StringTable::checkCellIndex(const CellCoordinate& cellCoordinate) const
 	}
 }
 
-NAS2D::Font* StringTable::getCellFont(std::size_t index) const
+const NAS2D::Font* StringTable::getCellFont(std::size_t index) const
 {
-	NAS2D::Font* font = mCells[index].font;
+	const NAS2D::Font* font = mCells[index].font;
 
 	if (font == nullptr) {
 		// If a different title font is not desired, it is set to nullptr

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -27,7 +27,7 @@ public:
 		static const NAS2D::Color ColorEmpty;
 
 		// Use StringTable::mDefaultFont if not set
-		NAS2D::Font* font = nullptr;
+		const NAS2D::Font* font = nullptr;
 		std::string text;
 		Justification justification = Justification::Left;
 		NAS2D::Color textColor = ColorEmpty;
@@ -44,7 +44,7 @@ public:
 	NAS2D::Point<int> position() const;
 
 	void setDefaultFont(NAS2D::Font& font);
-	void setDefaultTitleFont(NAS2D::Font* font);
+	void setDefaultTitleFont(const NAS2D::Font* font);
 	void setDefaultTextColor(NAS2D::Color textColor);
 
 	void setHorizontalPadding(float horizontalPadding);
@@ -69,8 +69,8 @@ private:
 	const std::size_t mColumnCount;
 	const std::size_t mRowCount;
 	NAS2D::Point<int> mPosition;
-	NAS2D::Font* mDefaultFont;
-	NAS2D::Font* mDefaultTitleFont;
+	const NAS2D::Font* mDefaultFont;
+	const NAS2D::Font* mDefaultTitleFont;
 	NAS2D::Color mDefaultTextColor = NAS2D::Color::White;
 	float mHorizontalPadding = 5;
 	float mVerticalPadding = 0;
@@ -83,6 +83,6 @@ private:
 	CellCoordinate getCellCoordinate(std::size_t index) const;
 	void checkCellIndex(const CellCoordinate& cellCoordinate) const;
 
-	NAS2D::Font* getCellFont(std::size_t index) const;
+	const NAS2D::Font* getCellFont(std::size_t index) const;
 	bool isFirstColumn(std::size_t index) const;
 };

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -17,8 +17,8 @@
 
 using namespace NAS2D;
 
-static Font* FONT = nullptr;
-static Font* FONT_BOLD = nullptr;
+static const Font* FONT = nullptr;
+static const Font* FONT_BOLD = nullptr;
 
 
 StructureInspector::StructureInspector() :

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -34,7 +34,7 @@ private:
 
 	TextArea txtStateDescription;
 
-	NAS2D::Image mIcons;
+	const NAS2D::Image mIcons;
 
 	std::string mStructureClass;
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -13,8 +13,8 @@ using namespace NAS2D;
 
 const int LIST_ITEM_HEIGHT = 30;
 
-static Font* MAIN_FONT = nullptr;
-static Font* MAIN_FONT_BOLD = nullptr;
+static const Font* MAIN_FONT = nullptr;
+static const Font* MAIN_FONT_BOLD = nullptr;
 
 
 static void drawItem(Renderer& renderer, StructureListBox::StructureListBoxItem& item, int x, int y, int w, int offset, bool highlight)

--- a/OPHD/UI/TextRender.cpp
+++ b/OPHD/UI/TextRender.cpp
@@ -12,8 +12,8 @@ void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, con
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += FONT_BOLD->width(title);
@@ -24,8 +24,8 @@ void drawLabelAndValueLeftJustify(NAS2D::Point<int> position, int labelWidth, co
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += labelWidth;
@@ -36,8 +36,8 @@ void drawLabelAndValueRightJustify(NAS2D::Point<int> position, int labelWidth, c
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += labelWidth - FONT->width(text);

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -32,7 +32,7 @@ const NAS2D::Image* IMG_LOADING = nullptr;
 const NAS2D::Image* IMG_SAVING = nullptr;
 const NAS2D::Image* IMG_PROCESSING_TURN = nullptr;
 
-NAS2D::Music* MARS = nullptr;
+const NAS2D::Music* MARS = nullptr;
 
 
 /**

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -28,9 +28,9 @@ using namespace NAS2D;
 
 
 /** Not thrilled with placement but this seems to be the easiest way to deal with it. */
-NAS2D::Image* IMG_LOADING = nullptr;
-NAS2D::Image* IMG_SAVING = nullptr;
-NAS2D::Image* IMG_PROCESSING_TURN = nullptr;
+const NAS2D::Image* IMG_LOADING = nullptr;
+const NAS2D::Image* IMG_SAVING = nullptr;
+const NAS2D::Image* IMG_PROCESSING_TURN = nullptr;
 
 NAS2D::Music* MARS = nullptr;
 


### PR DESCRIPTION
Mark static resources as `const`. Update NAS2D for some const correctness changes.

Reference:
https://github.com/lairworks/nas2d-core/pull/761
https://github.com/lairworks/nas2d-core/pull/762
