### PR TITLE
Refactor StructureListBox

### DIFF
--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -50,12 +50,6 @@ StructureListBox::StructureListBoxItem::StructureListBoxItem(Structure* s) :
 
 StructureListBox::StructureListBox()
 {
-	_init();
-}
-
-
-void StructureListBox::_init()
-{
 	item_height(LIST_ITEM_HEIGHT);
 	MAIN_FONT = &fontCache.load(constants::FONT_PRIMARY, 12);
 	MAIN_FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, 12);

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -40,7 +40,4 @@ public:
 	StructureListBoxItem* last();
 
 	void update() override;
-
-private:
-	void _init();
 };


### PR DESCRIPTION
A bit of misc cleanup for `StructureListBox`. Mostly deleting lines that didn't need to be there.

Reference: #479

----

Reference: #656 for corresponding changes to `FactoryListBox`
