### PR TITLE
Scope enum StructureState

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -50,21 +50,21 @@ Difficulty DifficultyFromString(std::string difficultyStr)
 
 std::map<StructureState, Color> STRUCTURE_COLOR_TABLE
 {
-	{ StructureState::UNDER_CONSTRUCTION, Color{150, 150, 150, 100} },
-	{ StructureState::OPERATIONAL, Color{0, 185, 0} },
-	{ StructureState::IDLE, Color{0, 185, 0, 100} },
-	{ StructureState::DISABLED, Color{220, 0, 0} },
-	{ StructureState::DESTROYED, Color{220, 0, 0} }
+	{ StructureState::UnderConstruction, Color{150, 150, 150, 100} },
+	{ StructureState::Operational, Color{0, 185, 0} },
+	{ StructureState::Idle, Color{0, 185, 0, 100} },
+	{ StructureState::Disabled, Color{220, 0, 0} },
+	{ StructureState::Destroyed, Color{220, 0, 0} }
 };
 
 
 std::map<StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 {
-	{ StructureState::UNDER_CONSTRUCTION, Color{185, 185, 185, 100} },
-	{ StructureState::OPERATIONAL, Color{0, 185, 0} },
-	{ StructureState::IDLE, Color{0, 185, 0, 100} },
-	{ StructureState::DISABLED, Color{220, 0, 0} },
-	{ StructureState::DESTROYED, Color{220, 0, 0} }
+	{ StructureState::UnderConstruction, Color{185, 185, 185, 100} },
+	{ StructureState::Operational, Color{0, 185, 0} },
+	{ StructureState::Idle, Color{0, 185, 0, 100} },
+	{ StructureState::Disabled, Color{220, 0, 0} },
+	{ StructureState::Destroyed, Color{220, 0, 0} }
 };
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -265,15 +265,15 @@ const std::string& idleReason(IdleReason _i)
 }
 
 
-Color& structureColorFromIndex(std::size_t index)
+Color& structureColorFromIndex(StructureState structureState)
 {
-	return STRUCTURE_COLOR_TABLE[static_cast<StructureState>(index)];
+	return STRUCTURE_COLOR_TABLE[structureState];
 }
 
 
-Color& structureTextColorFromIndex(std::size_t index)
+Color& structureTextColorFromIndex(StructureState structureState)
 {
-	return STRUCTURE_TEXT_COLOR_TABLE[static_cast<StructureState>(index)];
+	return STRUCTURE_TEXT_COLOR_TABLE[structureState];
 }
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -48,23 +48,23 @@ Difficulty DifficultyFromString(std::string difficultyStr)
 }
 
 
-std::map<Structure::StructureState, Color> STRUCTURE_COLOR_TABLE
+std::map<StructureState, Color> STRUCTURE_COLOR_TABLE
 {
-	{ Structure::StructureState::UNDER_CONSTRUCTION, Color{150, 150, 150, 100} },
-	{ Structure::StructureState::OPERATIONAL, Color{0, 185, 0} },
-	{ Structure::StructureState::IDLE, Color{0, 185, 0, 100} },
-	{ Structure::StructureState::DISABLED, Color{220, 0, 0} },
-	{ Structure::StructureState::DESTROYED, Color{220, 0, 0} }
+	{ StructureState::UNDER_CONSTRUCTION, Color{150, 150, 150, 100} },
+	{ StructureState::OPERATIONAL, Color{0, 185, 0} },
+	{ StructureState::IDLE, Color{0, 185, 0, 100} },
+	{ StructureState::DISABLED, Color{220, 0, 0} },
+	{ StructureState::DESTROYED, Color{220, 0, 0} }
 };
 
 
-std::map<Structure::StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
+std::map<StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 {
-	{ Structure::StructureState::UNDER_CONSTRUCTION, Color{185, 185, 185, 100} },
-	{ Structure::StructureState::OPERATIONAL, Color{0, 185, 0} },
-	{ Structure::StructureState::IDLE, Color{0, 185, 0, 100} },
-	{ Structure::StructureState::DISABLED, Color{220, 0, 0} },
-	{ Structure::StructureState::DESTROYED, Color{220, 0, 0} }
+	{ StructureState::UNDER_CONSTRUCTION, Color{185, 185, 185, 100} },
+	{ StructureState::OPERATIONAL, Color{0, 185, 0} },
+	{ StructureState::IDLE, Color{0, 185, 0, 100} },
+	{ StructureState::DISABLED, Color{220, 0, 0} },
+	{ StructureState::DESTROYED, Color{220, 0, 0} }
 };
 
 
