### PR TITLE
Mark TerrainType as enum class

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -70,13 +70,13 @@ const std::map<StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 };
 
 
-const std::map<int, std::string> TILE_INDEX_TRANSLATION =
+const std::map<TerrainType, std::string> TILE_INDEX_TRANSLATION =
 {
-	{ 0, constants::TILE_INDEX_TRANSLATION_BULLDOZED },
-	{ 1, constants::TILE_INDEX_TRANSLATION_CLEAR },
-	{ 2, constants::TILE_INDEX_TRANSLATION_ROUGH },
-	{ 3, constants::TILE_INDEX_TRANSLATION_DIFFICULT },
-	{ 4, constants::TILE_INDEX_TRANSLATION_IMPASSABLE },
+	{ TerrainType::TERRAIN_DOZED, constants::TILE_INDEX_TRANSLATION_BULLDOZED },
+	{ TerrainType::TERRAIN_CLEAR, constants::TILE_INDEX_TRANSLATION_CLEAR },
+	{ TerrainType::TERRAIN_ROUGH, constants::TILE_INDEX_TRANSLATION_ROUGH },
+	{ TerrainType::TERRAIN_DIFFICULT, constants::TILE_INDEX_TRANSLATION_DIFFICULT },
+	{ TerrainType::TERRAIN_IMPASSABLE, constants::TILE_INDEX_TRANSLATION_IMPASSABLE },
 };
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -72,11 +72,11 @@ const std::map<StructureState, Color> STRUCTURE_TEXT_COLOR_TABLE
 
 const std::map<TerrainType, std::string> TILE_INDEX_TRANSLATION =
 {
-	{ TerrainType::TERRAIN_DOZED, constants::TILE_INDEX_TRANSLATION_BULLDOZED },
-	{ TerrainType::TERRAIN_CLEAR, constants::TILE_INDEX_TRANSLATION_CLEAR },
-	{ TerrainType::TERRAIN_ROUGH, constants::TILE_INDEX_TRANSLATION_ROUGH },
-	{ TerrainType::TERRAIN_DIFFICULT, constants::TILE_INDEX_TRANSLATION_DIFFICULT },
-	{ TerrainType::TERRAIN_IMPASSABLE, constants::TILE_INDEX_TRANSLATION_IMPASSABLE },
+	{ TerrainType::Dozed, constants::TILE_INDEX_TRANSLATION_BULLDOZED },
+	{ TerrainType::Clear, constants::TILE_INDEX_TRANSLATION_CLEAR },
+	{ TerrainType::Rough, constants::TILE_INDEX_TRANSLATION_ROUGH },
+	{ TerrainType::Difficult, constants::TILE_INDEX_TRANSLATION_DIFFICULT },
+	{ TerrainType::Impassable, constants::TILE_INDEX_TRANSLATION_IMPASSABLE },
 };
 
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -43,11 +43,11 @@ enum class Direction
  */
 enum class TerrainType
 {
-	TERRAIN_DOZED,
-	TERRAIN_CLEAR,
-	TERRAIN_ROUGH,
-	TERRAIN_DIFFICULT,
-	TERRAIN_IMPASSABLE
+	Dozed,
+	Clear,
+	Rough,
+	Difficult,
+	Impassable
 };
 
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -41,7 +41,7 @@ enum class Direction
 /**
  * Terrain type enumeration
  */
