### PR TITLE
Reduce globals used by MapViewState

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -495,27 +495,27 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 		if (RESOURCE_PANEL_PIN.contains(MOUSE_COORDS)) { mPinResourcePanel = !mPinResourcePanel; }
 		if (POPULATION_PANEL_PIN.contains(MOUSE_COORDS)) { mPinPopulationPanel = !mPinPopulationPanel; }
 
-		if (MOVE_NORTH_ICON.contains(MOUSE_COORDS))
+		if (mMoveNorthIconRect.contains(MOUSE_COORDS))
 		{
 			mTileMap->mapViewLocation(pt + DirectionNorth);
 		}
-		else if (MOVE_SOUTH_ICON.contains(MOUSE_COORDS))
+		else if (mMoveSouthIconRect.contains(MOUSE_COORDS))
 		{
 			mTileMap->mapViewLocation(pt + DirectionSouth);
 		}
-		else if (MOVE_EAST_ICON.contains(MOUSE_COORDS))
+		else if (mMoveEastIconRect.contains(MOUSE_COORDS))
 		{
 			mTileMap->mapViewLocation(pt + DirectionEast);
 		}
-		else if (MOVE_WEST_ICON.contains(MOUSE_COORDS))
+		else if (mMoveWestIconRect.contains(MOUSE_COORDS))
 		{
 			mTileMap->mapViewLocation(pt + DirectionWest);
 		}
-		else if (MOVE_UP_ICON.contains(MOUSE_COORDS))
+		else if (mMoveUpIconRect.contains(MOUSE_COORDS))
 		{
 			changeViewDepth(mTileMap->currentDepth() - 1);
 		}
-		else if (MOVE_DOWN_ICON.contains(MOUSE_COORDS))
+		else if (mMoveDownIconRect.contains(MOUSE_COORDS))
 		{
 			changeViewDepth(mTileMap->currentDepth()+1);
 		}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -43,13 +43,6 @@ Rectangle<int> MENU_ICON;
 Rectangle<int> RESOURCE_PANEL_PIN{0, 1, 8, 19};
 Rectangle<int> POPULATION_PANEL_PIN{675, 1, 8, 19};
 
-Rectangle<int> MOVE_NORTH_ICON;
-Rectangle<int> MOVE_SOUTH_ICON;
-Rectangle<int> MOVE_EAST_ICON;
-Rectangle<int> MOVE_WEST_ICON;
-Rectangle<int> MOVE_UP_ICON;
-Rectangle<int> MOVE_DOWN_ICON;
-
 std::string CURRENT_LEVEL_STRING;
 
 std::map <int, std::string> LEVEL_STRING_TABLE = 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -39,7 +39,6 @@ extern MainReportsUiState* MAIN_REPORTS_UI;
 
 int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
 
-Rectangle<int> MENU_ICON;
 Rectangle<int> RESOURCE_PANEL_PIN{0, 1, 8, 19};
 Rectangle<int> POPULATION_PANEL_PIN{675, 1, 8, 19};
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -484,7 +484,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 
 		Point<int> pt = mTileMap->mapViewLocation();
 
