### PR TITLE
Refactor StructureManager

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -174,7 +174,7 @@ void MapViewState::_deactivate()
 void MapViewState::focusOnStructure(Structure* s)
 {
 	if (!s) { return; }
-	mTileMap->centerMapOnTile(Utility<StructureManager>::get().tileFromStructure(s));
+	mTileMap->centerMapOnTile(&Utility<StructureManager>::get().tileFromStructure(s));
 }
 
 

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -76,7 +76,7 @@ void MapViewState::drawMiniMap()
 	{
 		if (commTower->operational())
 		{
-			const auto commTowerPosition = structureManager.tileFromStructure(commTower)->position();
+			const auto commTowerPosition = structureManager.tileFromStructure(commTower).position();
 			const auto commTowerRangeImageRect = NAS2D::Rectangle{146, 236, 20, 20};
 			renderer.drawSubImage(mUiIcons, commTowerPosition + miniMapOffset - commTowerRangeImageRect.size() / 2, commTowerRangeImageRect);
 		}

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -282,7 +282,7 @@ void MapViewState::mineFacilityExtended(MineFacility* mineFacility)
 {
 	if (mMineOperationsWindow.mineFacility() == mineFacility) { mMineOperationsWindow.mineFacility(mineFacility); }
 	
-	auto& mineFacilityTile = *NAS2D::Utility<StructureManager>::get().tileFromStructure(mineFacility);
+	auto& mineFacilityTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(mineFacility);
 	auto& mineDepthTile = mTileMap->getTile(mineFacilityTile.position(), mineFacility->mine()->depth());
 	NAS2D::Utility<StructureManager>::get().addStructure(new MineShaft(), &mineDepthTile);
 	mineDepthTile.index(TerrainType::Dozed);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -309,8 +309,8 @@ bool inCommRange(NAS2D::Point<int> position)
 			continue;
 		}
 
-		const auto commTowerTile = structureManager.tileFromStructure(tower);
-		const auto towerDistance = position - commTowerTile->position();
+		const auto& commTowerTile = structureManager.tileFromStructure(tower);
+		const auto towerDistance = position - commTowerTile.position();
 		if (towerDistance.lengthSquared() <= maxTowerRangeSquared)
 		{
 			return true;

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -176,16 +176,16 @@ static RouteList findRoutes(micropather::MicroPather* solver, TileMap* tilemap, 
 {
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	Tile* start = structureManager.tileFromStructure(mine);
+	auto& start = structureManager.tileFromStructure(mine);
 
 	RouteList routeList;
 
 	for (auto smelter : smelters)
 	{
-		Tile* end = structureManager.tileFromStructure(smelter);
-		tilemap->pathStartAndEnd(start, end);
+		auto& end = structureManager.tileFromStructure(smelter);
+		tilemap->pathStartAndEnd(&start, &end);
 		Route route;
-		solver->Solve(start, end, &route.path, &route.cost);
+		solver->Solve(&start, &end, &route.path, &route.cost);
 
 		if (!route.empty()) { routeList.push_back(route); }
 	}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -20,27 +20,8 @@
  */
 static void fillPopulationRequirements(PopulationPool& _p, const PopulationRequirements& _populationRequired, PopulationRequirements& _populationAvailable)
 {
-	// Verbose but a lot easier to read than the ternary operators I was using before.
-
-	// WORKERS
-	if (_p.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, _populationRequired[0]))
-	{
-		_populationAvailable[0] = _populationRequired[0];
-	}
-	else
-	{
-		_populationAvailable[0] = _p.populationAvailable(Population::PersonRole::ROLE_WORKER);
-	}
-
-	// SCIENTISTS
-	if (_p.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]))
-	{
-		_populationAvailable[1] = _populationRequired[1];
-	}
-	else
-	{
-		_populationAvailable[1] = _p.populationAvailable(Population::PersonRole::ROLE_SCIENTIST);
-	}
+	_populationAvailable[0] = std::min(_populationRequired[0], _p.populationAvailable(Population::PersonRole::ROLE_WORKER));
+	_populationAvailable[1] = std::min(_populationRequired[1], _p.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -14,8 +14,6 @@
 #include <algorithm>
 #include <sstream>
 
-using namespace NAS2D::Xml;
-
 
 /**
  * Fills population requirements fields in a Structure.

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -128,8 +128,6 @@ void StructureManager::updateEnergyProduction()
 void StructureManager::updateStructures(StorableResources& resources, PopulationPool& population, StructureList& structures)
 {
 	bool chapAvailable = CHAPAvailable();
-	const PopulationRequirements* _populationRequired = nullptr;
-	PopulationRequirements* _populationAvailable = nullptr;
 
 	Structure* structure = nullptr;
 	for (std::size_t i = 0; i < structures.size(); ++i)
@@ -161,8 +159,8 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 
 
 		// Population Check
-		_populationRequired = &structure->populationRequirements();
-		_populationAvailable = &structure->populationAvailable();
+		const auto* _populationRequired = &structure->populationRequirements();
+		auto* _populationAvailable = &structure->populationAvailable();
 
 		fillPopulationRequirements(population, _populationRequired, _populationAvailable);
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -223,7 +223,7 @@ void StructureManager::updateFactoryProduction()
 /**
  * Adds a new Structure to the StructureManager.
  */
-void StructureManager::addStructure(Structure* st, Tile* tile)
+void StructureManager::addStructure(Structure* structure, Tile* tile)
 {
 	// Sanity checks
 	if (tile == nullptr)
@@ -231,7 +231,7 @@ void StructureManager::addStructure(Structure* st, Tile* tile)
 		return;
 	}
 
-	if (mStructureTileTable.find(st) != mStructureTileTable.end())
+	if (mStructureTileTable.find(structure) != mStructureTileTable.end())
 	{
 		throw std::runtime_error("StructureManager::addStructure(): Attempting to add a Structure that is already managed!");
 	}
@@ -242,10 +242,10 @@ void StructureManager::addStructure(Structure* st, Tile* tile)
 		tile->removeThing();
 	}
 
-	mStructureTileTable[st] = tile;
+	mStructureTileTable[structure] = tile;
 
-	mStructureLists[st->structureClass()].push_back(st);
-	tile->pushThing(st);
+	mStructureLists[structure->structureClass()].push_back(structure);
+	tile->pushThing(structure);
 	tile->thingIsStructure(true);
 }
 
@@ -256,9 +256,9 @@ void StructureManager::addStructure(Structure* st, Tile* tile)
  * \warning	A Structure removed from the StructureManager will be freed.
  *			Remaining pointers and references will be invalidated.
  */
-void StructureManager::removeStructure(Structure* st)
+void StructureManager::removeStructure(Structure* structure)
 {
-	StructureList& structures = mStructureLists[st->structureClass()];
+	StructureList& structures = mStructureLists[structure->structureClass()];
 
 	if (structures.empty())
 	{
@@ -267,14 +267,14 @@ void StructureManager::removeStructure(Structure* st)
 
 	for (std::size_t i = 0; i < structures.size(); ++i)
 	{
-		if (structures[i] == st)
+		if (structures[i] == structure)
 		{
 			structures.erase(structures.begin() + static_cast<std::ptrdiff_t>(i));
 			break;
 		}
 	}
 
-	auto tileTableIt = mStructureTileTable.find(st);
+	auto tileTableIt = mStructureTileTable.find(structure);
 	if (tileTableIt == mStructureTileTable.end())
 	{
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
@@ -386,9 +386,9 @@ void StructureManager::dropAllStructures()
 /**
  * 
  */
-Tile* StructureManager::tileFromStructure(Structure* st)
+Tile* StructureManager::tileFromStructure(Structure* structure)
 {
-	auto it = mStructureTileTable.find(st);
+	auto it = mStructureTileTable.find(structure);
 	if (it != mStructureTileTable.end()) { return it->second; }
 	return nullptr;
 }
@@ -485,7 +485,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 }
 
 
-bool StructureManager::structureConnected(Structure* st)
+bool StructureManager::structureConnected(Structure* structure)
 {
-	return mStructureTileTable[st]->connected();
+	return mStructureTileTable[structure]->connected();
 }

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -15,13 +15,15 @@
 #include <sstream>
 
 
-/**
- * Fills population requirements fields in a Structure.
- */
-static void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
-{
-	available[0] = std::min(required[0], populationPool.populationAvailable(Population::PersonRole::ROLE_WORKER));
-	available[1] = std::min(required[1], populationPool.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));
+namespace {
+	/**
+	 * Fills population requirements fields in a Structure.
+	 */
+	static void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
+	{
+		available[0] = std::min(required[0], populationPool.populationAvailable(Population::PersonRole::ROLE_WORKER));
+		available[1] = std::min(required[1], populationPool.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));
+	}
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -223,10 +223,10 @@ void StructureManager::updateFactoryProduction()
 /**
  * Adds a new Structure to the StructureManager.
  */
-void StructureManager::addStructure(Structure* st, Tile* t)
+void StructureManager::addStructure(Structure* st, Tile* tile)
 {
 	// Sanity checks
-	if (t == nullptr)
+	if (tile == nullptr)
 	{
 		return;
 	}
@@ -237,16 +237,16 @@ void StructureManager::addStructure(Structure* st, Tile* t)
 	}
 
 	// Remove things from tile only if we know we're adding a structure.
-	if (!t->empty())
+	if (!tile->empty())
 	{
-		t->removeThing();
+		tile->removeThing();
 	}
 
-	mStructureTileTable[st] = t;
+	mStructureTileTable[st] = tile;
 
 	mStructureLists[st->structureClass()].push_back(st);
-	t->pushThing(st);
-	t->thingIsStructure(true);
+	tile->pushThing(st);
+	tile->thingIsStructure(true);
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -140,13 +140,13 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 
 
 		// Population Check
-		const auto& _populationRequired = structure->populationRequirements();
-		auto& _populationAvailable = structure->populationAvailable();
+		const auto& populationRequired = structure->populationRequirements();
+		auto& populationAvailable = structure->populationAvailable();
 
-		fillPopulationRequirements(population, _populationRequired, _populationAvailable);
+		fillPopulationRequirements(population, populationRequired, populationAvailable);
 
-		if (!population.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, _populationRequired[0]) ||
-			!population.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]))
+		if (!population.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, populationRequired[0]) ||
+			!population.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, populationRequired[1]))
 		{
 			structure->disable(DisabledReason::Population);
 			continue;
@@ -171,8 +171,8 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 
 		if (structure->operational() || structure->isIdle())
 		{
-			population.usePopulation(Population::PersonRole::ROLE_WORKER, _populationRequired[0]);
-			population.usePopulation(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]);
+			population.usePopulation(Population::PersonRole::ROLE_WORKER, populationRequired[0]);
+			population.usePopulation(Population::PersonRole::ROLE_SCIENTIST, populationRequired[1]);
 
 			resources = resources - structure->resourcesIn();
 			mTotalEnergyUsed += structure->energyRequirement();

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -436,11 +436,11 @@ void serializeStructure(XmlElement* _ti, Structure* structure, Tile* _t)
  */
 void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 {
-	XmlElement* structures = new XmlElement("structures");
+	auto* structures = new XmlElement("structures");
 
 	for (auto it = mStructureTileTable.begin(); it != mStructureTileTable.end(); ++it)
 	{
-		XmlElement* structure = new XmlElement("structure");
+		auto* structure = new XmlElement("structure");
 		serializeStructure(structure, it->first, it->second);
 
 		if (it->first->isFactory())
@@ -451,14 +451,14 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 		if (it->first->isWarehouse())
 		{
-			XmlElement* warehouse_products = new XmlElement("warehouse_products");
+			auto* warehouse_products = new XmlElement("warehouse_products");
 			static_cast<Warehouse*>(it->first)->products().serialize(warehouse_products);
 			structure->linkEndChild(warehouse_products);
 		}
 
 		if (it->first->isRobotCommand())
 		{
-			XmlElement* robots = new XmlElement("robots");
+			auto* robots = new XmlElement("robots");
 
 			const RobotList& rl = static_cast<RobotCommand*>(it->first)->robots();
 
@@ -475,7 +475,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 		if (it->first->structureClass() == Structure::StructureClass::FoodProduction)
 		{
-			XmlElement* food = new XmlElement("food");
+			auto* food = new XmlElement("food");
 			food->attribute("level", static_cast<FoodProduction*>(it->first)->foodLevel());
 			structure->linkEndChild(food);
 		}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -159,13 +159,13 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 
 
 		// Population Check
-		const auto* _populationRequired = &structure->populationRequirements();
-		auto* _populationAvailable = &structure->populationAvailable();
+		const auto& _populationRequired = structure->populationRequirements();
+		auto& _populationAvailable = structure->populationAvailable();
 
-		fillPopulationRequirements(population, _populationRequired, _populationAvailable);
+		fillPopulationRequirements(population, &_populationRequired, &_populationAvailable);
 
-		if (!population.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, (*_populationRequired)[0]) ||
-			!population.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, (*_populationRequired)[1]))
+		if (!population.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, _populationRequired[0]) ||
+			!population.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]))
 		{
 			structure->disable(DisabledReason::Population);
 			continue;
@@ -190,8 +190,8 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 
 		if (structure->operational() || structure->isIdle())
 		{
-			population.usePopulation(Population::PersonRole::ROLE_WORKER, (*_populationRequired)[0]);
-			population.usePopulation(Population::PersonRole::ROLE_SCIENTIST, (*_populationRequired)[1]);
+			population.usePopulation(Population::PersonRole::ROLE_WORKER, _populationRequired[0]);
+			population.usePopulation(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]);
 
 			resources = resources - structure->resourcesIn();
 			mTotalEnergyUsed += structure->energyRequirement();

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -18,28 +18,28 @@
 /**
  * Fills population requirements fields in a Structure.
  */
-static void fillPopulationRequirements(PopulationPool& _p, const PopulationRequirements* _populationRequired, PopulationRequirements* _populationAvailable)
+static void fillPopulationRequirements(PopulationPool& _p, const PopulationRequirements& _populationRequired, PopulationRequirements& _populationAvailable)
 {
 	// Verbose but a lot easier to read than the ternary operators I was using before.
 
 	// WORKERS
-	if (_p.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, (*_populationRequired)[0]))
+	if (_p.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, _populationRequired[0]))
 	{
-		(*_populationAvailable)[0] = (*_populationRequired)[0];
+		_populationAvailable[0] = _populationRequired[0];
 	}
 	else
 	{
-		(*_populationAvailable)[0] = _p.populationAvailable(Population::PersonRole::ROLE_WORKER);
+		_populationAvailable[0] = _p.populationAvailable(Population::PersonRole::ROLE_WORKER);
 	}
 
 	// SCIENTISTS
