### PR TITLE
Fix sign conversion warnings

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -420,7 +420,8 @@ void TileMap::updateTileHighlight()
  */
 TileMap::MouseMapRegion TileMap::getMouseMapRegion(int x, int y)
 {
-	return mMouseMap[y][x];
+	const auto mapPosition = NAS2D::Point{x, y}.to<std::size_t>();
+	return mMouseMap[mapPosition.y][mapPosition.x];
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -608,7 +608,13 @@ void TileMap::AdjacentCost(void* state, std::vector<micropather::StateCost>* adj
 
 	for (const auto& offset : DirectionClockwise4)
 	{
-		Tile* adjacent_tile = getTile(tilePosition + offset, 0);
+		const auto position = tilePosition + offset;
+		if (!NAS2D::Rectangle{0, 0, mSizeInTiles.x, mSizeInTiles.y}.contains(position))
+		{
+			continue;
+		}
+
+		Tile* adjacent_tile = getTile(position, 0);
 		float cost = constants::ROUTE_BASE_COST;
 
 		if (!adjacent_tile || adjacent_tile->index() == TerrainType::TERRAIN_IMPASSABLE)

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -127,6 +127,12 @@ void TileMap::removeMineLocation(const NAS2D::Point<int>& pt)
 }
 
 
+bool TileMap::isValidPosition(NAS2D::Point<int> position, int level) const
+{
+	 return NAS2D::Rectangle{0, 0, mSizeInTiles.x, mSizeInTiles.y}.contains(position) && level >= 0 && level <= mMaxDepth;
+}
+
+
 Tile* TileMap::getTile(NAS2D::Point<int> position, int level)
 {
 	if (NAS2D::Rectangle{0, 0, mSizeInTiles.x, mSizeInTiles.y}.contains(position) && level >= 0 && level <= mMaxDepth)

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -193,7 +193,7 @@ void TileMap::setupMines(int mineCount, Planet::Hostility hostility)
 
 	auto generateMines = [&](int mineCountAtYield, MineProductionRate yield) {
 		for (int i = 0; i < mineCountAtYield; ++i) {
-			addMineSet(randPoint(), mMineLocations, mTileMap, yield);
+			addMineSet(randPoint(), mMineLocations, yield);
 		}
 	};
 
@@ -203,27 +203,28 @@ void TileMap::setupMines(int mineCount, Planet::Hostility hostility)
 }
 
 
-void TileMap::addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, TileArray& tileArray, MineProductionRate rate)
+void TileMap::addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, MineProductionRate rate)
 {
 	// Mines should not be right next to each other
 	// If mines are right next to each other, then overwrite the old location with the new mine parameters
-	const auto mineLocation = findSurroundingMineLocation(suggestedMineLocation, tileArray);
+	const auto mineLocation = findSurroundingMineLocation(suggestedMineLocation);
 
-	tileArray[0][mineLocation.y][mineLocation.x].pushMine(new Mine(rate));
-	tileArray[0][mineLocation.y][mineLocation.x].index(TerrainType::TERRAIN_DOZED);
+	auto& tile = *getTile(mineLocation, 0);
+	tile.pushMine(new Mine(rate));
+	tile.index(TerrainType::TERRAIN_DOZED);
 
 	plist.push_back(mineLocation);
 }
 
 
