### PR TITLE
Refactor ResourceBreakdownPanel

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -244,7 +244,6 @@ void MapViewState::load(const std::string& filePath)
 	}
 
 	CURRENT_LEVEL_STRING = LEVEL_STRING_TABLE[mTileMap->currentDepth()];
-	mResourceBreakdownPanel.resourceCheck();
 
 	mMapChangedCallback();
 }

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -416,11 +416,7 @@ void MapViewState::nextTurn()
 	updateCommercial();
 	updateMorale();
 	updateRobots();
-
 	updateResources();
-
-	mResourceBreakdownPanel.resourceCheck();
-
 	updateStructuresAvailability();
 
 	populateStructureMenu();

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -7,9 +7,9 @@
 #include "../Common.h"
 #include "../Constants.h"
 
+#include <NAS2D/StringUtils.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
-#include <NAS2D/StringUtils.h>
 
 #include <array>
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -46,7 +46,7 @@ namespace
 
 
 ResourceBreakdownPanel::ResourceBreakdownPanel() :
-	mFont{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
+	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
 	mIcons{imageCache.load("ui/icons.png")},
 	mSkin{
 		imageCache.load("ui/skin/window_top_left.png"),
@@ -110,14 +110,14 @@ void ResourceBreakdownPanel::update()
 	for (const auto& [imageRect, text, value, oldValue] : resources)
 	{
 		renderer.drawSubImage(mIcons, position, imageRect);
-		renderer.drawText(*mFont, text, position + NAS2D::Vector{23, 0}, NAS2D::Color::White);
+		renderer.drawText(mFont, text, position + NAS2D::Vector{23, 0}, NAS2D::Color::White);
 		const auto valueString = std::to_string(value);
-		renderer.drawText(*mFont, valueString, position + NAS2D::Vector{195 - mFont->width(valueString), 0}, NAS2D::Color::White);
+		renderer.drawText(mFont, valueString, position + NAS2D::Vector{195 - mFont.width(valueString), 0}, NAS2D::Color::White);
 		const auto resourceTrend = compareResources(value, oldValue);
 		const auto changeIconImageRect = NAS2D::Rectangle<int>::Create(ICON_SLICE[resourceTrend], NAS2D::Vector{8, 8});
 		renderer.drawSubImage(mIcons, position + NAS2D::Vector{215, 3}, changeIconImageRect);
 		const auto valueChangeColor = TEXT_COLOR[resourceTrend];
-		renderer.drawText(*mFont, formatDiff(value - oldValue), position + NAS2D::Vector{235, 0}, valueChangeColor);
+		renderer.drawText(mFont, formatDiff(value - oldValue), position + NAS2D::Vector{235, 0}, valueChangeColor);
 		position.y += 18;
 	}
 }

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -46,6 +46,7 @@ namespace
 
 
 ResourceBreakdownPanel::ResourceBreakdownPanel() :
+	mFont{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
 	mIcons{imageCache.load("ui/icons.png")},
 	mSkin{
 		imageCache.load("ui/skin/window_top_left.png"),
@@ -60,8 +61,6 @@ ResourceBreakdownPanel::ResourceBreakdownPanel() :
 	}
 {
 	size({270, 80});
-
-	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -61,7 +61,7 @@ ResourceBreakdownPanel::ResourceBreakdownPanel() :
 {
 	size({270, 80});
 
-	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 
@@ -111,14 +111,14 @@ void ResourceBreakdownPanel::update()
 	for (const auto& [imageRect, text, value, oldValue] : resources)
 	{
 		renderer.drawSubImage(mIcons, position, imageRect);
-		renderer.drawText(*FONT, text, position + NAS2D::Vector{23, 0}, NAS2D::Color::White);
+		renderer.drawText(*mFont, text, position + NAS2D::Vector{23, 0}, NAS2D::Color::White);
 		const auto valueString = std::to_string(value);
-		renderer.drawText(*FONT, valueString, position + NAS2D::Vector{195 - FONT->width(valueString), 0}, NAS2D::Color::White);
+		renderer.drawText(*mFont, valueString, position + NAS2D::Vector{195 - mFont->width(valueString), 0}, NAS2D::Color::White);
 		const auto resourceTrend = compareResources(value, oldValue);
 		const auto changeIconImageRect = NAS2D::Rectangle<int>::Create(ICON_SLICE[resourceTrend], NAS2D::Vector{8, 8});
 		renderer.drawSubImage(mIcons, position + NAS2D::Vector{215, 3}, changeIconImageRect);
 		const auto valueChangeColor = TEXT_COLOR[resourceTrend];
-		renderer.drawText(*FONT, formatDiff(value - oldValue), position + NAS2D::Vector{235, 0}, valueChangeColor);
+		renderer.drawText(*mFont, formatDiff(value - oldValue), position + NAS2D::Vector{235, 0}, valueChangeColor);
 		position.y += 18;
 	}
 }

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -15,11 +15,12 @@
 
 using namespace NAS2D;
 
-static const Font* FONT = nullptr;
-
 
 namespace
 {
+	static const Font* FONT = nullptr;
+
+
 	enum class ResourceTrend
 	{
 		None,

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -64,15 +64,6 @@ ResourceBreakdownPanel::ResourceBreakdownPanel() :
 }
 
 
-/**
- * Called after all resources are modified from structure updates,
- * mining and production. Allows for resource trend information.
- */
-void ResourceBreakdownPanel::resourceCheck()
-{
-}
-
-
 void ResourceBreakdownPanel::update()
 {
 	auto& renderer = Utility<Renderer>::get();

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -31,9 +31,9 @@ enum class ResourceTrend
  */
 static ResourceTrend compareResources(int src, int dst)
 {
-	if (src > dst) { return ResourceTrend::Up; }
-	if (src < dst) { return ResourceTrend::Down; }
-	return ResourceTrend::None;
+	return
+		(src > dst) ? ResourceTrend::Up :
+		(src < dst) ? ResourceTrend::Down : ResourceTrend::None;
 }
 
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -18,7 +18,7 @@ using namespace NAS2D;
 static const Font* FONT = nullptr;
 
 
-enum ResourceTrend
+enum class ResourceTrend
 {
 	RESOURCE_TREND_NONE,
 	RESOURCE_TREND_UP,

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -20,9 +20,9 @@ static const Font* FONT = nullptr;
 
 enum class ResourceTrend
 {
-	RESOURCE_TREND_NONE,
-	RESOURCE_TREND_UP,
-	RESOURCE_TREND_DOWN
+	None,
+	Up,
+	Down
 };
 
 
@@ -31,9 +31,9 @@ enum class ResourceTrend
  */
 static ResourceTrend compareResources(int src, int dst)
 {
-	if (src > dst) { return ResourceTrend::RESOURCE_TREND_UP; }
-	if (src < dst) { return ResourceTrend::RESOURCE_TREND_DOWN; }
-	return ResourceTrend::RESOURCE_TREND_NONE;
+	if (src > dst) { return ResourceTrend::Up; }
+	if (src < dst) { return ResourceTrend::Down; }
+	return ResourceTrend::None;
 }
 
 
@@ -82,17 +82,17 @@ void ResourceBreakdownPanel::update()
 
 	static std::map<ResourceTrend, Point<int>> ICON_SLICE
 	{
-		{ ResourceTrend::RESOURCE_TREND_NONE, Point{16, 64} },
-		{ ResourceTrend::RESOURCE_TREND_UP, Point{8, 64} },
-		{ ResourceTrend::RESOURCE_TREND_DOWN, Point{0, 64} }
+		{ ResourceTrend::None, Point{16, 64} },
+		{ ResourceTrend::Up, Point{8, 64} },
+		{ ResourceTrend::Down, Point{0, 64} }
 	};
 
 
 	static std::map<ResourceTrend, Color> TEXT_COLOR
 	{
-		{ ResourceTrend::RESOURCE_TREND_NONE, Color::White },
-		{ ResourceTrend::RESOURCE_TREND_UP, Color{0, 185, 0} },
-		{ ResourceTrend::RESOURCE_TREND_DOWN, Color::Red }
+		{ ResourceTrend::None, Color::White },
+		{ ResourceTrend::Up, Color{0, 185, 0} },
+		{ ResourceTrend::Down, Color::Red }
 	};
 
 	const auto commonMetalImageRect = NAS2D::Rectangle{64, 16, 16, 16};

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -18,27 +18,27 @@ using namespace NAS2D;
 static const Font* FONT = nullptr;
 
 
-enum class ResourceTrend
-{
-	None,
-	Up,
-	Down
-};
-
-
-/**
- * Convenience function for setting a resource trend.
- */
-static ResourceTrend compareResources(int src, int dst)
-{
-	return
-		(src > dst) ? ResourceTrend::Up :
-		(src < dst) ? ResourceTrend::Down : ResourceTrend::None;
-}
-
-
 namespace
 {
+	enum class ResourceTrend
+	{
+		None,
+		Up,
+		Down
+	};
+
+
+	/**
+	 * Convenience function for setting a resource trend.
+	 */
+	static ResourceTrend compareResources(int src, int dst)
+	{
+		return
+			(src > dst) ? ResourceTrend::Up :
+			(src < dst) ? ResourceTrend::Down : ResourceTrend::None;
+	}
+
+
 	std::string formatDiff(int diff)
 	{
 		return ((diff > 0) ? "+" : "") + std::to_string(diff);

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -19,9 +19,6 @@ using namespace NAS2D;
 
 namespace
 {
-	static const Font* FONT = nullptr;
-
-
 	enum class ResourceTrend
 	{
 		None,

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -13,6 +13,7 @@
 
 #include <array>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -23,7 +23,7 @@ public:
 	void update() override;
 
 private:
-	const NAS2D::Font* FONT = nullptr;
+	const NAS2D::Font* mFont = nullptr;
 	const NAS2D::Image& mIcons;
 	NAS2D::RectangleSkin mSkin;
 

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -15,11 +15,7 @@ public:
 
 	void playerResources(StorableResources* resources) { mPlayerResources = resources; }
 	void previousResources(StorableResources& resources) { mPreviousResources = resources; }
-
 	StorableResources& previousResources() { return mPreviousResources; }
-
-	void resourceCheck();
-
 	void update() override;
 
 private:

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -23,6 +23,7 @@ public:
 	void update() override;
 
 private:
+	const NAS2D::Font* FONT = nullptr;
 	const NAS2D::Image& mIcons;
 	NAS2D::RectangleSkin mSkin;
 

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -3,6 +3,7 @@
 #include "Core/Control.h"
 #include "../StorableResources.h"
 
+#include <NAS2D/Resources/Font.h>
 #include <NAS2D/Resources/Image.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
 

--- a/OPHD/UI/ResourceBreakdownPanel.h
+++ b/OPHD/UI/ResourceBreakdownPanel.h
@@ -23,7 +23,7 @@ public:
 	void update() override;
 
 private:
-	const NAS2D::Font* mFont = nullptr;
+	const NAS2D::Font& mFont;
 	const NAS2D::Image& mIcons;
 	NAS2D::RectangleSkin mSkin;
 


### PR DESCRIPTION
Reference: #319

Could potential use forward declares instead of `include` in the header, though that would require opening up the `NAS2D` namespace to add the forward declares.