@@ -267,13 +267,13 @@ const std::string& idleReason(IdleReason _i)
 
 Color& structureColorFromIndex(std::size_t index)
 {
-	return STRUCTURE_COLOR_TABLE[static_cast<Structure::StructureState>(index)];
+	return STRUCTURE_COLOR_TABLE[static_cast<StructureState>(index)];
 }
 
 
 Color& structureTextColorFromIndex(std::size_t index)
 {
-	return STRUCTURE_TEXT_COLOR_TABLE[static_cast<Structure::StructureState>(index)];
+	return STRUCTURE_TEXT_COLOR_TABLE[static_cast<StructureState>(index)];
 }
 
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -331,11 +331,11 @@ void drawBasicProgressBar(int x, int y, int width, int height, float percent, in
  */
 enum class StructureState
 {
-	UNDER_CONSTRUCTION,
-	OPERATIONAL,
-	IDLE,
-	DISABLED,
-	DESTROYED
+	UnderConstruction,
+	Operational,
+	Idle,
+	Disabled,
+	Destroyed
 };
 
 NAS2D::Color& structureColorFromIndex(StructureState structureState);

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -329,7 +329,7 @@ void drawBasicProgressBar(int x, int y, int width, int height, float percent, in
 /**
  * State of an individual Structure.
  */
-enum StructureState
+enum class StructureState
 {
 	UNDER_CONSTRUCTION,
 	OPERATIONAL,

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -326,6 +326,18 @@ const std::string& idleReason(IdleReason);
  */
 void drawBasicProgressBar(int x, int y, int width, int height, float percent, int padding = 4);
 
+/**
+ * State of an individual Structure.
+ */
+enum StructureState
+{
+	UNDER_CONSTRUCTION,
+	OPERATIONAL,
+	IDLE,
+	DISABLED,
+	DESTROYED
+};
+
 NAS2D::Color& structureColorFromIndex(std::size_t);
 NAS2D::Color& structureTextColorFromIndex(std::size_t);
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+enum class StructureState;
 
 enum class Difficulty
 {
@@ -325,18 +326,6 @@ const std::string& idleReason(IdleReason);
  * Super basic progress bar.
  */
 void drawBasicProgressBar(int x, int y, int width, int height, float percent, int padding = 4);
-
-/**
- * State of an individual Structure.
- */
-enum class StructureState
-{
-	UnderConstruction,
-	Operational,
-	Idle,
-	Disabled,
-	Destroyed
-};
 
 NAS2D::Color& structureColorFromIndex(StructureState structureState);
 NAS2D::Color& structureTextColorFromIndex(StructureState structureState);

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -338,7 +338,7 @@ enum StructureState
 	DESTROYED
 };
 
-NAS2D::Color& structureColorFromIndex(std::size_t);
-NAS2D::Color& structureTextColorFromIndex(std::size_t);
+NAS2D::Color& structureColorFromIndex(StructureState structureState);
+NAS2D::Color& structureTextColorFromIndex(StructureState structureState);
 
 bool windowMaximized();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1293,7 +1293,7 @@ void MapViewState::checkConnectedness()
 		throw std::runtime_error("CC coordinates do not actually point to a Command Center.");
 	}
 
-	if (cc->state() == StructureState::UNDER_CONSTRUCTION)
+	if (cc->state() == StructureState::UnderConstruction)
 	{
 		return;
 	}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1293,7 +1293,7 @@ void MapViewState::checkConnectedness()
 		throw std::runtime_error("CC coordinates do not actually point to a Command Center.");
 	}
 
-	if (cc->state() == Structure::StructureState::UNDER_CONSTRUCTION)
+	if (cc->state() == StructureState::UNDER_CONSTRUCTION)
 	{
 		return;
 	}

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -388,7 +388,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 		}
 
 		st->age(age);
