### PR TITLE
Structure inspector improvements

### DIFF
--- a/OPHD/Things/Structures/OreRefining.h
+++ b/OPHD/Things/Structures/OreRefining.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+#include "Structure.h"
+#include <string>
+
+/**
+ * \class	PowerStructure
+ * \brief	Virtual class for structures whose primary purpose is power production
+ *
+ * \note	PowerStructure is an abstract class
+ */
+class OreRefining : public Structure
+{
+public:
+	OreRefining(const std::string& name, const std::string& spritePath, StructureClass structureClass) :
+		Structure(name, spritePath, structureClass) {}
+
+	StringTable createInspectorViewTable() override
+	{
+		StringTable stringTable(2, 1);
+
+		stringTable[{0, 0}].text = "Storage Capacity:";
+		stringTable[{1, 0}].text = std::to_string(calculateMaxStorage());
+
+		return stringTable;
+	}
+
+protected:
+	virtual int calculateMaxStorage() = 0;
+};

--- a/OPHD/Things/Structures/SeedSmelter.h
+++ b/OPHD/Things/Structures/SeedSmelter.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Structure.h"
+#include "OreRefining.h"
 
 
-class SeedSmelter : public Structure
+class SeedSmelter : public OreRefining
 {
 	const int StorageCapacity = 500;
 
 public:
-	SeedSmelter() : Structure(constants::SEED_SMELTER, "structures/seed_1.sprite", StructureClass::Smelter)
+	SeedSmelter() : OreRefining(constants::SEED_SMELTER, "structures/seed_1.sprite", StructureClass::Smelter)
 	{
 		maxAge(150);
 		turnsToBuild(6);
@@ -19,7 +19,7 @@ public:
 	void input(StorableResources& resources) override
 	{
 		if (!operational()) { return; }
-		if (production() >= StorableResources{ StorageCapacity }) { return; }
+		if (production() >= StorableResources{ calculateMaxStorage() }) { return; }
 
 		production() = production() + resources;
 	}
@@ -30,7 +30,7 @@ protected:
 	{
 		if (isIdle())
 		{
-			if (storage() < StorableResources{ StorageCapacity / 4 })
+			if (storage() < StorableResources{ calculateMaxStorage() / 4 })
 			{
 				enable();
 			}
@@ -59,7 +59,7 @@ protected:
 		}
 
 		auto total = storage() + converted;
-		auto capped = total.cap(StorageCapacity / 4);
+		auto capped = total.cap(calculateMaxStorage() / 4);
 		auto overflow = total - capped;
 
 		storage() = storage() + capped;
@@ -69,6 +69,11 @@ protected:
 			ore = ore + overflow;
 			idle(IdleReason::InternalStorageFull);
 		}
+	}
+
+	int calculateMaxStorage() override
+	{
+		return StorageCapacity;
 	}
 
 private:

--- a/OPHD/Things/Structures/Smelter.h
+++ b/OPHD/Things/Structures/Smelter.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "Structure.h"
+#include "OreRefining.h"
 
-class Smelter : public Structure
+class Smelter : public OreRefining
 {
 	const int StorageCapacity = 800;
 
 public:
-	Smelter() : Structure(constants::SMELTER, "structures/smelter.sprite", StructureClass::Smelter)
+	Smelter() : OreRefining(constants::SMELTER, "structures/smelter.sprite", StructureClass::Smelter)
 	{
 		maxAge(600);
 		turnsToBuild(9);
@@ -17,7 +17,7 @@ public:
 	void input(StorableResources& resources) override
 	{
 		if (!operational()) { return; }
-		if (production() >= StorableResources{ StorageCapacity }) { return; }
+		if (production() >= StorableResources{ calculateMaxStorage() }) { return; }
 
 		production() = production() + resources;
 	}
@@ -28,7 +28,7 @@ protected:
 	{
 		if (isIdle())
 		{
-			if (storage() < StorableResources{ StorageCapacity / 4 })
+			if (storage() < StorableResources{ calculateMaxStorage() / 4 })
 			{
 				enable();
 			}
@@ -57,7 +57,7 @@ protected:
 		}
 
 		auto total = storage() + converted;
-		auto capped = total.cap(StorageCapacity / 4);
+		auto capped = total.cap(calculateMaxStorage() / 4);
 		auto overflow = total - capped;
 
 		storage() = storage() + capped;
@@ -67,6 +67,11 @@ protected:
 			ore = ore + overflow;
 			idle(IdleReason::InternalStorageFull);
 		}
+	}
+
+	int calculateMaxStorage() override
+	{
+		return StorageCapacity;
 	}
 
 private:

--- a/OPHD/Things/Structures/StorageTanks.h
+++ b/OPHD/Things/Structures/StorageTanks.h
@@ -15,6 +15,16 @@ public:
 		requiresCHAP(false);
 	}
 
+	StringTable createInspectorViewTable() override
+	{
+		StringTable stringTable(2, 1);
+
+		stringTable[{0, 0}].text = "Storage Capacity:";
+		stringTable[{1, 0}].text = std::to_string(StorageTanksCapacity);
+
+		return stringTable;
+	}
+
 protected:
 	void defineResourceInput() override
 	{

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -15,6 +15,7 @@ public:
 	{
 		connectorDirection(dir);
 		requiresCHAP(false);
+		state(StructureState::Operational);
 
 		maxAge(400);
 	}

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -142,6 +142,9 @@ void StructureInspector::update()
 	auto position = mRect.startPoint() + NAS2D::Vector{ 5, 25 };
 	drawLabelAndValue(position,"Type: ", mStructureClass);
 
+	position.y += 20;
+	drawLabelAndValue(position, "Power Required: ", std::to_string(mStructure->energyRequirement()));
+
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};
 	drawLabelAndValue(position,"State: ", structureStateDescription(mStructure->state()));
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -164,7 +164,4 @@ void StructureInspector::update()
 	stringTable.computeRelativeCellPositions();
 	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{10, 135});
 	stringTable.draw(renderer);
