### PR TITLE
Replace FontManager with ResourceCache

### DIFF
--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -15,28 +15,4 @@
  * The FontManager class is intended to be invoked with the NAS2D::Utility object so as to maintain
  * scope throughout the lifetime of a NAS2D application.
  */
-class FontManager
-{
-public:
-	/**
-	 * Gets a pointer to a NAS2D::Font object given a filename on disk
-	 * and a size in points.
-	 * 
-	 * \param	name	Name of the font. This matches the filename on disk.
-	 * \param	size	Size in point (pt).
-	 * 
-	 * \note	In practice for the sake of efficiency a reference to the NAS2D::Font should
-	 *			be stored rather than calling font() repeatedly. This avoids unnecessary
-	 *			table lookups.
-	 * 
-	 * \warning	The pointer returned by font() is owned by FontManager. Do not dispose of the
-	 *			pointer manually.
-	 */
-	const NAS2D::Font* font(const std::string& name, int size)
-	{
-		return &mFontTable.load(name, static_cast<unsigned int>(size));
-	}
-
-private:
-	ResourceCache<NAS2D::Font, std::string, unsigned int> mFontTable;
-};
+using FontManager = ResourceCache<NAS2D::Font, std::string, unsigned int>;

--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -2,6 +2,8 @@
 
 
 #include <NAS2D/Resources/Font.h>
+#include <NAS2D/Resources/ResourceCache.h>
+
 
 /**
  * A basic font table lookup manager for NAS2D::Font objects.
@@ -27,7 +29,6 @@ public:
 	 */
 	~FontManager()
 	{
-		for (auto font : mFontTable) { delete font.second; }
 	}
 
 	/**
@@ -44,25 +45,11 @@ public:
 	 * \warning	The pointer returned by font() is owned by FontManager. Do not dispose of the
 	 *			pointer manually.
 	 */
-	const NAS2D::Font* font(const std::string& name, std::size_t size)
+	const NAS2D::Font* font(const std::string& name, int size)
 	{
-		auto it = mFontTable.find(FontId(name, size));
-		if (it != mFontTable.end())
-		{
-			return it->second;
-		}
-		else
-		{
-			NAS2D::Font* new_font = new NAS2D::Font(name, static_cast<int>(size));
-			mFontTable[FontId(name, size)] = new_font;
-			return new_font;
-		}
+		return &mFontTable.load(name, static_cast<unsigned int>(size));
 	}
 
 private:
-	using FontId = std::pair<std::string, std::size_t>;
-	using FontTable = std::map<FontId, NAS2D::Font*>;
-
-private:
-	FontTable mFontTable;
+	ResourceCache<NAS2D::Font, std::string, unsigned int> mFontTable;
 };

