### PR TITLE
Use references from imageCache

### DIFF
--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -17,7 +17,8 @@
 
 #include "CheckBox.h"
 
-#include"../../Constants.h"
+#include "../../Cache.h"
+#include "../../Constants.h"
 #include "../../FontManager.h"
 
 #include <NAS2D/Utility.h>
@@ -35,7 +36,7 @@ static const Font* CBOX_FONT = nullptr;
  * C'tor
  */
 CheckBox::CheckBox(std::string newText) :
-	mSkin("ui/skin/checkbox.png")
+	mSkin{imageCache.load("ui/skin/checkbox.png")}
 {
 	CBOX_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	text(newText);

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -32,7 +32,7 @@ protected:
 	void onTextChanged() override;
 	
 private:
-	const NAS2D::Image mSkin;
+	const NAS2D::Image& mSkin;
 
 	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -4,6 +4,7 @@
 #include "RadioButton.h"
 
 #include "UIContainer.h"
+#include "../../Cache.h"
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
@@ -22,8 +23,8 @@ static const Font* CBOX_FONT = nullptr;
  * C'tor
  */
 RadioButton::RadioButton(std::string newText) :
-	mSkin("ui/skin/checkbox.png"),
-	mLabel(newText)
+	mSkin{imageCache.load("ui/skin/checkbox.png")},
+	mLabel{newText}
 {
 	CBOX_FONT = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &RadioButton::onMouseDown);

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -41,7 +41,7 @@ protected:
 	void parentContainer(UIContainer* parent);
 
 private:
-	const NAS2D::Image mSkin;
+	const NAS2D::Image& mSkin;
 	Label mLabel;
 	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
 	UIContainer* mParentContainer{nullptr};

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "GameOverDialog.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -13,7 +14,7 @@ using namespace NAS2D;
 
 
 GameOverDialog::GameOverDialog() :
-	mHeader{"ui/interface/game_over.png"},
+	mHeader{imageCache.load("ui/interface/game_over.png")},
 	btnClose{"Return to Main Menu"}
 {
 	init();

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -26,7 +26,7 @@ private:
 	void btnCloseClicked();
 
 private:
-	const NAS2D::Image mHeader;
+	const NAS2D::Image& mHeader;
 
 	Button btnClose;
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -3,6 +3,7 @@
 
 #include "IconGrid.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -25,7 +26,7 @@ static const Font* FONT = nullptr;
 IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 	mIconSize{iconEdgeSize},
 	mIconMargin{margin},
-	mIconSheet{filePath},
+	mIconSheet{imageCache.load(filePath)},
 	mSkin{
 		Image{"ui/skin/textbox_top_left.png"},
 		Image{"ui/skin/textbox_top_middle.png"},

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -108,7 +108,7 @@ private:
 
 	bool mShowTooltip = false; /**< Flag indicating that we want a tooltip drawn near an icon when hovering over it. */
 
-	const NAS2D::Image mIconSheet; /**< Image containing the icons. */
+	const NAS2D::Image& mIconSheet; /**< Image containing the icons. */
 
 	NAS2D::ImageList mSkin;
 

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -3,6 +3,7 @@
 
 #include "MajorEventAnnouncement.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -11,7 +12,8 @@
 
 using namespace NAS2D;
 
-MajorEventAnnouncement::MajorEventAnnouncement()
+MajorEventAnnouncement::MajorEventAnnouncement() :
+	mHeader{imageCache.load("ui/interface/colony_ship_crash.png")}
 {
 	init();
 }

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -33,7 +33,7 @@ private:
 	MajorEventAnnouncement& operator=(const MajorEventAnnouncement&) = delete;
 
 private:
-	const NAS2D::Image mHeader{"ui/interface/colony_ship_crash.png"};
+	const NAS2D::Image& mHeader;
 
 	std::string mMessage;
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -5,6 +5,7 @@
 
 #include "TextRender.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -18,8 +19,8 @@ static const Font* FONT_BOLD = nullptr;
  * 
  */
 MineOperationsWindow::MineOperationsWindow() :
-	mUiIcon{"ui/interface/mine.png"},
-	mIcons{"ui/icons.png"},
+	mUiIcon{imageCache.load("ui/interface/mine.png")},
+	mIcons{imageCache.load("ui/icons.png")},
 	mPanel{
 		Image{"ui/skin/textbox_top_left.png"},
 		Image{"ui/skin/textbox_top_middle.png"},

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -41,8 +41,8 @@ private:
 private:
 	MineFacility* mFacility = nullptr;
 
-	const NAS2D::Image mUiIcon;
-	const NAS2D::Image mIcons;
+	const NAS2D::Image& mUiIcon;
+	const NAS2D::Image& mIcons;
 
 	NAS2D::ImageList mPanel;
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -3,6 +3,7 @@
 
 #include "PopulationPanel.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -14,7 +15,7 @@ using namespace NAS2D;
 static const Font* FONT = nullptr;
 
 PopulationPanel::PopulationPanel() :
-	mIcons("ui/icons.png"),
+	mIcons{imageCache.load("ui/icons.png")},
 	mSkin{
 		Image{"ui/skin/window_top_left.png"},
 		Image{"ui/skin/window_top_middle.png"},

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -26,7 +26,7 @@ public:
 protected:
 
 private:
-	const NAS2D::Image mIcons;
+	const NAS2D::Image& mIcons;
 	NAS2D::ImageList mSkin;
 
 	Population* mPopulation = nullptr;

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -3,6 +3,7 @@
 
 #include "ResourceBreakdownPanel.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -44,7 +45,7 @@ namespace
 
 
 ResourceBreakdownPanel::ResourceBreakdownPanel() :
-	mIcons("ui/icons.png"),
+	mIcons{imageCache.load("ui/icons.png")},
 	mSkin{
 		Image{"ui/skin/window_top_left.png"},
 		Image{"ui/skin/window_top_middle.png"},

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -19,7 +19,7 @@ public:
 	void update() override;
 
 private:
-	const NAS2D::Image mIcons;
+	const NAS2D::Image& mIcons;
 	NAS2D::ImageList mSkin;
 
 	ResourcePool mPreviousResources;

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -3,6 +3,7 @@
 
 #include "StructureInspector.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 #include "../Things/Structures/Structure.h"
@@ -23,7 +24,7 @@ static const Font* FONT_BOLD = nullptr;
 
 StructureInspector::StructureInspector() :
 	btnClose{"Close"},
-	mIcons{"ui/icons.png"}
+	mIcons{imageCache.load("ui/icons.png")}
 {
 	text(constants::WINDOW_STRUCTURE_INSPECTOR);
 	init();

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -34,7 +34,7 @@ private:
 
 	TextArea txtStateDescription;
 
-	const NAS2D::Image mIcons;
+	const NAS2D::Image& mIcons;
 
 	std::string mStructureClass;
 


### PR DESCRIPTION
Prep-work for: https://github.com/lairworks/nas2d-core/issues/763

Use `imageCache` to load and store various UI icons. Focus is on smaller controls that are likely to be re-used, particularly with short lifetime.

Omitted are controls that are used only once (splash screen), and so don't need external caching of images, or single use images for controls with very long lifetimes, such as `MapViewState` and `TileMap` that exist for the lifetime of a game. Also omitted was the main menu graphics and planet select graphics, which should only need to re-load images between games, which are assumed to be long lasting. We can always adjust policy later if we feel we need more or less caching, though I figured that might be a good starting point.

Uses of `ImageList` were omitted in this update. They will be handled separately.

More long term, the generic `Control` classes should probably avoid relying on a global `imageCache`. Instead, they should consider taking required images as constructor parameters. That would provide more flexibility for image source if those controls are moved to the NAS2D library.