-
-	position = mRect.startPoint() + NAS2D::Vector{5, mRect.height - FONT->height() - 5};
-	renderer.drawText(*FONT, "This window is a work in progress", position, NAS2D::Color::White);
 }

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -132,15 +132,14 @@ void StructureInspector::update()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	auto position = mRect.startPoint() + NAS2D::Vector{5, 25};
 	if (mStructure == nullptr)
 	{
-		drawLabelAndValue(position, "NULLPTR!", "");
+		text("NULLPTR!");
 		return;
 	}
-	drawLabelAndValue(position, mStructure->name(), "");
+	text(mStructure->name());
 
-	position.y += 20;
+	auto position = mRect.startPoint() + NAS2D::Vector{ 5, 25 };
 	drawLabelAndValue(position,"Type: ", mStructureClass);
 
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -388,6 +388,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="Things\Structures\SeedPower.h" />
     <ClInclude Include="Things\Structures\SeedSmelter.h" />
     <ClInclude Include="Things\Structures\Smelter.h" />
+    <ClInclude Include="Things\Structures\OreRefining.h" />
     <ClInclude Include="Things\Structures\SolarPanelArray.h" />
     <ClInclude Include="Things\Structures\SolarPlant.h" />
     <ClInclude Include="Things\Structures\StorageTanks.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -644,6 +644,9 @@
     <ClInclude Include="IOHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Things\Structures\OreRefining.h">
+      <Filter>Header Files\Things\Structures</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ophd.rc">


### PR DESCRIPTION
Couple of notes:

- I created a base class called OreRefining for the SeedSmelter and Smelter. I used that to combine the StringTable results in the StructureInspector. I didn't look at further code sharing opportunites. Not sure the name is the best for the base class, but something to start with.
- I was having trouble figuring out how to pull the current capacity of the Storage Tanks and Smelters, so I just displayed Max Capacity for now. It looks like resource pools are continuing to get overhauled, so maybe better to wait until that settles anyways?
- The smelters should include their conversion rates of the different minerals and planned conversion for the next turn. This may lead to a dedicated smelter inspector window instead of trying to use the generic StructureInspector similar to a mine or warehouse
- I was having trouble figuring out how to display if a structure is actually powered or not, so I left it as just power requirement. I didn't look too hard either though.