-		st->forced_state_change(static_cast<Structure::StructureState>(state), static_cast<DisabledReason>(disabled_reason), static_cast<IdleReason>(idle_reason));
+		st->forced_state_change(static_cast<StructureState>(state), static_cast<DisabledReason>(disabled_reason), static_cast<IdleReason>(idle_reason));
 		st->connectorDirection(static_cast<ConnectorDir>(direction));
 		
 		if (forced_idle != 0) { st->forceIdle(forced_idle != 0); }

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -43,10 +43,10 @@ void MapViewState::updatePopulation()
 {
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 	
-	int residences = structureManager.getCountInState(Structure::StructureClass::Residence, StructureState::OPERATIONAL);
-	int universities = structureManager.getCountInState(Structure::StructureClass::University, StructureState::OPERATIONAL);
-	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, StructureState::OPERATIONAL);
-	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::OPERATIONAL);
+	int residences = structureManager.getCountInState(Structure::StructureClass::Residence, StructureState::Operational);
+	int universities = structureManager.getCountInState(Structure::StructureClass::University, StructureState::Operational);
+	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, StructureState::Operational);
+	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::Operational);
 
 	// FOOD CONSUMPTION
 	int food_consumed = mPopulation.update(mCurrentMorale, foodInStorage(), residences, universities, nurseries, hospitals);
@@ -80,7 +80,7 @@ void MapViewState::updateCommercial()
 	// No need to do anything if there are no commercial structures.
 	if (_commercial.empty()) { return; }
 
-	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::OPERATIONAL);
+	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
 	int commercialCount = luxuryCount;
 
 	for (auto warehouse : _warehouses)
@@ -137,13 +137,13 @@ void MapViewState::updateMorale()
 	// POSITIVE MORALE EFFECTS
 	// =========================================
 	mCurrentMorale += mPopulation.birthCount();
-	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Park, StructureState::OPERATIONAL);
-	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::RecreationCenter, StructureState::OPERATIONAL);
+	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Park, StructureState::Operational);
+	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::RecreationCenter, StructureState::Operational);
 
-	int food_production = structureManager.getCountInState(Structure::StructureClass::FoodProduction, StructureState::OPERATIONAL);
+	int food_production = structureManager.getCountInState(Structure::StructureClass::FoodProduction, StructureState::Operational);
 	mCurrentMorale += food_production > 0 ? food_production : -5;
 
-	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::OPERATIONAL);
+	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
 
 	// NEGATIVE MORALE EFFECTS
 	// =========================================

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -43,10 +43,10 @@ void MapViewState::updatePopulation()
 {
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 	
-	int residences = structureManager.getCountInState(Structure::StructureClass::Residence, Structure::StructureState::OPERATIONAL);
-	int universities = structureManager.getCountInState(Structure::StructureClass::University, Structure::StructureState::OPERATIONAL);
-	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, Structure::StructureState::OPERATIONAL);
-	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, Structure::StructureState::OPERATIONAL);
+	int residences = structureManager.getCountInState(Structure::StructureClass::Residence, StructureState::OPERATIONAL);
+	int universities = structureManager.getCountInState(Structure::StructureClass::University, StructureState::OPERATIONAL);
+	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, StructureState::OPERATIONAL);
+	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::OPERATIONAL);
 
 	// FOOD CONSUMPTION
 	int food_consumed = mPopulation.update(mCurrentMorale, foodInStorage(), residences, universities, nurseries, hospitals);
@@ -80,7 +80,7 @@ void MapViewState::updateCommercial()
 	// No need to do anything if there are no commercial structures.
 	if (_commercial.empty()) { return; }
 
-	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, Structure::StructureState::OPERATIONAL);
+	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::OPERATIONAL);
 	int commercialCount = luxuryCount;
 
 	for (auto warehouse : _warehouses)
@@ -137,13 +137,13 @@ void MapViewState::updateMorale()
 	// POSITIVE MORALE EFFECTS
 	// =========================================
 	mCurrentMorale += mPopulation.birthCount();
-	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Park, Structure::StructureState::OPERATIONAL);
-	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::RecreationCenter, Structure::StructureState::OPERATIONAL);
+	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Park, StructureState::OPERATIONAL);
+	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::RecreationCenter, StructureState::OPERATIONAL);
 
