### PR TITLE
Structure&structure inspector improvements reapply

### DIFF
--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -427,8 +427,6 @@ void MapViewState::nextTurn()
 
 	checkColonyShip();
 
-	mStructureInspector.check();
-
 	// Check for Game Over conditions
 	if (mPopulation.size() < 1 && mLandersColonist == 0)
 	{

--- a/OPHD/Things/Structures/OreRefining.h
+++ b/OPHD/Things/Structures/OreRefining.h
@@ -18,20 +18,34 @@ public:
 
 	StringTable createInspectorViewTable() override
 	{
-		StringTable stringTable(2, 4);
-		
+		StringTable stringTable(3, 5);
+
+		stringTable.setColumnFont(0, stringTable.GetDefaultFont());
+		stringTable.setRowFont(0, stringTable.GetDefaultTitleFont());
+		stringTable.setHorizontalPadding(20);
+
 		stringTable.setColumnText(
 			0,
 			{
-				"Common Metals Storage:",
-				"Rare Metals Storage:",
-				"Common Minerals Storage:",
-				"Rare Minerals Storage:"
+				"",
+				"Common Metal",
+				"Rare Metal",
+				"Common Minerals",
+				"Rare Minerals"
+			});
+
+		stringTable.setRowText(
+			0,
+			{
+				"Material",
+				"Storage",
+				"Ore Conversion Rate"
 			});
 
 		for (std::size_t i = 0; i < storage().resources.size(); ++i)
 		{
-			stringTable[{1, i}].text = writeStorageAmount(storage().resources[i]);
+			stringTable[{1, i + 1}].text = writeStorageAmount(storage().resources[i]);
+			stringTable[{2, i + 1}].text = std::to_string(OreConversionDivisor[i]) + " : 1";
 		}
 
 		return stringTable;

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -202,6 +202,11 @@ const std::string& Structure::stateDescription(StructureState state)
 	return STRUCTURE_STATE_TRANSLATION[state];
 }
 
+const std::string& Structure::classDescription() const
+{
+	return classDescription(structureClass());
+}
+
 const std::string& Structure::classDescription(Structure::StructureClass structureClass)
 {
 	return STRUCTURE_CLASS_TRANSLATION[structureClass];

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -48,13 +48,6 @@ std::map<Structure::StructureClass, std::string> STRUCTURE_CLASS_TRANSLATION =
 };
 
 
-const std::string& structureClassDescription(Structure::StructureClass _class)
-{
-	return STRUCTURE_CLASS_TRANSLATION[_class];
-}
-
-
-
 static std::array<std::string, StructureID::SID_COUNT> StructureNameTable =
 {
 	"Not a Structure",
@@ -209,6 +202,10 @@ const std::string& Structure::stateDescription(StructureState state)
 	return STRUCTURE_STATE_TRANSLATION[state];
 }
 
+const std::string& Structure::classDescription(Structure::StructureClass structureClass)
+{
+	return STRUCTURE_CLASS_TRANSLATION[structureClass];
+}
 
 /**
  * Called when a building is finished being built.

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -48,12 +48,6 @@ std::map<Structure::StructureClass, std::string> STRUCTURE_CLASS_TRANSLATION =
 };
 
 
-const std::string& structureStateDescription(StructureState _state)
-{
-	return STRUCTURE_STATE_TRANSLATION[_state];
-}
-
-
 const std::string& structureClassDescription(Structure::StructureClass _class)
 {
 	return STRUCTURE_CLASS_TRANSLATION[_class];
@@ -203,6 +197,12 @@ void Structure::forceIdle(bool force)
 		mForcedIdle = false;
 		enable();
 	}
+}
+
+
+const std::string& Structure::stateDescription(StructureState state)
+{
+	return STRUCTURE_STATE_TRANSLATION[state];
 }
 
 

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -199,6 +199,10 @@ void Structure::forceIdle(bool force)
 	}
 }
 
+const std::string& Structure::stateDescription() const
+{
+	return stateDescription(state());
+}
 
 const std::string& Structure::stateDescription(StructureState state)
 {

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -101,6 +101,7 @@ public:
 
 	// ATTRIBUTES
 	StructureClass structureClass() const { return mStructureClass; }
+	const std::string& stateDescription() const;
 	static const std::string& stateDescription(StructureState state);
 	ConnectorDir connectorDirection() const { return mConnectorDirection; }
 

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -103,6 +103,7 @@ public:
 	StructureClass structureClass() const { return mStructureClass; }
 	const std::string& stateDescription() const;
 	static const std::string& stateDescription(StructureState state);
+	const std::string& classDescription() const;
 	static const std::string& classDescription(Structure::StructureClass structureClass);
 	ConnectorDir connectorDirection() const { return mConnectorDirection; }
 

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -103,6 +103,7 @@ public:
 	StructureClass structureClass() const { return mStructureClass; }
 	const std::string& stateDescription() const;
 	static const std::string& stateDescription(StructureState state);
+	static const std::string& classDescription(Structure::StructureClass structureClass);
 	ConnectorDir connectorDirection() const { return mConnectorDirection; }
 
 	int turnsToBuild() const { return mTurnsToBuild; }
@@ -212,5 +213,4 @@ private:
 
 using StructureList = std::vector<Structure*>;
 
-const std::string& structureClassDescription(Structure::StructureClass);
 std::string StructureName(StructureID id);

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -101,6 +101,7 @@ public:
 
 	// ATTRIBUTES
 	StructureClass structureClass() const { return mStructureClass; }
+	static const std::string& stateDescription(StructureState state);
 	ConnectorDir connectorDirection() const { return mConnectorDirection; }
 
 	int turnsToBuild() const { return mTurnsToBuild; }
@@ -210,6 +211,5 @@ private:
 
 using StructureList = std::vector<Structure*>;
 
-const std::string& structureStateDescription(StructureState);
 const std::string& structureClassDescription(Structure::StructureClass);
 std::string StructureName(StructureID id);

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -207,7 +207,7 @@ void MineOperationsWindow::update()
 	const std::string statusString =
 		mFacility->extending() ? "Digging New Level" :
 		mFacility->mine()->exhausted() ? "Exhausted" :
-		structureStateDescription(mFacility->state());
+		Structure::stateDescription(mFacility->state());
 	drawLabelAndValue(origin + NAS2D::Vector{148, 45}, "Status: ", statusString);
 
 	if (mFacility && mFacility->extending())

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -207,7 +207,7 @@ void MineOperationsWindow::update()
 	const std::string statusString =
 		mFacility->extending() ? "Digging New Level" :
 		mFacility->mine()->exhausted() ? "Exhausted" :
-		Structure::stateDescription(mFacility->state());
+		mFacility->stateDescription();
 	drawLabelAndValue(origin + NAS2D::Vector{148, 45}, "Status: ", statusString);
 
 	if (mFacility && mFacility->extending())

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -455,7 +455,7 @@ void FactoryReport::btnShowDisabledClicked()
 void FactoryReport::btnIdleClicked()
 {
 	SELECTED_FACTORY->forceIdle(btnIdle.toggled());
-	FACTORY_STATUS = structureStateDescription(SELECTED_FACTORY->state());
+	FACTORY_STATUS = Structure::stateDescription(SELECTED_FACTORY->state());
 }
 
 
@@ -507,7 +507,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { FACTORY_IMAGE = FACTORY_AG; }
 	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { FACTORY_IMAGE = FACTORY_UG; }
 
-	FACTORY_STATUS = structureStateDescription(SELECTED_FACTORY->state());
+	FACTORY_STATUS = Structure::stateDescription(SELECTED_FACTORY->state());
 
 	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
 	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -455,7 +455,7 @@ void FactoryReport::btnShowDisabledClicked()
 void FactoryReport::btnIdleClicked()
 {
 	SELECTED_FACTORY->forceIdle(btnIdle.toggled());
-	FACTORY_STATUS = Structure::stateDescription(SELECTED_FACTORY->state());
+	FACTORY_STATUS = SELECTED_FACTORY->stateDescription();
 }
 
 
@@ -507,7 +507,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { FACTORY_IMAGE = FACTORY_AG; }
 	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { FACTORY_IMAGE = FACTORY_UG; }
 
-	FACTORY_STATUS = Structure::stateDescription(SELECTED_FACTORY->state());
+	FACTORY_STATUS = SELECTED_FACTORY->stateDescription();
 
 	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
 	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -171,7 +171,7 @@ void WarehouseReport::_fillListFromStructureList(StructureList& list)
 		// \fixme	Abuse of interface to achieve custom results.
 		ProductPool& products = static_cast<Warehouse*>(structure)->products();
 
-		if (useStateString(structure->state())) { item->structureState = structureStateDescription(structure->state()); }
+		if (useStateString(structure->state())) { item->structureState = Structure::stateDescription(structure->state()); }
 		else if (products.empty()) { item->structureState = constants::WAREHOUSE_EMPTY; }
 		else if (products.atCapacity()) { item->structureState = constants::WAREHOUSE_FULL; }
 		else if (!products.empty() && !products.atCapacity()) { item->structureState = constants::WAREHOUSE_SPACE_AVAILABLE; }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -171,7 +171,7 @@ void WarehouseReport::_fillListFromStructureList(StructureList& list)
 		// \fixme	Abuse of interface to achieve custom results.
 		ProductPool& products = static_cast<Warehouse*>(structure)->products();
 
-		if (useStateString(structure->state())) { item->structureState = Structure::stateDescription(structure->state()); }
+		if (useStateString(structure->state())) { item->structureState = structure->stateDescription(); }
 		else if (products.empty()) { item->structureState = constants::WAREHOUSE_EMPTY; }
 		else if (products.atCapacity()) { item->structureState = constants::WAREHOUSE_FULL; }
 		else if (!products.empty() && !products.atCapacity()) { item->structureState = constants::WAREHOUSE_SPACE_AVAILABLE; }

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -117,6 +117,22 @@ void StringTable::setColumnJustification(std::size_t column, Justification justi
 	}
 }
 
+void StringTable::setColumnFont(std::size_t column, const NAS2D::Font* const font)
+{
+	for (std::size_t row = 0; row < mRowCount; ++row)
+	{
+		mCells[getCellIndex({ column, row })].font = font;
+	}
+}
+
+void StringTable::setRowFont(std::size_t row, const NAS2D::Font* const font)
+{
+	for (std::size_t column = 0; column < mColumnCount; ++column)
+	{
+		mCells[getCellIndex({ column, row })].font = font;
+	}
+}
+
 void StringTable::computeRelativeCellPositions()
 {
 	auto columnWidths = computeColumnWidths();

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -64,6 +64,21 @@ void StringTable::setDefaultTextColor(NAS2D::Color color)
 	mDefaultTextColor = color;
 }
 
+const NAS2D::Font* StringTable::GetDefaultFont() const
+{
+	return mDefaultFont;
+}
+
+const NAS2D::Font* StringTable::GetDefaultTitleFont() const
+{
+	return mDefaultTitleFont;
+}
+
+NAS2D::Color StringTable::GetDefaultFontColor() const
+{
+	return mDefaultTextColor;
+}
+
 void StringTable::setHorizontalPadding(int padding)
 {
 	mHorizontalPadding = padding;

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -59,6 +59,9 @@ public:
 	void setColumnText(std::size_t column, const std::vector<NAS2D::StringValue>& rows);
 	void setRowText(std::size_t row, const std::vector<NAS2D::StringValue>& columns);
 	void setColumnJustification(std::size_t column, Justification justification);
+	
+	void setColumnFont(std::size_t column, const NAS2D::Font* const font);
+	void setRowFont(std::size_t row, const NAS2D::Font* const font);
 
 	// Call after updating table properties to recompute cell positions
 	void computeRelativeCellPositions();

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -49,6 +49,10 @@ public:
 	void setDefaultTitleFont(const NAS2D::Font* font);
 	void setDefaultTextColor(NAS2D::Color textColor);
 
+	const NAS2D::Font* GetDefaultFont() const;
+	const NAS2D::Font* GetDefaultTitleFont() const;
+	NAS2D::Color GetDefaultFontColor() const;
+
 	void setHorizontalPadding(int horizontalPadding);
 	void setVerticalPadding(int verticalPadding);
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -65,7 +65,6 @@ void StructureInspector::init()
 void StructureInspector::structure(Structure* s)
 {
 	mStructure = s;
-	mStructureClass = Structure::classDescription(mStructure->structureClass());
 	check();
 }
 
@@ -139,7 +138,7 @@ void StructureInspector::update()
 	text(mStructure->name());
 
 	auto position = mRect.startPoint() + NAS2D::Vector{ 5, 25 };
-	drawLabelAndValue(position,"Type: ", mStructureClass);
+	drawLabelAndValue(position,"Type: ", Structure::classDescription(mStructure->structureClass()));
 
 	position.y += 20;
 	drawLabelAndValue(position, "Power Required: ", std::to_string(mStructure->energyRequirement()));

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -145,7 +145,7 @@ void StructureInspector::update()
 	drawLabelAndValue(position, "Power Required: ", std::to_string(mStructure->energyRequirement()));
 
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};
-	drawLabelAndValue(position,"State: ", structureStateDescription(mStructure->state()));
+	drawLabelAndValue(position,"State: ", Structure::stateDescription(mStructure->state()));
 
 	position.y += 20;
 	if (mStructure->underConstruction())

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -62,9 +62,9 @@ void StructureInspector::init()
 /**
  * 
  */
-void StructureInspector::structure(Structure* s)
+void StructureInspector::structure(Structure* structure)
 {
-	mStructure = s;
+	mStructure = structure;
 	check();
 }
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -11,8 +11,6 @@
 
 #include <NAS2D/Utility.h>
 
-#include <map>
-#include <sstream>
 #include <stdexcept>
 
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -65,20 +65,6 @@ void StructureInspector::init()
 void StructureInspector::structure(Structure* structure)
 {
 	mStructure = structure;
-	check();
-}
-
-
-/**
- * Forces a state check. Used to update text area for descriptions.
- */
-void StructureInspector::check()
-{
-	if (!mStructure) { return; }
-
-	txtStateDescription.text("");
-	txtStateDescription.text(getDisabledReason());
-	txtStateDescription.visible(!txtStateDescription.text().empty());
 }
 
 
@@ -142,6 +128,10 @@ void StructureInspector::update()
 
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};
 	drawLabelAndValue(position,"State: ", mStructure->stateDescription());