-enum TerrainType
+enum class TerrainType
 {
 	TERRAIN_DOZED,
 	TERRAIN_CLEAR,

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -292,7 +292,7 @@ using PopulationRequirements = std::array<int, 2>;
 class Robot;
 using RobotList = std::vector<Robot*>;
 
-extern const std::map<int, std::string> TILE_INDEX_TRANSLATION;
+extern const std::map<TerrainType, std::string> TILE_INDEX_TRANSLATION;
 extern const std::map<MineProductionRate, std::string> MINE_YIELD_TRANSLATION;
 
 extern const std::array<std::string, 4> ResourceNamesRefined;

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 
 
-Tile::Tile(NAS2D::Point<int> position, int depth, int index) :
+Tile::Tile(NAS2D::Point<int> position, int depth, TerrainType index) :
 	mIndex{index},
 	mPosition{position},
 	mDepth{depth}

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -16,15 +16,15 @@ class Tile
 {
 public:
 	Tile() = default;
-	Tile(NAS2D::Point<int> position, int depth, int index);
+	Tile(NAS2D::Point<int> position, int depth, TerrainType index);
 	Tile(const Tile& other) = delete;
 	Tile& operator=(const Tile& other) = delete;
 	Tile(Tile&& other) noexcept;
 	Tile& operator=(Tile&& other) noexcept;
 	~Tile();
 
-	int index() const { return mIndex; }
-	void index(int index) { mIndex = index; }
+	TerrainType index() const { return mIndex; }
+	void index(TerrainType index) { mIndex = index; }
 
 	NAS2D::Point<int> position() const { return mPosition; }
 
@@ -71,7 +71,7 @@ protected:
 	void thingIsStructure(bool value) { mThingIsStructure = value; }
 
 private:
-	int mIndex = 0;
+	TerrainType mIndex = TerrainType::TERRAIN_DOZED;
 
 	NAS2D::Point<int> mPosition; /**< Tile Position Information */
 	int mDepth = 0; /**< Tile Position Information */

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -31,7 +31,7 @@ public:
 	int depth() const { return mDepth; }
 	void depth(int i) { mDepth = i; }
 
-	bool bulldozed() const { return index() == 0; }
+	bool bulldozed() const { return index() == TerrainType::TERRAIN_DOZED; }
 
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -31,7 +31,7 @@ public:
 	int depth() const { return mDepth; }
 	void depth(int i) { mDepth = i; }
 
-	bool bulldozed() const { return index() == TerrainType::TERRAIN_DOZED; }
+	bool bulldozed() const { return index() == TerrainType::Dozed; }
 
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }
@@ -71,7 +71,7 @@ protected:
 	void thingIsStructure(bool value) { mThingIsStructure = value; }
 
 private:
-	TerrainType mIndex = TerrainType::TERRAIN_DOZED;
+	TerrainType mIndex = TerrainType::Dozed;
 
 	NAS2D::Point<int> mPosition; /**< Tile Position Information */
 	int mDepth = 0; /**< Tile Position Information */

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -131,7 +131,7 @@ void TileMap::buildTerrainMap(const std::string& path)
 			{
 				auto color = heightmap.pixelColor({col, row});
 				auto& tile = getTile({col, row}, depth);
-				tile = {{col, row}, depth, color.red / 50};
+				tile = {{col, row}, depth, static_cast<TerrainType>(color.red / 50)};
 				if (depth > 0) { tile.excavated(false); }
 			}
 		}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -185,7 +185,7 @@ void TileMap::addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& p
 
 	auto& tile = getTile(mineLocation, 0);
 	tile.pushMine(new Mine(rate));
-	tile.index(TerrainType::TERRAIN_DOZED);
+	tile.index(TerrainType::Dozed);
 
 	plist.push_back(mineLocation);
 }
@@ -466,7 +466,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element, const Planet::Attribute
 				{
 					serializeTile(tiles, x, y, depth, tile.index());
 				}
-				else if (tile.index() == TerrainType::TERRAIN_DOZED && tile.empty() && tile.mine() == nullptr)
+				else if (tile.index() == TerrainType::Dozed && tile.empty() && tile.mine() == nullptr)
 				{
 					serializeTile(tiles, x, y, depth, tile.index());
 				}
@@ -509,7 +509,7 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 
 		auto& tile = getTile({x, y}, 0);
 		tile.pushMine(m);
-		tile.index(TerrainType::TERRAIN_DOZED);
+		tile.index(TerrainType::Dozed);
 
 		mMineLocations.push_back(Point{x, y});
 
@@ -595,7 +595,7 @@ void TileMap::AdjacentCost(void* state, std::vector<micropather::StateCost>* adj
 		auto& adjacentTile = getTile(position, 0);
 		float cost = constants::ROUTE_BASE_COST;
 
-		if (adjacentTile.index() == TerrainType::TERRAIN_IMPASSABLE)
+		if (adjacentTile.index() == TerrainType::Impassable)
 		{
 			cost = FLT_MAX;
 		}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -396,13 +396,13 @@ TileMap::MouseMapRegion TileMap::getMouseMapRegion(int x, int y)
 }
 
 