-	if (_p.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, (*_populationRequired)[1]))
+	if (_p.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]))
 	{
-		(*_populationAvailable)[1] = (*_populationRequired)[1];
+		_populationAvailable[1] = _populationRequired[1];
 	}
 	else
 	{
-		(*_populationAvailable)[1] = _p.populationAvailable(Population::PersonRole::ROLE_SCIENTIST);
+		_populationAvailable[1] = _p.populationAvailable(Population::PersonRole::ROLE_SCIENTIST);
 	}
 }
 
@@ -162,7 +162,7 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 		const auto& _populationRequired = structure->populationRequirements();
 		auto& _populationAvailable = structure->populationAvailable();
 
-		fillPopulationRequirements(population, &_populationRequired, &_populationAvailable);
+		fillPopulationRequirements(population, _populationRequired, _populationAvailable);
 
 		if (!population.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, _populationRequired[0]) ||
 			!population.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, _populationRequired[1]))

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -7,7 +7,7 @@
 #include "ProductPool.h"
 #include "IOHelper.h"
 #include "PopulationPool.h"
-
+#include "Map/Tile.h"
 #include "Things/Robots/Robot.h"
 #include "Things/Structures/Structures.h"
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -385,14 +385,14 @@ void StructureManager::dropAllStructures()
 /**
  * 
  */
