### PR TITLE
Delay construction of mini map Image objects

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -74,8 +74,8 @@ MapViewState::MapViewState(const std::string& savegame) :
 MapViewState::MapViewState(const Planet::Attributes& planetAttributes) :
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
 	mPlanetAttributes(planetAttributes),
-	mMapDisplay(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION),
-	mHeightMap(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION)
+	mMapDisplay{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION)},
+	mHeightMap{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION)}
 {
 	ccLocation() = CcNotPlaced;
 	Utility<EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -202,10 +202,10 @@ private:
 
 	Planet::Attributes mPlanetAttributes;
 
+	const NAS2D::Image mUiIcons{"ui/icons.png"}; /**< User interface icons. */
 	const NAS2D::Image mBackground{"sys/bg1.png"}; /**< Background image drawn behind the tile map. */
 	NAS2D::Image mMapDisplay; /**< Satellite view of the Site Map. */
 	NAS2D::Image mHeightMap; /**< Height view of the Site Map. */
-	const NAS2D::Image mUiIcons{"ui/icons.png"}; /**< User interface icons. */
 
 	NAS2D::Point<int> mTileMapMouseHover; /**< Tile position the mouse is currently hovering over. */
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -28,6 +28,7 @@
 #include <NAS2D/Renderer/Point.h>
 
 #include <string>
+#include <memory>
 
 
 enum PointerType
@@ -204,8 +205,8 @@ private:
 
 	const NAS2D::Image mUiIcons{"ui/icons.png"}; /**< User interface icons. */
 	const NAS2D::Image mBackground{"sys/bg1.png"}; /**< Background image drawn behind the tile map. */
-	NAS2D::Image mMapDisplay; /**< Satellite view of the Site Map. */
-	NAS2D::Image mHeightMap; /**< Height view of the Site Map. */
+	std::unique_ptr<NAS2D::Image> mMapDisplay; /**< Satellite view of the Site Map. */
+	std::unique_ptr<NAS2D::Image> mHeightMap; /**< Height view of the Site Map. */
 
 	NAS2D::Point<int> mTileMapMouseHover; /**< Tile position the mouse is currently hovering over. */
 

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -66,7 +66,7 @@ void MapViewState::drawMiniMap()
 	renderer.clipRect(miniMapBoxFloat);
 
 	bool isHeightmapToggled = mBtnToggleHeightmap.toggled();
-	renderer.drawImage(isHeightmapToggled ? mHeightMap : mMapDisplay, miniMapBoxFloat.startPoint());
+	renderer.drawImage(*(isHeightmapToggled ? mHeightMap : mMapDisplay).get(), miniMapBoxFloat.startPoint());
 
 	const auto miniMapOffset = mMiniMapBoundingBox.startPoint() - NAS2D::Point{0, 0};
 	const auto ccPosition = ccLocation();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -153,8 +153,8 @@ void MapViewState::load(const std::string& filePath)
 	}
 
 	StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
-	mMapDisplay = Image(mPlanetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION);
-	mHeightMap = Image(mPlanetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION);
+	mMapDisplay = std::make_unique<Image>(mPlanetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION);
+	mHeightMap = std::make_unique<Image>(mPlanetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION);
 	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.tilesetPath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 


### PR DESCRIPTION
Delay construction of mini map `Image` objects. By storing them in a `std::unique_ptr`, we can use delayed construction. This means we can avoid default initializing the objects, and then later overwriting them with new objects.

This removes the last use of the default `Image` constructor. Removing the default constructor will make upstream refactoring easier.

Reference: https://github.com/lairworks/nas2d-core/issues/763