-static void serializeTile(XmlElement* _ti, int x, int y, int depth, int index)
+static void serializeTile(XmlElement* _ti, int x, int y, int depth, TerrainType index)
 {
 	XmlElement* t = new XmlElement("tile");
 	t->attribute("x", x);
 	t->attribute("y", y);
 	t->attribute("depth", depth);
-	t->attribute("index", index);
+	t->attribute("index", static_cast<int>(index));
 
 	_ti->linkEndChild(t);
 }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -466,7 +466,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element, const Planet::Attribute
 				{
 					serializeTile(tiles, x, y, depth, tile.index());
 				}
-				else if (tile.index() == 0 && tile.empty() && tile.mine() == nullptr)
+				else if (tile.index() == TerrainType::TERRAIN_DOZED && tile.empty() && tile.mine() == nullptr)
 				{
 					serializeTile(tiles, x, y, depth, tile.index());
 				}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -309,7 +309,7 @@ void TileMap::draw()
 			if (tile.excavated())
 			{
 				const auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
-				const auto subImageRect = NAS2D::Rectangle{tile.index() * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
+				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 				const bool isConnectionHighlighted = mShowConnections && tile.connected();
 				const NAS2D::Color highlightColor =

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -896,7 +896,7 @@ void MapViewState::placeRobot()
 			checkConnectedness();
 		}
 
-		int taskTime = tile->index() == 0 ? 1 : tile->index(); 
+		int taskTime = tile->index() == TerrainType::TERRAIN_DOZED ? 1 : static_cast<int>(tile->index());
 		robot->startTask(taskTime);
 		mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 		static_cast<Robodozer*>(robot)->tileIndex(static_cast<std::size_t>(tile->index()));

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1195,7 +1195,7 @@ void MapViewState::updateRobots()
 				const auto text = "Your " + robot->name() + " at location " + robotLocationText + " has broken down. It will not be able to complete its task and will be removed from your inventory.";
 				doAlertMessage("Robot Breakdown", text);
 				Robodozer* _d = dynamic_cast<Robodozer*>(robot);
-				if (_d) { tile->index(static_cast<int>(_d->tileIndex())); }
+				if (_d) { tile->index(static_cast<TerrainType>(_d->tileIndex())); }
 			}
 
 			if (tile->thing() == robot)

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -823,7 +823,7 @@ void MapViewState::placeRobot()
 		{
 			return;
 		}
-		else if (tile->index() == TerrainType::TERRAIN_DOZED && !tile->thingIsStructure())
+		else if (tile->index() == TerrainType::Dozed && !tile->thingIsStructure())
 		{
 			doAlertMessage(constants::ALERT_INVALID_ROBOT_PLACEMENT, constants::ALERT_TILE_BULLDOZED);
 			return;
@@ -892,15 +892,15 @@ void MapViewState::placeRobot()
 			Utility<StructureManager>::get().removeStructure(structure);
 			tile->deleteThing();
 			Utility<StructureManager>::get().disconnectAll();
-			static_cast<Robodozer*>(robot)->tileIndex(static_cast<std::size_t>(TerrainType::TERRAIN_DOZED));
+			static_cast<Robodozer*>(robot)->tileIndex(static_cast<std::size_t>(TerrainType::Dozed));
 			checkConnectedness();
 		}
 
-		int taskTime = tile->index() == TerrainType::TERRAIN_DOZED ? 1 : static_cast<int>(tile->index());
+		int taskTime = tile->index() == TerrainType::Dozed ? 1 : static_cast<int>(tile->index());
 		robot->startTask(taskTime);
 		mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 		static_cast<Robodozer*>(robot)->tileIndex(static_cast<std::size_t>(tile->index()));