-	int food_production = structureManager.getCountInState(Structure::StructureClass::FoodProduction, Structure::StructureState::OPERATIONAL);
+	int food_production = structureManager.getCountInState(Structure::StructureClass::FoodProduction, StructureState::OPERATIONAL);
 	mCurrentMorale += food_production > 0 ? food_production : -5;
 
-	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Commercial, Structure::StructureState::OPERATIONAL);
+	mCurrentMorale += structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::OPERATIONAL);
 
 	// NEGATIVE MORALE EFFECTS
 	// =========================================

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -411,7 +411,7 @@ void serializeStructure(XmlElement* _ti, Structure* structure, Tile* _t)
 	_ti->attribute("depth", _t->depth());
 
 	_ti->attribute("age", structure->age());
-	_ti->attribute("state", structure->state());
+	_ti->attribute("state", static_cast<int>(structure->state()));
 	_ti->attribute("forced_idle", structure->forceIdle());
 	_ti->attribute("disabled_reason", static_cast<int>(structure->disabledReason()));
 	_ti->attribute("idle_reason", static_cast<int>(structure->idleReason()));

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -318,7 +318,7 @@ int StructureManager::count() const
 /**
  *
  */
-int StructureManager::getCountInState(Structure::StructureClass st, Structure::StructureState state)
+int StructureManager::getCountInState(Structure::StructureClass st, StructureState state)
 {
 	int count = 0;
 	for (std::size_t i = 0; i < structureList(st).size(); ++i)
@@ -341,7 +341,7 @@ int StructureManager::disabled()
 	int count = 0;
 	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
 	{
-		count += getCountInState(it->first, Structure::StructureState::DISABLED);
+		count += getCountInState(it->first, StructureState::DISABLED);
 	}
 
 	return count;
@@ -356,7 +356,7 @@ int StructureManager::destroyed()
 	int count = 0;
 	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
 	{
-		count += getCountInState(it->first, Structure::StructureState::DESTROYED);
+		count += getCountInState(it->first, StructureState::DESTROYED);
 	}
 
 	return count;

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -341,7 +341,7 @@ int StructureManager::disabled()
 	int count = 0;
 	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
 	{
-		count += getCountInState(it->first, StructureState::DISABLED);
+		count += getCountInState(it->first, StructureState::Disabled);
 	}
 
 	return count;
@@ -356,7 +356,7 @@ int StructureManager::destroyed()
 	int count = 0;
 	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
 	{
-		count += getCountInState(it->first, StructureState::DESTROYED);
+		count += getCountInState(it->first, StructureState::Destroyed);
 	}
 
 	return count;

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -28,7 +28,7 @@ public:
 
 	int count() const;
 
-	int getCountInState(Structure::StructureClass st, Structure::StructureState state);
+	int getCountInState(Structure::StructureClass st, StructureState state);
 
 	int disabled();
 	int destroyed();

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -105,7 +105,7 @@ void Factory::updateProduction()
 	 * \fixme	Most of these can be combined into a single
 	 *			compound conditional statement.
 	 */
-	if (state() != StructureState::OPERATIONAL)
+	if (state() != StructureState::Operational)
 	{
 		return;
 	}

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -11,11 +11,11 @@
  */
 std::map<StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
 {
-	{ StructureState::UNDER_CONSTRUCTION, "Under Construction" },
-	{ StructureState::OPERATIONAL, "Operational" },
-	{ StructureState::IDLE, "Idle" },
-	{ StructureState::DISABLED, "Disabled" },
-	{ StructureState::DESTROYED, "Destroyed" },
+	{ StructureState::UnderConstruction, "Under Construction" },
+	{ StructureState::Operational, "Operational" },
+	{ StructureState::Idle, "Idle" },
+	{ StructureState::Disabled, "Disabled" },
+	{ StructureState::Destroyed, "Destroyed" },
 };
 
 
@@ -88,7 +88,7 @@ void Structure::disable(DisabledReason reason)
 {
 	sprite().pause();
 	sprite().color(NAS2D::Color{255, 0, 0, 185});
-	state(StructureState::DISABLED);
+	state(StructureState::Disabled);
 	mDisabledReason = reason;
 	mIdleReason = IdleReason::None;
 	disabledStateSet();
@@ -108,7 +108,7 @@ void Structure::enable()
 
 	sprite().resume();
 	sprite().color(NAS2D::Color::White);
-	state(StructureState::OPERATIONAL);
+	state(StructureState::Operational);
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = IdleReason::None;
 }
@@ -128,7 +128,7 @@ void Structure::idle(IdleReason reason)
 	sprite().color(NAS2D::Color{255, 255, 255, 185});
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = reason;
-	state(StructureState::IDLE);
+	state(StructureState::Idle);
 }
 
 
