### PR TITLE
Reduce global data in WarehouseReport

### DIFF
--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -24,11 +24,7 @@ namespace {
 	static std::string WH_CAPACITY;
 
 
-	/**
-	 * Internal function to determine current capacity of all
-	 * warehouses in the game.
-	 */
-	static void computeCapacity()
+	static void computeTotalWarehouseCapacity()
 	{
 		int capacity_total = 0;
 		int available_capacity = 0;
@@ -145,7 +141,7 @@ void WarehouseReport::fillLists()
 	_fillListFromStructureList(Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse));
 
 	lstStructures.setSelection(0);
-	computeCapacity();
+	computeTotalWarehouseCapacity();
 }
 
 
@@ -166,7 +162,7 @@ void WarehouseReport::fillListSpaceAvailable()
 	_fillListFromStructureList(list);
 
 	lstStructures.setSelection(0);
-	computeCapacity();
+	computeTotalWarehouseCapacity();
 }
 
 
@@ -188,7 +184,7 @@ void WarehouseReport::fillListFull()
 	_fillListFromStructureList(list);
 
 	lstStructures.setSelection(0);
-	computeCapacity();
+	computeTotalWarehouseCapacity();
 }
 
 
@@ -209,7 +205,7 @@ void WarehouseReport::fillListEmpty()
 	_fillListFromStructureList(list);
 
 	lstStructures.setSelection(0);
-	computeCapacity();
+	computeTotalWarehouseCapacity();
 }
 
 
@@ -229,7 +225,7 @@ void WarehouseReport::fillListDisabled()
 	_fillListFromStructureList(list);
 
 	lstStructures.setSelection(0);
-	computeCapacity();
+	computeTotalWarehouseCapacity();
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -120,8 +120,6 @@ WarehouseReport::WarehouseReport() :
 	btnTakeMeThere.size({140, 30});
 	btnTakeMeThere.click().connect(this, &WarehouseReport::btnTakeMeThereClicked);
 