-		tile->index(TerrainType::TERRAIN_DOZED);
+		tile->index(TerrainType::Dozed);
 
 		if(!mRobotPool.robotAvailable(RobotType::ROBOT_DOZER))
 		{
@@ -996,7 +996,7 @@ void MapViewState::placeRobot()
 		Robot* robot = mRobotPool.getMiner();
 		robot->startTask(constants::MINER_TASK_TIME);
 		mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
-		tile->index(TerrainType::TERRAIN_DOZED);
+		tile->index(TerrainType::Dozed);
 
 		if (!mRobotPool.robotAvailable(RobotType::ROBOT_MINER))
 		{

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -131,7 +131,7 @@ void MapViewState::deploySeedLander(NAS2D::Point<int> point)
 	// Bulldoze lander region
 	for (const auto& direction : DirectionScan3x3)
 	{
-		mTileMap->getTile(point + direction).index(TerrainType::TERRAIN_DOZED);
+		mTileMap->getTile(point + direction).index(TerrainType::Dozed);
 	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
@@ -213,8 +213,8 @@ void MapViewState::diggerTaskFinished(Robot* robot)
 		as2->ug();
 		NAS2D::Utility<StructureManager>::get().addStructure(as2, &mTileMap->getTile(origin, newDepth));
 
-		mTileMap->getTile(origin, t->depth()).index(TerrainType::TERRAIN_DOZED);
-		mTileMap->getTile(origin, newDepth).index(TerrainType::TERRAIN_DOZED);
+		mTileMap->getTile(origin, t->depth()).index(TerrainType::Dozed);
+		mTileMap->getTile(origin, newDepth).index(TerrainType::Dozed);
 
 		/// \fixme Naive approach; will be slow with large colonies.
 		NAS2D::Utility<StructureManager>::get().disconnectAll();
@@ -270,8 +270,8 @@ void MapViewState::minerTaskFinished(Robot* robot)
 	auto& tileBelow = mTileMap->getTile(robotTile.position(), robotTile.depth() + 1);
 	NAS2D::Utility<StructureManager>::get().addStructure(new MineShaft(), &tileBelow);
 
-	robotTile.index(TerrainType::TERRAIN_DOZED);
-	tileBelow.index(TerrainType::TERRAIN_DOZED);
+	robotTile.index(TerrainType::Dozed);
+	tileBelow.index(TerrainType::Dozed);
 	tileBelow.excavated(true);
 
 	robot->die();
@@ -285,6 +285,6 @@ void MapViewState::mineFacilityExtended(MineFacility* mineFacility)
 	auto& mineFacilityTile = *NAS2D::Utility<StructureManager>::get().tileFromStructure(mineFacility);
 	auto& mineDepthTile = mTileMap->getTile(mineFacilityTile.position(), mineFacility->mine()->depth());
 	NAS2D::Utility<StructureManager>::get().addStructure(new MineShaft(), &mineDepthTile);
-	mineDepthTile.index(TerrainType::TERRAIN_DOZED);
+	mineDepthTile.index(TerrainType::Dozed);
 	mineDepthTile.excavated(true);
 }

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -270,8 +270,8 @@ void MapViewState::minerTaskFinished(Robot* robot)
 	auto& tileBelow = mTileMap->getTile(robotTile.position(), robotTile.depth() + 1);
 	NAS2D::Utility<StructureManager>::get().addStructure(new MineShaft(), &tileBelow);
 
-	robotTile.index(0);
-	tileBelow.index(0);
+	robotTile.index(TerrainType::TERRAIN_DOZED);
+	tileBelow.index(TerrainType::TERRAIN_DOZED);
 	tileBelow.excavated(true);
 
 	robot->die();
@@ -285,6 +285,6 @@ void MapViewState::mineFacilityExtended(MineFacility* mineFacility)
 	auto& mineFacilityTile = *NAS2D::Utility<StructureManager>::get().tileFromStructure(mineFacility);
 	auto& mineDepthTile = mTileMap->getTile(mineFacilityTile.position(), mineFacility->mine()->depth());
 	NAS2D::Utility<StructureManager>::get().addStructure(new MineShaft(), &mineDepthTile);
-	mineDepthTile.index(0);
+	mineDepthTile.index(TerrainType::TERRAIN_DOZED);
 	mineDepthTile.excavated(true);
 }

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -171,7 +171,7 @@ bool validLanderSite(Tile& tile)
 		return false;
 	}
 
-	if (tile.index() == TerrainType::TERRAIN_IMPASSABLE)
+	if (tile.index() == TerrainType::Impassable)
 	{
 		doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_LANDER_TERRAIN);
 		return false;
