### PR TITLE
Refactor TextField

### DIFF
--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -57,8 +57,8 @@ TextField::TextField() :
 	hasFocus(true);
 	Utility<EventHandler>::get().textInputMode(true);
 
-	TXT_FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-	height(TXT_FONT->height() + FIELD_PADDING * 2);
+	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	height(mFont->height() + FIELD_PADDING * 2);
 }
 
 
@@ -230,7 +230,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
-	if(TXT_FONT->width(text()) < relativePosition)
+	if(mFont->width(text()) < relativePosition)
 	{
 		mCursorPosition = static_cast<int>(text().size());
 		return;
@@ -242,7 +242,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 	while(static_cast<std::size_t>(i) <= text().size() - mScrollOffset)
 	{
 		std::string cmpStr = text().substr(mScrollOffset, i);
-		int strLen = TXT_FONT->width(cmpStr);
+		int strLen = mFont->width(cmpStr);
 		if(strLen > relativePosition)
 		{
 			mCursorPosition = i - 1;
@@ -283,7 +283,7 @@ void TextField::drawCursor()
 
 void TextField::updateCursor()
 {
-	int cursorX = TXT_FONT->width(text().substr(0, mCursorPosition));
+	int cursorX = mFont->width(text().substr(0, mCursorPosition));
 
 	// Check if cursor is after visible area
 	if (mScrollOffset <= cursorX - textAreaWidth())
@@ -320,5 +320,5 @@ void TextField::update()
 
 	drawCursor();
 
-	renderer.drawText(*TXT_FONT, text(), position() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING}, NAS2D::Color::White);
+	renderer.drawText(*mFont, text(), position() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING}, NAS2D::Color::White);
 }

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -23,8 +23,8 @@ using namespace NAS2D;
 
 
 namespace {
-	constexpr int FIELD_PADDING = 4;
-	constexpr int CURSOR_BLINK_DELAY = 250;
+	constexpr int fieldPadding = 4;
+	constexpr int cursorBlinkDelay = 250;
 }
 
 
@@ -60,7 +60,7 @@ TextField::TextField() :
 	hasFocus(true);
 	Utility<EventHandler>::get().textInputMode(true);
 
-	height(mFont.height() + FIELD_PADDING * 2);
+	height(mFont.height() + fieldPadding * 2);
 }
 
 
@@ -104,7 +104,7 @@ void TextField::maxCharacters(std::size_t count)
 
 int TextField::textAreaWidth() const
 {
-	return mRect.width - FIELD_PADDING * 2;
+	return mRect.width - fieldPadding * 2;
 }
 
 
@@ -268,13 +268,13 @@ void TextField::drawCursor()
 			// updateCursor() should be called only on events relating to the cursor so this is temporary.
 			updateCursor();
 			auto& renderer = Utility<Renderer>::get();
-			const auto startPosition = NAS2D::Point{mCursorX, mRect.y + FIELD_PADDING};
-			const auto endPosition = NAS2D::Point{mCursorX, mRect.y + mRect.height - FIELD_PADDING - 1};
+			const auto startPosition = NAS2D::Point{mCursorX, mRect.y + fieldPadding};
+			const auto endPosition = NAS2D::Point{mCursorX, mRect.y + mRect.height - fieldPadding - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);
 			renderer.drawLine(startPosition, endPosition, NAS2D::Color::White);
 		}
 		
-		if(mCursorTimer.accumulator() > CURSOR_BLINK_DELAY)
+		if(mCursorTimer.accumulator() > cursorBlinkDelay)
 		{
 			mCursorTimer.reset();
 			mShowCursor = !mShowCursor;
@@ -304,7 +304,7 @@ void TextField::updateCursor()
 		mScrollOffset = 0;
 	}
 
-	mCursorX = mRect.x + FIELD_PADDING + cursorX - mScrollOffset;
+	mCursorX = mRect.x + fieldPadding + cursorX - mScrollOffset;
 }
 
 
@@ -322,5 +322,5 @@ void TextField::update()
 
 	drawCursor();
 
