### PR TITLE
OreRefining const functions and encapsulation

### DIFF
--- a/OPHD/Things/Structures/OreRefining.h
+++ b/OPHD/Things/Structures/OreRefining.h
@@ -37,11 +37,6 @@ public:
 		return stringTable;
 	}
 
-	std::string writeStorageAmount(int storageAmount) const
-	{
-		return std::to_string(storageAmount) + " / " + std::to_string(IndividualMaterialCapacity());
-	}
-
 	/**
 	 * Maximum capacity of all refined resources combined
 	 */
@@ -98,5 +93,11 @@ protected:
 			ore = ore + overflow;
 			idle(IdleReason::InternalStorageFull);
 		}
+	}
+
+private:
+	std::string writeStorageAmount(int storageAmount) const
+	{
+		return std::to_string(storageAmount) + " / " + std::to_string(IndividualMaterialCapacity());
 	}
 };

--- a/OPHD/Things/Structures/OreRefining.h
+++ b/OPHD/Things/Structures/OreRefining.h
@@ -37,7 +37,7 @@ public:
 		return stringTable;
 	}
 
-	std::string writeStorageAmount(int storageAmount)
+	std::string writeStorageAmount(int storageAmount) const
 	{
 		return std::to_string(storageAmount) + " / " + std::to_string(IndividualMaterialCapacity());
 	}
@@ -45,12 +45,12 @@ public:
 	/**
 	 * Maximum capacity of all refined resources combined
 	 */
-	virtual int TotalCapacity() = 0;
+	virtual int TotalCapacity() const = 0;
 
 	/**
      * Capacity of an individual type of refined resource
      */
-	int IndividualMaterialCapacity() { return TotalCapacity() / 4; }
+	int IndividualMaterialCapacity() const { return TotalCapacity() / 4; }
 
 protected:
 	std::array<int, 4> OreConversionDivisor{ 2, 2, 3, 3 };

--- a/OPHD/Things/Structures/SeedSmelter.h
+++ b/OPHD/Things/Structures/SeedSmelter.h
@@ -16,7 +16,7 @@ public:
 	}
 
 protected:
-	int TotalCapacity() override
+	int TotalCapacity() const override
 	{
 		return StorageCapacity;
 	}

--- a/OPHD/Things/Structures/Smelter.h
+++ b/OPHD/Things/Structures/Smelter.h
@@ -15,7 +15,7 @@ public:
 	}
 
 protected:
-	int TotalCapacity() override
+	int TotalCapacity() const override
 	{
 		return StorageCapacity;
 	}


### PR DESCRIPTION
I missed a couple of details on original push of OreRefining where functions were more appropriate to mark as constant and private encapsulation of class function.