@@ -213,7 +213,7 @@ void Structure::incrementAge()
 void Structure::destroy()
 {
 	sprite().play(constants::STRUCTURE_STATE_DESTROYED);
-	state(StructureState::DESTROYED);
+	state(StructureState::Destroyed);
 
 	// Destroyed buildings just need to be rebuilt right?
 	repairable(false);
@@ -234,11 +234,11 @@ void Structure::forced_state_change(StructureState structureState, DisabledReaso
 		//enable();
 	}
 
-	if (structureState == StructureState::OPERATIONAL) { enable(); }
-	else if (structureState == StructureState::IDLE) { idle(idleReason); }
-	else if (structureState == StructureState::DISABLED) { disable(disabledReason); }
-	else if (structureState == StructureState::DESTROYED) { destroy(); }
-	else if (structureState == StructureState::UNDER_CONSTRUCTION) { mStructureState = StructureState::UNDER_CONSTRUCTION; } // Kludge
+	if (structureState == StructureState::Operational) { enable(); }
+	else if (structureState == StructureState::Idle) { idle(idleReason); }
+	else if (structureState == StructureState::Disabled) { disable(disabledReason); }
+	else if (structureState == StructureState::Destroyed) { destroy(); }
+	else if (structureState == StructureState::UnderConstruction) { mStructureState = StructureState::UnderConstruction; } // Kludge
 }
 
 

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -9,13 +9,13 @@
 /**
  * Translation table for Structure States.
  */
-std::map<Structure::StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
+std::map<StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
 {
-	{ Structure::StructureState::UNDER_CONSTRUCTION, "Under Construction" },
-	{ Structure::StructureState::OPERATIONAL, "Operational" },
-	{ Structure::StructureState::IDLE, "Idle" },
-	{ Structure::StructureState::DISABLED, "Disabled" },
-	{ Structure::StructureState::DESTROYED, "Destroyed" },
+	{ StructureState::UNDER_CONSTRUCTION, "Under Construction" },
+	{ StructureState::OPERATIONAL, "Operational" },
+	{ StructureState::IDLE, "Idle" },
+	{ StructureState::DISABLED, "Disabled" },
+	{ StructureState::DESTROYED, "Destroyed" },
 };
 
 
@@ -48,7 +48,7 @@ std::map<Structure::StructureClass, std::string> STRUCTURE_CLASS_TRANSLATION =
 };
 
 
-const std::string& structureStateDescription(Structure::StructureState _state)
+const std::string& structureStateDescription(StructureState _state)
 {
 	return STRUCTURE_STATE_TRANSLATION[_state];
 }

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -57,21 +57,21 @@ public:
 	// STATES & STATE MANAGEMENT
 	StructureState state() const { return mStructureState; }
 
-	bool disabled() const { return mStructureState == StructureState::DISABLED; }
+	bool disabled() const { return mStructureState == StructureState::Disabled; }
 	void disable(DisabledReason);
 	DisabledReason disabledReason() const { return mDisabledReason; }
 
-	bool operational() const { return mStructureState == StructureState::OPERATIONAL; }
+	bool operational() const { return mStructureState == StructureState::Operational; }
 	void enable();
 
-	bool isIdle() const { return mStructureState == StructureState::IDLE; }
+	bool isIdle() const { return mStructureState == StructureState::Idle; }
 	void idle(IdleReason);
 	IdleReason idleReason() const { return mIdleReason; }
 
-	bool destroyed() const { return mStructureState == StructureState::DESTROYED; }
+	bool destroyed() const { return mStructureState == StructureState::Destroyed; }
 	void destroy();
 
-	bool underConstruction() const { return mStructureState == StructureState::UNDER_CONSTRUCTION; }
+	bool underConstruction() const { return mStructureState == StructureState::UnderConstruction; }
 
 	void forceIdle(bool force);
 	bool forceIdle() const { return mForcedIdle; }
