### PR TITLE
Fix warning unreachable code

### DIFF
--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -345,12 +345,10 @@ void StructureCatalogue::buildPopulationRequirementsTable()
 StorableResources StructureCatalogue::recycleValue(StructureID type, float percent)
 {
 	auto recyclingValue = mStructureCostTable[type];
-
 	for (size_t i = 0; i < recyclingValue.resources.size(); ++i)
 	{
 		/** Truncation of value from float to int cast is intended and desired behavior. */
 		recyclingValue.resources[i] = static_cast<int>(recyclingValue.resources[i] * percent);
 	}
-
 	return recyclingValue;
 }

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -347,7 +347,7 @@ StorableResources StructureCatalogue::recycleValue(StructureID type, float perce
 	auto recyclingValue = mStructureCostTable[type];
 	for (size_t i = 0; i < recyclingValue.resources.size(); ++i)
 	{
-		/** Truncation of value from float to int cast is intended and desired behavior. */
+		// Truncation of value from float to int cast is intended and desired behavior
 		recyclingValue.resources[i] = static_cast<int>(recyclingValue.resources[i] * percent);
 	}
 	return recyclingValue;

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -344,11 +344,6 @@ void StructureCatalogue::buildPopulationRequirementsTable()
  */
 StorableResources StructureCatalogue::recycleValue(StructureID type, float percent)
 {
-	if (mStructureCostTable.empty())
-	{
-		throw std::runtime_error("StructureCatalogue::recycleValue() called before StructureCatalogue::buildCostTable().");
-	}
-
 	auto recyclingValue = mStructureCostTable[type];
 
 	for (size_t i = 0; i < recyclingValue.resources.size(); ++i)


### PR DESCRIPTION
There is a single warning for `-Wunreachable-code`:
> OPHD/StructureCatalogue.cpp:349:28: warning: code will never be executed [-Wunreachable-code]
>                 throw std::runtime_error("StructureCatalogue::recycleValue() called before StructureCatalogue::buildCostTable().");

It seems the `StructureCatalogue` table has switched from `std::vector` to `std::array`, so the size is known at compile time. That means the code knows the `if (mStructureCostTable.empty())` guard will always be false, and so the exception is never possible.

Effectively, the check was on the pre-set size of the table, rather than on whether or not it had been initialized (which was the intended check). There is of course no way to check this for `std::array`, other than possibly checking for a zeroed out table.

A better approach is to initialized the table where it is declared, and then mark it as `const`. The same can be done for the other tables in that class. One slight complication is the `std::array` effectively has holes in it, and becomes less self documenting to initialize by placement order than by index. A `std::map` could be more self documenting for that. Alternatively, the various tables could be combined in such a way that a structure name becomes part of the data, and so becomes more self documenting. This would perhaps work better if code was refactored to remove reliance on an `enum` which is defined externally to the table.

Reference: #307