-Tile* StructureManager::tileFromStructure(Structure* structure)
+Tile& StructureManager::tileFromStructure(Structure* structure)
 {
 	auto it = mStructureTileTable.find(structure);
 	if (it == mStructureTileTable.end())
 	{
 		throw std::runtime_error("Could not find tile for structure");
 	}
-	return it->second;
+	return *it->second;
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -388,8 +388,11 @@ void StructureManager::dropAllStructures()
 Tile* StructureManager::tileFromStructure(Structure* structure)
 {
 	auto it = mStructureTileTable.find(structure);
-	if (it != mStructureTileTable.end()) { return it->second; }
-	return nullptr;
+	if (it == mStructureTileTable.end())
+	{
+		throw std::runtime_error("Could not find tile for structure");
+	}
+	return it->second;
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -477,3 +477,9 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 	element->linkEndChild(structures);
 }
+
+
+bool StructureManager::structureConnected(Structure* st)
+{
+	return mStructureTileTable[st]->connected();
+}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -326,14 +326,13 @@ int StructureManager::count() const
 int StructureManager::getCountInState(Structure::StructureClass structureClass, StructureState state)
 {
 	int count = 0;
-	for (std::size_t i = 0; i < structureList(structureClass).size(); ++i)
+	for (const auto* structure : structureList(structureClass))
 	{
-		if (structureList(structureClass)[i]->state() == state)
+		if (structure->state() == state)
 		{
 			++count;
 		}
 	}
-
 	return count;
 }
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -18,10 +18,10 @@
 /**
  * Fills population requirements fields in a Structure.
  */
-static void fillPopulationRequirements(PopulationPool& _p, const PopulationRequirements& _populationRequired, PopulationRequirements& _populationAvailable)
+static void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
 {
-	_populationAvailable[0] = std::min(_populationRequired[0], _p.populationAvailable(Population::PersonRole::ROLE_WORKER));
-	_populationAvailable[1] = std::min(_populationRequired[1], _p.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));
+	available[0] = std::min(required[0], populationPool.populationAvailable(Population::PersonRole::ROLE_WORKER));
+	available[1] = std::min(required[1], populationPool.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -145,8 +145,8 @@ void StructureManager::updateStructures(StorableResources& resources, Population
 
 		fillPopulationRequirements(population, populationRequired, populationAvailable);
 
-		if (!population.enoughPopulationAvailable(Population::PersonRole::ROLE_WORKER, populationRequired[0]) ||
-			!population.enoughPopulationAvailable(Population::PersonRole::ROLE_SCIENTIST, populationRequired[1]))
+		if ((populationAvailable[0] < populationRequired[0]) ||
+			(populationAvailable[1] < populationRequired[1]))
 		{
 			structure->disable(DisabledReason::Population);
 			continue;

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -399,7 +399,7 @@ Tile& StructureManager::tileFromStructure(Structure* structure)
 /**
  * 
  */
-void serializeStructure(XmlElement* _ti, Structure* structure, Tile* _t)
+void serializeStructure(NAS2D::Xml::XmlElement* _ti, Structure* structure, Tile* _t)
 {
 	const auto position = _t->position();
 	_ti->attribute("x", position.x);
@@ -436,11 +436,11 @@ void serializeStructure(XmlElement* _ti, Structure* structure, Tile* _t)
  */
 void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 {
-	auto* structures = new XmlElement("structures");
+	auto* structures = new NAS2D::Xml::XmlElement("structures");
 
 	for (auto it = mStructureTileTable.begin(); it != mStructureTileTable.end(); ++it)
 	{
-		auto* structure = new XmlElement("structure");
+		auto* structure = new NAS2D::Xml::XmlElement("structure");
 		serializeStructure(structure, it->first, it->second);
 
 		if (it->first->isFactory())
@@ -451,14 +451,14 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 		if (it->first->isWarehouse())
 		{
-			auto* warehouse_products = new XmlElement("warehouse_products");
+			auto* warehouse_products = new NAS2D::Xml::XmlElement("warehouse_products");
 			static_cast<Warehouse*>(it->first)->products().serialize(warehouse_products);
 			structure->linkEndChild(warehouse_products);
 		}
 
 		if (it->first->isRobotCommand())
 		{
-			auto* robots = new XmlElement("robots");
+			auto* robots = new NAS2D::Xml::XmlElement("robots");
 
 			const RobotList& rl = static_cast<RobotCommand*>(it->first)->robots();
 
@@ -475,7 +475,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 		if (it->first->structureClass() == Structure::StructureClass::FoodProduction)
 		{
-			auto* food = new XmlElement("food");
+			auto* food = new NAS2D::Xml::XmlElement("food");
 			food->attribute("level", static_cast<FoodProduction*>(it->first)->foodLevel());
 			structure->linkEndChild(food);
 		}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -287,9 +287,9 @@ void StructureManager::removeStructure(Structure* structure)
 }
 
 
-StructureList& StructureManager::structureList(Structure::StructureClass st)
+StructureList& StructureManager::structureList(Structure::StructureClass structureClass)
 {
-	return mStructureLists[st];
+	return mStructureLists[structureClass];
 }
 
 
@@ -323,12 +323,12 @@ int StructureManager::count() const
 /**
  *
  */
-int StructureManager::getCountInState(Structure::StructureClass st, StructureState state)
+int StructureManager::getCountInState(Structure::StructureClass structureClass, StructureState state)
 {
 	int count = 0;
-	for (std::size_t i = 0; i < structureList(st).size(); ++i)
+	for (std::size_t i = 0; i < structureList(structureClass).size(); ++i)
 	{
-		if (structureList(st)[i]->state() == state)
+		if (structureList(structureClass)[i]->state() == state)
 		{
 			++count;
 		}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -287,6 +287,12 @@ void StructureManager::removeStructure(Structure* st)
 }
 
 
+StructureList& StructureManager::structureList(Structure::StructureClass st)
+{
+	return mStructureLists[st];
+}
+
+
 /**
  * Resets the 'connected' flag on all structures in the primary structure list.
  */

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -100,8 +100,8 @@ void StructureManager::updateEnergyProduction()
 		if (powerStructure->operational())
 		{
 			mTotalEnergyOutput += powerStructure->energyProduced();
+		}
 	}
-}
 }
 
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Things/Structures/Structure.h"
-#include "Map/Tile.h"
 
 
 namespace NAS2D {
@@ -10,6 +9,7 @@ namespace NAS2D {
 	}
 }
 
+class Tile;
 class PopulationPool;
 struct StorableResources;
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -22,9 +22,6 @@ struct StorableResources;
 class StructureManager
 {
 public:
-	StructureManager() = default;
-	~StructureManager() = default;
-
 	void addStructure(Structure* structure, Tile* tile);
 	void removeStructure(Structure* structure);
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -54,7 +54,7 @@ private:
 	void updateStructures(StorableResources&, PopulationPool&, StructureList&);
 	void updateFactoryProduction();
 
-	bool structureConnected(Structure* st) { return mStructureTileTable[st]->connected(); }
+	bool structureConnected(Structure* st);
 
 
 	StructureTileTable mStructureTileTable; /**< List mapping Structures to a particular tile. */

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -4,6 +4,12 @@
 #include "Map/Tile.h"
 
 
+namespace NAS2D {
+	namespace Xml {
+		class XmlElement;
+	}
+}
+
 class PopulationPool;
 struct StorableResources;
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -22,7 +22,7 @@ public:
 	void addStructure(Structure* st, Tile* t);
 	void removeStructure(Structure* st);
 
-	StructureList& structureList(Structure::StructureClass st) { return mStructureLists[st]; }
+	StructureList& structureList(Structure::StructureClass st);
 	Tile* tileFromStructure(Structure* st);
 
 	void disconnectAll();

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -19,7 +19,6 @@ public:
 	StructureManager() = default;
 	~StructureManager() = default;
 
-public:
 	void addStructure(Structure* st, Tile* t);
 	void removeStructure(Structure* st);
 
@@ -47,19 +46,17 @@ public:
 
 	void serialize(NAS2D::Xml::XmlElement* element);
 
-protected:
-
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;
 	using StructureClassTable = std::map<Structure::StructureClass, StructureList>;
 
-private:
+
 	void updateStructures(StorableResources&, PopulationPool&, StructureList&);
 	void updateFactoryProduction();
 
 	bool structureConnected(Structure* st) { return mStructureTileTable[st]->connected(); }
 
-private:
+
 	StructureTileTable mStructureTileTable; /**< List mapping Structures to a particular tile. */
 	StructureClassTable mStructureLists; /**< Map containing all of the structure list types available. */
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -29,7 +29,7 @@ public:
 	void removeStructure(Structure* structure);
 
 	StructureList& structureList(Structure::StructureClass structureClass);
-	Tile* tileFromStructure(Structure* structure);
+	Tile& tileFromStructure(Structure* structure);
 
 	void disconnectAll();
 	void dropAllStructures();

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -25,18 +25,18 @@ public:
 	StructureManager() = default;
 	~StructureManager() = default;
 
-	void addStructure(Structure* st, Tile* t);
-	void removeStructure(Structure* st);
+	void addStructure(Structure* structure, Tile* tile);
+	void removeStructure(Structure* structure);
 
-	StructureList& structureList(Structure::StructureClass st);
-	Tile* tileFromStructure(Structure* st);
+	StructureList& structureList(Structure::StructureClass structureClass);
+	Tile* tileFromStructure(Structure* structure);
 
 	void disconnectAll();
 	void dropAllStructures();
 
 	int count() const;
 
-	int getCountInState(Structure::StructureClass st, StructureState state);
+	int getCountInState(Structure::StructureClass structureClass, StructureState state);
 
 	int disabled();
 	int destroyed();
@@ -60,7 +60,7 @@ private:
 	void updateStructures(StorableResources&, PopulationPool&, StructureList&);
 	void updateFactoryProduction();
 
-	bool structureConnected(Structure* st);
+	bool structureConnected(Structure* structure);
 
 
 	StructureTileTable mStructureTileTable; /**< List mapping Structures to a particular tile. */


### PR DESCRIPTION
Reference: #138

The `cppclean` tool noted some possibility for forward declaration usage in `StructureManager`, which lead to some general refactoring.
