### PR TITLE
Fix MSVC warnings about `size_t` for Font pointSize

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -87,9 +87,9 @@ bool Button::toggled() const
 }
 
 
-void Button::fontSize(unsigned int size)
+void Button::fontSize(unsigned int pointSize)
 {
-	mFont = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, size);
+	mFont = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, pointSize);
 }
 
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -87,7 +87,7 @@ bool Button::toggled() const
 }
 
 
-void Button::fontSize(std::size_t size)
+void Button::fontSize(unsigned int size)
 {
 	mFont = &Utility<FontManager>::get().load(constants::FONT_PRIMARY, size);
 }

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -32,7 +32,7 @@ public:
 	void toggle(bool toggle);
 	bool toggled() const;
 
-	void fontSize(std::size_t);
+	void fontSize(unsigned int);
 
 	void image(const std::string& path);
 	bool hasImage() const;

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -32,7 +32,7 @@ public:
 	void toggle(bool toggle);
 	bool toggled() const;
 
-	void fontSize(unsigned int);
+	void fontSize(unsigned int pointSize);
 
 	void image(const std::string& path);
 	bool hasImage() const;

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -13,9 +13,9 @@
 using namespace NAS2D;
 
 
-void TextArea::font(const std::string& font, unsigned int size)
+void TextArea::font(const std::string& filePath, unsigned int pointSize)
 {
-	mFont = &Utility<FontManager>::get().load(font, size);
+	mFont = &Utility<FontManager>::get().load(filePath, pointSize);
 }
 
 

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -13,7 +13,7 @@
 using namespace NAS2D;
 
 
-void TextArea::font(const std::string& font, std::size_t size)
+void TextArea::font(const std::string& font, unsigned int size)
 {
 	mFont = &Utility<FontManager>::get().load(font, size);
 }

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -15,7 +15,7 @@ public:
 
 	void textColor(const NAS2D::Color& color) { mTextColor = color; }
 
-	void font(const std::string&, std::size_t);
+	void font(const std::string&, unsigned int);
 
 	void update() override;
 

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -15,7 +15,7 @@ public:
 
 	void textColor(const NAS2D::Color& color) { mTextColor = color; }
 
-	void font(const std::string&, unsigned int);
+	void font(const std::string& filePath, unsigned int pointSize);
 
 	void update() override;
 


### PR DESCRIPTION
Closes #602