@@ -170,7 +170,7 @@ private:
 	int mAge = 0; /**< Age of the Structure in turns. */
 	int mMaxAge = 0; /**< Maximum number of turns the Structure can remain in good repair. */
 
-	StructureState mStructureState = StructureState::UNDER_CONSTRUCTION; /**< State the structure is in. */
+	StructureState mStructureState = StructureState::UnderConstruction; /**< State the structure is in. */
 	StructureClass mStructureClass; /**< Indicates the Structure's Type. */
 	ConnectorDir mConnectorDirection = ConnectorDir::CONNECTOR_INTERSECTION; /**< Directions available for connections. */
 

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -11,18 +11,6 @@ class Structure: public Thing
 {
 public:
 	/**
-	 * State of an individual Structure.
-	 */
-	enum StructureState
-	{
-		UNDER_CONSTRUCTION,
-		OPERATIONAL,
-		IDLE,
-		DISABLED,
-		DESTROYED
-	};
-
-	/**
 	 * Class of a Structure.
 	 * 
 	 * Structures are grouped by 'class'. Basically it's just an easy
@@ -207,5 +195,5 @@ private:
 
 using StructureList = std::vector<Structure*>;
 
-const std::string& structureStateDescription(Structure::StructureState);
+const std::string& structureStateDescription(StructureState);
 const std::string& structureClassDescription(Structure::StructureClass);

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -7,6 +7,18 @@
 #include "../../ResourcePool.h"
 #include "../../UI/StringTable.h"
 
+/**
+ * State of an individual Structure.
+ */
+enum class StructureState
+{
+	UnderConstruction,
+	Operational,
+	Idle,
+	Disabled,
+	Destroyed
+};
+
 class Structure: public Thing
 {
 public:

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -95,7 +95,7 @@ void FactoryListBox::addItem(Factory* factory)
 	else if (item->Text == constants::UNDERGROUND_FACTORY) { item->icon_slice = {138, 276}; }
 	else if (item->Text == constants::SEED_FACTORY) { item->icon_slice = {460, 368}; }
 	
-	if (factory->state() == StructureState::DESTROYED) { item->icon_slice = {414, 368}; }
+	if (factory->state() == StructureState::Destroyed) { item->icon_slice = {414, 368}; }
 	_update_item_display();
 }
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -95,7 +95,7 @@ void FactoryListBox::addItem(Factory* factory)
 	else if (item->Text == constants::UNDERGROUND_FACTORY) { item->icon_slice = {138, 276}; }
 	else if (item->Text == constants::SEED_FACTORY) { item->icon_slice = {460, 368}; }
 	
-	if (factory->state() == Structure::StructureState::DESTROYED) { item->icon_slice = {414, 368}; }
+	if (factory->state() == StructureState::DESTROYED) { item->icon_slice = {414, 368}; }
 	_update_item_display();
 }
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -282,7 +282,7 @@ void FactoryReport::fillFactoryList(bool surface)
 /**
  * Fills the factory list based on structure state.
  */