-	renderer.drawText(mFont, text(), position() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING}, NAS2D::Color::White);
+	renderer.drawText(mFont, text(), position() + NAS2D::Vector{fieldPadding, fieldPadding}, NAS2D::Color::White);
 }

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -24,7 +24,6 @@ using namespace NAS2D;
 
 static const int FIELD_PADDING = 4;
 static const int CURSOR_BLINK_DELAY = 250;
-static const Font* TXT_FONT = nullptr;
 
 
 TextField::TextField() :

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -23,8 +23,8 @@ using namespace NAS2D;
 
 
 namespace {
-	const int FIELD_PADDING = 4;
-	const int CURSOR_BLINK_DELAY = 250;
+	constexpr int FIELD_PADDING = 4;
+	constexpr int CURSOR_BLINK_DELAY = 250;
 }
 
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -22,8 +22,10 @@
 using namespace NAS2D;
 
 
-static const int FIELD_PADDING = 4;
-static const int CURSOR_BLINK_DELAY = 250;
+namespace {
+	const int FIELD_PADDING = 4;
+	const int CURSOR_BLINK_DELAY = 250;
+}
 
 
 TextField::TextField() :

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -27,7 +27,7 @@ static const int CURSOR_BLINK_DELAY = 250;
 
 
 TextField::TextField() :