-NAS2D::Point<int> TileMap::findSurroundingMineLocation(NAS2D::Point<int> centerPoint, TileArray& tileArray)
+NAS2D::Point<int> TileMap::findSurroundingMineLocation(NAS2D::Point<int> centerPoint)
 {
-	if (tileArray[0][centerPoint.y][centerPoint.x].hasMine())
+	if (getTile(centerPoint, 0)->hasMine())
 	{
 		for (const auto& direction : DirectionScan323)
 		{
 			const auto point = centerPoint + direction;
-			if (tileArray[0][point.y][point.x].hasMine()) { return point; }
+			if (getTile(point, 0)->hasMine()) { return point; }
 		}
 	}
 	return centerPoint;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -135,12 +135,11 @@ bool TileMap::isValidPosition(NAS2D::Point<int> position, int level) const
 
 Tile* TileMap::getTile(NAS2D::Point<int> position, int level)
 {
-	if (isValidPosition(position, level))
+	if (!isValidPosition(position, level))
 	{
-		return &mTileMap[level][position.y][position.x];
+		throw std::runtime_error("Tile coordinates out of bounds: {" + std::to_string(position.x) + ", " + std::to_string(position.y) + ", " + std::to_string(level) + "}");
 	}
-
-	return nullptr;
+	return &mTileMap[level][position.y][position.x];
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -155,13 +155,14 @@ void TileMap::buildTerrainMap(const std::string& path)
 
 	const Image heightmap(path + MAP_TERRAIN_EXTENSION);
 
-	mTileMap.resize(static_cast<std::size_t>(mMaxDepth) + 1);
-	for(int level = 0; level <= mMaxDepth; level++)
+	const auto levelCount = static_cast<std::size_t>(mMaxDepth) + 1;
+	mTileMap.resize(levelCount);
+	for(std::size_t level = 0; level < levelCount; level++)
 	{
-		mTileMap[level].resize(mSizeInTiles.y);
+		mTileMap[level].resize(static_cast<std::size_t>(mSizeInTiles.y));
 		for (std::size_t i = 0; i < mTileMap[level].size(); i++)
 		{
-			mTileMap[level][i].resize(mSizeInTiles.x);
+			mTileMap[level][i].resize(static_cast<std::size_t>(mSizeInTiles.x));
 		}
 	}
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -330,7 +330,7 @@ void TileMap::draw()
 	{
 		for (int col = 0; col < mEdgeLength; col++)
 		{
-			Tile& tile = mTileMap[mCurrentDepth][row + mMapViewLocation.y][col + mMapViewLocation.x];
+			Tile& tile = *getTile(mMapViewLocation + NAS2D::Vector{col, row}, mCurrentDepth);
 
 			if (tile.excavated())
 			{

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -617,7 +617,7 @@ void TileMap::AdjacentCost(void* state, std::vector<micropather::StateCost>* adj
 		Tile* adjacent_tile = getTile(position, 0);
 		float cost = constants::ROUTE_BASE_COST;
 
-		if (!adjacent_tile || adjacent_tile->index() == TerrainType::TERRAIN_IMPASSABLE)
+		if (adjacent_tile->index() == TerrainType::TERRAIN_IMPASSABLE)
 		{
 			cost = FLT_MAX;
 		}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -615,7 +615,7 @@ void TileMap::AdjacentCost(void* state, std::vector<micropather::StateCost>* adj
 		{
 			cost = FLT_MAX;
 		}
-		else if (adjacent_tile && !adjacent_tile->empty())
+		else if (!adjacent_tile->empty())
 		{
 			if (adjacent_tile == mPathStartEndPair.first || adjacent_tile == mPathStartEndPair.second)
 			{

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -547,11 +547,11 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 	}
 
 	// TILES AT INDEX 0 WITH NO THING'S
-	for (XmlNode* tile = element->firstChildElement("tiles")->firstChildElement("tile"); tile; tile = tile->nextSibling())
+	for (XmlNode* tileNode = element->firstChildElement("tiles")->firstChildElement("tile"); tileNode; tileNode = tileNode->nextSibling())
 	{
 		int x = 0, y = 0, depth = 0, index = 0;
 
-		attribute = tile->toElement()->firstAttribute();
+		attribute = tileNode->toElement()->firstAttribute();
 		while (attribute)
 		{
 			if (attribute->name() == "x") { attribute->queryIntValue(x); }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -181,7 +181,7 @@ void TileMap::buildTerrainMap(const std::string& path)
 			for(int col = 0; col < mSizeInTiles.x; col++)
 			{
 				Color color = heightmap.pixelColor({col, row});
-				Tile& tile = mTileMap[depth][row][col];
+				Tile& tile = *getTile({col, row}, depth);
 				tile = {{col, row}, depth, color.red / 50};
 				if (depth > 0) { tile.excavated(false); }
 			}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -135,7 +135,7 @@ bool TileMap::isValidPosition(NAS2D::Point<int> position, int level) const
 
 Tile* TileMap::getTile(NAS2D::Point<int> position, int level)
 {
-	if (NAS2D::Rectangle{0, 0, mSizeInTiles.x, mSizeInTiles.y}.contains(position) && level >= 0 && level <= mMaxDepth)
+	if (isValidPosition(position, level))
 	{
 		return &mTileMap[level][position.y][position.x];
 	}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -58,19 +58,6 @@ Point<int> TRANSFORM; /**< Used to adjust mouse and screen spaces based on posit
 // = STATIC/LOCAL FUNCTIONS
 // ===============================================================================
 using TileArray = std::vector<std::vector<std::vector<Tile> > >;
-static Point<int> findSurroundingMineLocation(Point<int> centerPoint, TileArray& tileArray)
-{
-	if (tileArray[0][centerPoint.y][centerPoint.x].hasMine())
-	{
-		for (const auto& direction : DirectionScan323)
-		{
-			const auto point = centerPoint + direction;
-			if (tileArray[0][point.y][point.x].hasMine()) { return point; }
-		}
-	}
-	return centerPoint;
-}
-
 
 
 // ===============================================================================
@@ -226,6 +213,20 @@ void TileMap::addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& p
 	tileArray[0][mineLocation.y][mineLocation.x].index(TerrainType::TERRAIN_DOZED);
 
 	plist.push_back(mineLocation);
+}
+
+
+NAS2D::Point<int> TileMap::findSurroundingMineLocation(NAS2D::Point<int> centerPoint, TileArray& tileArray)
+{
+	if (tileArray[0][centerPoint.y][centerPoint.x].hasMine())
+	{
+		for (const auto& direction : DirectionScan323)
+		{
+			const auto point = centerPoint + direction;
+			if (tileArray[0][point.y][point.x].hasMine()) { return point; }
+		}
+	}
+	return centerPoint;
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -537,8 +537,9 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		Mine* m = new Mine();
 		m->deserialize(mine->toElement());
 
-		mTileMap[0][y][x].pushMine(m);
-		mTileMap[0][y][x].index(TerrainType::TERRAIN_DOZED);
+		auto& tile = *getTile({x, y}, 0);
+		tile.pushMine(m);
+		tile.index(TerrainType::TERRAIN_DOZED);
 
 		mMineLocations.push_back(Point{x, y});
 
@@ -562,9 +563,10 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 			attribute = attribute->next();
 		}
 
-		mTileMap[depth][y][x].index(static_cast<TerrainType>(index));
+		auto& tile = *getTile({x, y}, depth);
+		tile.index(static_cast<TerrainType>(index));
 
-		if (depth > 0) { mTileMap[depth][y][x].excavated(true); }
+		if (depth > 0) { tile.excavated(true); }
 	}
 }
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -72,19 +72,6 @@ static Point<int> findSurroundingMineLocation(Point<int> centerPoint, TileArray&
 }
 
 
-static void addMineSet(Point<int> suggestedMineLocation, Point2dList& plist, TileArray& tileArray, MineProductionRate rate)
-{
-	// Mines should not be right next to each other
-	// If mines are right next to each other, then overwrite the old location with the new mine parameters
-	const auto mineLocation = findSurroundingMineLocation(suggestedMineLocation, tileArray);
-
-	tileArray[0][mineLocation.y][mineLocation.x].pushMine(new Mine(rate));
-	tileArray[0][mineLocation.y][mineLocation.x].index(TerrainType::TERRAIN_DOZED);
-
-	plist.push_back(mineLocation);
-}
-
-
 
 // ===============================================================================
 // = CLASS/PUBLIC FUNCTIONS
@@ -226,6 +213,19 @@ void TileMap::setupMines(int mineCount, Planet::Hostility hostility)
 	generateMines(yieldLow, MineProductionRate::Low);
 	generateMines(yieldMedium, MineProductionRate::Medium);
 	generateMines(yieldHigh, MineProductionRate::High);
+}
+
+
+void TileMap::addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, TileArray& tileArray, MineProductionRate rate)
+{
+	// Mines should not be right next to each other
+	// If mines are right next to each other, then overwrite the old location with the new mine parameters
+	const auto mineLocation = findSurroundingMineLocation(suggestedMineLocation, tileArray);
+
+	tileArray[0][mineLocation.y][mineLocation.x].pushMine(new Mine(rate));
+	tileArray[0][mineLocation.y][mineLocation.x].index(TerrainType::TERRAIN_DOZED);
+
+	plist.push_back(mineLocation);
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -139,7 +139,8 @@ Tile* TileMap::getTile(NAS2D::Point<int> position, int level)
 	{
 		throw std::runtime_error("Tile coordinates out of bounds: {" + std::to_string(position.x) + ", " + std::to_string(position.y) + ", " + std::to_string(level) + "}");
 	}
-	return &mTileMap[level][position.y][position.x];
+	const auto mapPosition = position.to<std::size_t>();
+	return &mTileMap[static_cast<std::size_t>(level)][mapPosition.y][mapPosition.x];
 }
 
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -16,9 +16,6 @@ using Point2dList = std::vector<NAS2D::Point<int>>;
 class TileMap: public micropather::Graph
 {
 public:
-	/**
-	 * 
-	 */
 	enum TileMapLevel
 	{
 		LEVEL_SURFACE = 0,
@@ -82,9 +79,6 @@ public:
 	void pathStartAndEnd(void* start, void* end);
 
 protected:
-	/**
-	 * 
-	 */
 	enum MouseMapRegion
 	{
 		MMR_MIDDLE,

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -33,7 +33,7 @@ public:
 	TileMap& operator=(const TileMap&) = delete;
 	~TileMap() override;
 
-	bool isValidPosition(NAS2D::Point<int> position, int level) const;
+	bool isValidPosition(NAS2D::Point<int> position, int level = 0) const;
 
 	Tile* getTile(NAS2D::Point<int> position, int level);
 	Tile* getTile(NAS2D::Point<int> position) { return getTile(position, mCurrentDepth); }

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -104,6 +104,7 @@ private:
 	void buildTerrainMap(const std::string& path);
 	void setupMines(int, Planet::Hostility);
 	void addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, TileArray& tileArray, MineProductionRate rate);
+	NAS2D::Point<int> findSurroundingMineLocation(NAS2D::Point<int> centerPoint, TileArray& tileArray);
 
 	void updateTileHighlight();
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -103,6 +103,7 @@ private:
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
 	void setupMines(int, Planet::Hostility);
+	void addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, TileArray& tileArray, MineProductionRate rate);
 
 	void updateTileHighlight();
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -103,8 +103,8 @@ private:
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
 	void setupMines(int, Planet::Hostility);
-	void addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, TileArray& tileArray, MineProductionRate rate);
-	NAS2D::Point<int> findSurroundingMineLocation(NAS2D::Point<int> centerPoint, TileArray& tileArray);
+	void addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, MineProductionRate rate);
+	NAS2D::Point<int> findSurroundingMineLocation(NAS2D::Point<int> centerPoint);
 
 	void updateTileHighlight();
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -11,7 +11,9 @@
 
 #include <algorithm>
 
+
 using Point2dList = std::vector<NAS2D::Point<int>>;
+
 
 class TileMap: public micropather::Graph
 {

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -27,7 +27,7 @@ public:
 		LEVEL_UG_4
 	};
 
-public:
+
 	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility /*= constants::Hostility::None*/, bool setupMines = true);
 	~TileMap() override;
 
@@ -72,7 +72,7 @@ public:
 	void serialize(NAS2D::Xml::XmlElement* element, const Planet::Attributes& planetAttributes);
 	void deserialize(NAS2D::Xml::XmlElement* element);
 
-public:
+
 	/** MicroPather public interface implementation. */
 	float LeastCostEstimate(void* stateStart, void* stateEnd) override;
 	void AdjacentCost(void* state, std::vector<micropather::StateCost>* adjacent) override;
@@ -96,11 +96,9 @@ private:
 	using TileGrid = std::vector<std::vector<Tile> >;
 	using TileArray = std::vector<TileGrid>;
 	
-private:
 	TileMap(const TileMap&) = delete; /**< Not Allowed */
 	TileMap& operator=(const TileMap&) = delete; /**< Not allowed */
 
-private:
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
 	void setupMines(int, Planet::Hostility);
@@ -109,7 +107,7 @@ private:
 
 	MouseMapRegion getMouseMapRegion(int x, int y);
 
-private:
+
 	int mEdgeLength = 0;
 	const NAS2D::Vector<int> mSizeInTiles;
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -33,6 +33,8 @@ public:
 	TileMap& operator=(const TileMap&) = delete;
 	~TileMap() override;
 
+	bool isValidPosition(NAS2D::Point<int> position, int level) const;
+
 	Tile* getTile(NAS2D::Point<int> position, int level);
 	Tile* getTile(NAS2D::Point<int> position) { return getTile(position, mCurrentDepth); }
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -29,6 +29,8 @@ public:
 
 
 	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility /*= constants::Hostility::None*/, bool setupMines = true);
+	TileMap(const TileMap&) = delete;
+	TileMap& operator=(const TileMap&) = delete;
 	~TileMap() override;
 
 	Tile* getTile(NAS2D::Point<int> position, int level);
@@ -95,9 +97,6 @@ protected:
 private:
 	using TileGrid = std::vector<std::vector<Tile> >;
 	using TileArray = std::vector<TileGrid>;
-	
-	TileMap(const TileMap&) = delete; /**< Not Allowed */
-	TileMap& operator=(const TileMap&) = delete; /**< Not allowed */
 
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -434,13 +434,10 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 		}
 
 		if (!mTileMap->tileHighlightVisible()) { return; }
+		if (!mTileMap->isValidPosition(mTileMap->tileMouseHover())) { return; }
 
 		Tile* _t = mTileMap->getTile(mTileMap->tileMouseHover());
-		if (!_t)
-		{
-			return;
-		}
-		else if (_t->empty() && mTileMap->boundingBox().contains(MOUSE_COORDS))
+		if (_t->empty() && mTileMap->boundingBox().contains(MOUSE_COORDS))
 		{
 			clearSelections();
 			mTileInspector.tile(_t);
@@ -557,9 +554,10 @@ void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int /*x*
 	{
 		if (mWindowStack.pointInWindow(MOUSE_COORDS)) { return; }
 		if (!mTileMap->tileHighlightVisible()) { return; }
+		if (!mTileMap->isValidPosition(mTileMap->tileMouseHover())) { return; }
 
 		Tile* _t = mTileMap->getTile(mTileMap->tileMouseHover());
-		if (_t && _t->thingIsStructure())
+		if (_t->thingIsStructure())
 		{
 			Structure* structure = _t->structure();
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -166,7 +166,7 @@ void ComboBox::addItem(const std::string& item, int tag)
 	lstItems.addItem(item, tag);
 
 	if (lstItems.count() > mMaxDisplayItems) { return; }
-	lstItems.height(static_cast<int>(lstItems.count()) * lstItems.lineHeight());
+	lstItems.height(static_cast<int>(lstItems.count() * lstItems.lineHeight()));
 
 	lstItems.clearSelection();
 }

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -229,9 +229,9 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 	
-	mCurrentHighlight = (y - mRect.y + mCurrentOffset) / (mFont.height() + 2);
+	mCurrentHighlight = (static_cast<std::size_t>(y - mRect.y) + mCurrentOffset) / static_cast<std::size_t>(mFont.height() + 2);
 
-	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
+	if (mCurrentHighlight >= mItems.size())
 	{
 		mCurrentHighlight = constants::NO_SELECTION;
 	}

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -19,9 +19,6 @@
 using namespace NAS2D;
 
 
-static const Font* LST_FONT = nullptr;
-
-
 /**
  * C'tor
  */

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -32,8 +32,8 @@ ListBox::ListBox() :
 	mSlider.change().connect(this, &ListBox::slideChanged);
 	_updateItemDisplay();
 
-	mLineHeight = (mFont.height() + 2);
-	mLineCount = static_cast<int>(mRect.height / mLineHeight);
+	mLineHeight = static_cast<unsigned int>(mFont.height() + 2);
+	mLineCount = static_cast<unsigned int>(mRect.height) / mLineHeight;
 	_updateItemDisplay();
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -268,13 +268,13 @@ void ListBox::update()
 
 	// draw boundaries of the widget
 	NAS2D::Rectangle<int> listBounds = mRect;
-	listBounds.width = mItemWidth;
+	listBounds.width = static_cast<int>(mItemWidth);
 	renderer.drawBox(listBounds, NAS2D::Color{0, 0, 0, 100});
 	renderer.drawBoxFilled(listBounds, NAS2D::Color{0, 85, 0, 220});
 
 	// Highlight currently selected item
 	auto itemBounds = listBounds;
-	itemBounds.height = mLineHeight;
+	itemBounds.height = static_cast<int>(mLineHeight);
 	itemBounds.y += static_cast<int>((mCurrentSelection * mLineHeight) - mCurrentOffset);
 	renderer.drawBoxFilled(itemBounds, mHighlightBg.alphaFade(80));
 
@@ -282,7 +282,7 @@ void ListBox::update()
 	if (mCurrentHighlight != constants::NO_SELECTION)
 	{
 		auto highlightBounds = listBounds;
-		highlightBounds.height = mLineHeight;
+		highlightBounds.height = static_cast<int>(mLineHeight);
 		highlightBounds.y += static_cast<int>((mCurrentHighlight * mLineHeight) - mCurrentOffset);
 		renderer.drawBox(highlightBounds, mHighlightBg);
 	}

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -19,9 +19,6 @@
 using namespace NAS2D;
 
 
-/**
- * C'tor
- */
 ListBox::ListBox() :
 	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
 {
@@ -41,9 +38,6 @@ ListBox::ListBox() :
 }
 
 
-/**
- * D'tor
- */
 ListBox::~ListBox()
 {
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ListBox::onMouseDown);
@@ -101,9 +95,6 @@ bool ListBox::empty() const
 }
 
 
-/**
- *
- */
 const std::string& ListBox::selectionText() const
 {
 	if (mCurrentSelection == constants::NO_SELECTION) { return constants::EMPTY_STR; }
@@ -111,9 +102,6 @@ const std::string& ListBox::selectionText() const
 }
 
 
-/**
- *
- */
 int ListBox::selectionTag() const
 {
 	if (mCurrentSelection == constants::NO_SELECTION) { return 0; }
@@ -167,9 +155,6 @@ bool ListBox::itemExists(const std::string& item)
 }
 
 
-/**
- * 
- */
 void ListBox::setSelectionByName(const std::string& item)
 {
 	for (std::size_t i = 0; i < mItems.size(); i++)

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -66,12 +66,12 @@ void ListBox::_updateItemDisplay()
 
 	if ((mLineHeight * mItems.size()) > static_cast<std::size_t>(mRect.height))
 	{
-		mLineCount = static_cast<unsigned int>(mRect.height / mLineHeight);
+		mLineCount = static_cast<unsigned int>(mRect.height) / mLineHeight;
 		if (mLineCount < mItems.size())
 		{
 			mSlider.position({rect().x + mRect.width - 14, mRect.y});
 			mSlider.size({14, mRect.height});
-			mSlider.length(static_cast<float>(mLineHeight * mItems.size() - mRect.height));
+			mSlider.length(static_cast<float>(static_cast<int>(mLineHeight * mItems.size()) - mRect.height));
 			mCurrentOffset = static_cast<std::size_t>(mSlider.thumbPosition());
 			mItemWidth = static_cast<unsigned int>(mRect.width - mSlider.size().x);
 			mSlider.visible(true);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -157,9 +157,10 @@ bool ListBox::itemExists(const std::string& item)
 
 void ListBox::setSelectionByName(const std::string& item)
 {
+	const auto target = toLowercase(item);
 	for (std::size_t i = 0; i < mItems.size(); i++)
 	{
-		if (toLowercase(mItems[i].Text) == toLowercase(item)) { mCurrentSelection = i; return; }
+		if (toLowercase(mItems[i].Text) == target) { mCurrentSelection = i; return; }
 	}
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -159,7 +159,7 @@ void ListBox::setSelectionByName(const std::string& item)
 {
 	for (std::size_t i = 0; i < mItems.size(); i++)
 	{
-		if (toLowercase(mItems[i].Text) == toLowercase(item)) { mCurrentSelection = static_cast<int>(i); return; }
+		if (toLowercase(mItems[i].Text) == toLowercase(item)) { mCurrentSelection = i; return; }
 	}
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -23,7 +23,7 @@ using namespace NAS2D;
  * C'tor
  */
 ListBox::ListBox() :
-	mFont{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
+	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
@@ -35,7 +35,7 @@ ListBox::ListBox() :
 	mSlider.change().connect(this, &ListBox::slideChanged);
 	_updateItemDisplay();
 
-	mLineHeight = (mFont->height() + 2);
+	mLineHeight = (mFont.height() + 2);
 	mLineCount = static_cast<int>(mRect.height / mLineHeight);
 	_updateItemDisplay();
 }
@@ -243,7 +243,7 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 	
-	mCurrentHighlight = (y - mRect.y + mCurrentOffset) / (mFont->height() + 2);
+	mCurrentHighlight = (y - mRect.y + mCurrentOffset) / (mFont.height() + 2);
 
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{
@@ -307,7 +307,7 @@ void ListBox::update()
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
 		const auto textColor = (i == mCurrentHighlight) ? mHighlightText : mText;
-		renderer.drawTextShadow(*mFont, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+		renderer.drawTextShadow(mFont, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 		textPosition.y += mLineHeight;
 	}
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -22,10 +22,9 @@ using namespace NAS2D;
 /**
  * C'tor
  */
-ListBox::ListBox()
+ListBox::ListBox() :
+	LST_FONT{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
 {
-	LST_FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
-
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
 	Utility<EventHandler>::get().mouseWheel().connect(this, &ListBox::onMouseWheel);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -23,7 +23,7 @@ using namespace NAS2D;
  * C'tor
  */
 ListBox::ListBox() :
-	LST_FONT{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
+	mFont{&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
@@ -35,7 +35,7 @@ ListBox::ListBox() :
 	mSlider.change().connect(this, &ListBox::slideChanged);
 	_updateItemDisplay();
 
-	mLineHeight = (LST_FONT->height() + 2);
+	mLineHeight = (mFont->height() + 2);
 	mLineCount = static_cast<int>(mRect.height / mLineHeight);
 	_updateItemDisplay();
 }
@@ -243,7 +243,7 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 	
-	mCurrentHighlight = (y - mRect.y + mCurrentOffset) / (LST_FONT->height() + 2);
+	mCurrentHighlight = (y - mRect.y + mCurrentOffset) / (mFont->height() + 2);
 
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{
@@ -307,7 +307,7 @@ void ListBox::update()
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
 		const auto textColor = (i == mCurrentHighlight) ? mHighlightText : mText;
-		renderer.drawTextShadow(*LST_FONT, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+		renderer.drawTextShadow(*mFont, mItems[i].Text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 		textPosition.y += mLineHeight;
 	}
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -24,28 +24,6 @@ using namespace NAS2D;
  */
 ListBox::ListBox()
 {
-	_init();
-}
-
-
-/**
- * D'tor
- */
-ListBox::~ListBox()
-{
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ListBox::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &ListBox::onMouseMove);
-	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ListBox::onMouseWheel);
-
-	mSlider.change().disconnect(this, &ListBox::slideChanged);
-}
-
-
-/**
-*
-*/
-void ListBox::_init()
-{
 	LST_FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
@@ -61,6 +39,19 @@ void ListBox::_init()
 	mLineHeight = (LST_FONT->height() + 2);
 	mLineCount = static_cast<int>(mRect.height / mLineHeight);
 	_updateItemDisplay();
+}
+
+
+/**
+ * D'tor
+ */
+ListBox::~ListBox()
+{
+	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ListBox::onMouseDown);
+	Utility<EventHandler>::get().mouseMotion().disconnect(this, &ListBox::onMouseMove);
+	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ListBox::onMouseWheel);
+
+	mSlider.change().disconnect(this, &ListBox::slideChanged);
 }
 
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -86,7 +86,7 @@ private:
 	void _updateItemDisplay();
 
 
-	const NAS2D::Font* LST_FONT = nullptr;
+	const NAS2D::Font* mFont = nullptr;
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	std::size_t mCurrentSelection = 0; /**< Current selection index. */

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -86,7 +86,7 @@ private:
 	void _updateItemDisplay();
 
 
-	const NAS2D::Font* mFont = nullptr;
+	const NAS2D::Font& mFont;
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	std::size_t mCurrentSelection = 0; /**< Current selection index. */

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -84,7 +84,6 @@ private:
 	void onSizeChanged() override;
 
 	void _updateItemDisplay();
-	void _init();
 
 
 	const NAS2D::Font* LST_FONT = nullptr;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -13,6 +13,11 @@
 #include <cstddef>
 
 
+namespace NAS2D {
+	class Font;
+}
+
+
 /**
  * Implements a ListBox control.
  */
@@ -81,6 +86,8 @@ private:
 	void _updateItemDisplay();
 	void _init();
 
+
+	const NAS2D::Font* LST_FONT = nullptr;
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	std::size_t mCurrentSelection = 0; /**< Current selection index. */

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -280,7 +280,7 @@ unsigned int ListBoxBase::currentSelection() const
  */
 void ListBoxBase::setSelection(unsigned int selection)
 {
-	mItems.empty() ? mCurrentSelection = constants::NO_SELECTION : mCurrentSelection = selection;
+	mCurrentSelection = mItems.empty() ? constants::NO_SELECTION : selection;
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -329,7 +329,7 @@ void ListBoxBase::update()
 	renderer.clipRect(mRect);
 
 	// MOUSE HIGHLIGHT
-	int highlight_y = positionY() + (mCurrentHighlight * mItemHeight) - mCurrentOffset;
+	int highlight_y = positionY() + (static_cast<int>(mCurrentHighlight) * mItemHeight) - static_cast<int>(mCurrentOffset);
 	renderer.drawBoxFilled(NAS2D::Rectangle{positionX(), highlight_y, mItemWidth, mItemHeight}, NAS2D::Color{0, 185, 0, 50});
 
 	mSlider.update();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -75,7 +75,7 @@ void ListBoxBase::_update_item_display()
 {
 	mItemWidth = mRect.width;
 
-	if ((mItemHeight * mItems.size()) > static_cast<std::size_t>(mRect.height))
+	if ((mItemHeight * static_cast<int>(mItems.size())) > mRect.height)
 	{
 		mLineCount = mRect.height / mItemHeight;
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -157,7 +157,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 
-	mCurrentHighlight = (y - positionY() + mCurrentOffset) / mItemHeight;
+	mCurrentHighlight = (static_cast<unsigned int>(y - positionY()) + mCurrentOffset) / static_cast<unsigned int>(mItemHeight);
 
 	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
 	{

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -280,7 +280,7 @@ unsigned int ListBoxBase::currentSelection() const
  */
 void ListBoxBase::setSelection(unsigned int selection)
 {
-	mCurrentSelection = mItems.empty() ? constants::NO_SELECTION : selection;
+	mCurrentSelection = (selection < mItems.size()) ? selection : constants::NO_SELECTION;
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -278,7 +278,7 @@ unsigned int ListBoxBase::currentSelection() const
  * 
  * \note	Out of range selection indicies will set the ListBoxBase to no selection.
  */
-void ListBoxBase::setSelection(int selection)
+void ListBoxBase::setSelection(unsigned int selection)
 {
 	mItems.empty() ? mCurrentSelection == constants::NO_SELECTION : mCurrentSelection = selection;
 	mSelectionChanged();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -83,7 +83,7 @@ void ListBoxBase::_update_item_display()
 		{
 			mSlider.position({rect().x + mRect.width - 14, mRect.y});
 			mSlider.size({14, mRect.height});
-			mSlider.length(static_cast<float>(mItemHeight * mItems.size() - mRect.height));
+			mSlider.length(static_cast<float>(mItemHeight * static_cast<int>(mItems.size()) - mRect.height));
 			mCurrentOffset = static_cast<unsigned int>(mSlider.thumbPosition());
 			mItemWidth -= static_cast<unsigned int>(mSlider.size().x);
 			mSlider.visible(true);

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -280,7 +280,7 @@ unsigned int ListBoxBase::currentSelection() const
  */
 void ListBoxBase::setSelection(unsigned int selection)
 {
-	mItems.empty() ? mCurrentSelection == constants::NO_SELECTION : mCurrentSelection = selection;
+	mItems.empty() ? mCurrentSelection = constants::NO_SELECTION : mCurrentSelection = selection;
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -55,7 +55,7 @@ public:
 
 	unsigned int currentHighlight() const;
 	unsigned int currentSelection() const;
-	void setSelection(int selection);
+	void setSelection(unsigned int selection);
 
 	const std::string& selectionText() const;
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -80,8 +80,8 @@ protected:
 
 	void _update_item_display();
 
-	unsigned int item_width() const { return mItemWidth; }
-	unsigned int item_height() const { return mItemHeight; }
+	unsigned int item_width() const { return static_cast<unsigned int>(mItemWidth); }
+	unsigned int item_height() const { return static_cast<unsigned int>(mItemHeight); }
 	void item_height(int);
 
 	unsigned int draw_offset() const { return mCurrentOffset; }

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -174,7 +174,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		case EventHandler::KeyCode::KEY_END:
-			mCursorPosition = static_cast<int>(text().length());
+			mCursorPosition = text().length();
 			break;
 
 		case EventHandler::KeyCode::KEY_DELETE:
@@ -192,7 +192,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		case EventHandler::KeyCode::KEY_RIGHT:
-			if(static_cast<std::size_t>(mCursorPosition) < text().length())
+			if(mCursorPosition < text().length())
 				++mCursorPosition;
 			break;
 
@@ -203,7 +203,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		case EventHandler::KeyCode::KEY_KP6:
-			if((static_cast<std::size_t>(mCursorPosition) < text().length()) && !Utility<EventHandler>::get().query_numlock())
+			if((mCursorPosition < text().length()) && !Utility<EventHandler>::get().query_numlock())
 				++mCursorPosition;
 			break;
 
@@ -234,14 +234,14 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 	// set the position to the end and move on.
 	if(mFont.width(text()) < relativePosition)
 	{
-		mCursorPosition = static_cast<int>(text().size());
+		mCursorPosition = text().size();
 		return;
 	}
 
 
 	// Figure out where the click occured within the visible string.
-	int i = 0;
-	while(static_cast<std::size_t>(i) <= text().size() - mScrollOffset)
+	std::size_t i = 0;
+	while(i <= text().size() - mScrollOffset)
 	{
 		std::string cmpStr = text().substr(mScrollOffset, i);
 		int strLen = mFont.width(cmpStr);

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -241,9 +241,10 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 
 	// Figure out where the click occured within the visible string.
 	std::size_t i = 0;
-	while(i <= text().size() - mScrollOffset)
+	const auto scrollOffset = static_cast<std::size_t>(mScrollOffset);
+	while(i <= text().size() - scrollOffset)
 	{
-		std::string cmpStr = text().substr(mScrollOffset, i);
+		std::string cmpStr = text().substr(scrollOffset, i);
 		int strLen = mFont.width(cmpStr);
 		if(strLen > relativePosition)
 		{

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -78,7 +78,7 @@ private:
 
 	NAS2D::Timer mCursorTimer; /**< Timer for the cursor blink. */
 
-	int mCursorPosition = 0; /**< Position of the Insertion Cursor. */
+	std::size_t mCursorPosition = 0; /**< Position of the Insertion Cursor. */
 	int mCursorX = 0; /**< Pixel position of the Cursor. */
 	int mScrollOffset = 0; /**< Scroller offset. */
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -137,7 +137,7 @@ void FactoryListBox::currentSelection(Factory* f)
 		FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems[i]);
 		if (item->factory == f)
 		{
-			setSelection(static_cast<int>(i));
+			setSelection(i);
 			return;
 		}
 	}

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -168,8 +168,8 @@ void FactoryListBox::update()
 		drawItem(renderer, *static_cast<FactoryListBoxItem*>(mItems[i]),
 			positionX(),
 			positionY() + (static_cast<int>(i) * LIST_ITEM_HEIGHT),
-			item_width(),
-			draw_offset(),
+			static_cast<int>(item_width()),
+			static_cast<int>(draw_offset()),
 			i == currentSelection());
 	}
 

--- a/OPHD/UI/ProductListBox.h
+++ b/OPHD/UI/ProductListBox.h
@@ -18,7 +18,7 @@ class ProductListBox : public ListBoxBase
 public:
 	struct ProductListBoxItem : public ListBoxItem
 	{
-		std::size_t count = 0; /**< Count of the product. */
+		int count = 0; /**< Count of the product. */
 		float usage = 0.0f; /**< Usage of available capacity. */
 	};
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -128,7 +128,7 @@ void StructureListBox::currentSelection(Structure* structure)
 		StructureListBoxItem* item = static_cast<StructureListBoxItem*>(mItems[i]);
 		if (item->structure == structure)
 		{
-			setSelection(static_cast<int>(i));
+			setSelection(i);
 			return;
 		}
 	}

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -168,8 +168,8 @@ void StructureListBox::update()
 		drawItem(renderer, *static_cast<StructureListBoxItem*>(mItems[i]),
 			positionX(),
 			positionY() + (static_cast<int>(i) * LIST_ITEM_HEIGHT),
-			item_width(),
-			draw_offset(),
+			static_cast<int>(item_width()),
+			static_cast<int>(draw_offset()),
 			i == currentSelection());
 	}
 


### PR DESCRIPTION
Reference: #307

Fix sign conversion warnings for Clang with flag `-Wsign-conversion`.

Build command:
```
make CXXFLAGS_EXTRA=-Wsign-conversion
```

Probably should have split this one up into multiple PRs.
