### PR TITLE
Fix use of std::clamp during resource processing

### DIFF
--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -277,10 +277,10 @@ void MapViewState::updateResources()
 			auto& stored = mineFacility->storage();
 			StorableResources moved
 			{
-				std::clamp(oreMovementPart, 0, stored.resources[0]),
-				std::clamp(oreMovementPart, 0, stored.resources[1]),
-				std::clamp(oreMovementPart, 0, stored.resources[2]),
-				std::clamp(oreMovementPart + oreMovementRemainder, 0, stored.resources[3])
+				std::clamp(stored.resources[0], 0, oreMovementPart),
+				std::clamp(stored.resources[1], 0, oreMovementPart),
+				std::clamp(stored.resources[2], 0, oreMovementPart),
+				std::clamp(stored.resources[3], 0, oreMovementPart + oreMovementRemainder)
 			};
 
 			auto& smelterProduction = smelter->production();


### PR DESCRIPTION
Fixes a similar issue to #589 