### PR TITLE
Add missing includes for Utility and related headers

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -6,6 +6,8 @@
 
 #include "Things/Structures/Structure.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
 #include <NAS2D/Xml/XmlDocument.h>
 #include <NAS2D/Xml/XmlElement.h>
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -6,6 +6,9 @@
 #include "../Constants.h"
 #include "../DirectionOffset.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
+
 #include <algorithm>
 #include <functional>
 #include <random>

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -9,6 +9,8 @@
 
 #include "Wrapper.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
 #include <NAS2D/Mixer/Mixer.h>
 #include <NAS2D/Renderer/Renderer.h>
 

--- a/OPHD/States/GameState.h
+++ b/OPHD/States/GameState.h
@@ -2,8 +2,10 @@
 
 #include <NAS2D/State.h>
 
+
 class MapViewState;
 class Structure;
+
 
 class GameState : public NAS2D::State
 {

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -10,6 +10,8 @@
 #include "../Cache.h"
 #include "../Constants.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
 #include <NAS2D/Mixer/Mixer.h>
 #include <NAS2D/Renderer/Renderer.h>
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -11,6 +11,9 @@
 #include "../UI/Reports/FactoryReport.h"
 #include "../UI/Reports/WarehouseReport.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 #include <array>
 
 

--- a/OPHD/States/MainReportsUiState.h
+++ b/OPHD/States/MainReportsUiState.h
@@ -2,6 +2,9 @@
 
 #include "Wrapper.h"
 
+#include <NAS2D/Signal.h>
+#include <NAS2D/EventHandler.h>
+
 #include <vector>
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -16,6 +16,10 @@
 #include "../Things/Robots/Robots.h"
 #include "../Things/Structures/Structures.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 #include <algorithm>
 #include <sstream>
 #include <vector>

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -10,6 +10,9 @@
 #include "../Constants.h"
 #include "../Cache.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 #include <string>
 #include <vector>
 #include <algorithm>

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -13,6 +13,8 @@
 #include "../Things/Robots/Robots.h"
 #include "../Things/Structures/Structures.h"
 
+#include <NAS2D/Utility.h>
+
 
 void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 {

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -16,9 +16,10 @@
 #include "../StructureCatalogue.h"
 #include "../DirectionOffset.h"
 
-
 #include "../Things/Structures/RobotCommand.h"
 #include "../Things/Structures/Warehouse.h"
+
+#include <NAS2D/Utility.h>
 
 #include <cmath>
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -15,6 +15,8 @@
 #include "../StructureCatalogue.h"
 #include "../StructureTranslator.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
 #include <NAS2D/Xml/XmlDocument.h>
 #include <NAS2D/Xml/XmlMemoryBuffer.h>
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -13,6 +13,9 @@
 #include "../Cache.h"
 #include "../StorableResources.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 #include <vector>
 #include <algorithm>
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -17,6 +17,9 @@
 #include "../StructureCatalogue.h"
 #include "../StructureTranslator.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 #include <cmath>
 
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -10,6 +10,7 @@
 #include "../Constants.h"
 #include "../Cache.h"
 
+#include <NAS2D/Utility.h>
 #include <NAS2D/Mixer/Mixer.h>
 #include <NAS2D/Renderer/Renderer.h>
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -8,6 +8,9 @@
 #include "../Cache.h"
 #include "../Constants.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 
 using namespace NAS2D;
 

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -5,6 +5,9 @@
 
 #include "StringTable.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 
 using namespace NAS2D;
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -9,6 +9,7 @@
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/MathUtils.h>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -9,6 +9,9 @@
 #include "../Constants.h"
 #include "../Things/Structures/MineFacility.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 
 using namespace NAS2D;
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -12,9 +12,14 @@
 #include "../../Things/Structures/SeedFactory.h"
 #include "../../Things/Structures/UndergroundFactory.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 #include <array>
 
+
 using namespace NAS2D;
+
 
 static int SORT_BY_PRODUCT_POSITION = 0;
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -9,6 +9,10 @@
 
 #include "../../Things/Structures/Warehouse.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 
 using namespace NAS2D;
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -8,6 +8,10 @@
 #include "../Constants.h"
 #include "../Cache.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
+
 using namespace NAS2D;
 
 

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -12,12 +12,14 @@
 #include "States/MapViewState.h"
 #include "States/MainReportsUiState.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
+#include <NAS2D/StateManager.h>
 #include <NAS2D/Resources/Image.h>
 #include <NAS2D/Resources/Music.h>
 #include <NAS2D/Mixer/MixerSDL.h>
 #include <NAS2D/Mixer/MixerNull.h>
 #include <NAS2D/Renderer/RendererOpenGL.h>
-#include <NAS2D/StateManager.h>
 
 #include <SDL2/SDL.h>
 


### PR DESCRIPTION
Reference: #138

Add missing includes for `<Utility.h>` header, and associated global object types.
