### PR TITLE
Increase Linux warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ jobs:
   build-linux-gcc:
     docker:
       - image: outpostuniverse/nas2d-gcc:1.2
+    environment:
+      WARN_EXTRA: -Wsuggest-override
     steps:
       - build
   build-linux-clang:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ jobs:
   build-linux-clang:
     docker:
       - image: outpostuniverse/nas2d-clang:1.1
+    environment:
+      WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
       - build
   build-linux-mingw:

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
-CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
+CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW


### PR DESCRIPTION
Reference: #307

Use the new Docker images, with newer compilers, to increase the warning checks for the Linux builds.

Some flags apply equally to all compilers, and so can be added to the general warning flag section of the `makefile`. Other flags are compiler (or version) specific. These flags are instead added to the environment section of the CircleCI config file. This allows specific compiler environments to use compiler specific warning flags, which will apply to all files being compiled by that compiler. This is implemented using a custom `WARN_EXTRA` environment variable, which is used by the `makefile` to add additional warning flags to the compile command.
