### PR TITLE
Convert ImageList skins to RectangleSkin

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -167,18 +167,9 @@ void Button::draw()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	if (enabled() && mMouseHover && mState != State::Pressed)
-	{
-		renderer.drawImageRect(mRect, mSkinHover);
-	}
-	else if (mState == State::Normal)
-	{
-		renderer.drawImageRect(mRect, mSkinNormal);
-	}
-	else
-	{
-		renderer.drawImageRect(mRect, mSkinPressed);
-	}
+	const auto& skin = (mState == State::Pressed) ? mSkinPressed :
+		(enabled() && mMouseHover) ? mSkinHover : mSkinNormal;
+	renderer.drawImageRect(mRect, skin);
 
 	if (mImage)
 	{

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -169,7 +169,7 @@ void Button::draw()
 
 	const auto& skin = (mState == State::Pressed) ? mSkinPressed :
 		(enabled() && mMouseHover) ? mSkinHover : mSkinNormal;
-	renderer.drawImageRect(mRect, skin);
+	skin.draw(renderer, mRect);
 
 	if (mImage)
 	{

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -6,6 +6,7 @@
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Resources/Image.h>
 #include <NAS2D/Resources/Font.h>
+#include <NAS2D/Renderer/RectangleSkin.h>
 
 #include <string>
 
@@ -61,9 +62,9 @@ private:
 
 	const NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
 
-	NAS2D::ImageList mSkinNormal;
-	NAS2D::ImageList mSkinHover;
-	NAS2D::ImageList mSkinPressed;
+	NAS2D::RectangleSkin mSkinNormal;
+	NAS2D::RectangleSkin mSkinHover;
+	NAS2D::RectangleSkin mSkinPressed;
 
 	const NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -344,9 +344,9 @@ void Slider::draw()
 {
 	auto& renderer = Utility<Renderer>::get();
 
-	renderer.drawImageRect(mSlideBar, mSkins.skinMiddle); // slide area
-	renderer.drawImageRect(mButton1, mSkins.skinButton1); // top or left button
-	renderer.drawImageRect(mButton2, mSkins.skinButton2); // bottom or right button
+	mSkins.skinMiddle.draw(renderer, mSlideBar); // Slide area
+	mSkins.skinButton1.draw(renderer, mButton1); // Top or left button
+	mSkins.skinButton2.draw(renderer, mButton2); // Bottom or right button
 
 	if (mSliderType == SliderType::Vertical)
 	{
@@ -369,7 +369,7 @@ void Slider::draw()
 		mSlider = {mSlideBar.x + relativeThumbPosition, mSlideBar.y, newSize, mSlideBar.height};
 	}
 
-	renderer.drawImageRect(mSlider, mSkins.skinSlider);
+	mSkins.skinSlider.draw(renderer, mSlider);
 
 	if (mDisplayPosition && mMouseHoverSlide)
 	{

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -4,11 +4,14 @@
  * \author Goof
  */
 #pragma once
+
 #include "Button.h"
 #include "Control.h"
 #include "../../Common.h"
 
 #include <NAS2D/Timer.h>
+#include <NAS2D/Renderer/RectangleSkin.h>
+
 
  /**
  * \class	Slider
@@ -33,10 +36,10 @@ public:
 	};
 
 	struct Skins {
-		NAS2D::ImageList skinButton1;
-		NAS2D::ImageList skinMiddle;
-		NAS2D::ImageList skinButton2;
-		NAS2D::ImageList skinSlider;
+		NAS2D::RectangleSkin skinButton1;
+		NAS2D::RectangleSkin skinMiddle;
+		NAS2D::RectangleSkin skinButton2;
+		NAS2D::RectangleSkin skinSlider;
 	};
 
 	using ValueChangedCallback = NAS2D::Signals::Signal<float>; /*!< type for Callback on value changed. */

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -319,7 +319,7 @@ void TextField::update()
 
 	const auto showFocused = hasFocus() && editable();
 	const auto& skin = showFocused ? mSkinFocus : mSkinNormal;
-	renderer.drawImageRect(mRect, skin);
+	skin.draw(renderer, mRect);
 
 	if (highlight()) { renderer.drawBox(mRect, NAS2D::Color::Yellow); }
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -318,7 +318,8 @@ void TextField::update()
 	auto& renderer = Utility<Renderer>::get();
 
 	const auto showFocused = hasFocus() && editable();
-	renderer.drawImageRect(mRect, (showFocused ? mSkinFocus : mSkinNormal));
+	const auto& skin = showFocused ? mSkinFocus : mSkinNormal;
+	renderer.drawImageRect(mRect, skin);
 
 	if (highlight()) { renderer.drawBox(mRect, NAS2D::Color::Yellow); }
 

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -12,6 +12,7 @@
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Timer.h>
 #include <NAS2D/Resources/Image.h>
+#include <NAS2D/Renderer/RectangleSkin.h>
 
 
 /**
@@ -78,8 +79,8 @@ private:
 
 	BorderVisibility mBorderVisibility = BorderVisibility::FOCUS_ONLY; /**< Border visibility flag. */
 
-	NAS2D::ImageList mSkinNormal;
-	NAS2D::ImageList mSkinFocus;
+	NAS2D::RectangleSkin mSkinNormal;
+	NAS2D::RectangleSkin mSkinFocus;
 
 	bool mEditable = true; /**< Toggle editing of the field. */
 	bool mShowCursor = true; /**< Flag indicating whether or not to draw the cursor. */

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -104,7 +104,7 @@ void Window::update()
 	renderer.drawImageRepeated(mTitle[1], NAS2D::Rectangle{mRect.x + 4, mRect.y, mRect.width - 8, sWindowTitleBarHeight});
 	renderer.drawImage(mTitle[2], NAS2D::Point{mRect.x + mRect.width - 4, mRect.y});
 
-	renderer.drawImageRect(NAS2D::Rectangle{mRect.x, mRect.y + 20, mRect.width, mRect.height - 20}, mBody);
+	mBody.draw(renderer, NAS2D::Rectangle{mRect.x, mRect.y + 20, mRect.width, mRect.height - 20});
 
 	renderer.drawText(*WINDOW_TITLE_FONT, text(), NAS2D::Point{mRect.x + 5, mRect.y + 2}, NAS2D::Color::White);
 

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -3,6 +3,7 @@
 #include "UIContainer.h"
 
 #include <NAS2D/Resources/Image.h>
+#include <NAS2D/Renderer/RectangleSkin.h>
 
 #include <string>
 
@@ -33,5 +34,5 @@ private:
 	bool mAnchored = false;
 
 	NAS2D::ImageList mTitle;
-	NAS2D::ImageList mBody;
+	NAS2D::RectangleSkin mBody;
 };

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -387,7 +387,7 @@ void IconGrid::update()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	renderer.drawImageRect(mRect, mSkin);
+	mSkin.draw(renderer, mRect);
 
 	if (mGridSize.x == 0) { return; }
 	const auto indexToGridPosition = [gridSize = mGridSize, startPoint = mRect.startPoint(), spacing = mIconSize + mIconMargin](std::size_t index) {

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -6,6 +6,7 @@
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Renderer/Point.h>
 #include <NAS2D/Renderer/Vector.h>
+#include <NAS2D/Renderer/RectangleSkin.h>
 #include <NAS2D/Resources/Image.h>
 
 
@@ -110,7 +111,7 @@ private:
 
 	const NAS2D::Image& mIconSheet; /**< Image containing the icons. */
 
-	NAS2D::ImageList mSkin;
+	NAS2D::RectangleSkin mSkin;
 
 	NAS2D::Vector<int> mGridSize; /**< Dimensions of the grid that can be contained in the IconGrid with the current Icon Size and Icon Margin. */
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -219,7 +219,7 @@ void MineOperationsWindow::update()
 	const auto width = mRect.width;
 	renderer.drawText(*FONT_BOLD, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
-	renderer.drawImageRect(NAS2D::Rectangle<int>::Create(origin + NAS2D::Vector{10, 180}, NAS2D::Vector{width - 20, 40}), mPanel);
+	mPanel.draw(renderer, NAS2D::Rectangle<int>::Create(origin + NAS2D::Vector{10, 180}, NAS2D::Vector{width - 20, 40}));
 
 	renderer.drawLine(origin + NAS2D::Vector{98, 180}, origin + NAS2D::Vector{98, 219}, NAS2D::Color{22, 22, 22});
 	renderer.drawLine(origin + NAS2D::Vector{187, 180}, origin + NAS2D::Vector{187, 219}, NAS2D::Color{22, 22, 22});

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -5,6 +5,8 @@
 #include "../Mine.h"
 #include "../Things/Structures/MineFacility.h"
 
+#include <NAS2D/Renderer/RectangleSkin.h>
+
 
 /**
  * \brief Implements the Mine Facility Operations Window
@@ -44,7 +46,7 @@ private:
 	const NAS2D::Image& mUiIcon;
 	const NAS2D::Image& mIcons;
 
-	NAS2D::ImageList mPanel;
+	NAS2D::RectangleSkin mPanel;
 
 	CheckBox chkCommonMetals;
 	CheckBox chkCommonMinerals;

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -37,7 +37,7 @@ PopulationPanel::PopulationPanel() :
 void PopulationPanel::update()
 {
 	auto& renderer = Utility<Renderer>::get();
-	renderer.drawImageRect(mRect, mSkin);
+	mSkin.draw(renderer, mRect);
 
 	auto position = NAS2D::Point{positionX() + 5, positionY() + 5};
 	renderer.drawText(*FONT, "Morale: " + std::to_string(*mMorale), position, NAS2D::Color::White);

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -4,6 +4,9 @@
 
 #include "../Population/Population.h"
 
+#include <NAS2D/Renderer/RectangleSkin.h>
+
+
 class PopulationPanel: public Control
 {
 public:
@@ -27,7 +30,7 @@ protected:
 
 private:
 	const NAS2D::Image& mIcons;
-	NAS2D::ImageList mSkin;
+	NAS2D::RectangleSkin mSkin;
 
 	Population* mPopulation = nullptr;
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -79,7 +79,7 @@ void ResourceBreakdownPanel::resourceCheck()
 void ResourceBreakdownPanel::update()
 {
 	auto& renderer = Utility<Renderer>::get();
-	renderer.drawImageRect(mRect, mSkin);
+	mSkin.draw(renderer, mRect);
 
 	static std::map<ResourceTrend, Point<int>> ICON_SLICE
 	{

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -4,6 +4,7 @@
 #include "../StorableResources.h"
 
 #include <NAS2D/Resources/Image.h>
+#include <NAS2D/Renderer/RectangleSkin.h>
 
 
 class ResourceBreakdownPanel : public Control
@@ -22,7 +23,7 @@ public:
 
 private:
 	const NAS2D::Image& mIcons;
-	NAS2D::ImageList mSkin;
+	NAS2D::RectangleSkin mSkin;
 
 	StorableResources mPreviousResources;
 	StorableResources* mPlayerResources = nullptr;


### PR DESCRIPTION
Convert uses of `ImageList` for skinning to the new `RectangleSkin` class.

Reference:
https://github.com/lairworks/nas2d-core/pull/777
https://github.com/lairworks/nas2d-core/issues/37
https://github.com/lairworks/nas2d-core/issues/36
