### PR TITLE
Fix memory leak of mPathSolver object

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -79,6 +79,8 @@ MapViewState::MapViewState(const Planet::Attributes& planetAttributes) :
 
 MapViewState::~MapViewState()
 {
+	delete mPathSolver;
+
 	scrubRobotList();
 	delete mTileMap;
 


### PR DESCRIPTION
Memory leak found with `valgrind`.
