### PR TITLE
Remove unused forward declare for Tile in Thing

### DIFF
--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -3,10 +3,9 @@
 #include <NAS2D/Signal.h>
 #include <NAS2D/Resources/Sprite.h>
 
-class Tile;
-
 #include <iostream>
 #include <string>
+
 
 /**
  * Class implementing a Thing interface.


### PR DESCRIPTION
Reference: #138

Noticed by a `cppclean` scan.
