### PR TITLE
Add asset submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ clone_script:
       git fetch -q origin +refs/pull/$env:APPVEYOR_PULL_REQUEST_NUMBER/merge:
       git checkout -qf FETCH_HEAD
     }
-- cmd: git submodule update --init --recursive
+- cmd: git submodule update --init nas2d-core/
 cache:
   - C:\tools\vcpkg\installed\ -> nas2d-core\InstallVcpkgDeps.bat
 install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ commands:
   build:
     steps:
       - checkout
-      - run: git submodule update --init
+      - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror"
       - run: make package
@@ -32,7 +32,7 @@ jobs:
       - image: outpostuniverse/nas2d-mingw:1.4
     steps:
       - checkout
-      - run: git submodule update --init
+      - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" intermediate
 
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # All platforms
-/data/
 *.log
 
 # Linux - Makefile

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "nas2d-core"]
 	path = nas2d-core
 	url = https://github.com/lairworks/nas2d-core.git
+[submodule "data"]
+	path = data
+	url = https://github.com/OutpostUniverse/ophd-assets.git


### PR DESCRIPTION
Add `data/` folder assets as a submodule using the new ophd-assets repository.

Do not checkout the `data/` assets on CI build servers for regular builds. We may want to check out the data assets for the purposes of release packaging, but that will be a future issue.

Closes #555