-
-
 	add(&lstStructures, 10, mRect.y + 115);
 	lstStructures.selectionChanged().connect(this, &WarehouseReport::lstStructuresSelectionChanged);
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -32,10 +32,12 @@ namespace {
 		const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
 		for (auto warehouseStructure : structures)
 		{
-			if (!warehouseStructure->operational()) { continue; } // yuck
-			Warehouse* warehouse = static_cast<Warehouse*>(warehouseStructure);
-			capacityAvailable += warehouse->products().availableStorage();
-			capacityTotal += warehouse->products().capacity();
+			if (warehouseStructure->operational())
+			{
+				Warehouse* warehouse = static_cast<Warehouse*>(warehouseStructure);
+				capacityAvailable += warehouse->products().availableStorage();
+				capacityTotal += warehouse->products().capacity();
+			}
 		}
 
 		int capacityUsed = capacityTotal - capacityAvailable;

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -17,6 +17,7 @@
 using namespace NAS2D;
 
 
+namespace {
 static const Font* FONT_BOLD = nullptr;
 static const Font* FONT_MED = nullptr;
 static const Font* FONT_MED_BOLD = nullptr;
@@ -65,6 +66,7 @@ static void computeCapacity()
 	CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
 
 	CAPACITY_PERCENT = static_cast<float>(capacity_used) / static_cast<float>(capacity_total);
+}
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -30,12 +30,12 @@ namespace {
 		int capacityAvailable = 0;
 
 		const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
-		for (auto warehouse : structures)
+		for (auto warehouseStructure : structures)
 		{
-			if (!warehouse->operational()) { continue; } // yuck
-			Warehouse* _wh = static_cast<Warehouse*>(warehouse);
-			capacityAvailable += _wh->products().availableStorage();
-			capacityTotal += _wh->products().capacity();
+			if (!warehouseStructure->operational()) { continue; } // yuck
+			Warehouse* warehouse = static_cast<Warehouse*>(warehouseStructure);
+			capacityAvailable += warehouse->products().availableStorage();
+			capacityTotal += warehouse->products().capacity();
 		}
 
 		int capacityUsed = capacityTotal - capacityAvailable;

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -241,9 +241,9 @@ void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int
 	if (!visible()) { return; }
 	if (button != EventHandler::MouseButton::BUTTON_LEFT) { return; }
 
-	if (SELECTED_WAREHOUSE && lstStructures.rect().contains(NAS2D::Point{x, y}))
+	if (selectedWarehouse && lstStructures.rect().contains(NAS2D::Point{x, y}))
 	{
-		takeMeThereCallback()(SELECTED_WAREHOUSE);
+		takeMeThereCallback()(selectedWarehouse);
 	}
 }
 
@@ -251,7 +251,7 @@ void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int
 void WarehouseReport::clearSelection()
 {
 	lstStructures.clearSelection();
-	SELECTED_WAREHOUSE = nullptr;
+	selectedWarehouse = nullptr;
 }
 
 
@@ -264,7 +264,7 @@ void WarehouseReport::refresh()
 void WarehouseReport::selectStructure(Structure* structure)
 {
 	lstStructures.currentSelection(structure);
-	SELECTED_WAREHOUSE = static_cast<Warehouse*>(structure);
+	selectedWarehouse = static_cast<Warehouse*>(structure);
 }
 
 
@@ -338,20 +338,20 @@ void WarehouseReport::btnDisabledClicked()
 
 void WarehouseReport::btnTakeMeThereClicked()
 {
-	takeMeThereCallback()(SELECTED_WAREHOUSE);
+	takeMeThereCallback()(selectedWarehouse);
 }
 
 
 void WarehouseReport::lstStructuresSelectionChanged()
 {
-	SELECTED_WAREHOUSE = static_cast<Warehouse*>(lstStructures.selectedStructure());
+	selectedWarehouse = static_cast<Warehouse*>(lstStructures.selectedStructure());
 
-	if (SELECTED_WAREHOUSE != nullptr)
+	if (selectedWarehouse != nullptr)
 	{
-		lstProducts.productPool(SELECTED_WAREHOUSE->products());
+		lstProducts.productPool(selectedWarehouse->products());
 	}
 
-	btnTakeMeThere.visible(SELECTED_WAREHOUSE != nullptr);
+	btnTakeMeThere.visible(selectedWarehouse != nullptr);
 }
 
 
@@ -374,10 +374,10 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 
 void WarehouseReport::drawRightPanel(Renderer& renderer)
 {
-	if (!SELECTED_WAREHOUSE) { return; }
+	if (!selectedWarehouse) { return; }
 
 	const auto positionX = renderer.center().x + 10;
-	renderer.drawText(fontBigBold, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
+	renderer.drawText(fontBigBold, selectedWarehouse->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
 	renderer.drawImage(imageWarehouse, NAS2D::Point{positionX, positionY() + 35});
 }
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -34,9 +34,9 @@ namespace {
 		{
 			if (warehouseStructure->operational())
 			{
-				Warehouse* warehouse = static_cast<Warehouse*>(warehouseStructure);
-				capacityAvailable += warehouse->products().availableStorage();
-				capacityTotal += warehouse->products().capacity();
+				Warehouse& warehouse = *static_cast<Warehouse*>(warehouseStructure);
+				capacityAvailable += warehouse.products().availableStorage();
+				capacityTotal += warehouse.products().capacity();
 			}
 		}
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -356,17 +356,17 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 	renderer.drawText(fontMediumBold, "Total Storage", NAS2D::Point{10, positionY() + 62}, textColor);
 	renderer.drawText(fontMediumBold, "Capacity Used", NAS2D::Point{10, positionY() + 84}, textColor);
 
-	const auto COUNT_WIDTH = fontMedium.width(WH_COUNT);
-	const auto CAPACITY_WIDTH = fontMedium.width(WH_CAPACITY);
+	const auto countTextWidth = fontMedium.width(WH_COUNT);
+	const auto capacityTextWidth = fontMedium.width(WH_CAPACITY);
 
-	renderer.drawText(fontMedium, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
-	renderer.drawText(fontMedium, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
+	renderer.drawText(fontMedium, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - countTextWidth, positionY() + 35}, textColor);
+	renderer.drawText(fontMedium, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - capacityTextWidth, positionY() + 57}, textColor);
 
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
-	const auto CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - capacityUsedTextWidth;
-	const auto CAPACITY_BAR_POSITION_X = 20 + capacityUsedTextWidth;
+	const auto capacityBarWidth = mRect.width / 2 - 30 - capacityUsedTextWidth;
+	const auto capacityBarPositionX = 20 + capacityUsedTextWidth;
 
-	drawBasicProgressBar(CAPACITY_BAR_POSITION_X, positionY() + 84, CAPACITY_BAR_WIDTH, 20, CAPACITY_PERCENT);
+	drawBasicProgressBar(capacityBarPositionX, positionY() + 84, capacityBarWidth, 20, CAPACITY_PERCENT);
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -44,9 +44,6 @@ static Warehouse* SELECTED_WAREHOUSE = nullptr;
  */
 static void computeCapacity()
 {
-	COUNT_WIDTH = FONT_MED->width(WH_COUNT);
-	CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
-
 	int capacity_total = 0;
 	int available_capacity = 0;
 
@@ -63,6 +60,9 @@ static void computeCapacity()
 
 	WH_COUNT = std::to_string(structures.size());
 	WH_CAPACITY = std::to_string(capacity_total);
+
+	COUNT_WIDTH = FONT_MED->width(WH_COUNT);
+	CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
 
 	CAPACITY_PERCENT = static_cast<float>(capacity_used) / static_cast<float>(capacity_total);
 }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -68,9 +68,6 @@ static void computeCapacity()
 }
 
 
-/**
- * C'tor
- */
 WarehouseReport::WarehouseReport() :
 	btnShowAll{"All"},
 	btnSpaceAvailable{"Space Available"},
@@ -132,9 +129,6 @@ WarehouseReport::WarehouseReport() :
 }
 
 
-/**
- * D'tor
- */
 WarehouseReport::~WarehouseReport()
 {
 	Control::resized().disconnect(this, &WarehouseReport::_resized);
@@ -174,9 +168,6 @@ void WarehouseReport::fillLists()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::fillListSpaceAvailable()
 {
 	lstStructures.clearItems();
@@ -199,9 +190,6 @@ void WarehouseReport::fillListSpaceAvailable()
 
 
 
-/**
- * 
- */
 void WarehouseReport::fillListFull()
 {
 	lstStructures.clearItems();
@@ -223,9 +211,6 @@ void WarehouseReport::fillListFull()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::fillListEmpty()
 {
 	lstStructures.clearItems();
@@ -247,9 +232,6 @@ void WarehouseReport::fillListEmpty()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::fillListDisabled()
 {
 	lstStructures.clearItems();
@@ -270,9 +252,6 @@ void WarehouseReport::fillListDisabled()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int y)
 {
 	if (!visible()) { return; }
@@ -285,9 +264,6 @@ void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int
 }
 
 
-/**
- * 
- */
 void WarehouseReport::clearSelection()
 {
 	lstStructures.clearSelection();
@@ -295,18 +271,12 @@ void WarehouseReport::clearSelection()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::refresh()
 {
 	btnShowAllClicked();
 }
 
 
-/**
- * 
- */
 void WarehouseReport::selectStructure(Structure* structure)
 {
 	lstStructures.currentSelection(structure);
@@ -314,9 +284,6 @@ void WarehouseReport::selectStructure(Structure* structure)
 }
 
 
-/**
- * 
- */
 void WarehouseReport::_resized(Control*)
 {
 	lstStructures.size({(mRect.width / 2) - 20, mRect.height - 126});
@@ -330,9 +297,6 @@ void WarehouseReport::_resized(Control*)
 }
 
 
-/**
- * 
- */
 void WarehouseReport::filterButtonClicked()
 {
 	btnShowAll.toggle(false);
@@ -343,9 +307,6 @@ void WarehouseReport::filterButtonClicked()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::btnShowAllClicked()
 {
 	filterButtonClicked();
@@ -355,9 +316,6 @@ void WarehouseReport::btnShowAllClicked()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::btnSpaceAvailableClicked()
 {
 	filterButtonClicked();
@@ -367,9 +325,6 @@ void WarehouseReport::btnSpaceAvailableClicked()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::btnFullClicked()
 {
 	filterButtonClicked();
@@ -379,9 +334,6 @@ void WarehouseReport::btnFullClicked()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::btnEmptyClicked()
 {
 	filterButtonClicked();
@@ -391,9 +343,6 @@ void WarehouseReport::btnEmptyClicked()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::btnDisabledClicked()
 {
 	filterButtonClicked();
@@ -403,18 +352,12 @@ void WarehouseReport::btnDisabledClicked()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::btnTakeMeThereClicked()
 {
 	takeMeThereCallback()(SELECTED_WAREHOUSE);
 }
 
 
-/**
- * 
- */
 void WarehouseReport::lstStructuresSelectionChanged()
 {
 	SELECTED_WAREHOUSE = static_cast<Warehouse*>(lstStructures.selectedStructure());
@@ -428,9 +371,6 @@ void WarehouseReport::lstStructuresSelectionChanged()
 }
 
 
-/**
- * 
- */
 void WarehouseReport::drawLeftPanel(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
@@ -445,9 +385,6 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 }
 
 
-/**
- * 
- */
 void WarehouseReport::drawRightPanel(Renderer& renderer)
 {
 	if (!SELECTED_WAREHOUSE) { return; }
@@ -458,9 +395,6 @@ void WarehouseReport::drawRightPanel(Renderer& renderer)
 }
 
 
-/**
- * 
- */
 void WarehouseReport::update()
 {
 	if (!visible()) { return; }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -58,7 +58,6 @@ namespace {
 
 
 WarehouseReport::WarehouseReport() :
-	FONT_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL)},
 	FONT_MED{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
 	FONT_MED_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
 	FONT_BIG_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -58,10 +58,10 @@ namespace {
 
 
 WarehouseReport::WarehouseReport() :
-	FONT_MED{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
-	FONT_MED_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
-	FONT_BIG_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
-	WAREHOUSE_IMG{imageCache.load("ui/interface/warehouse.png")},
+	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
+	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
+	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
+	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All"},
 	btnSpaceAvailable{"Space Available"},
 	btnFull{"Full"},
@@ -278,8 +278,8 @@ void WarehouseReport::_resized(Control*)
 
 	btnTakeMeThere.position({Utility<Renderer>::get().size().x - 150, positionY() + 35});
 
-	CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - FONT_MED_BOLD.width("Capacity Used");
-	CAPACITY_BAR_POSITION_X = 20 + FONT_MED_BOLD.width("Capacity Used");
+	CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - fontMediumBold.width("Capacity Used");
+	CAPACITY_BAR_POSITION_X = 20 + fontMediumBold.width("Capacity Used");
 }
 
 
@@ -360,15 +360,15 @@ void WarehouseReport::lstStructuresSelectionChanged()
 void WarehouseReport::drawLeftPanel(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	renderer.drawText(FONT_MED_BOLD, "Warehouse Count", NAS2D::Point{10, positionY() + 40}, textColor);
-	renderer.drawText(FONT_MED_BOLD, "Total Storage", NAS2D::Point{10, positionY() + 62}, textColor);
-	renderer.drawText(FONT_MED_BOLD, "Capacity Used", NAS2D::Point{10, positionY() + 84}, textColor);
+	renderer.drawText(fontMediumBold, "Warehouse Count", NAS2D::Point{10, positionY() + 40}, textColor);
+	renderer.drawText(fontMediumBold, "Total Storage", NAS2D::Point{10, positionY() + 62}, textColor);
+	renderer.drawText(fontMediumBold, "Capacity Used", NAS2D::Point{10, positionY() + 84}, textColor);
 
-	const auto COUNT_WIDTH = FONT_MED.width(WH_COUNT);
-	const auto CAPACITY_WIDTH = FONT_MED.width(WH_CAPACITY);
+	const auto COUNT_WIDTH = fontMedium.width(WH_COUNT);
+	const auto CAPACITY_WIDTH = fontMedium.width(WH_CAPACITY);
 
-	renderer.drawText(FONT_MED, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
-	renderer.drawText(FONT_MED, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
+	renderer.drawText(fontMedium, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
+	renderer.drawText(fontMedium, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
 
 	drawBasicProgressBar(CAPACITY_BAR_POSITION_X, positionY() + 84, CAPACITY_BAR_WIDTH, 20, CAPACITY_PERCENT);
 }
@@ -379,8 +379,8 @@ void WarehouseReport::drawRightPanel(Renderer& renderer)
 	if (!SELECTED_WAREHOUSE) { return; }
 
 	const auto positionX = renderer.center().x + 10;
-	renderer.drawText(FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
-	renderer.drawImage(WAREHOUSE_IMG, NAS2D::Point{positionX, positionY() + 35});
+	renderer.drawText(fontBigBold, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
+	renderer.drawImage(imageWarehouse, NAS2D::Point{positionX, positionY() + 35});
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -25,9 +25,6 @@ namespace {
 
 	static const Image* WAREHOUSE_IMG = nullptr;
 
-	static int COUNT_WIDTH = 0;
-	static int CAPACITY_WIDTH = 0;
-
 	static int CAPACITY_BAR_WIDTH = 0;
 	static int CAPACITY_BAR_POSITION_X = 0;
 
@@ -61,9 +58,6 @@ namespace {
 
 		WH_COUNT = std::to_string(structures.size());
 		WH_CAPACITY = std::to_string(capacity_total);
-
-		COUNT_WIDTH = FONT_MED->width(WH_COUNT);
-		CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
 
 		CAPACITY_PERCENT = static_cast<float>(capacity_used) / static_cast<float>(capacity_total);
 	}
@@ -379,6 +373,9 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 	renderer.drawText(*FONT_MED_BOLD, "Warehouse Count", NAS2D::Point{10, positionY() + 40}, textColor);
 	renderer.drawText(*FONT_MED_BOLD, "Total Storage", NAS2D::Point{10, positionY() + 62}, textColor);
 	renderer.drawText(*FONT_MED_BOLD, "Capacity Used", NAS2D::Point{10, positionY() + 84}, textColor);
+
+	const auto COUNT_WIDTH = FONT_MED->width(WH_COUNT);
+	const auto CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
 
 	renderer.drawText(*FONT_MED, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
 	renderer.drawText(*FONT_MED, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -39,15 +39,6 @@ static Warehouse* SELECTED_WAREHOUSE = nullptr;
 
 
 /**
- * Internal convenience function to avoid really fugly code.
- */
-static bool useStateString(StructureState _state)
-{
-	return _state != StructureState::Operational;
-}
-
-
-/**
  * Internal function to determine current capacity of all
  * warehouses in the game.
  */
@@ -171,7 +162,7 @@ void WarehouseReport::_fillListFromStructureList(StructureList& list)
 		// \fixme	Abuse of interface to achieve custom results.
 		ProductPool& products = static_cast<Warehouse*>(structure)->products();
 
-		if (useStateString(structure->state())) { item->structureState = structure->stateDescription(); }
+		if (structure->state() != StructureState::Operational) { item->structureState = structure->stateDescription(); }
 		else if (products.empty()) { item->structureState = constants::WAREHOUSE_EMPTY; }
 		else if (products.atCapacity()) { item->structureState = constants::WAREHOUSE_FULL; }
 		else if (!products.empty() && !products.atCapacity()) { item->structureState = constants::WAREHOUSE_SPACE_AVAILABLE; }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -18,13 +18,6 @@ using namespace NAS2D;
 
 
 namespace {
-	static const Font* FONT_BOLD = nullptr;
-	static const Font* FONT_MED = nullptr;
-	static const Font* FONT_MED_BOLD = nullptr;
-	static const Font* FONT_BIG_BOLD = nullptr;
-
-	static const Image* WAREHOUSE_IMG = nullptr;
-
 	static int CAPACITY_BAR_WIDTH = 0;
 	static int CAPACITY_BAR_POSITION_X = 0;
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -18,9 +18,6 @@ using namespace NAS2D;
 
 
 namespace {
-	static int CAPACITY_BAR_WIDTH = 0;
-	static int CAPACITY_BAR_POSITION_X = 0;
-
 	static float CAPACITY_PERCENT = 0.0f;
 
 	static std::string WH_COUNT;
@@ -275,9 +272,6 @@ void WarehouseReport::_resized(Control*)
 	lstProducts.position({Utility<Renderer>::get().center().x + 10, lstProducts.positionY()});
 
 	btnTakeMeThere.position({Utility<Renderer>::get().size().x - 150, positionY() + 35});
-
-	CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - fontMediumBold.width("Capacity Used");
-	CAPACITY_BAR_POSITION_X = 20 + fontMediumBold.width("Capacity Used");
 }
 
 
@@ -367,6 +361,9 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 
 	renderer.drawText(fontMedium, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
 	renderer.drawText(fontMedium, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
+
+	const auto CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - fontMediumBold.width("Capacity Used");
+	const auto CAPACITY_BAR_POSITION_X = 20 + fontMediumBold.width("Capacity Used");
 
 	drawBasicProgressBar(CAPACITY_BAR_POSITION_X, positionY() + 84, CAPACITY_BAR_WIDTH, 20, CAPACITY_PERCENT);
 }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -362,8 +362,9 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 	renderer.drawText(fontMedium, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
 	renderer.drawText(fontMedium, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
 
-	const auto CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - fontMediumBold.width("Capacity Used");
-	const auto CAPACITY_BAR_POSITION_X = 20 + fontMediumBold.width("Capacity Used");
+	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
+	const auto CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - capacityUsedTextWidth;
+	const auto CAPACITY_BAR_POSITION_X = 20 + capacityUsedTextWidth;
 
 	drawBasicProgressBar(CAPACITY_BAR_POSITION_X, positionY() + 84, CAPACITY_BAR_WIDTH, 20, CAPACITY_PERCENT);
 }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -79,24 +79,6 @@ WarehouseReport::WarehouseReport() :
 	btnDisabled{"Disabled"},
 	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE}
 {
-	init();
-}
-
-
-/**
- * D'tor
- */
-WarehouseReport::~WarehouseReport()
-{
-	Control::resized().disconnect(this, &WarehouseReport::_resized);
-}
-
-
-/**
- * Sets up UI positions.
- */
-void WarehouseReport::init()
-{
 	FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 	FONT_MED = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
 	FONT_MED_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
@@ -149,6 +131,15 @@ void WarehouseReport::init()
 
 	Control::resized().connect(this, &WarehouseReport::_resized);
 	fillLists();
+}
+
+
+/**
+ * D'tor
+ */
+WarehouseReport::~WarehouseReport()
+{
+	Control::resized().disconnect(this, &WarehouseReport::_resized);
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -43,7 +43,7 @@ static Warehouse* SELECTED_WAREHOUSE = nullptr;
  */
 static bool useStateString(StructureState _state)
 {
-	return _state == StructureState::Disabled || _state == StructureState::Destroyed || _state == StructureState::UnderConstruction || _state == StructureState::Idle;
+	return _state != StructureState::Operational;
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -34,9 +34,9 @@ namespace {
 		{
 			if (warehouseStructure->operational())
 			{
-				Warehouse& warehouse = *static_cast<Warehouse*>(warehouseStructure);
-				capacityAvailable += warehouse.products().availableStorage();
-				capacityTotal += warehouse.products().capacity();
+				const auto& warehouseProducts = static_cast<Warehouse*>(warehouseStructure)->products();
+				capacityAvailable += warehouseProducts.availableStorage();
+				capacityTotal += warehouseProducts.capacity();
 			}
 		}
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -58,6 +58,11 @@ namespace {
 
 
 WarehouseReport::WarehouseReport() :
+	FONT_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL)},
+	FONT_MED{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
+	FONT_MED_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
+	FONT_BIG_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
+	WAREHOUSE_IMG{&imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All"},
 	btnSpaceAvailable{"Space Available"},
 	btnFull{"Full"},
@@ -65,13 +70,6 @@ WarehouseReport::WarehouseReport() :
 	btnDisabled{"Disabled"},
 	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE}
 {
-	FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
-	FONT_MED = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
-	FONT_MED_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-	FONT_BIG_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
-
-	WAREHOUSE_IMG = &imageCache.load("ui/interface/warehouse.png");
-
 	add(&btnShowAll, 10, 10);
 	btnShowAll.size({75, 20});
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -58,11 +58,11 @@ namespace {
 
 
 WarehouseReport::WarehouseReport() :
-	FONT_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL)},
-	FONT_MED{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
-	FONT_MED_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
-	FONT_BIG_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
-	WAREHOUSE_IMG{&imageCache.load("ui/interface/warehouse.png")},
+	FONT_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL)},
+	FONT_MED{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
+	FONT_MED_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
+	FONT_BIG_BOLD{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
+	WAREHOUSE_IMG{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All"},
 	btnSpaceAvailable{"Space Available"},
 	btnFull{"Full"},
@@ -279,8 +279,8 @@ void WarehouseReport::_resized(Control*)
 
 	btnTakeMeThere.position({Utility<Renderer>::get().size().x - 150, positionY() + 35});
 
-	CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - FONT_MED_BOLD->width("Capacity Used");
-	CAPACITY_BAR_POSITION_X = 20 + FONT_MED_BOLD->width("Capacity Used");
+	CAPACITY_BAR_WIDTH = mRect.width / 2 - 30 - FONT_MED_BOLD.width("Capacity Used");
+	CAPACITY_BAR_POSITION_X = 20 + FONT_MED_BOLD.width("Capacity Used");
 }
 
 
@@ -361,15 +361,15 @@ void WarehouseReport::lstStructuresSelectionChanged()
 void WarehouseReport::drawLeftPanel(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	renderer.drawText(*FONT_MED_BOLD, "Warehouse Count", NAS2D::Point{10, positionY() + 40}, textColor);
-	renderer.drawText(*FONT_MED_BOLD, "Total Storage", NAS2D::Point{10, positionY() + 62}, textColor);
-	renderer.drawText(*FONT_MED_BOLD, "Capacity Used", NAS2D::Point{10, positionY() + 84}, textColor);
+	renderer.drawText(FONT_MED_BOLD, "Warehouse Count", NAS2D::Point{10, positionY() + 40}, textColor);
+	renderer.drawText(FONT_MED_BOLD, "Total Storage", NAS2D::Point{10, positionY() + 62}, textColor);
+	renderer.drawText(FONT_MED_BOLD, "Capacity Used", NAS2D::Point{10, positionY() + 84}, textColor);
 
-	const auto COUNT_WIDTH = FONT_MED->width(WH_COUNT);
-	const auto CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
+	const auto COUNT_WIDTH = FONT_MED.width(WH_COUNT);
+	const auto CAPACITY_WIDTH = FONT_MED.width(WH_CAPACITY);
 
-	renderer.drawText(*FONT_MED, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
-	renderer.drawText(*FONT_MED, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
+	renderer.drawText(FONT_MED, WH_COUNT, NAS2D::Point{mRect.width / 2 - 10 - COUNT_WIDTH, positionY() + 35}, textColor);
+	renderer.drawText(FONT_MED, WH_CAPACITY, NAS2D::Point{mRect.width / 2 - 10 - CAPACITY_WIDTH, positionY() + 57}, textColor);
 
 	drawBasicProgressBar(CAPACITY_BAR_POSITION_X, positionY() + 84, CAPACITY_BAR_WIDTH, 20, CAPACITY_PERCENT);
 }
@@ -380,8 +380,8 @@ void WarehouseReport::drawRightPanel(Renderer& renderer)
 	if (!SELECTED_WAREHOUSE) { return; }
 
 	const auto positionX = renderer.center().x + 10;
-	renderer.drawText(*FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
-	renderer.drawImage(*WAREHOUSE_IMG, NAS2D::Point{positionX, positionY() + 35});
+	renderer.drawText(FONT_BIG_BOLD, SELECTED_WAREHOUSE->name(), NAS2D::Point{positionX, positionY() + 2}, NAS2D::Color{0, 185, 0});
+	renderer.drawImage(WAREHOUSE_IMG, NAS2D::Point{positionX, positionY() + 35});
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -26,24 +26,24 @@ namespace {
 
 	static void computeTotalWarehouseCapacity()
 	{
-		int capacity_total = 0;
-		int available_capacity = 0;
+		int capacityTotal = 0;
+		int capacityAvailable = 0;
 
 		const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
 		for (auto warehouse : structures)
 		{
 			if (!warehouse->operational()) { continue; } // yuck
 			Warehouse* _wh = static_cast<Warehouse*>(warehouse);
-			available_capacity += _wh->products().availableStorage();
-			capacity_total += _wh->products().capacity();
+			capacityAvailable += _wh->products().availableStorage();
+			capacityTotal += _wh->products().capacity();
 		}
 
-		int capacity_used = capacity_total - available_capacity;
+		int capacityUsed = capacityTotal - capacityAvailable;
 
 		WH_COUNT = std::to_string(structures.size());
-		WH_CAPACITY = std::to_string(capacity_total);
+		WH_CAPACITY = std::to_string(capacityTotal);
 
-		CAPACITY_PERCENT = static_cast<float>(capacity_used) / static_cast<float>(capacity_total);
+		CAPACITY_PERCENT = static_cast<float>(capacityUsed) / static_cast<float>(capacityTotal);
 	}
 }
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -26,8 +26,6 @@ namespace {
 	static std::string WH_COUNT;
 	static std::string WH_CAPACITY;
 
-	static Warehouse* SELECTED_WAREHOUSE = nullptr;
-
 
 	/**
 	 * Internal function to determine current capacity of all

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -18,55 +18,55 @@ using namespace NAS2D;
 
 
 namespace {
-static const Font* FONT_BOLD = nullptr;
-static const Font* FONT_MED = nullptr;
-static const Font* FONT_MED_BOLD = nullptr;
-static const Font* FONT_BIG_BOLD = nullptr;
+	static const Font* FONT_BOLD = nullptr;
+	static const Font* FONT_MED = nullptr;
+	static const Font* FONT_MED_BOLD = nullptr;
+	static const Font* FONT_BIG_BOLD = nullptr;
 
-static const Image* WAREHOUSE_IMG = nullptr;
+	static const Image* WAREHOUSE_IMG = nullptr;
 
-static int COUNT_WIDTH = 0;
-static int CAPACITY_WIDTH = 0;
+	static int COUNT_WIDTH = 0;
+	static int CAPACITY_WIDTH = 0;
 
-static int CAPACITY_BAR_WIDTH = 0;
-static int CAPACITY_BAR_POSITION_X = 0;
+	static int CAPACITY_BAR_WIDTH = 0;
+	static int CAPACITY_BAR_POSITION_X = 0;
 
-static float CAPACITY_PERCENT = 0.0f;
+	static float CAPACITY_PERCENT = 0.0f;
 
-static std::string WH_COUNT;
-static std::string WH_CAPACITY;
+	static std::string WH_COUNT;
+	static std::string WH_CAPACITY;
 
-static Warehouse* SELECTED_WAREHOUSE = nullptr;
+	static Warehouse* SELECTED_WAREHOUSE = nullptr;
 
 
-/**
- * Internal function to determine current capacity of all
- * warehouses in the game.
- */
-static void computeCapacity()
-{
-	int capacity_total = 0;
-	int available_capacity = 0;
-
-	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
-	for (auto warehouse : structures)
+	/**
+	 * Internal function to determine current capacity of all
+	 * warehouses in the game.
+	 */
+	static void computeCapacity()
 	{
-		if (!warehouse->operational()) { continue; } // yuck
-		Warehouse* _wh = static_cast<Warehouse*>(warehouse);
-		available_capacity += _wh->products().availableStorage();
-		capacity_total += _wh->products().capacity();
+		int capacity_total = 0;
+		int available_capacity = 0;
+
+		const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+		for (auto warehouse : structures)
+		{
+			if (!warehouse->operational()) { continue; } // yuck
+			Warehouse* _wh = static_cast<Warehouse*>(warehouse);
+			available_capacity += _wh->products().availableStorage();
+			capacity_total += _wh->products().capacity();
+		}
+
+		int capacity_used = capacity_total - available_capacity;
+
+		WH_COUNT = std::to_string(structures.size());
+		WH_CAPACITY = std::to_string(capacity_total);
+
+		COUNT_WIDTH = FONT_MED->width(WH_COUNT);
+		CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
+
+		CAPACITY_PERCENT = static_cast<float>(capacity_used) / static_cast<float>(capacity_total);
 	}
-
-	int capacity_used = capacity_total - available_capacity;
-
-	WH_COUNT = std::to_string(structures.size());
-	WH_CAPACITY = std::to_string(capacity_total);
-
-	COUNT_WIDTH = FONT_MED->width(WH_COUNT);
-	CAPACITY_WIDTH = FONT_MED->width(WH_CAPACITY);
-
-	CAPACITY_PERCENT = static_cast<float>(capacity_used) / static_cast<float>(capacity_total);
-}
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -15,6 +15,8 @@ namespace NAS2D {
 	class Image;
 }
 
+class Warehouse;
+
 
 class WarehouseReport : public ReportInterface
 {
@@ -62,6 +64,8 @@ private:
 	const NAS2D::Font& fontMediumBold;
 	const NAS2D::Font& fontBigBold;
 	const NAS2D::Image& imageWarehouse;
+
+	Warehouse* SELECTED_WAREHOUSE = nullptr;
 
 	Button btnShowAll;
 	Button btnSpaceAvailable;

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -65,7 +65,7 @@ private:
 	const NAS2D::Font& fontBigBold;
 	const NAS2D::Image& imageWarehouse;
 
-	Warehouse* SELECTED_WAREHOUSE = nullptr;
+	Warehouse* selectedWarehouse = nullptr;
 
 	Button btnShowAll;
 	Button btnSpaceAvailable;

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -58,7 +58,6 @@ private:
 	void drawRightPanel(NAS2D::Renderer&);
 
 private:
-	const NAS2D::Font& FONT_BOLD;
 	const NAS2D::Font& FONT_MED;
 	const NAS2D::Font& FONT_MED_BOLD;
 	const NAS2D::Font& FONT_BIG_BOLD;

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -10,6 +10,12 @@
 #include "../../Things/Structures/Structure.h"
 
 
+namespace NAS2D {
+	class Font;
+	class Image;
+}
+
+
 class WarehouseReport : public ReportInterface
 {
 public:
@@ -52,6 +58,12 @@ private:
 	void drawRightPanel(NAS2D::Renderer&);
 
 private:
+	const NAS2D::Font* FONT_BOLD = nullptr;
+	const NAS2D::Font* FONT_MED = nullptr;
+	const NAS2D::Font* FONT_MED_BOLD = nullptr;
+	const NAS2D::Font* FONT_BIG_BOLD = nullptr;
+	const NAS2D::Image* WAREHOUSE_IMG = nullptr;
+
 	Button btnShowAll;
 	Button btnSpaceAvailable;
 	Button btnFull;

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -25,7 +25,6 @@ public:
 	void update() override;
 
 private:
-	void init();
 	void _resized(Control*);
 
 	void _fillListFromStructureList(StructureList&);

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -13,8 +13,6 @@
 class WarehouseReport : public ReportInterface
 {
 public:
-
-public:
 	WarehouseReport();
 	~WarehouseReport() override;
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -58,10 +58,10 @@ private:
 	void drawRightPanel(NAS2D::Renderer&);
 
 private:
-	const NAS2D::Font& FONT_MED;
-	const NAS2D::Font& FONT_MED_BOLD;
-	const NAS2D::Font& FONT_BIG_BOLD;
-	const NAS2D::Image& WAREHOUSE_IMG;
+	const NAS2D::Font& fontMedium;
+	const NAS2D::Font& fontMediumBold;
+	const NAS2D::Font& fontBigBold;
+	const NAS2D::Image& imageWarehouse;
 
 	Button btnShowAll;
 	Button btnSpaceAvailable;

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -58,11 +58,11 @@ private:
 	void drawRightPanel(NAS2D::Renderer&);
 
 private:
-	const NAS2D::Font* FONT_BOLD = nullptr;
-	const NAS2D::Font* FONT_MED = nullptr;
-	const NAS2D::Font* FONT_MED_BOLD = nullptr;
-	const NAS2D::Font* FONT_BIG_BOLD = nullptr;
-	const NAS2D::Image* WAREHOUSE_IMG = nullptr;
+	const NAS2D::Font& FONT_BOLD;
+	const NAS2D::Font& FONT_MED;
+	const NAS2D::Font& FONT_MED_BOLD;
+	const NAS2D::Font& FONT_BIG_BOLD;
+	const NAS2D::Image& WAREHOUSE_IMG;
 
 	Button btnShowAll;
 	Button btnSpaceAvailable;


### PR DESCRIPTION
Reference: #138

Cleanup and reduce use of globals in `WarehouseReport` that are mentioned by `cppclean`. There's a bit more to do, but I'm stopping for the day.