--- a/OPHD/FontManager.h
+++ b/OPHD/FontManager.h
@@ -19,19 +19,6 @@ class FontManager
 {
 public:
 	/**
-	 * C'tor
-	 */
-	FontManager()
-	{}
-	
-	/**
-	 * D'tor
-	 */
-	~FontManager()
-	{
-	}
-
-	/**
 	 * Gets a pointer to a NAS2D::Font object given a filename on disk
 	 * and a size in points.
 	 * 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -81,7 +81,7 @@ void MainMenuState::initialize()
 	mFileIoDialog.anchored(false);
 	mFileIoDialog.hide();
 
-	const Font* tiny_font = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const Font* tiny_font = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	lblVersion.font(tiny_font);
 	lblVersion.color(NAS2D::Color::White);
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -158,8 +158,8 @@ void MainReportsUiState::initialize()
 {
 	WINDOW_BACKGROUND = new Image("ui/skin/window_middle_middle.png");
 
-	BIG_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, 16);
-	BIG_FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, 16);
+	BIG_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, 16);
+	BIG_FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, 16);
 
 	Panels[NavigationPanel::PANEL_EXIT].Img = new Image("ui/icons/exit.png");
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -156,7 +156,7 @@ void MapViewState::initialize()
 
 	e.textInputMode(true);
 
-	MAIN_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	MAIN_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 
 	delete mPathSolver;
 	mPathSolver = new micropather::MicroPather(mTileMap);
@@ -205,7 +205,7 @@ State* MapViewState::update()
 	renderer.drawImageStretched(mBackground, renderArea);
 
 	// explicit current level
-	const Font* font = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
+	const Font* font = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
 	const auto currentLevelPosition = mMiniMapBoundingBox.crossXPoint() - font->size(CURRENT_LEVEL_STRING) - NAS2D::Vector{0, 12};
 	renderer.drawText(*font, CURRENT_LEVEL_STRING, currentLevelPosition, NAS2D::Color::White);
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -138,9 +138,9 @@ void PlanetSelectState::initialize()
 	renderer.showSystemPointer(true);
 	renderer.fadeIn(constants::FADE_SPEED);
 
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
-	FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-	FONT_TINY = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
+	FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
+	FONT_TINY = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 
 
 	EXPLODE = new Explosion();

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -53,7 +53,7 @@ Button::Button(std::string newText)
 	mSkinPressed.push_back(Image("ui/skin/button_pressed_bottom_middle.png"));
 	mSkinPressed.push_back(Image("ui/skin/button_pressed_bottom_right.png"));
 
-	mFont = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	mFont = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 
@@ -87,7 +87,7 @@ bool Button::toggled() const
 
 void Button::fontSize(std::size_t size)
 {
-	mFont = Utility<FontManager>::get().font(constants::FONT_PRIMARY, size);
+	mFont = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, size);
 }
 
 

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -36,7 +36,7 @@ static const Font* CBOX_FONT = nullptr;
  */
 CheckBox::CheckBox(std::string newText) : mSkin("ui/skin/checkbox.png")
 {
-	CBOX_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	CBOX_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	text(newText);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &CheckBox::onMouseDown);
 }

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -15,7 +15,7 @@ static const NAS2D::Font* TXT_FONT = nullptr;
 Label::Label(std::string newText)
 {
 	text(newText);
-	TXT_FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	TXT_FONT = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	autoSize();
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -48,7 +48,7 @@ ListBox::~ListBox()
 */
 void ListBox::_init()
 {
-	LST_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	LST_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -25,7 +25,7 @@ RadioButton::RadioButton(std::string newText) :
 	mSkin("ui/skin/checkbox.png"),
 	mLabel(newText)
 {
-	CBOX_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	CBOX_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &RadioButton::onMouseDown);
 }
 

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -28,7 +28,7 @@ static const Font* SLD_FONT = nullptr;
 Slider::Slider(SliderType sliderType) :
 	mSliderType(sliderType)
 {
-	SLD_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	SLD_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Slider::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Slider::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &Slider::onMouseMove);

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -15,7 +15,7 @@ using namespace NAS2D;
 
 void TextArea::font(const std::string& font, std::size_t size)
 {
-	mFont = Utility<FontManager>::get().font(font, size);
+	mFont = &Utility<FontManager>::get().load(font, size);
 }
 
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -60,7 +60,7 @@ TextField::TextField()
 	mSkinFocus.push_back(Image("ui/skin/textbox_bottom_middle_highlight.png"));
 	mSkinFocus.push_back(Image("ui/skin/textbox_bottom_right_highlight.png"));
 
-	TXT_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	TXT_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	height(TXT_FONT->height() + FIELD_PADDING * 2);
 }
 

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -33,7 +33,7 @@ void Window::_init()
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Window::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMove);
 
