### PR TITLE
Add global Image cache

### DIFF
--- a/OPHD/Cache.h
+++ b/OPHD/Cache.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <NAS2D/Resources/Image.h>
+#include <NAS2D/Resources/ResourceCache.h>
+
+
+inline ResourceCache<NAS2D::Image, std::string> imageCache;

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -3,6 +3,7 @@
 
 #include "MainReportsUiState.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -141,11 +142,8 @@ MainReportsUiState::~MainReportsUiState()
 	Utility<EventHandler>::get().keyDown().disconnect(this, &MainReportsUiState::onKeyDown);
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &MainReportsUiState::onMouseDown);
 
-	delete WINDOW_BACKGROUND;
-
 	for (Panel& panel : Panels)
 	{
-		delete panel.Img;
 		delete panel.UiPanel;
 	}
 }
@@ -156,29 +154,29 @@ MainReportsUiState::~MainReportsUiState()
  */
 void MainReportsUiState::initialize()
 {
-	WINDOW_BACKGROUND = new Image("ui/skin/window_middle_middle.png");
+	WINDOW_BACKGROUND = &imageCache.load("ui/skin/window_middle_middle.png");
 
 	BIG_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, 16);
 	BIG_FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, 16);
 
-	Panels[NavigationPanel::PANEL_EXIT].Img = new Image("ui/icons/exit.png");
+	Panels[NavigationPanel::PANEL_EXIT].Img = &imageCache.load("ui/icons/exit.png");
 
-	Panels[NavigationPanel::PANEL_RESEARCH].Img = new Image("ui/icons/research.png");
+	Panels[NavigationPanel::PANEL_RESEARCH].Img = &imageCache.load("ui/icons/research.png");
 	Panels[NavigationPanel::PANEL_RESEARCH].Name = "Laboratories";
 
-	Panels[NavigationPanel::PANEL_PRODUCTION].Img = new Image("ui/icons/production.png");
+	Panels[NavigationPanel::PANEL_PRODUCTION].Img = &imageCache.load("ui/icons/production.png");
 	Panels[NavigationPanel::PANEL_PRODUCTION].Name = "Factories";
 
-	Panels[NavigationPanel::PANEL_WAREHOUSE].Img = new Image("ui/icons/warehouse.png");
+	Panels[NavigationPanel::PANEL_WAREHOUSE].Img = &imageCache.load("ui/icons/warehouse.png");
 	Panels[NavigationPanel::PANEL_WAREHOUSE].Name = "Warehouses";
 
-	Panels[NavigationPanel::PANEL_MINING].Img = new Image("ui/icons/mine.png");
+	Panels[NavigationPanel::PANEL_MINING].Img = &imageCache.load("ui/icons/mine.png");
 	Panels[NavigationPanel::PANEL_MINING].Name = "Mines";
 
-	Panels[NavigationPanel::PANEL_SATELLITES].Img = new Image("ui/icons/satellite.png");
+	Panels[NavigationPanel::PANEL_SATELLITES].Img = &imageCache.load("ui/icons/satellite.png");
 	Panels[NavigationPanel::PANEL_SATELLITES].Name = "Satellites";
 
-	Panels[NavigationPanel::PANEL_SPACEPORT].Img = new Image("ui/icons/spaceport.png");
+	Panels[NavigationPanel::PANEL_SPACEPORT].Img = &imageCache.load("ui/icons/spaceport.png");
 	Panels[NavigationPanel::PANEL_SPACEPORT].Name = "Space Ports";
 
 	auto& renderer = Utility<Renderer>::get();

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -3,6 +3,7 @@
 
 #include "Button.h"
 
+#include "../../Cache.h"
 #include "../../Common.h"
 #include "../../Constants.h"
 #include "../../FontManager.h"
@@ -65,8 +66,6 @@ Button::~Button()
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Button::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Button::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Button::onMouseMove);
-
-	delete mImage;
 }
 
 
@@ -96,7 +95,7 @@ void Button::fontSize(std::size_t size)
 
 void Button::image(const std::string& path)
 {
-	mImage = new Image(path);
+	mImage = &imageCache.load(path);
 }
 
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -3,6 +3,7 @@
 
 #include "FactoryListBox.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -56,14 +57,13 @@ FactoryListBox::FactoryListBox()
  */
 FactoryListBox::~FactoryListBox()
 {
-	delete STRUCTURE_ICONS;
 }
 
 
 void FactoryListBox::_init()
 {
 	item_height(LIST_ITEM_HEIGHT);
-	STRUCTURE_ICONS = new Image("ui/structures.png");
+	STRUCTURE_ICONS = &imageCache.load("ui/structures.png");
 	MAIN_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, 12);
 	MAIN_FONT_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, 12);
 }

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -11,7 +11,7 @@ using namespace NAS2D;
 
 
 const int LIST_ITEM_HEIGHT = 58;
-Image* STRUCTURE_ICONS = nullptr;
+const Image* STRUCTURE_ICONS = nullptr;
 
 static const Font* MAIN_FONT = nullptr;
 static const Font* MAIN_FONT_BOLD = nullptr;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -4,6 +4,7 @@
 #include "FactoryReport.h"
 
 #include "../TextRender.h"
+#include "../../Cache.h"
 #include "../../Constants.h"
 #include "../../FontManager.h"
 #include "../../StructureManager.h"
@@ -68,14 +69,7 @@ FactoryReport::FactoryReport() :
  */
 FactoryReport::~FactoryReport()
 {
-	delete FACTORY_SEED;
-	delete FACTORY_AG;
-	delete FACTORY_UG;
-	delete _PRODUCT_NONE;
-
 	SELECTED_FACTORY = nullptr;
-
-	for (auto img : PRODUCT_IMAGE_ARRAY) { delete img; }
 }
 
 