-void FactoryReport::fillFactoryList(Structure::StructureState state)
+void FactoryReport::fillFactoryList(StructureState state)
 {
 	SELECTED_FACTORY = nullptr;
 	lstFactoryList.clearItems();
@@ -362,8 +362,8 @@ void FactoryReport::visibilityChanged(bool visible)
 {
 	if (!SELECTED_FACTORY) { return; }
 
-	Structure::StructureState _state = SELECTED_FACTORY->state();
-	btnApply.visible(visible && (_state == Structure::StructureState::OPERATIONAL || _state == Structure::StructureState::IDLE));
+	StructureState _state = SELECTED_FACTORY->state();
+	btnApply.visible(visible && (_state == StructureState::OPERATIONAL || _state == StructureState::IDLE));
 	checkFactoryActionControls();
 }
 
@@ -425,7 +425,7 @@ void FactoryReport::btnShowActiveClicked()
 {
 	filterButtonClicked(true);
 	btnShowActive.toggle(true);
-	fillFactoryList(Structure::StructureState::OPERATIONAL);
+	fillFactoryList(StructureState::OPERATIONAL);
 }
 
 
@@ -436,7 +436,7 @@ void FactoryReport::btnShowIdleClicked()
 {
 	filterButtonClicked(true);
 	btnShowIdle.toggle(true);
-	fillFactoryList(Structure::StructureState::IDLE);
+	fillFactoryList(StructureState::IDLE);
 }
 
 
@@ -447,7 +447,7 @@ void FactoryReport::btnShowDisabledClicked()
 {
 	filterButtonClicked(true);
 	btnShowDisabled.toggle(true);
-	fillFactoryList(Structure::StructureState::DISABLED);
+	fillFactoryList(StructureState::DISABLED);
 }
 
 
@@ -511,13 +511,13 @@ void FactoryReport::lstFactoryListSelectionChanged()
 
 	FACTORY_STATUS = structureStateDescription(SELECTED_FACTORY->state());
 
-	btnIdle.toggle(SELECTED_FACTORY->state() == Structure::StructureState::IDLE);
-	btnIdle.enabled(SELECTED_FACTORY->state() == Structure::StructureState::OPERATIONAL || SELECTED_FACTORY->state() == Structure::StructureState::IDLE);
+	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::IDLE);
+	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::OPERATIONAL || SELECTED_FACTORY->state() == StructureState::IDLE);
 
-	btnClearProduction.enabled(SELECTED_FACTORY->state() == Structure::StructureState::OPERATIONAL || SELECTED_FACTORY->state() == Structure::StructureState::IDLE);
+	btnClearProduction.enabled(SELECTED_FACTORY->state() == StructureState::OPERATIONAL || SELECTED_FACTORY->state() == StructureState::IDLE);
 
 	lstProducts.dropAllItems();
-	if (SELECTED_FACTORY->state() != Structure::StructureState::DESTROYED)
+	if (SELECTED_FACTORY->state() != StructureState::DESTROYED)
 	{
 		const Factory::ProductionTypeList& _pl = SELECTED_FACTORY->productList();
 		for (auto item : _pl)
@@ -529,8 +529,8 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	lstProducts.setSelectionByName(productDescription(SELECTED_FACTORY->productType()));
 	SELECTED_PRODUCT_TYPE = SELECTED_FACTORY->productType();
 
-	Structure::StructureState _state = SELECTED_FACTORY->state();
-	btnApply.visible(_state == Structure::StructureState::OPERATIONAL || _state == Structure::StructureState::IDLE);
+	StructureState _state = SELECTED_FACTORY->state();
+	btnApply.visible(_state == StructureState::OPERATIONAL || _state == StructureState::IDLE);
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -363,7 +363,7 @@ void FactoryReport::visibilityChanged(bool visible)
 	if (!SELECTED_FACTORY) { return; }
 
 	StructureState _state = SELECTED_FACTORY->state();
-	btnApply.visible(visible && (_state == StructureState::OPERATIONAL || _state == StructureState::IDLE));
+	btnApply.visible(visible && (_state == StructureState::Operational || _state == StructureState::Idle));
 	checkFactoryActionControls();
 }
 
@@ -425,7 +425,7 @@ void FactoryReport::btnShowActiveClicked()
 {
 	filterButtonClicked(true);
 	btnShowActive.toggle(true);
-	fillFactoryList(StructureState::OPERATIONAL);
+	fillFactoryList(StructureState::Operational);
 }
 
 
@@ -436,7 +436,7 @@ void FactoryReport::btnShowIdleClicked()
 {
 	filterButtonClicked(true);
 	btnShowIdle.toggle(true);
-	fillFactoryList(StructureState::IDLE);
+	fillFactoryList(StructureState::Idle);
 }
 
 
@@ -447,7 +447,7 @@ void FactoryReport::btnShowDisabledClicked()
 {
 	filterButtonClicked(true);
 	btnShowDisabled.toggle(true);
-	fillFactoryList(StructureState::DISABLED);
+	fillFactoryList(StructureState::Disabled);
 }
 
 
@@ -511,13 +511,13 @@ void FactoryReport::lstFactoryListSelectionChanged()
 
 	FACTORY_STATUS = structureStateDescription(SELECTED_FACTORY->state());
 
-	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::IDLE);
-	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::OPERATIONAL || SELECTED_FACTORY->state() == StructureState::IDLE);
+	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
+	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
 