-	mFont{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
+	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
 	mSkinNormal{
 		imageCache.load("ui/skin/textbox_top_left.png"),
 		imageCache.load("ui/skin/textbox_top_middle.png"),
@@ -58,7 +58,7 @@ TextField::TextField() :
 	hasFocus(true);
 	Utility<EventHandler>::get().textInputMode(true);
 
-	height(mFont->height() + FIELD_PADDING * 2);
+	height(mFont.height() + FIELD_PADDING * 2);
 }
 
 
@@ -230,7 +230,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
-	if(mFont->width(text()) < relativePosition)
+	if(mFont.width(text()) < relativePosition)
 	{
 		mCursorPosition = static_cast<int>(text().size());
 		return;
@@ -242,7 +242,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 	while(static_cast<std::size_t>(i) <= text().size() - mScrollOffset)
 	{
 		std::string cmpStr = text().substr(mScrollOffset, i);
-		int strLen = mFont->width(cmpStr);
+		int strLen = mFont.width(cmpStr);
 		if(strLen > relativePosition)
 		{
 			mCursorPosition = i - 1;
@@ -283,7 +283,7 @@ void TextField::drawCursor()
 
 void TextField::updateCursor()
 {
-	int cursorX = mFont->width(text().substr(0, mCursorPosition));
+	int cursorX = mFont.width(text().substr(0, mCursorPosition));
 
 	// Check if cursor is after visible area
 	if (mScrollOffset <= cursorX - textAreaWidth())
@@ -320,5 +320,5 @@ void TextField::update()
 
 	drawCursor();
 
-	renderer.drawText(*mFont, text(), position() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING}, NAS2D::Color::White);
+	renderer.drawText(mFont, text(), position() + NAS2D::Vector{FIELD_PADDING, FIELD_PADDING}, NAS2D::Color::White);
 }

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -23,11 +23,7 @@ using namespace NAS2D;
 
 
 static const int FIELD_PADDING = 4;
-
 static const int CURSOR_BLINK_DELAY = 250;
-
-static std::locale LOC;
-
 static const Font* TXT_FONT = nullptr;
 
 
@@ -143,7 +139,8 @@ void TextField::onTextInput(const std::string& newTextInput)
 
 	auto prvLen = text().length();
 
-	if (mNumbersOnly && !std::isdigit(newTextInput[0], LOC)) { return; }
+	std::locale locale;
+	if (mNumbersOnly && !std::isdigit(newTextInput[0], locale)) { return; }
 
 	mText = mText.insert(mCursorPosition, newTextInput);
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -27,6 +27,7 @@ static const int CURSOR_BLINK_DELAY = 250;
 
 
 TextField::TextField() :
+	mFont{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
 	mSkinNormal{
 		imageCache.load("ui/skin/textbox_top_left.png"),
 		imageCache.load("ui/skin/textbox_top_middle.png"),
@@ -57,7 +58,6 @@ TextField::TextField() :
 	hasFocus(true);
 	Utility<EventHandler>::get().textInputMode(true);
 
-	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	height(mFont->height() + FIELD_PADDING * 2);
 }
 

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -72,7 +72,7 @@ private:
 	void updateCursor();
 
 private:
-	const NAS2D::Font* TXT_FONT = nullptr;
+	const NAS2D::Font* mFont = nullptr;
 	const NAS2D::RectangleSkin mSkinNormal;
 	const NAS2D::RectangleSkin mSkinFocus;
 

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -34,7 +34,7 @@ public:
 	*
 	* \note	TextField defaults to a BorderVisibility::FOCUS_ONLY setting.
 	*/
-	enum BorderVisibility
+	enum class BorderVisibility
 	{
 		NEVER,
 		ALWAYS,

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -14,6 +14,11 @@
 #include <NAS2D/Renderer/RectangleSkin.h>
 
 
+namespace NAS2D {
+	class Font;
+}
+
+
 /**
  * \class TextField
  * \brief A Basic Text Field.
@@ -67,6 +72,7 @@ private:
 	void updateCursor();
 
 private:
+	const NAS2D::Font* TXT_FONT = nullptr;
 	const NAS2D::RectangleSkin mSkinNormal;
 	const NAS2D::RectangleSkin mSkinFocus;
 

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -32,13 +32,13 @@ public:
 	* \enum	BorderVisiblity
 	* \brief	Enumerates border visibility options.
 	*
-	* \note	TextField defaults to a BorderVisibility::FOCUS_ONLY setting.
+	* \note	TextField defaults to a BorderVisibility::FocusOnly setting.
 	*/
 	enum class BorderVisibility
 	{
-		NEVER,
-		ALWAYS,
-		FOCUS_ONLY
+		Never,
+		Always,
+		FocusOnly
 	};
 
 public:
@@ -84,7 +84,7 @@ private:
 
 	std::size_t mMaxCharacters = 0; /**< Max number of characters allowed in the text field. */
 
-	BorderVisibility mBorderVisibility = BorderVisibility::FOCUS_ONLY; /**< Border visibility flag. */
+	BorderVisibility mBorderVisibility = BorderVisibility::FocusOnly; /**< Border visibility flag. */
 
 	bool mEditable = true; /**< Toggle editing of the field. */
 	bool mShowCursor = true; /**< Flag indicating whether or not to draw the cursor. */

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -72,7 +72,7 @@ private:
 	void updateCursor();
 
 private:
-	const NAS2D::Font* mFont = nullptr;
+	const NAS2D::Font& mFont;
 	const NAS2D::RectangleSkin mSkinNormal;
 	const NAS2D::RectangleSkin mSkinFocus;
 

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -67,6 +67,9 @@ private:
 	void updateCursor();
 
 private:
+	const NAS2D::RectangleSkin mSkinNormal;
+	const NAS2D::RectangleSkin mSkinFocus;
+
 	NAS2D::Timer mCursorTimer; /**< Timer for the cursor blink. */
 
 	int mCursorPosition = 0; /**< Position of the Insertion Cursor. */
@@ -76,9 +79,6 @@ private:
 	std::size_t mMaxCharacters = 0; /**< Max number of characters allowed in the text field. */
 
 	BorderVisibility mBorderVisibility = BorderVisibility::FOCUS_ONLY; /**< Border visibility flag. */
-
-	NAS2D::RectangleSkin mSkinNormal;
-	NAS2D::RectangleSkin mSkinFocus;
 
 	bool mEditable = true; /**< Toggle editing of the field. */
 	bool mShowCursor = true; /**< Flag indicating whether or not to draw the cursor. */

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -11,7 +11,6 @@
 
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Timer.h>
-#include <NAS2D/Resources/Image.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
 
 
@@ -21,7 +20,6 @@
  *
  * The Field Control is just a set of rendered text a user can enter.
  */
-
 class TextField: public Control
 {
 public:


### PR DESCRIPTION
Reference: #138
Reference: #319

Refactor `TextField` to reduce use of globals, and make use of `enum class`.