@@ -93,23 +87,23 @@ void FactoryReport::init()
 	FONT_BIG = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_HUGE);
 	FONT_BIG_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
-	FACTORY_SEED = new Image("ui/interface/factory_seed.png");
-	FACTORY_AG = new Image("ui/interface/factory_ag.png");
-	FACTORY_UG = new Image("ui/interface/factory_ug.png");
+	FACTORY_SEED = &imageCache.load("ui/interface/factory_seed.png");
+	FACTORY_AG = &imageCache.load("ui/interface/factory_ag.png");
+	FACTORY_UG = &imageCache.load("ui/interface/factory_ug.png");
 
 	/// \todo Decide if this is the best place to have these images live or if it should be done at program start.
 	PRODUCT_IMAGE_ARRAY.fill(nullptr);
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DIGGER] = new Image("ui/interface/product_robodigger.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DOZER] = new Image("ui/interface/product_robodozer.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MINER] = new Image("ui/interface/product_robominer.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_EXPLORER] = new Image("ui/interface/product_roboexplorer.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_TRUCK] = new Image("ui/interface/product_truck.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_ROAD_MATERIALS] = new Image("ui/interface/product_road_materials.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MAINTENANCE_PARTS] = new Image("ui/interface/product_maintenance_parts.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_CLOTHING] = new Image("ui/interface/product_clothing.png");
-	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MEDICINE] = new Image("ui/interface/product_medicine.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DIGGER] = &imageCache.load("ui/interface/product_robodigger.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DOZER] = &imageCache.load("ui/interface/product_robodozer.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MINER] = &imageCache.load("ui/interface/product_robominer.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_EXPLORER] = &imageCache.load("ui/interface/product_roboexplorer.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_TRUCK] = &imageCache.load("ui/interface/product_truck.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_ROAD_MATERIALS] = &imageCache.load("ui/interface/product_road_materials.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MAINTENANCE_PARTS] = &imageCache.load("ui/interface/product_maintenance_parts.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_CLOTHING] = &imageCache.load("ui/interface/product_clothing.png");
+	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MEDICINE] = &imageCache.load("ui/interface/product_medicine.png");
 
-	_PRODUCT_NONE = new Image("ui/interface/product_none.png");
+	_PRODUCT_NONE = &imageCache.load("ui/interface/product_none.png");
 
 	add(&lstFactoryList, 10, 63);
 	lstFactoryList.selectionChanged().connect(this, &FactoryReport::lstFactoryListSelectionChanged);

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -35,7 +35,7 @@ static const Image* FACTORY_AG = nullptr;
 static const Image* FACTORY_UG = nullptr;
 static const Image* FACTORY_IMAGE = nullptr;
 
-std::array<Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
+std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
 static const Image* _PRODUCT_NONE = nullptr;
 
 static std::string FACTORY_STATUS;

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -3,6 +3,7 @@
 
 #include "WarehouseReport.h"
 
+#include "../../Cache.h"
 #include "../../Constants.h"
 #include "../../FontManager.h"
 #include "../../StructureManager.h"
@@ -94,7 +95,6 @@ WarehouseReport::WarehouseReport() :
 WarehouseReport::~WarehouseReport()
 {
 	Control::resized().disconnect(this, &WarehouseReport::_resized);
-	delete WAREHOUSE_IMG;
 }
 
 
@@ -108,7 +108,7 @@ void WarehouseReport::init()
 	FONT_MED_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
 	FONT_BIG_BOLD = &Utility<FontManager>::get().load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
-	WAREHOUSE_IMG = new Image("ui/interface/warehouse.png");
+	WAREHOUSE_IMG = &imageCache.load("ui/interface/warehouse.png");
 
 	add(&btnShowAll, 10, 10);
 	btnShowAll.size({75, 20});

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -1,6 +1,7 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
+#include "Cache.h"
 #include "Common.h"
 #include "Constants.h"
 #include "StructureTranslator.h"
@@ -147,9 +148,9 @@ int main(int /*argc*/, char *argv[])
 		std::cout << "done." << std::endl;
 
 		// Loading/Saving plaque's
-		IMG_LOADING = new Image("sys/loading.png");
-		IMG_SAVING = new Image("sys/saving.png");
-		IMG_PROCESSING_TURN = new Image("sys/processing_turn.png");
+		IMG_LOADING = &imageCache.load("sys/loading.png");
+		IMG_SAVING = &imageCache.load("sys/saving.png");
+		IMG_PROCESSING_TURN = &imageCache.load("sys/processing_turn.png");
 
 		MARS = new Music("music/mars.ogg");
 		Utility<Mixer>::get().playMusic(*MARS);
@@ -178,6 +179,8 @@ int main(int /*argc*/, char *argv[])
 	{
 		doNonFatalErrorMessage("Application Error", e.what());
 	}
+
+	imageCache.clear();
 
 	#ifdef NDEBUG
 	filestr.close();

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -322,6 +322,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="WindowEventWrapper.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Cache.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="Constants.h" />
     <ClInclude Include="Constants\Numbers.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -290,6 +290,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Cache.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Common.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Add a global `Image` cache, using `ResourceCache`. Replace uses of `new Image` with references to the new global `imageCache`.

Prep-work for removing `Image` internal caching in upstream NAS2D library.

Reference: #480
Reference: https://github.com/lairworks/nas2d-core/issues/763