+
+	txtStateDescription.text("");
+	txtStateDescription.text(getDisabledReason());
+	txtStateDescription.visible(!txtStateDescription.text().empty());
 
 	position.y += 20;
 	if (mStructure->underConstruction())

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -77,10 +77,7 @@ void StructureInspector::check()
 	if (!mStructure) { return; }
 
 	txtStateDescription.text("");
-
-	if (mStructure->disabled() || mStructure->destroyed()) { txtStateDescription.text(disabledReason(mStructure->disabledReason())); }
-	else if (mStructure->isIdle()) { txtStateDescription.text(idleReason(mStructure->idleReason())); }
-
+	txtStateDescription.text(getDisabledReason());
 	txtStateDescription.visible(!txtStateDescription.text().empty());
 }
 
@@ -162,4 +159,18 @@ void StructureInspector::update()
 	stringTable.computeRelativeCellPositions();
 	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{10, 135});
 	stringTable.draw(renderer);
+}
+
+std::string StructureInspector::getDisabledReason() const
+{
+	if (mStructure->disabled())
+	{
+		return disabledReason(mStructure->disabledReason());
+	}
+	else if (mStructure->isIdle())
+	{
+		return idleReason(mStructure->idleReason());
+	}
+
+	return "";
 }

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -49,11 +49,6 @@ void StructureInspector::init()
 	btnClose.size({50, 20});
 	btnClose.click().connect(this, &StructureInspector::btnCloseClicked);
 
