### PR TITLE
Reduce global data in FactoryReport

### DIFF
--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -49,9 +49,6 @@ static const std::string RESOURCES_REQUIRED = "Resources Required";
 static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 
-/**
- * C'tor
- */
 FactoryReport::FactoryReport() :
 	btnShowAll{"All"},
 	btnShowSurface{"Surface"},
@@ -68,9 +65,6 @@ FactoryReport::FactoryReport() :
 }
 
 
-/**
- * D'tor
- */
 FactoryReport::~FactoryReport()
 {
 	SELECTED_FACTORY = nullptr;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -301,14 +301,7 @@ void FactoryReport::resized(Control* /*c*/)
 {
 	const auto comboEndPoint = cboFilterByProduct.rect().endPoint();
 
-	const Rectangle<int> FACTORY_LISTBOX = {
-		positionX() + 10,
-		comboEndPoint.y + 10,
-		comboEndPoint.x - 10,
-		mRect.height - 74
-	};
-
-	lstFactoryList.size(FACTORY_LISTBOX.size());
+	lstFactoryList.size({comboEndPoint.x - 10, mRect.height - 74});
 
 	DETAIL_PANEL = {
 		comboEndPoint.x + 20,

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -21,8 +21,6 @@
 using namespace NAS2D;
 
 
-static int SORT_BY_PRODUCT_POSITION = 0;
-
 static Rectangle<int> FACTORY_LISTBOX;
 static Rectangle<int> DETAIL_PANEL;
 
@@ -171,8 +169,6 @@ void FactoryReport::init()
 	txtProductDescription.height(128);
 	txtProductDescription.textColor(NAS2D::Color{0, 185, 0});
 	txtProductDescription.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
-
-	SORT_BY_PRODUCT_POSITION = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width - FONT->width("Filter by Product");
 
 	Control::resized().connect(this, &FactoryReport::resized);
 	fillLists();
@@ -576,6 +572,7 @@ void FactoryReport::update()
 
 	const auto textColor = NAS2D::Color{0, 185, 0};
 	const auto positionX = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width + 10;
+	const auto SORT_BY_PRODUCT_POSITION = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width - FONT->width("Filter by Product");
 	renderer.drawLine(NAS2D::Point{positionX, mRect.y + 10}, NAS2D::Point{positionX, mRect.y + mRect.height - 10}, textColor);
 	renderer.drawText(*FONT, "Filter by Product", NAS2D::Point{SORT_BY_PRODUCT_POSITION, mRect.y + 10}, textColor);
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -314,9 +314,6 @@ void FactoryReport::checkFactoryActionControls()
 }
 
 
-/**
- * 
- */
 void FactoryReport::resized(Control* /*c*/)
 {
 	const auto comboEndPoint = cboFilterByProduct.rect().endPoint();
@@ -366,9 +363,6 @@ void FactoryReport::visibilityChanged(bool visible)
 }
 
 
-/**
- * 
- */
 void FactoryReport::filterButtonClicked(bool clearCbo)
 {
 	btnShowAll.toggle(false);
@@ -382,9 +376,6 @@ void FactoryReport::filterButtonClicked(bool clearCbo)
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnShowAllClicked()
 {
 	filterButtonClicked(true);
@@ -394,9 +385,6 @@ void FactoryReport::btnShowAllClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnShowSurfaceClicked()
 {
 	filterButtonClicked(true);
@@ -405,9 +393,6 @@ void FactoryReport::btnShowSurfaceClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnShowUndergroundClicked()
 {
 	filterButtonClicked(true);
@@ -416,9 +401,6 @@ void FactoryReport::btnShowUndergroundClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnShowActiveClicked()
 {
 	filterButtonClicked(true);
@@ -427,9 +409,6 @@ void FactoryReport::btnShowActiveClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnShowIdleClicked()
 {
 	filterButtonClicked(true);
@@ -438,9 +417,6 @@ void FactoryReport::btnShowIdleClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnShowDisabledClicked()
 {
 	filterButtonClicked(true);
@@ -449,9 +425,6 @@ void FactoryReport::btnShowDisabledClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnIdleClicked()
 {
 	SELECTED_FACTORY->forceIdle(btnIdle.toggled());
@@ -459,9 +432,6 @@ void FactoryReport::btnIdleClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnClearProductionClicked()
 {
 	SELECTED_FACTORY->productType(ProductType::PRODUCT_NONE);
@@ -470,18 +440,12 @@ void FactoryReport::btnClearProductionClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnTakeMeThereClicked()
 {
 	takeMeThereCallback()(SELECTED_FACTORY);
 }
 
 
-/**
- * 
- */
 void FactoryReport::btnApplyClicked()
 {
 	SELECTED_FACTORY->productType(SELECTED_PRODUCT_TYPE);
@@ -489,9 +453,6 @@ void FactoryReport::btnApplyClicked()
 }
 
 
-/**
- * 
- */
 void FactoryReport::lstFactoryListSelectionChanged()
 {
 	SELECTED_FACTORY = lstFactoryList.selectedFactory();
@@ -532,18 +493,12 @@ void FactoryReport::lstFactoryListSelectionChanged()
 }
 
 
-/**
- * 
- */
 void FactoryReport::lstProductsSelectionChanged()
 {
 	SELECTED_PRODUCT_TYPE = static_cast<ProductType>(lstProducts.selectionTag());
 }
 
 
-/**
- * 
- */
 void FactoryReport::cboFilterByProductSelectionChanged()
 {
 	if (cboFilterByProduct.currentSelection() == constants::NO_SELECTION) { return; }
@@ -552,9 +507,6 @@ void FactoryReport::cboFilterByProductSelectionChanged()
 }
 
 
-/**
- * 
- */
 void FactoryReport::drawDetailPane(Renderer& renderer)
 {
 	NAS2D::Color defaultTextColor{0, 185, 0};
@@ -595,9 +547,6 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 }
 
 
-/**
- * 
- */
 void FactoryReport::drawProductPane(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
@@ -632,9 +581,6 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 }
 
 
-/**
- * 
- */
 void FactoryReport::update()
 {
 	if (!visible()) { return; }

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -27,10 +27,8 @@ static Rectangle<int> FACTORY_LISTBOX;
 static Rectangle<int> DETAIL_PANEL;
 
 static const Font* FONT = nullptr;
-static const Font* FONT_BOLD = nullptr;
 static const Font* FONT_MED = nullptr;
 static const Font* FONT_MED_BOLD = nullptr;
-static const Font* FONT_BIG = nullptr;
 static const Font* FONT_BIG_BOLD = nullptr;
 
 static Factory* SELECTED_FACTORY = nullptr;
@@ -77,12 +75,8 @@ FactoryReport::~FactoryReport()
 void FactoryReport::init()
 {
 	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
-
 	FONT_MED = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
 	FONT_MED_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-
-	FONT_BIG = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_HUGE);
 	FONT_BIG_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
 
 	FACTORY_SEED = &imageCache.load("ui/interface/factory_seed.png");

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -21,7 +21,6 @@
 using namespace NAS2D;
 
 
-static Rectangle<int> FACTORY_LISTBOX;
 static Rectangle<int> DETAIL_PANEL;
 
 static const Font* FONT = nullptr;
@@ -302,7 +301,7 @@ void FactoryReport::resized(Control* /*c*/)
 {
 	const auto comboEndPoint = cboFilterByProduct.rect().endPoint();
 
-	FACTORY_LISTBOX = {
+	const Rectangle<int> FACTORY_LISTBOX = {
 		positionX() + 10,
 		comboEndPoint.y + 10,
 		comboEndPoint.x - 10,

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -24,7 +24,6 @@ using namespace NAS2D;
 static Rectangle<int> DETAIL_PANEL;
 
 std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
-static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 
 FactoryReport::FactoryReport() :

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -140,7 +140,7 @@ FactoryReport::FactoryReport() :
 
 FactoryReport::~FactoryReport()
 {
-	SELECTED_FACTORY = nullptr;
+	selectedFactory = nullptr;
 }
 
 
@@ -158,7 +158,7 @@ void FactoryReport::selectStructure(Structure* structure)
 void FactoryReport::clearSelection()
 {
 	lstFactoryList.clearSelection();
-	SELECTED_FACTORY = nullptr;
+	selectedFactory = nullptr;
 }
 
 
@@ -176,7 +176,7 @@ void FactoryReport::refresh()
  */
 void FactoryReport::fillLists()
 {
-	SELECTED_FACTORY = nullptr;
+	selectedFactory = nullptr;
 	lstFactoryList.clearItems();
 	for (auto factory : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
@@ -191,7 +191,7 @@ void FactoryReport::fillLists()
  */
 void FactoryReport::fillFactoryList(ProductType type)
 {
-	SELECTED_FACTORY = nullptr;
+	selectedFactory = nullptr;
 	lstFactoryList.clearItems();
 	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
@@ -211,7 +211,7 @@ void FactoryReport::fillFactoryList(ProductType type)
  */
 void FactoryReport::fillFactoryList(bool surface)
 {
-	SELECTED_FACTORY = nullptr;
+	selectedFactory = nullptr;
 	lstFactoryList.clearItems();
 	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
@@ -235,7 +235,7 @@ void FactoryReport::fillFactoryList(bool surface)
  */
 void FactoryReport::fillFactoryList(StructureState state)
 {
-	SELECTED_FACTORY = nullptr;
+	selectedFactory = nullptr;
 	lstFactoryList.clearItems();
 	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
@@ -301,9 +301,9 @@ void FactoryReport::resized(Control* /*c*/)
  */
 void FactoryReport::visibilityChanged(bool visible)
 {
-	if (!SELECTED_FACTORY) { return; }
+	if (!selectedFactory) { return; }
 
-	StructureState _state = SELECTED_FACTORY->state();
+	StructureState _state = selectedFactory->state();
 	btnApply.visible(visible && (_state == StructureState::Operational || _state == StructureState::Idle));
 	checkFactoryActionControls();
 }
@@ -373,13 +373,13 @@ void FactoryReport::btnShowDisabledClicked()
 
 void FactoryReport::btnIdleClicked()
 {
-	SELECTED_FACTORY->forceIdle(btnIdle.toggled());
+	selectedFactory->forceIdle(btnIdle.toggled());
 }
 
 
 void FactoryReport::btnClearProductionClicked()
 {
-	SELECTED_FACTORY->productType(ProductType::PRODUCT_NONE);
+	selectedFactory->productType(ProductType::PRODUCT_NONE);
 	lstProducts.clearSelection();
 	cboFilterByProductSelectionChanged();
 }
@@ -387,51 +387,51 @@ void FactoryReport::btnClearProductionClicked()
 
 void FactoryReport::btnTakeMeThereClicked()
 {
-	takeMeThereCallback()(SELECTED_FACTORY);
+	takeMeThereCallback()(selectedFactory);
 }
 
 
 void FactoryReport::btnApplyClicked()
 {
-	SELECTED_FACTORY->productType(SELECTED_PRODUCT_TYPE);
+	selectedFactory->productType(SELECTED_PRODUCT_TYPE);
 	cboFilterByProductSelectionChanged();
 }
 
 
 void FactoryReport::lstFactoryListSelectionChanged()
 {
-	SELECTED_FACTORY = lstFactoryList.selectedFactory();
+	selectedFactory = lstFactoryList.selectedFactory();
 
-	if (!SELECTED_FACTORY)
+	if (!selectedFactory)
 	{
 		checkFactoryActionControls();
 		return;
 	}
 
 	/// \fixme Ugly
-	if (SELECTED_FACTORY->name() == constants::SEED_FACTORY) { factoryImage = &factorySeed; }
-	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { factoryImage = &factoryAboveGround; }
-	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { factoryImage = &factoryUnderGround; }
+	if (selectedFactory->name() == constants::SEED_FACTORY) { factoryImage = &factorySeed; }
+	else if (selectedFactory->name() == constants::SURFACE_FACTORY) { factoryImage = &factoryAboveGround; }
+	else if (selectedFactory->name() == constants::UNDERGROUND_FACTORY) { factoryImage = &factoryUnderGround; }
 
-	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
-	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
+	btnIdle.toggle(selectedFactory->state() == StructureState::Idle);
+	btnIdle.enabled(selectedFactory->state() == StructureState::Operational || selectedFactory->state() == StructureState::Idle);
 
-	btnClearProduction.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
+	btnClearProduction.enabled(selectedFactory->state() == StructureState::Operational || selectedFactory->state() == StructureState::Idle);
 
 	lstProducts.dropAllItems();
-	if (SELECTED_FACTORY->state() != StructureState::Destroyed)
+	if (selectedFactory->state() != StructureState::Destroyed)
 	{
-		const Factory::ProductionTypeList& _pl = SELECTED_FACTORY->productList();
+		const Factory::ProductionTypeList& _pl = selectedFactory->productList();
 		for (auto item : _pl)
 		{
 			lstProducts.addItem(productDescription(item), static_cast<int>(item));
 		}
 	}
 	lstProducts.clearSelection();
-	lstProducts.setSelectionByName(productDescription(SELECTED_FACTORY->productType()));
-	SELECTED_PRODUCT_TYPE = SELECTED_FACTORY->productType();
+	lstProducts.setSelectionByName(productDescription(selectedFactory->productType()));
+	SELECTED_PRODUCT_TYPE = selectedFactory->productType();
 
-	StructureState _state = SELECTED_FACTORY->state();
+	StructureState _state = selectedFactory->state();
 	btnApply.visible(_state == StructureState::Operational || _state == StructureState::Idle);
 }
 
@@ -456,21 +456,21 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	renderer.drawImage(*factoryImage, startPoint + NAS2D::Vector{0, 25});
-	renderer.drawText(fontBigBold, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
+	renderer.drawText(fontBigBold, selectedFactory->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
 
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
 	renderer.drawText(fontMediumBold, "Status", statusPosition, defaultTextColor);
 
-	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
+	bool isStatusHighlighted = selectedFactory->disabled() || selectedFactory->destroyed();
 	statusPosition.x += fontMediumBold.width("Status") + 20;
-	renderer.drawText(fontMedium, SELECTED_FACTORY->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
+	renderer.drawText(fontMedium, selectedFactory->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
 
 	renderer.drawText(fontMediumBold, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
 
 	const auto labelWidth = fontMediumBold.width("Resources Required");
 
 	// MINERAL RESOURCES
-	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());
+	const ProductionCost& _pc = productCost(selectedFactory->productType());
 	const std::array requiredResources{
 		std::pair{"Common Metals", _pc.commonMetals()},
 		std::pair{"Common Minerals", _pc.commonMinerals()},
@@ -484,8 +484,8 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 	}
 
 	// POPULATION
-	bool isPopulationRequirementHighlighted = SELECTED_FACTORY->populationAvailable()[0] != SELECTED_FACTORY->populationRequirements()[0];
-	auto text = std::to_string(SELECTED_FACTORY->populationAvailable()[0]) + " / " + std::to_string(SELECTED_FACTORY->populationRequirements()[0]);
+	bool isPopulationRequirementHighlighted = selectedFactory->populationAvailable()[0] != selectedFactory->populationRequirements()[0];
+	auto text = std::to_string(selectedFactory->populationAvailable()[0]) + " / " + std::to_string(selectedFactory->populationRequirements()[0]);
 	drawLabelAndValueLeftJustify(position, labelWidth, "Workers", text, (isPopulationRequirementHighlighted ? NAS2D::Color::Red : defaultTextColor));
 }
 
@@ -504,21 +504,21 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 		txtProductDescription.update();
 	}
 
-	if (SELECTED_FACTORY->productType() == ProductType::PRODUCT_NONE) { return; }
+	if (selectedFactory->productType() == ProductType::PRODUCT_NONE) { return; }
 	
 	renderer.drawText(fontBigBold, "Progress", NAS2D::Point{position_x, DETAIL_PANEL.y + 358}, textColor);
-	renderer.drawText(fontMedium, "Building " + productDescription(SELECTED_FACTORY->productType()), NAS2D::Point{position_x, DETAIL_PANEL.y + 393}, textColor);
+	renderer.drawText(fontMedium, "Building " + productDescription(selectedFactory->productType()), NAS2D::Point{position_x, DETAIL_PANEL.y + 393}, textColor);
 
 	float percent = 0.0f;
-	if (SELECTED_FACTORY->productType() != ProductType::PRODUCT_NONE)
+	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
 	{
-		percent = static_cast<float>(SELECTED_FACTORY->productionTurnsCompleted()) /
-			static_cast<float>(SELECTED_FACTORY->productionTurnsToComplete());
+		percent = static_cast<float>(selectedFactory->productionTurnsCompleted()) /
+			static_cast<float>(selectedFactory->productionTurnsToComplete());
 	}
 	
 	drawBasicProgressBar(position_x, DETAIL_PANEL.y + 413, mRect.width - position_x - 10, 30, percent, 4);
 
-	const auto text = std::to_string(SELECTED_FACTORY->productionTurnsCompleted()) + " / " + std::to_string(SELECTED_FACTORY->productionTurnsToComplete());
+	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
 	renderer.drawText(fontMediumBold, "Turns", NAS2D::Point{position_x, DETAIL_PANEL.y + 449}, textColor);
 	renderer.drawText(fontMedium, text, NAS2D::Point{mRect.width - fontMedium.width(text) - 10, DETAIL_PANEL.y + 449}, textColor);
 }
@@ -534,7 +534,7 @@ void FactoryReport::update()
 	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.y + 10}, NAS2D::Point{positionX + 10, mRect.y + mRect.height - 10}, textColor);
 	renderer.drawText(font, "Filter by Product", NAS2D::Point{positionX - font.width("Filter by Product"), mRect.y + 10}, textColor);
 
-	if (SELECTED_FACTORY)
+	if (selectedFactory)
 	{
 		drawDetailPane(renderer);
 		drawProductPane(renderer);

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -36,7 +36,6 @@ static const Image* FACTORY_UG = nullptr;
 static const Image* FACTORY_IMAGE = nullptr;
 
 std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
-static const Image* _PRODUCT_NONE = nullptr;
 
 static std::string FACTORY_STATUS;
 static const std::string RESOURCES_REQUIRED = "Resources Required";
@@ -91,8 +90,6 @@ void FactoryReport::init()
 	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MAINTENANCE_PARTS] = &imageCache.load("ui/interface/product_maintenance_parts.png");
 	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_CLOTHING] = &imageCache.load("ui/interface/product_clothing.png");
 	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_MEDICINE] = &imageCache.load("ui/interface/product_medicine.png");
-
-	_PRODUCT_NONE = &imageCache.load("ui/interface/product_none.png");
 
 	add(&lstFactoryList, 10, 63);
 	lstFactoryList.selectionChanged().connect(this, &FactoryReport::lstFactoryListSelectionChanged);

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -40,21 +40,6 @@ FactoryReport::FactoryReport() :
 	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE},
 	btnApply{"Apply"}
 {
-	init();
-}
-
-
-FactoryReport::~FactoryReport()
-{
-	SELECTED_FACTORY = nullptr;
-}
-
-
-/**
- * Sets up UI positions.
- */
-void FactoryReport::init()
-{
 	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	FONT_MED = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
 	FONT_MED_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
@@ -153,6 +138,12 @@ void FactoryReport::init()
 
 	Control::resized().connect(this, &FactoryReport::resized);
 	fillLists();
+}
+
+
+FactoryReport::~FactoryReport()
+{
+	SELECTED_FACTORY = nullptr;
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -392,7 +392,7 @@ void FactoryReport::btnTakeMeThereClicked()
 
 void FactoryReport::btnApplyClicked()
 {
-	selectedFactory->productType(SELECTED_PRODUCT_TYPE);
+	selectedFactory->productType(selectedProductType);
 	cboFilterByProductSelectionChanged();
 }
 
@@ -428,7 +428,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	}
 	lstProducts.clearSelection();
 	lstProducts.setSelectionByName(productDescription(selectedFactory->productType()));
-	SELECTED_PRODUCT_TYPE = selectedFactory->productType();
+	selectedProductType = selectedFactory->productType();
 
 	StructureState _state = selectedFactory->state();
 	btnApply.visible(_state == StructureState::Operational || _state == StructureState::Idle);
@@ -437,7 +437,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 
 void FactoryReport::lstProductsSelectionChanged()
 {
-	SELECTED_PRODUCT_TYPE = static_cast<ProductType>(lstProducts.selectionTag());
+	selectedProductType = static_cast<ProductType>(lstProducts.selectionTag());
 }
 
 
@@ -496,10 +496,10 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 
 	int position_x = DETAIL_PANEL.x + lstProducts.size().x + 20;
 
-	if (SELECTED_PRODUCT_TYPE != ProductType::PRODUCT_NONE)
+	if (selectedProductType != ProductType::PRODUCT_NONE)
 	{
-		renderer.drawText(fontBigBold, productDescription(SELECTED_PRODUCT_TYPE), NAS2D::Point{position_x, DETAIL_PANEL.y + 180}, textColor);
-		renderer.drawImage(*PRODUCT_IMAGE_ARRAY[static_cast<std::size_t>(SELECTED_PRODUCT_TYPE)], NAS2D::Point{position_x, lstProducts.positionY()});
+		renderer.drawText(fontBigBold, productDescription(selectedProductType), NAS2D::Point{position_x, DETAIL_PANEL.y + 180}, textColor);
+		renderer.drawImage(*PRODUCT_IMAGE_ARRAY[static_cast<std::size_t>(selectedProductType)], NAS2D::Point{position_x, lstProducts.positionY()});
 		txtProductDescription.update();
 	}
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -22,7 +22,6 @@ using namespace NAS2D;
 
 
 static Rectangle<int> DETAIL_PANEL;
-static Factory* SELECTED_FACTORY = nullptr;
 
 std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
 static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -37,8 +37,6 @@ static const Image* FACTORY_IMAGE = nullptr;
 
 std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
 
-static std::string FACTORY_STATUS;
-
 static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 
@@ -400,7 +398,6 @@ void FactoryReport::btnShowDisabledClicked()
 void FactoryReport::btnIdleClicked()
 {
 	SELECTED_FACTORY->forceIdle(btnIdle.toggled());
-	FACTORY_STATUS = SELECTED_FACTORY->stateDescription();
 }
 
 
@@ -439,8 +436,6 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	if (SELECTED_FACTORY->name() == constants::SEED_FACTORY) { FACTORY_IMAGE = FACTORY_SEED; }
 	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { FACTORY_IMAGE = FACTORY_AG; }
 	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { FACTORY_IMAGE = FACTORY_UG; }
-
-	FACTORY_STATUS = SELECTED_FACTORY->stateDescription();
 
 	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
 	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
@@ -492,7 +487,7 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 
 	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
 	statusPosition.x += FONT_MED_BOLD->width("Status") + 20;
-	renderer.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
+	renderer.drawText(*FONT_MED, SELECTED_FACTORY->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
 
 	renderer.drawText(*FONT_MED_BOLD, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -29,13 +29,13 @@ static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 
 FactoryReport::FactoryReport() :
-	font{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
-	fontMedium{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
-	fontMediumBold{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
-	fontBigBold{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
-	factorySeed{&imageCache.load("ui/interface/factory_seed.png")},
-	factoryAboveGround{&imageCache.load("ui/interface/factory_ag.png")},
-	factoryUnderGround{&imageCache.load("ui/interface/factory_ug.png")},
+	font{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
+	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
+	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
+	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
+	factorySeed{imageCache.load("ui/interface/factory_seed.png")},
+	factoryAboveGround{imageCache.load("ui/interface/factory_ag.png")},
+	factoryUnderGround{imageCache.load("ui/interface/factory_ug.png")},
 	btnShowAll{"All"},
 	btnShowSurface{"Surface"},
 	btnShowUnderground{"Underground"},
@@ -410,9 +410,9 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	}
 
 	/// \fixme Ugly
-	if (SELECTED_FACTORY->name() == constants::SEED_FACTORY) { factoryImage = factorySeed; }
-	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { factoryImage = factoryAboveGround; }
-	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { factoryImage = factoryUnderGround; }
+	if (SELECTED_FACTORY->name() == constants::SEED_FACTORY) { factoryImage = &factorySeed; }
+	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { factoryImage = &factoryAboveGround; }
+	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { factoryImage = &factoryUnderGround; }
 
 	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
 	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
@@ -457,18 +457,18 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
 	renderer.drawImage(*factoryImage, startPoint + NAS2D::Vector{0, 25});
-	renderer.drawText(*fontBigBold, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
+	renderer.drawText(fontBigBold, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
 
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
-	renderer.drawText(*fontMediumBold, "Status", statusPosition, defaultTextColor);
+	renderer.drawText(fontMediumBold, "Status", statusPosition, defaultTextColor);
 
 	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
-	statusPosition.x += fontMediumBold->width("Status") + 20;
-	renderer.drawText(*fontMedium, SELECTED_FACTORY->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
+	statusPosition.x += fontMediumBold.width("Status") + 20;
+	renderer.drawText(fontMedium, SELECTED_FACTORY->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
 
-	renderer.drawText(*fontMediumBold, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
+	renderer.drawText(fontMediumBold, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
 
-	const auto labelWidth = fontMediumBold->width("Resources Required");
+	const auto labelWidth = fontMediumBold.width("Resources Required");
 
 	// MINERAL RESOURCES
 	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());
@@ -494,21 +494,21 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 void FactoryReport::drawProductPane(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	renderer.drawText(*fontBigBold, "Production", NAS2D::Point{DETAIL_PANEL.x, DETAIL_PANEL.y + 180}, textColor);
+	renderer.drawText(fontBigBold, "Production", NAS2D::Point{DETAIL_PANEL.x, DETAIL_PANEL.y + 180}, textColor);
 
 	int position_x = DETAIL_PANEL.x + lstProducts.size().x + 20;
 
 	if (SELECTED_PRODUCT_TYPE != ProductType::PRODUCT_NONE)
 	{
-		renderer.drawText(*fontBigBold, productDescription(SELECTED_PRODUCT_TYPE), NAS2D::Point{position_x, DETAIL_PANEL.y + 180}, textColor);
+		renderer.drawText(fontBigBold, productDescription(SELECTED_PRODUCT_TYPE), NAS2D::Point{position_x, DETAIL_PANEL.y + 180}, textColor);
 		renderer.drawImage(*PRODUCT_IMAGE_ARRAY[static_cast<std::size_t>(SELECTED_PRODUCT_TYPE)], NAS2D::Point{position_x, lstProducts.positionY()});
 		txtProductDescription.update();
 	}
 
 	if (SELECTED_FACTORY->productType() == ProductType::PRODUCT_NONE) { return; }
 	
-	renderer.drawText(*fontBigBold, "Progress", NAS2D::Point{position_x, DETAIL_PANEL.y + 358}, textColor);
-	renderer.drawText(*fontMedium, "Building " + productDescription(SELECTED_FACTORY->productType()), NAS2D::Point{position_x, DETAIL_PANEL.y + 393}, textColor);
+	renderer.drawText(fontBigBold, "Progress", NAS2D::Point{position_x, DETAIL_PANEL.y + 358}, textColor);
+	renderer.drawText(fontMedium, "Building " + productDescription(SELECTED_FACTORY->productType()), NAS2D::Point{position_x, DETAIL_PANEL.y + 393}, textColor);
 
 	float percent = 0.0f;
 	if (SELECTED_FACTORY->productType() != ProductType::PRODUCT_NONE)
@@ -520,8 +520,8 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	drawBasicProgressBar(position_x, DETAIL_PANEL.y + 413, mRect.width - position_x - 10, 30, percent, 4);
 
 	const auto text = std::to_string(SELECTED_FACTORY->productionTurnsCompleted()) + " / " + std::to_string(SELECTED_FACTORY->productionTurnsToComplete());
-	renderer.drawText(*fontMediumBold, "Turns", NAS2D::Point{position_x, DETAIL_PANEL.y + 449}, textColor);
-	renderer.drawText(*fontMedium, text, NAS2D::Point{mRect.width - fontMedium->width(text) - 10, DETAIL_PANEL.y + 449}, textColor);
+	renderer.drawText(fontMediumBold, "Turns", NAS2D::Point{position_x, DETAIL_PANEL.y + 449}, textColor);
+	renderer.drawText(fontMedium, text, NAS2D::Point{mRect.width - fontMedium.width(text) - 10, DETAIL_PANEL.y + 449}, textColor);
 }
 
 
@@ -533,7 +533,7 @@ void FactoryReport::update()
 	const auto textColor = NAS2D::Color{0, 185, 0};
 	const auto positionX = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width;
 	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.y + 10}, NAS2D::Point{positionX + 10, mRect.y + mRect.height - 10}, textColor);
-	renderer.drawText(*font, "Filter by Product", NAS2D::Point{positionX - font->width("Filter by Product"), mRect.y + 10}, textColor);
+	renderer.drawText(font, "Filter by Product", NAS2D::Point{positionX - font.width("Filter by Product"), mRect.y + 10}, textColor);
 
 	if (SELECTED_FACTORY)
 	{

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -571,10 +571,9 @@ void FactoryReport::update()
 	auto& renderer = Utility<Renderer>::get();
 
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	const auto positionX = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width + 10;
-	const auto SORT_BY_PRODUCT_POSITION = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width - FONT->width("Filter by Product");
-	renderer.drawLine(NAS2D::Point{positionX, mRect.y + 10}, NAS2D::Point{positionX, mRect.y + mRect.height - 10}, textColor);
-	renderer.drawText(*FONT, "Filter by Product", NAS2D::Point{SORT_BY_PRODUCT_POSITION, mRect.y + 10}, textColor);
+	const auto positionX = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width;
+	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.y + 10}, NAS2D::Point{positionX + 10, mRect.y + mRect.height - 10}, textColor);
+	renderer.drawText(*FONT, "Filter by Product", NAS2D::Point{positionX - FONT->width("Filter by Product"), mRect.y + 10}, textColor);
 
 	if (SELECTED_FACTORY)
 	{

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -29,6 +29,13 @@ static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 
 FactoryReport::FactoryReport() :
+	FONT{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
+	FONT_MED{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
+	FONT_MED_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
+	FONT_BIG_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
+	FACTORY_SEED{&imageCache.load("ui/interface/factory_seed.png")},
+	FACTORY_AG{&imageCache.load("ui/interface/factory_ag.png")},
+	FACTORY_UG{&imageCache.load("ui/interface/factory_ug.png")},
 	btnShowAll{"All"},
 	btnShowSurface{"Surface"},
 	btnShowUnderground{"Underground"},
@@ -40,15 +47,6 @@ FactoryReport::FactoryReport() :
 	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE},
 	btnApply{"Apply"}
 {
-	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	FONT_MED = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
-	FONT_MED_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM);
-	FONT_BIG_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE);
-
-	FACTORY_SEED = &imageCache.load("ui/interface/factory_seed.png");
-	FACTORY_AG = &imageCache.load("ui/interface/factory_ag.png");
-	FACTORY_UG = &imageCache.load("ui/interface/factory_ug.png");
-
 	/// \todo Decide if this is the best place to have these images live or if it should be done at program start.
 	PRODUCT_IMAGE_ARRAY.fill(nullptr);
 	PRODUCT_IMAGE_ARRAY[ProductType::PRODUCT_DIGGER] = &imageCache.load("ui/interface/product_robodigger.png");

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -38,7 +38,6 @@ static const Image* FACTORY_IMAGE = nullptr;
 std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
 
 static std::string FACTORY_STATUS;
-static const std::string RESOURCES_REQUIRED = "Resources Required";
 
 static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
@@ -495,9 +494,9 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 	statusPosition.x += FONT_MED_BOLD->width("Status") + 20;
 	renderer.drawText(*FONT_MED, FACTORY_STATUS, statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
 
-	renderer.drawText(*FONT_MED_BOLD, RESOURCES_REQUIRED, startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
+	renderer.drawText(*FONT_MED_BOLD, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
 
-	const auto labelWidth = FONT_MED_BOLD->width(RESOURCES_REQUIRED);
+	const auto labelWidth = FONT_MED_BOLD->width("Resources Required");
 
 	// MINERAL RESOURCES
 	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -22,21 +22,9 @@ using namespace NAS2D;
 
 
 static Rectangle<int> DETAIL_PANEL;
-
-static const Font* FONT = nullptr;
-static const Font* FONT_MED = nullptr;
-static const Font* FONT_MED_BOLD = nullptr;
-static const Font* FONT_BIG_BOLD = nullptr;
-
 static Factory* SELECTED_FACTORY = nullptr;
 
-static const Image* FACTORY_SEED = nullptr;
-static const Image* FACTORY_AG = nullptr;
-static const Image* FACTORY_UG = nullptr;
-static const Image* FACTORY_IMAGE = nullptr;
-
 std::array<const Image*, ProductType::PRODUCT_COUNT> PRODUCT_IMAGE_ARRAY;
-
 static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -29,13 +29,13 @@ static ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 
 
 FactoryReport::FactoryReport() :
-	FONT{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
-	FONT_MED{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
-	FONT_MED_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
-	FONT_BIG_BOLD{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
-	FACTORY_SEED{&imageCache.load("ui/interface/factory_seed.png")},
-	FACTORY_AG{&imageCache.load("ui/interface/factory_ag.png")},
-	FACTORY_UG{&imageCache.load("ui/interface/factory_ug.png")},
+	font{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
+	fontMedium{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
+	fontMediumBold{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
+	fontBigBold{&fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
+	factorySeed{&imageCache.load("ui/interface/factory_seed.png")},
+	factoryAboveGround{&imageCache.load("ui/interface/factory_ag.png")},
+	factoryUnderGround{&imageCache.load("ui/interface/factory_ug.png")},
 	btnShowAll{"All"},
 	btnShowSurface{"Surface"},
 	btnShowUnderground{"Underground"},
@@ -410,9 +410,9 @@ void FactoryReport::lstFactoryListSelectionChanged()
 	}
 
 	/// \fixme Ugly
-	if (SELECTED_FACTORY->name() == constants::SEED_FACTORY) { FACTORY_IMAGE = FACTORY_SEED; }
-	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { FACTORY_IMAGE = FACTORY_AG; }
-	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { FACTORY_IMAGE = FACTORY_UG; }
+	if (SELECTED_FACTORY->name() == constants::SEED_FACTORY) { factoryImage = factorySeed; }
+	else if (SELECTED_FACTORY->name() == constants::SURFACE_FACTORY) { factoryImage = factoryAboveGround; }
+	else if (SELECTED_FACTORY->name() == constants::UNDERGROUND_FACTORY) { factoryImage = factoryUnderGround; }
 
 	btnIdle.toggle(SELECTED_FACTORY->state() == StructureState::Idle);
 	btnIdle.enabled(SELECTED_FACTORY->state() == StructureState::Operational || SELECTED_FACTORY->state() == StructureState::Idle);
@@ -456,19 +456,19 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 	NAS2D::Color defaultTextColor{0, 185, 0};
 
 	const auto startPoint = DETAIL_PANEL.startPoint();
-	renderer.drawImage(*FACTORY_IMAGE, startPoint + NAS2D::Vector{0, 25});
-	renderer.drawText(*FONT_BIG_BOLD, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
+	renderer.drawImage(*factoryImage, startPoint + NAS2D::Vector{0, 25});
+	renderer.drawText(*fontBigBold, SELECTED_FACTORY->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
 
 	auto statusPosition = startPoint + NAS2D::Vector{138, 20};
-	renderer.drawText(*FONT_MED_BOLD, "Status", statusPosition, defaultTextColor);
+	renderer.drawText(*fontMediumBold, "Status", statusPosition, defaultTextColor);
 
 	bool isStatusHighlighted = SELECTED_FACTORY->disabled() || SELECTED_FACTORY->destroyed();
-	statusPosition.x += FONT_MED_BOLD->width("Status") + 20;
-	renderer.drawText(*FONT_MED, SELECTED_FACTORY->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
+	statusPosition.x += fontMediumBold->width("Status") + 20;
+	renderer.drawText(*fontMedium, SELECTED_FACTORY->stateDescription(), statusPosition, (isStatusHighlighted ? NAS2D::Color::Red : defaultTextColor));
 
-	renderer.drawText(*FONT_MED_BOLD, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
+	renderer.drawText(*fontMediumBold, "Resources Required", startPoint + NAS2D::Vector{138, 60}, defaultTextColor);
 
-	const auto labelWidth = FONT_MED_BOLD->width("Resources Required");
+	const auto labelWidth = fontMediumBold->width("Resources Required");
 
 	// MINERAL RESOURCES
 	const ProductionCost& _pc = productCost(SELECTED_FACTORY->productType());
@@ -494,21 +494,21 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 void FactoryReport::drawProductPane(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	renderer.drawText(*FONT_BIG_BOLD, "Production", NAS2D::Point{DETAIL_PANEL.x, DETAIL_PANEL.y + 180}, textColor);
+	renderer.drawText(*fontBigBold, "Production", NAS2D::Point{DETAIL_PANEL.x, DETAIL_PANEL.y + 180}, textColor);
 
 	int position_x = DETAIL_PANEL.x + lstProducts.size().x + 20;
 
 	if (SELECTED_PRODUCT_TYPE != ProductType::PRODUCT_NONE)
 	{
-		renderer.drawText(*FONT_BIG_BOLD, productDescription(SELECTED_PRODUCT_TYPE), NAS2D::Point{position_x, DETAIL_PANEL.y + 180}, textColor);
+		renderer.drawText(*fontBigBold, productDescription(SELECTED_PRODUCT_TYPE), NAS2D::Point{position_x, DETAIL_PANEL.y + 180}, textColor);
 		renderer.drawImage(*PRODUCT_IMAGE_ARRAY[static_cast<std::size_t>(SELECTED_PRODUCT_TYPE)], NAS2D::Point{position_x, lstProducts.positionY()});
 		txtProductDescription.update();
 	}
 
 	if (SELECTED_FACTORY->productType() == ProductType::PRODUCT_NONE) { return; }
 	
-	renderer.drawText(*FONT_BIG_BOLD, "Progress", NAS2D::Point{position_x, DETAIL_PANEL.y + 358}, textColor);
-	renderer.drawText(*FONT_MED, "Building " + productDescription(SELECTED_FACTORY->productType()), NAS2D::Point{position_x, DETAIL_PANEL.y + 393}, textColor);
+	renderer.drawText(*fontBigBold, "Progress", NAS2D::Point{position_x, DETAIL_PANEL.y + 358}, textColor);
+	renderer.drawText(*fontMedium, "Building " + productDescription(SELECTED_FACTORY->productType()), NAS2D::Point{position_x, DETAIL_PANEL.y + 393}, textColor);
 
 	float percent = 0.0f;
 	if (SELECTED_FACTORY->productType() != ProductType::PRODUCT_NONE)
@@ -520,8 +520,8 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	drawBasicProgressBar(position_x, DETAIL_PANEL.y + 413, mRect.width - position_x - 10, 30, percent, 4);
 
 	const auto text = std::to_string(SELECTED_FACTORY->productionTurnsCompleted()) + " / " + std::to_string(SELECTED_FACTORY->productionTurnsToComplete());
-	renderer.drawText(*FONT_MED_BOLD, "Turns", NAS2D::Point{position_x, DETAIL_PANEL.y + 449}, textColor);
-	renderer.drawText(*FONT_MED, text, NAS2D::Point{mRect.width - FONT_MED->width(text) - 10, DETAIL_PANEL.y + 449}, textColor);
+	renderer.drawText(*fontMediumBold, "Turns", NAS2D::Point{position_x, DETAIL_PANEL.y + 449}, textColor);
+	renderer.drawText(*fontMedium, text, NAS2D::Point{mRect.width - fontMedium->width(text) - 10, DETAIL_PANEL.y + 449}, textColor);
 }
 
 
@@ -533,7 +533,7 @@ void FactoryReport::update()
 	const auto textColor = NAS2D::Color{0, 185, 0};
 	const auto positionX = cboFilterByProduct.rect().x + cboFilterByProduct.rect().width;
 	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.y + 10}, NAS2D::Point{positionX + 10, mRect.y + mRect.height - 10}, textColor);
-	renderer.drawText(*FONT, "Filter by Product", NAS2D::Point{positionX - FONT->width("Filter by Product"), mRect.y + 10}, textColor);
+	renderer.drawText(*font, "Filter by Product", NAS2D::Point{positionX - font->width("Filter by Product"), mRect.y + 10}, textColor);
 
 	if (SELECTED_FACTORY)
 	{

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -96,4 +96,5 @@ private:
 	TextArea txtProductDescription;
 
 	Factory* selectedFactory = nullptr;
+	ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
 };

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -14,6 +14,8 @@ namespace NAS2D {
 	class Image;
 }
 
+class Factory;
+
 
 class FactoryReport : public ReportInterface
 {
@@ -92,4 +94,6 @@ private:
 	ListBox lstProducts;
 
 	TextArea txtProductDescription;
+
+	Factory* SELECTED_FACTORY = nullptr;
 };

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -63,14 +63,14 @@ private:
 	void visibilityChanged(bool visible) override;
 
 private:
-	const NAS2D::Font* FONT = nullptr;
-	const NAS2D::Font* FONT_MED = nullptr;
-	const NAS2D::Font* FONT_MED_BOLD = nullptr;
-	const NAS2D::Font* FONT_BIG_BOLD = nullptr;
-	const NAS2D::Image* FACTORY_SEED = nullptr;
-	const NAS2D::Image* FACTORY_AG = nullptr;
-	const NAS2D::Image* FACTORY_UG = nullptr;
-	const NAS2D::Image* FACTORY_IMAGE = nullptr;
+	const NAS2D::Font* font = nullptr;
+	const NAS2D::Font* fontMedium = nullptr;
+	const NAS2D::Font* fontMediumBold = nullptr;
+	const NAS2D::Font* fontBigBold = nullptr;
+	const NAS2D::Image* factorySeed = nullptr;
+	const NAS2D::Image* factoryAboveGround = nullptr;
+	const NAS2D::Image* factoryUnderGround = nullptr;
+	const NAS2D::Image* factoryImage = nullptr;
 
 	Button btnShowAll;
 	Button btnShowSurface;

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -63,13 +63,13 @@ private:
 	void visibilityChanged(bool visible) override;
 
 private:
-	const NAS2D::Font* font = nullptr;
-	const NAS2D::Font* fontMedium = nullptr;
-	const NAS2D::Font* fontMediumBold = nullptr;
-	const NAS2D::Font* fontBigBold = nullptr;
-	const NAS2D::Image* factorySeed = nullptr;
-	const NAS2D::Image* factoryAboveGround = nullptr;
-	const NAS2D::Image* factoryUnderGround = nullptr;
+	const NAS2D::Font& font;
+	const NAS2D::Font& fontMedium;
+	const NAS2D::Font& fontMediumBold;
+	const NAS2D::Font& fontBigBold;
+	const NAS2D::Image& factorySeed;
+	const NAS2D::Image& factoryAboveGround;
+	const NAS2D::Image& factoryUnderGround;
 	const NAS2D::Image* factoryImage = nullptr;
 
 	Button btnShowAll;

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -9,6 +9,12 @@
 #include "../../Common.h"
 
 
+namespace NAS2D {
+	class Font;
+	class Image;
+}
+
+
 class FactoryReport : public ReportInterface
 {
 public:
@@ -59,6 +65,15 @@ private:
 	void visibilityChanged(bool visible) override;
 
 private:
+	const NAS2D::Font* FONT = nullptr;
+	const NAS2D::Font* FONT_MED = nullptr;
+	const NAS2D::Font* FONT_MED_BOLD = nullptr;
+	const NAS2D::Font* FONT_BIG_BOLD = nullptr;
+	const NAS2D::Image* FACTORY_SEED = nullptr;
+	const NAS2D::Image* FACTORY_AG = nullptr;
+	const NAS2D::Image* FACTORY_UG = nullptr;
+	const NAS2D::Image* FACTORY_IMAGE = nullptr;
+
 	Button btnShowAll;
 	Button btnShowSurface;
 	Button btnShowUnderground;

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -96,5 +96,5 @@ private:
 	TextArea txtProductDescription;
 
 	Factory* selectedFactory = nullptr;
-	ProductType SELECTED_PRODUCT_TYPE = ProductType::PRODUCT_NONE;
+	ProductType selectedProductType = ProductType::PRODUCT_NONE;
 };

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -30,8 +30,6 @@ public:
 	void update() override;
 
 private:
-	void init();
-
 	void fillFactoryList(ProductType);
 	void fillFactoryList(bool);
 	void fillFactoryList(StructureState);

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -95,5 +95,5 @@ private:
 
 	TextArea txtProductDescription;
 
-	Factory* SELECTED_FACTORY = nullptr;
+	Factory* selectedFactory = nullptr;
 };


### PR DESCRIPTION
Reference: #138

Cleanup and reduce use of globals in `FactoryReport` that are mentioned by `cppclean`. There's a bit more to do, which I'm deferring until later.

----

Reference: #638 for similar changes to `WarehouseReport`
