### PR TITLE
Fix load saved game seg fault

### DIFF
--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -35,9 +35,6 @@ Structure* StructureCatalogue::get(StructureID type)
 	// derived types.
 	switch (type)
 	{
-		case StructureID::SID_NONE:
-			break;
-
 		case StructureID::SID_AGRIDOME:
 			structure = new Agridome();
 			break;

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -3,6 +3,8 @@
 
 #include "StructureCatalogue.h"
 
+#include <stdexcept>
+
 
 //vector<ResourcePool> StructureCatalogue::mStructureCostTable;
 std::array<StorableResources, StructureID::SID_COUNT> StructureCatalogue::mStructureCostTable;
@@ -172,8 +174,7 @@ Structure* StructureCatalogue::get(StructureID type)
 			break;
 
 		default:
-			std::cout << "StructureCatalogue::get(): Unsupported structure type called." << std::endl;
-			break;
+			throw std::runtime_error("StructureCatalogue::get(): Unsupported structure type called.");
 	}
 
 	if (structure)

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -171,14 +171,23 @@ Structure* StructureCatalogue::get(StructureID type)
 			structure = new Warehouse();
 			break;
 
-		default:
-			throw std::runtime_error("StructureCatalogue::get(): Unsupported structure type: " + std::to_string(type));
+
+		case StructureID::SID_TUBE:
+			break;
+
+		case StructureID::SID_NONE:
+			break;
+
+		case StructureID::SID_COUNT:
+			break;
 	}
 
-	if (structure)
+	if (!structure)
 	{
-		structure->setPopulationRequirements(StructureCatalogue::populationRequirements(type));
+		throw std::runtime_error("StructureCatalogue::get(): Unsupported structure type: " + std::to_string(type));
 	}
+
+	structure->setPopulationRequirements(StructureCatalogue::populationRequirements(type));
 
 	return structure;
 }

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -3,6 +3,7 @@
 
 #include "StructureCatalogue.h"
 
+#include <string>
 #include <stdexcept>
 
 
@@ -174,7 +175,7 @@ Structure* StructureCatalogue::get(StructureID type)
 			break;
 
 		default:
-			throw std::runtime_error("StructureCatalogue::get(): Unsupported structure type called.");
+			throw std::runtime_error("StructureCatalogue::get(): Unsupported structure type: " + std::to_string(type));
 	}
 
 	if (structure)


### PR DESCRIPTION
Noticed a crash bug due to a segmentation fault. This converts the error to an exception, which can be caught and displayed in a message box instead.