-
-	add(&txtStateDescription, 190, 75);
-	txtStateDescription.size({155, 80});
-	txtStateDescription.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-
 	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
@@ -129,9 +124,7 @@ void StructureInspector::update()
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};
 	drawLabelAndValue(position,"State: ", mStructure->stateDescription());
 
-	txtStateDescription.text("");
-	txtStateDescription.text(getDisabledReason());
-	txtStateDescription.visible(!txtStateDescription.text().empty());
+	drawLabelAndValue(mRect.startPoint() + NAS2D::Vector<int>{ 190, 75 }, "", getDisabledReason());
 
 	position.y += 20;
 	if (mStructure->underConstruction())

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -138,7 +138,7 @@ void StructureInspector::update()
 	text(mStructure->name());
 
 	auto position = mRect.startPoint() + NAS2D::Vector{ 5, 25 };
-	drawLabelAndValue(position,"Type: ", Structure::classDescription(mStructure->structureClass()));
+	drawLabelAndValue(position,"Type: ", mStructure->classDescription());
 
 	position.y += 20;
 	drawLabelAndValue(position, "Power Required: ", std::to_string(mStructure->energyRequirement()));

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -136,9 +136,14 @@ void StructureInspector::update()
 
 	drawPopulationRequirements();
 
+	drawStructureSpecificTable(mRect.startPoint() + NAS2D::Vector<float>{5, 135}, renderer);
+}
+
+void StructureInspector::drawStructureSpecificTable(NAS2D::Point<int> position, NAS2D::Renderer& renderer)
+{
 	StringTable stringTable = mStructure->createInspectorViewTable();
 	stringTable.computeRelativeCellPositions();
-	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{5, 135});
+	stringTable.position(position);
 	stringTable.draw(renderer);
 }
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -74,7 +74,7 @@ void StructureInspector::drawPopulationRequirements()
 {
 	auto& renderer = Utility<Renderer>::get();
 
-	auto position = mRect.startPoint() + NAS2D::Vector{10, 85};
+	auto position = mRect.startPoint() + NAS2D::Vector{5, 85};
 	renderer.drawText(*FONT_BOLD, "Population Required", position, NAS2D::Color::White);
 
 	const std::array<std::string, 2> populationTypes{
@@ -138,7 +138,7 @@ void StructureInspector::update()
 
 	StringTable stringTable = mStructure->createInspectorViewTable();
 	stringTable.computeRelativeCellPositions();
-	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{10, 135});
+	stringTable.position(mRect.startPoint() + NAS2D::Vector<float>{5, 135});
 	stringTable.draw(renderer);
 }
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -145,7 +145,7 @@ void StructureInspector::update()
 	drawLabelAndValue(position, "Power Required: ", std::to_string(mStructure->energyRequirement()));
 
 	position = mRect.startPoint() + NAS2D::Vector{190, 25};