-	WINDOW_TITLE_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	WINDOW_TITLE_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	mBody.push_back(Image("ui/skin/window_top_left.png"));
 	mBody.push_back(Image("ui/skin/window_top_middle.png"));

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -64,8 +64,8 @@ void FactoryListBox::_init()
 {
 	item_height(LIST_ITEM_HEIGHT);
 	STRUCTURE_ICONS = new Image("ui/structures.png");
-	MAIN_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, 12);
-	MAIN_FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, 12);
+	MAIN_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, 12);
+	MAIN_FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, 12);
 }
 
 

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -54,6 +54,6 @@ void GameOverDialog::update()
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
-	const auto& font = *Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const auto& font = *&Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	renderer.drawText(font, "You have failed. Your colony is dead.", position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -51,7 +51,7 @@ IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 	mSkin.push_back(Image("ui/skin/textbox_bottom_middle.png"));
 	mSkin.push_back(Image("ui/skin/textbox_bottom_right.png"));
 
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -68,6 +68,6 @@ void MajorEventAnnouncement::update()
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
-	const auto& font = *Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const auto& font = *&Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	renderer.drawText(font, mMessage, position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -84,8 +84,8 @@ void MineOperationsWindow::init()
 	mPanel.push_back(Image("ui/skin/textbox_bottom_middle.png"));
 	mPanel.push_back(Image("ui/skin/textbox_bottom_right.png"));
 
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -27,7 +27,7 @@ PopulationPanel::PopulationPanel() : mIcons("ui/icons.png")
 	mSkin.push_back(Image("ui/skin/window_bottom_middle.png"));
 	mSkin.push_back(Image("ui/skin/window_bottom_right.png"));
 
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -61,8 +61,8 @@ ProductListBox::ProductListBox()
 void ProductListBox::_init()
 {
 	item_height(LIST_ITEM_HEIGHT);
-	MAIN_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, 12);
-	MAIN_FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, 12);
+	MAIN_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, 12);
+	MAIN_FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, 12);
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -84,14 +84,14 @@ FactoryReport::~FactoryReport()
  */
 void FactoryReport::init()
 {
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
-	FONT_MED = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
-	FONT_MED_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
+	FONT_MED = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
+	FONT_MED_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
 
-	FONT_BIG = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_HUGE);
-	FONT_BIG_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
+	FONT_BIG = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_HUGE);
+	FONT_BIG_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
 	FACTORY_SEED = new Image("ui/interface/factory_seed.png");
 	FACTORY_AG = new Image("ui/interface/factory_ag.png");

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -103,10 +103,10 @@ WarehouseReport::~WarehouseReport()
  */
 void WarehouseReport::init()
 {
-	FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
-	FONT_MED = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
-	FONT_MED_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-	FONT_BIG_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
+	FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	FONT_MED = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
+	FONT_MED_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
+	FONT_BIG_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
 	WAREHOUSE_IMG = new Image("ui/interface/warehouse.png");
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -57,7 +57,7 @@ ResourceBreakdownPanel::ResourceBreakdownPanel() : mIcons("ui/icons.png")
 	mSkin.push_back(Image("ui/skin/window_bottom_middle.png"));
 	mSkin.push_back(Image("ui/skin/window_bottom_right.png"));
 
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -16,8 +16,8 @@ StringTable::StringTable(std::size_t columns, std::size_t rows) : mColumnCount(c
 {
 	mCells.resize(columns * rows);
 
-	mDefaultFont = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	mDefaultTitleFont = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	mDefaultFont = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	mDefaultTitleFont = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
 
 void StringTable::draw(NAS2D::Renderer& renderer) const

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -53,8 +53,8 @@ void StructureInspector::init()
 	txtStateDescription.size({155, 80});
 	txtStateDescription.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 
-	FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -59,8 +59,8 @@ StructureListBox::~StructureListBox()
 void StructureListBox::_init()
 {
 	item_height(LIST_ITEM_HEIGHT);
-	MAIN_FONT = Utility<FontManager>::get().font(constants::FONT_PRIMARY, 12);
-	MAIN_FONT_BOLD = Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, 12);
+	MAIN_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, 12);
+	MAIN_FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, 12);
 }
 
 

--- a/OPHD/UI/TextRender.cpp
+++ b/OPHD/UI/TextRender.cpp
@@ -12,8 +12,8 @@ void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, con
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	const NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT_BOLD = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += FONT_BOLD->width(title);
@@ -24,8 +24,8 @@ void drawLabelAndValueLeftJustify(NAS2D::Point<int> position, int labelWidth, co
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	const NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT_BOLD = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += labelWidth;
@@ -36,8 +36,8 @@ void drawLabelAndValueRightJustify(NAS2D::Point<int> position, int labelWidth, c
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	const NAS2D::Font* FONT_BOLD = NAS2D::Utility<FontManager>::get().font(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const NAS2D::Font* FONT_BOLD = &NAS2D::Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += labelWidth - FONT->width(text);


### PR DESCRIPTION
Replace `FontManager` class with `using` alias for `ResourceCache`. The two classes have a nearly identical interface, with just a small method rename, and a slight adjustment for reference versus pointer semantics.

We can potentially get rid of the `using` alias and use of `Utility` at some point in the future, and instead declare a global variable. It is effectively a global variable, so may make more sense to declare it as such.