-		if (MENU_ICON.contains(MOUSE_COORDS))
+		if (mMenuIconRect.contains(MOUSE_COORDS))
 		{
 			mGameOptionsDialog.show();
 			resetUi();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -260,12 +260,12 @@ private:
 
 	WindowStack mWindowStack;
 
-	NAS2D::Rectangle<int> MOVE_NORTH_ICON;
-	NAS2D::Rectangle<int> MOVE_SOUTH_ICON;
-	NAS2D::Rectangle<int> MOVE_EAST_ICON;
-	NAS2D::Rectangle<int> MOVE_WEST_ICON;
-	NAS2D::Rectangle<int> MOVE_UP_ICON;
-	NAS2D::Rectangle<int> MOVE_DOWN_ICON;
+	NAS2D::Rectangle<int> mMoveNorthIconRect;
+	NAS2D::Rectangle<int> mMoveSouthIconRect;
+	NAS2D::Rectangle<int> mMoveEastIconRect;
+	NAS2D::Rectangle<int> mMoveWestIconRect;
+	NAS2D::Rectangle<int> mMoveUpIconRect;
+	NAS2D::Rectangle<int> mMoveDownIconRect;
 
 	// SIGNALS
 	QuitCallback mQuitCallback;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -267,7 +267,7 @@ private:
 	NAS2D::Rectangle<int> mMoveWestIconRect;
 	NAS2D::Rectangle<int> mMoveUpIconRect;
 	NAS2D::Rectangle<int> mMoveDownIconRect;
-	NAS2D::Rectangle<int> BOTTOM_UI_AREA;
+	NAS2D::Rectangle<int> mBottomUiRect;
 
 	// SIGNALS
 	QuitCallback mQuitCallback;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -267,6 +267,7 @@ private:
 	NAS2D::Rectangle<int> mMoveWestIconRect;
 	NAS2D::Rectangle<int> mMoveUpIconRect;
 	NAS2D::Rectangle<int> mMoveDownIconRect;
+	NAS2D::Rectangle<int> BOTTOM_UI_AREA;
 
 	// SIGNALS
 	QuitCallback mQuitCallback;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -260,6 +260,7 @@ private:
 
 	WindowStack mWindowStack;
 
+	NAS2D::Rectangle<int> MENU_ICON;
 	NAS2D::Rectangle<int> mMoveNorthIconRect;
 	NAS2D::Rectangle<int> mMoveSouthIconRect;
 	NAS2D::Rectangle<int> mMoveEastIconRect;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -28,6 +28,7 @@
 
 #include <NAS2D/Signal.h>
 #include <NAS2D/Renderer/Point.h>
+#include <NAS2D/Renderer/Rectangle.h>
 
 #include <string>
 #include <memory>
@@ -258,6 +259,13 @@ private:
 	WarehouseInspector mWarehouseInspector;
 
 	WindowStack mWindowStack;
+
+	NAS2D::Rectangle<int> MOVE_NORTH_ICON;
+	NAS2D::Rectangle<int> MOVE_SOUTH_ICON;
+	NAS2D::Rectangle<int> MOVE_EAST_ICON;
+	NAS2D::Rectangle<int> MOVE_WEST_ICON;
+	NAS2D::Rectangle<int> MOVE_UP_ICON;
+	NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 	// SIGNALS
 	QuitCallback mQuitCallback;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -260,7 +260,7 @@ private:
 
 	WindowStack mWindowStack;
 
-	NAS2D::Rectangle<int> MENU_ICON;
+	NAS2D::Rectangle<int> mMenuIconRect;
 	NAS2D::Rectangle<int> mMoveNorthIconRect;
 	NAS2D::Rectangle<int> mMoveSouthIconRect;
 	NAS2D::Rectangle<int> mMoveEastIconRect;

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -270,12 +270,12 @@ void MapViewState::drawNavInfo()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	drawNavIcon(renderer, MOVE_DOWN_ICON, NAS2D::Rectangle{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_UP_ICON, NAS2D::Rectangle{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_EAST_ICON, NAS2D::Rectangle{32, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_WEST_ICON, NAS2D::Rectangle{32, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_NORTH_ICON, NAS2D::Rectangle{0, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
-	drawNavIcon(renderer, MOVE_SOUTH_ICON, NAS2D::Rectangle{0, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, mMoveDownIconRect, NAS2D::Rectangle{64, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, mMoveUpIconRect, NAS2D::Rectangle{96, 128, 32, 32}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, mMoveEastIconRect, NAS2D::Rectangle{32, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, mMoveWestIconRect, NAS2D::Rectangle{32, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, mMoveNorthIconRect, NAS2D::Rectangle{0, 128, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
+	drawNavIcon(renderer, mMoveSouthIconRect, NAS2D::Rectangle{0, 144, 32, 16}, NAS2D::Color::White, NAS2D::Color::Red);
 
 	// Display the levels "bar"
 	const auto stepSizeWidth = MAIN_FONT->width("IX");

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -212,8 +212,8 @@ void MapViewState::drawResourceInfo()
 	renderer.drawSubImage(mUiIcons, position, turnImageRect);
 	renderer.drawText(*MAIN_FONT, std::to_string(mTurnCount), position + textOffset, NAS2D::Color::White);
 
-	position = MENU_ICON.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, constants::MARGIN_TIGHT};
-	bool isMouseInMenu = MENU_ICON.contains(MOUSE_COORDS);
+	position = mMenuIconRect.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, constants::MARGIN_TIGHT};
+	bool isMouseInMenu = mMenuIconRect.contains(MOUSE_COORDS);
 	int menuGearHighlightOffsetX = isMouseInMenu ? 144 : 128;
 	const auto menuImageRect = NAS2D::Rectangle{menuGearHighlightOffsetX, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE};
 	renderer.drawSubImage(mUiIcons, position, menuImageRect);

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -18,16 +18,7 @@
 #include <algorithm>
 
 extern NAS2D::Rectangle<int> MENU_ICON;
-
-extern NAS2D::Rectangle<int> MOVE_NORTH_ICON;
-extern NAS2D::Rectangle<int> MOVE_SOUTH_ICON;
-extern NAS2D::Rectangle<int> MOVE_EAST_ICON;
-extern NAS2D::Rectangle<int> MOVE_WEST_ICON;
-extern NAS2D::Rectangle<int> MOVE_UP_ICON;
-extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
-
 extern NAS2D::Point<int> MOUSE_COORDS;
-
 extern const NAS2D::Font* MAIN_FONT; /// yuck
 
 

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -17,7 +17,6 @@
 #include <vector>
 #include <algorithm>
 
-extern NAS2D::Rectangle<int> MENU_ICON;
 extern NAS2D::Point<int> MOUSE_COORDS;
 extern const NAS2D::Font* MAIN_FONT; /// yuck
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -129,7 +129,7 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	// Menu / System Icon
 	const auto menuIconSpacing = constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2;
-	MENU_ICON = {size.x - menuIconSpacing, 0, menuIconSpacing, menuIconSpacing};
+	mMenuIconRect = {size.x - menuIconSpacing, 0, menuIconSpacing, menuIconSpacing};
 
 	// NAVIGATION BUTTONS
 	// Bottom line

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -140,14 +140,14 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	// NAVIGATION BUTTONS
 	// Bottom line
 	const auto navIconSpacing = 32 + constants::MARGIN_TIGHT;
-	MOVE_DOWN_ICON = {size.x - navIconSpacing, size.y - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
-	MOVE_EAST_ICON = {MOVE_DOWN_ICON.x - navIconSpacing, MOVE_DOWN_ICON.y + 8, 32, 16};
-	MOVE_SOUTH_ICON = {MOVE_DOWN_ICON.x - 2 * navIconSpacing, MOVE_DOWN_ICON.y + 8, 32, 16};
+	mMoveDownIconRect = {size.x - navIconSpacing, size.y - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
+	mMoveEastIconRect = {mMoveDownIconRect.x - navIconSpacing, mMoveDownIconRect.y + 8, 32, 16};
+	mMoveSouthIconRect = {mMoveDownIconRect.x - 2 * navIconSpacing, mMoveDownIconRect.y + 8, 32, 16};
 
 	// Top line
-	MOVE_UP_ICON = {MOVE_DOWN_ICON.x, MOVE_DOWN_ICON.y - navIconSpacing, 32, 32};
-	MOVE_NORTH_ICON = {MOVE_UP_ICON.x - navIconSpacing, MOVE_UP_ICON.y + 8, 32, 16};
-	MOVE_WEST_ICON = {MOVE_UP_ICON.x - 2 * navIconSpacing, MOVE_UP_ICON.y + 8, 32, 16};
+	mMoveUpIconRect = {mMoveDownIconRect.x, mMoveDownIconRect.y - navIconSpacing, 32, 32};
+	mMoveNorthIconRect = {mMoveUpIconRect.x - navIconSpacing, mMoveUpIconRect.y + 8, 32, 16};
+	mMoveWestIconRect = {mMoveUpIconRect.x - 2 * navIconSpacing, mMoveUpIconRect.y + 8, 32, 16};
 
 	// Mini Map
 	mMiniMapBoundingBox = {size.x - 300 - constants::MARGIN, BOTTOM_UI_AREA.y + constants::MARGIN, 300, 150};

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -28,12 +28,6 @@ NAS2D::Rectangle<int> BOTTOM_UI_AREA;
 
 
 /**
- * \fixme	Yuck, not thrilled with this but whatever, it works.
- */
-extern NAS2D::Rectangle<int> MENU_ICON;
-
-
-/**
  * Sets up the user interface elements
  * 
  * \note	The explicit casts to int to truncate floating point values to force

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -31,12 +31,6 @@ NAS2D::Rectangle<int> BOTTOM_UI_AREA;
  * \fixme	Yuck, not thrilled with this but whatever, it works.
  */
 extern NAS2D::Rectangle<int> MENU_ICON;
-extern NAS2D::Rectangle<int> MOVE_NORTH_ICON;
-extern NAS2D::Rectangle<int> MOVE_SOUTH_ICON;
-extern NAS2D::Rectangle<int> MOVE_EAST_ICON;
-extern NAS2D::Rectangle<int> MOVE_WEST_ICON;
-extern NAS2D::Rectangle<int> MOVE_UP_ICON;
-extern NAS2D::Rectangle<int> MOVE_DOWN_ICON;
 
 
 /**

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -24,8 +24,6 @@
 
 using namespace constants;
 
-NAS2D::Rectangle<int> BOTTOM_UI_AREA;
-
 
 /**
  * Sets up the user interface elements

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -82,7 +82,7 @@ void MapViewState::initUi()
 	mWindowStack.addWindow(&mMineOperationsWindow);
 
 	const auto size = renderer.size().to<int>();
-	BOTTOM_UI_AREA = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
+	mBottomUiRect = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
 
 	// BUTTONS
 	mBtnTurns.image("ui/icons/turns.png");
@@ -101,16 +101,16 @@ void MapViewState::initUi()
 	mBtnToggleConnectedness.click().connect(this, &MapViewState::btnToggleConnectednessClicked);
 
 	// Menus
-	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
+	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
 	mRobots.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 	mRobots.showTooltip(true);
 	mRobots.selectionChanged().connect(this, &MapViewState::robotsSelectionChanged);
 
-	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
+	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
 	mConnections.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 	mConnections.selectionChanged().connect(this, &MapViewState::connectionsSelectionChanged);
 
-	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
+	mStructures.position(NAS2D::Point{constants::MARGIN, mBottomUiRect.y + MARGIN});
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 	mStructures.showTooltip(true);
 	mStructures.selectionChanged().connect(this, &MapViewState::structuresSelectionChanged);
@@ -123,7 +123,7 @@ void MapViewState::initUi()
 void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 {
 	// Bottom UI Area
-	BOTTOM_UI_AREA = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
+	mBottomUiRect = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
 
 	// Menu / System Icon
 	const auto menuIconSpacing = constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2;
@@ -142,7 +142,7 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mMoveWestIconRect = {mMoveUpIconRect.x - 2 * navIconSpacing, mMoveUpIconRect.y + 8, 32, 16};
 
 	// Mini Map
-	mMiniMapBoundingBox = {size.x - 300 - constants::MARGIN, BOTTOM_UI_AREA.y + constants::MARGIN, 300, 150};
+	mMiniMapBoundingBox = {size.x - 300 - constants::MARGIN, mBottomUiRect.y + constants::MARGIN, 300, 150};
 
 	// Position UI Buttons
 	mBtnTurns.position(NAS2D::Point{mMiniMapBoundingBox.x - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT, size.y - constants::MARGIN - MAIN_BUTTON_SIZE});
@@ -150,9 +150,9 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mBtnToggleConnectedness.position({mBtnTurns.positionX(), mMiniMapBoundingBox.y + constants::MAIN_BUTTON_SIZE + constants::MARGIN_TIGHT});
 
 	// UI Panels
-	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
-	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, BOTTOM_UI_AREA.y + MARGIN});
-	mStructures.position(NAS2D::Point{constants::MARGIN, BOTTOM_UI_AREA.y + MARGIN});
+	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
+	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
+	mStructures.position(NAS2D::Point{constants::MARGIN, mBottomUiRect.y + MARGIN});
 
 	mStructures.size({mConnections.positionX() - constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
 
@@ -323,9 +323,9 @@ void MapViewState::drawUI()
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI
-	renderer.drawBoxFilled(BOTTOM_UI_AREA, NAS2D::Color{39, 39, 39});
-	renderer.drawBox(BOTTOM_UI_AREA, NAS2D::Color{21, 21, 21});
-	renderer.drawLine(NAS2D::Point{BOTTOM_UI_AREA.x + 1, BOTTOM_UI_AREA.y}, NAS2D::Point{BOTTOM_UI_AREA.x + BOTTOM_UI_AREA.width - 2, BOTTOM_UI_AREA.y}, NAS2D::Color{56, 56, 56});
+	renderer.drawBoxFilled(mBottomUiRect, NAS2D::Color{39, 39, 39});
+	renderer.drawBox(mBottomUiRect, NAS2D::Color{21, 21, 21});
+	renderer.drawLine(NAS2D::Point{mBottomUiRect.x + 1, mBottomUiRect.y}, NAS2D::Point{mBottomUiRect.x + mBottomUiRect.width - 2, mBottomUiRect.y}, NAS2D::Color{56, 56, 56});
 
 	drawMiniMap();
 	drawResourceInfo();


### PR DESCRIPTION
Reference: #138

Refactor `MapViewState` to reduce use of globals. These globals were listed by `cppclean`.