@@ -196,7 +196,7 @@ bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position)
 	{
 		auto& tile = tilemap->getTile(position + offset);
 
-		if (tile.index() == TerrainType::TERRAIN_IMPASSABLE)
+		if (tile.index() == TerrainType::Impassable)
 		{
 			doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_SEED_TERRAIN);
 			return false;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -317,7 +317,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 		{
 			robot->startTask(production_time);
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, &mTileMap->getTile({x, y}, depth));
-			mRobotList[robot]->index(0);
+			mRobotList[robot]->index(TerrainType::TERRAIN_DOZED);
 		}
 
 		if (depth > 0)
@@ -364,7 +364,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 		}
 
 		auto& tile = mTileMap->getTile({x, y}, depth);
-		tile.index(0);
+		tile.index(TerrainType::TERRAIN_DOZED);
 		tile.excavated(true);
 
 		auto structureId = static_cast<StructureID>(type);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -317,7 +317,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 		{
 			robot->startTask(production_time);
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, &mTileMap->getTile({x, y}, depth));
-			mRobotList[robot]->index(TerrainType::TERRAIN_DOZED);
+			mRobotList[robot]->index(TerrainType::Dozed);
 		}
 
 		if (depth > 0)
@@ -364,7 +364,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 		}
 
 		auto& tile = mTileMap->getTile({x, y}, depth);
-		tile.index(TerrainType::TERRAIN_DOZED);
+		tile.index(TerrainType::Dozed);
 		tile.excavated(true);
 
 		auto structureId = static_cast<StructureID>(type);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -212,7 +212,7 @@ static bool routeObstructed(Route& route)
 		// \note	Tile being occupied by a robot is not an obstruction for the
 		//			purposes of routing/pathing.
 		if (t->thingIsStructure() && !t->structure()->isRoad()) { return true; }
-		if (t->index() == TERRAIN_IMPASSABLE) { return true; }
+		if (t->index() == TerrainType::TERRAIN_IMPASSABLE) { return true; }
 	}
 
 	return false;

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -212,7 +212,7 @@ static bool routeObstructed(Route& route)
 		// \note	Tile being occupied by a robot is not an obstruction for the
 		//			purposes of routing/pathing.
 		if (t->thingIsStructure() && !t->structure()->isRoad()) { return true; }
-		if (t->index() == TerrainType::TERRAIN_IMPASSABLE) { return true; }
+		if (t->index() == TerrainType::Impassable) { return true; }
 	}
 
 	return false;

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -434,7 +434,7 @@ void MapViewState::diggerSelectionDialog(Direction direction, Tile* tile)
 
 	// Assumes a digger is available.
 	Robodigger* robot = mRobotPool.getDigger();
-	robot->startTask(tile->index() + DIGGER_TASK_TIME);
+	robot->startTask(static_cast<int>(tile->index()) + DIGGER_TASK_TIME);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
 	robot->direction(direction);

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -34,7 +34,7 @@ protected:
 		if (age() == turnsToBuild())
 		{
 			mDeploy();
-			mTile->index(TerrainType::TERRAIN_DOZED);
+			mTile->index(TerrainType::Dozed);
 		}
 	}
 

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -34,7 +34,7 @@ protected:
 		if (age() == turnsToBuild())
 		{
 			mDeploy();
-			mTile->index(0);
+			mTile->index(TerrainType::TERRAIN_DOZED);
 		}
 	}
 

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -35,7 +35,7 @@ protected:
 		if (age() == turnsToBuild())
 		{
 			mDeploy();
-			mTile->index(0);
+			mTile->index(TerrainType::TERRAIN_DOZED);
 		}
 	}
 

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -35,7 +35,7 @@ protected:
 		if (age() == turnsToBuild())
 		{
 			mDeploy();
-			mTile->index(TerrainType::TERRAIN_DOZED);
+			mTile->index(TerrainType::Dozed);
 		}
 	}
 


### PR DESCRIPTION
Reference: #319

Admittedly I was a little uncertain if the `Tile` `index` value should be `int` or `TerrainType`. I figured there was enough special casing of the values that I went with the `enum` type.

Maybe in the future we'll switch back to `int`. I suppose we could use property methods or table lookups to determine the tile properties, instead of raw comparisons with enum values.