-	drawLabelAndValue(position,"State: ", Structure::stateDescription(mStructure->state()));
+	drawLabelAndValue(position,"State: ", mStructure->stateDescription());
 
 	position.y += 20;
 	if (mStructure->underConstruction())

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -65,7 +65,7 @@ void StructureInspector::init()
 void StructureInspector::structure(Structure* s)
 {
 	mStructure = s;
-	mStructureClass = structureClassDescription(mStructure->structureClass());
+	mStructureClass = Structure::classDescription(mStructure->structureClass());
 	check();
 }
 

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -26,6 +26,7 @@ protected:
 
 private:
 	void btnCloseClicked();
+	std::string getDisabledReason() const;
 	void drawPopulationRequirements();
 
 private:

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -33,7 +33,6 @@ private:
 
 private:
 	Button btnClose;
-	TextArea txtStateDescription;
 	const NAS2D::Image& mIcons;
 	Structure* mStructure = nullptr;
 };

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -26,7 +26,6 @@ private:
 	void btnCloseClicked();
 	std::string getDisabledReason() const;
 	void drawStructureSpecificTable(NAS2D::Point<int> position, NAS2D::Renderer& renderer);
-	void drawPopulationRequirements();
 
 private:
 	StructureInspector(const StructureInspector&) = delete;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -2,7 +2,8 @@
 
 #include "Core/Window.h"
 #include "Core/Button.h"
