### PR TITLE
Remove main globals

### DIFF
--- a/OPHD/Cache.h
+++ b/OPHD/Cache.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include <NAS2D/Resources/Image.h>
+#include <NAS2D/Resources/Music.h>
 #include <NAS2D/Resources/ResourceCache.h>
+
+#include <memory>
 
 
 inline ResourceCache<NAS2D::Image, std::string> imageCache;
+
+inline std::unique_ptr<NAS2D::Music> trackMars;

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -7,6 +7,7 @@
 #include "PlanetSelectState.h"
 #include "Wrapper.h"
 
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../FontManager.h"
 
@@ -94,9 +95,8 @@ void MainMenuState::initialize()
 	renderer.fadeIn(constants::FADE_SPEED);
 	renderer.showSystemPointer(true);
 
-	extern const Music* MARS; /// yuck
 	Mixer& mixer = Utility<Mixer>::get();
-	if (!mixer.musicPlaying()) { mixer.playMusic(*MARS); }
+	if (!mixer.musicPlaying()) { mixer.playMusic(*trackMars); }
 }
 
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -9,7 +9,7 @@
 
 #include "MapViewState.h"
 
-
+#include "../Cache.h"
 #include "../Constants.h"
 #include "../IOHelper.h"
 #include "../StructureCatalogue.h"
@@ -34,10 +34,6 @@ extern const std::string MAP_DISPLAY_EXTENSION = "_b.png";
 
 extern std::string CURRENT_LEVEL_STRING;
 extern std::map <int, std::string> LEVEL_STRING_TABLE;
-
-
-extern const NAS2D::Image* IMG_LOADING; /// \fixme	Hate having these as externs.
-extern const NAS2D::Image* IMG_SAVING;
 
 
 extern int ROBOT_ID_COUNTER; /// \fixme Kludge
@@ -69,7 +65,8 @@ void MapViewState::save(const std::string& filePath)
 {
 	auto& renderer = Utility<Renderer>::get();
 	renderer.drawBoxFilled(NAS2D::Rectangle{0, 0, renderer.size().x, renderer.size().y}, NAS2D::Color{0, 0, 0, 100});
-	renderer.drawImage(*IMG_SAVING, renderer.center() - IMG_SAVING->size() / 2);
+	const auto imageSaving = &imageCache.load("sys/saving.png");
+	renderer.drawImage(*imageSaving, renderer.center() - imageSaving->size() / 2);
 	renderer.update();
 
 	XmlDocument doc;
@@ -118,7 +115,8 @@ void MapViewState::load(const std::string& filePath)
 
 	auto& renderer = Utility<Renderer>::get();
 	renderer.drawBoxFilled(NAS2D::Rectangle{0, 0, renderer.size().x, renderer.size().y}, NAS2D::Color{0, 0, 0, 100});
-	renderer.drawImage(*IMG_LOADING, renderer.center() - IMG_LOADING->size() / 2);
+	const auto imageLoading = &imageCache.load("sys/loading.png");
+	renderer.drawImage(*imageLoading, renderer.center() - imageLoading->size() / 2);
 	renderer.update();
 
 	mBtnToggleConnectedness.toggle(false);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -10,13 +10,11 @@
 
 #include "../Things/Structures/Structures.h"
 
+#include "../Cache.h"
 #include "../StorableResources.h"
 
 #include <vector>
 #include <algorithm>
-
-
-extern const NAS2D::Image* IMG_PROCESSING_TURN; /// \fixme Find a sane place for this.
 
 
 /**
@@ -391,7 +389,8 @@ void MapViewState::updateFood()
 void MapViewState::nextTurn()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	renderer.drawImage(*IMG_PROCESSING_TURN, renderer.center() - IMG_PROCESSING_TURN->size() / 2);
+	const auto imageProcessingTurn = &imageCache.load("sys/processing_turn.png");
+	renderer.drawImage(*imageProcessingTurn, renderer.center() - imageProcessingTurn->size() / 2);
 	renderer.update();
 
 	clearMode();

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -28,11 +28,6 @@
 using namespace NAS2D;
 
 
-/** Not thrilled with placement but this seems to be the easiest way to deal with it. */
-const NAS2D::Image* IMG_LOADING = nullptr;
-const NAS2D::Image* IMG_SAVING = nullptr;
-
-
 /**
  * Makes sure video resolution is never less than 1024x768
  */
@@ -142,10 +137,6 @@ int main(int /*argc*/, char *argv[])
 		fs.mountSoftFail("planets.dat");
 
 		std::cout << "done." << std::endl;
-
-		// Loading/Saving plaque's
-		IMG_LOADING = &imageCache.load("sys/loading.png");
-		IMG_SAVING = &imageCache.load("sys/saving.png");
 
 		trackMars = std::make_unique<NAS2D::Music>("music/mars.ogg");
 		Utility<Mixer>::get().playMusic(*trackMars);

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -31,7 +31,6 @@ using namespace NAS2D;
 /** Not thrilled with placement but this seems to be the easiest way to deal with it. */
 const NAS2D::Image* IMG_LOADING = nullptr;
 const NAS2D::Image* IMG_SAVING = nullptr;
-const NAS2D::Image* IMG_PROCESSING_TURN = nullptr;
 
 
 /**
@@ -147,7 +146,6 @@ int main(int /*argc*/, char *argv[])
 		// Loading/Saving plaque's
 		IMG_LOADING = &imageCache.load("sys/loading.png");
 		IMG_SAVING = &imageCache.load("sys/saving.png");
-		IMG_PROCESSING_TURN = &imageCache.load("sys/processing_turn.png");
 
 		trackMars = std::make_unique<NAS2D::Music>("music/mars.ogg");
 		Utility<Mixer>::get().playMusic(*trackMars);

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -33,8 +33,6 @@ const NAS2D::Image* IMG_LOADING = nullptr;
 const NAS2D::Image* IMG_SAVING = nullptr;
 const NAS2D::Image* IMG_PROCESSING_TURN = nullptr;
 
-const NAS2D::Music* MARS = nullptr;
-
 
 /**
  * Makes sure video resolution is never less than 1024x768
@@ -151,8 +149,8 @@ int main(int /*argc*/, char *argv[])
 		IMG_SAVING = &imageCache.load("sys/saving.png");
 		IMG_PROCESSING_TURN = &imageCache.load("sys/processing_turn.png");
 
-		MARS = new Music("music/mars.ogg");
-		Utility<Mixer>::get().playMusic(*MARS);
+		trackMars = std::make_unique<NAS2D::Music>("music/mars.ogg");
+		Utility<Mixer>::get().playMusic(*trackMars);
 
 		StateManager stateManager;
 		stateManager.forceStopAudio(false);


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/issues/763

Make the Mars music track a global variable cached resource.

We probably don't need the Mars track to really be a global, though it does have effects beyond a single file with the current setup. Maybe if the intro screen and main menu had some kind of parent controller, possibly the main menu screen itself, we could remove the global. Considering how large music tracks are, we probably don't want to cache them if we're not using them.