-	btnClearProduction.enabled(SELECTED_FACTORY->state() == StructureState::OPERATIONAL || SELECTED_FACTORY->state() == StructureState::IDLE);
+	btnClearProduction.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
 
 	lstProducts.dropAllItems();
-	if (SELECTED_FACTORY->state() != StructureState::DESTROYED)
+	if (SELECTED_FACTORY->state() != StructureState::Destroyed)
 	{
 		const Factory::ProductionTypeList& _pl = SELECTED_FACTORY->productList();
 		for (auto item : _pl)
@@ -530,7 +530,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	SELECTED_PRODUCT_TYPE = SELECTED_FACTORY->productType();
 
 	StructureState _state = SELECTED_FACTORY->state();
-	btnApply.visible(_state == StructureState::OPERATIONAL || _state == StructureState::IDLE);
+	btnApply.visible(_state == StructureState::Operational || _state == StructureState::Idle);
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -7,7 +7,7 @@
 #include "../Core/UIContainer.h"
 #include "../Core/TextArea.h"
 #include "../FactoryListBox.h"
-
+#include "../../Common.h"
 
 class FactoryReport : public ReportInterface
 {
@@ -28,7 +28,7 @@ private:
 
 	void fillFactoryList(ProductType);
 	void fillFactoryList(bool);
-	void fillFactoryList(Structure::StructureState);
+	void fillFactoryList(StructureState);
 
 	void btnShowAllClicked();
 	void btnShowSurfaceClicked();

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -39,7 +39,7 @@ static Warehouse* SELECTED_WAREHOUSE = nullptr;
  */
 static bool useStateString(StructureState _state)
 {
-	return _state == StructureState::DISABLED || _state == StructureState::DESTROYED || _state == StructureState::UNDER_CONSTRUCTION || _state == StructureState::IDLE;
+	return _state == StructureState::Disabled || _state == StructureState::Destroyed || _state == StructureState::UnderConstruction || _state == StructureState::Idle;
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -37,9 +37,9 @@ static Warehouse* SELECTED_WAREHOUSE = nullptr;
 /**
  * Internal convenience function to avoid really fugly code.
  */
-static bool useStateString(Structure::StructureState _state)
+static bool useStateString(StructureState _state)
 {
-	return _state == Structure::StructureState::DISABLED || _state == Structure::StructureState::DESTROYED || _state == Structure::StructureState::UNDER_CONSTRUCTION || _state == Structure::StructureState::IDLE;
+	return _state == StructureState::DISABLED || _state == StructureState::DESTROYED || _state == StructureState::UNDER_CONSTRUCTION || _state == StructureState::IDLE;
 }
 
 

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Core/ListBoxBase.h"
-#include "../Common.h"
+#include "../Things/Structures/Structure.h"
 
 #include <NAS2D/Signal.h>
 

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -27,7 +27,7 @@ public:
 	public:
 		Structure* structure = nullptr; /**< Pointer to a Structure. */
 		std::string structureState; /**< String description of the state of a Structure. */
-		StructureState colorIndex = StructureState::UNDER_CONSTRUCTION; /**< Index to use from the listbox color table. */
+		StructureState colorIndex = StructureState::UnderConstruction; /**< Index to use from the listbox color table. */
 	};
 
 public:

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Core/ListBoxBase.h"
+#include "../Common.h"
 
 #include <NAS2D/Signal.h>
 
@@ -26,7 +27,7 @@ public:
 	public:
 		Structure* structure = nullptr; /**< Pointer to a Structure. */
 		std::string structureState; /**< String description of the state of a Structure. */
-		std::size_t colorIndex = 0; /**< Index to use from the listbox color table. */
+		StructureState colorIndex = StructureState::UNDER_CONSTRUCTION; /**< Index to use from the listbox color table. */
 	};
 
 public:


### PR DESCRIPTION
A couple of interesting changes were required to prevent some casting. I think it all improves readability.

This changeset will likely cause merge conflict in other uncommitted branches due to the prolific use of StructureState.

I wasn't sure it was best to move StructureState out of Structure.h, but I didn't think it was wise for Structure.h to reference Common.h and Common.h to reference Structure.h at the same time. And I'm not sure you are allowed to forward declare enum class? If this move isn't palatable, maybe there is an alternate solution.