-
+#include <NAS2D/Renderer/Renderer.h>
+#include <NAS2D/Renderer/Point.h>
 
 class Structure;
 
@@ -24,6 +25,7 @@ protected:
 private:
 	void btnCloseClicked();
 	std::string getDisabledReason() const;
+	void drawStructureSpecificTable(NAS2D::Point<int> position, NAS2D::Renderer& renderer);
 	void drawPopulationRequirements();
 
 private:

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -17,8 +17,6 @@ public:
 	void structure(Structure* structure);
 	Structure* structure() { return mStructure; }
 
-	void check();
-
 	void update() override;
 
 protected:

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -26,7 +26,6 @@ protected:
 
 private:
 	void btnCloseClicked();
-
 	void drawPopulationRequirements();
 
 private:
@@ -35,10 +34,7 @@ private:
 
 private:
 	Button btnClose;
-
 	TextArea txtStateDescription;
-
 	const NAS2D::Image& mIcons;
-
 	Structure* mStructure = nullptr;
 };

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -2,7 +2,6 @@
 
 #include "Core/Window.h"
 #include "Core/Button.h"
-#include "Core/TextArea.h"
 
 
 class Structure;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -14,7 +14,7 @@ public:
 	StructureInspector();
 	~StructureInspector() override;
 
-	void structure(Structure* s);
+	void structure(Structure* structure);
 	Structure* structure() { return mStructure; }
 
 	void check();

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -40,7 +40,5 @@ private:
 
 	const NAS2D::Image& mIcons;
 
-	std::string mStructureClass;
-
 	Structure* mStructure = nullptr;
 };


### PR DESCRIPTION
Rework from #627 

Style notes:
* Do we want to have multiple calls to public, protected, private in headers to distinguish different categories of class members
   * I removed multiple calls to private from `StructureInspector`, but that doesn't seem in line with the rest of the code base

```C++
private:
virtual functions

private:
instance functions

private:
class variables
```

* Some function arguments include an _ prefix
   * I removed this prefix in a couple of places. Is that ok, or do we want to standardize one way or the other.

Thanks,
Brett