### PR TITLE
Remove unused includes

### DIFF
--- a/OPHD/GraphWalker.cpp
+++ b/OPHD/GraphWalker.cpp
@@ -5,6 +5,7 @@
 #include "DirectionOffset.h"
 
 #include "Map/TileMap.h"
+#include "Things/Structures/Structure.h"
 
 
 using namespace NAS2D;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -6,6 +6,7 @@
 #include "../Constants.h"
 #include "../DirectionOffset.h"
 #include "../Mine.h"
+#include "../Things/Structures/Structure.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -3,7 +3,6 @@
 #include "Tile.h"
 
 #include "../States/Planet.h"
-#include "../Things/Structures/Structure.h"
 #include "../MicroPather/micropather.h"
 
 #include <NAS2D/Renderer/Point.h>

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -6,8 +6,8 @@
 #include "MainMenuState.h"
 #include "MapViewState.h"
 #include "MainReportsUiState.h"
-
 #include "Wrapper.h"
+#include "../StructureManager.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/EventHandler.h>

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -3,6 +3,7 @@
 
 #include "MapViewState.h"
 #include "MainMenuState.h"
+#include "MainReportsUiState.h"
 
 #include "../Constants.h"
 #include "../DirectionOffset.h"

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -9,6 +9,7 @@
 #include "../Cache.h"
 #include "../GraphWalker.h"
 #include "../StructureCatalogue.h"
+#include "../StructureManager.h"
 
 #include "../Map/Tile.h"
 #include "../Map/TileMap.h"

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -9,13 +9,11 @@
 
 #include "../Common.h"
 #include "../Constants.h"
-
 #include "../PopulationPool.h"
 #include "../Population/Population.h"
-
 #include "../StorableResources.h"
-
 #include "../RobotPool.h"
+#include "../Things/Structures/Structure.h"
 
 #include "../UI/Gui.h"
 #include "../UI/UI.h"
@@ -34,7 +32,6 @@ namespace micropather {
 
 class Tile;
 class TileMap;
-class Structure;
 
 
 enum PointerType

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -26,6 +26,12 @@
 #include <memory>
 
 
+namespace NAS2D {
+	namespace Xml {
+		class XmlElement;
+	}
+}
+
 namespace micropather {
 	class MicroPather;
 }

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "MapViewStateHelper.h"
-#include "MainReportsUiState.h"
 #include "Wrapper.h"
 
 #include "Planet.h"

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -9,10 +9,10 @@
 
 #include "../Common.h"
 #include "../Constants.h"
-#include "../PopulationPool.h"
-#include "../Population/Population.h"
 #include "../StorableResources.h"
 #include "../RobotPool.h"
+#include "../PopulationPool.h"
+#include "../Population/Population.h"
 #include "../Things/Structures/Structure.h"
 
 #include "../UI/Gui.h"

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -9,8 +9,9 @@
 
 #include "../Constants.h"
 #include "../Cache.h"
-#include "../Map/TileMap.h"
 #include "../Mine.h"
+#include "../StructureManager.h"
+#include "../Map/TileMap.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -9,6 +9,7 @@
 
 #include "../DirectionOffset.h"
 #include "../StructureCatalogue.h"
+#include "../StructureManager.h"
 #include "../Map/TileMap.h"
 #include "../Things/Robots/Robots.h"
 #include "../Things/Structures/Structures.h"

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -14,6 +14,7 @@
 
 #include "../Constants.h"
 #include "../StructureCatalogue.h"
+#include "../StructureManager.h"
 #include "../DirectionOffset.h"
 #include "../RobotPool.h"
 #include "../Map/TileMap.h"

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../Common.h"
-#include "../StructureManager.h"
 
 
 namespace NAS2D {

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -19,10 +19,12 @@ namespace NAS2D {
 	}
 }
 
+class Tile;
 class TileMap;
 class Warehouse; /**< Forward declaration for getAvailableWarehouse() function. */
 class RobotCommand; /**< Forward declaration for getAvailableRobotCommand() function. */
 class RobotPool;
+class Robot;
 struct StorableResources;
 
 using RobotTileTable = std::map<Robot*, Tile*>;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -13,6 +13,7 @@
 #include "../Constants.h"
 #include "../IOHelper.h"
 #include "../StructureCatalogue.h"
+#include "../StructureManager.h"
 #include "../Map/TileMap.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -13,6 +13,7 @@
 
 #include "../Cache.h"
 #include "../StorableResources.h"
+#include "../StructureManager.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -15,6 +15,7 @@
 #include "../Constants.h"
 #include "../DirectionOffset.h"
 #include "../StructureCatalogue.h"
+#include "../StructureManager.h"
 #include "../Map/TileMap.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/Things/Structures/MineShaft.h
+++ b/OPHD/Things/Structures/MineShaft.h
@@ -4,7 +4,6 @@
 
 #include "../../Constants.h"
 
-#include "../../Mine.h"
 
 class MineShaft : public Structure
 {

--- a/OPHD/Things/Structures/SeedFactory.h
+++ b/OPHD/Things/Structures/SeedFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Structure.h"
 #include "Factory.h"
+
 
 class SeedFactory: public Factory
 {

--- a/OPHD/Things/Structures/SeedPower.h
+++ b/OPHD/Things/Structures/SeedPower.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "Structure.h"
 #include "../../Constants.h"
+
 #include <string>
+
 
 const int SEED_POWER_PRODUCTION = 50;
 

--- a/OPHD/Things/Structures/SurfaceFactory.h
+++ b/OPHD/Things/Structures/SurfaceFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Structure.h"
 #include "Factory.h"
+
 
 class SurfaceFactory: public Factory
 {

--- a/OPHD/Things/Structures/UndergroundFactory.h
+++ b/OPHD/Things/Structures/UndergroundFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Structure.h"
 #include "Factory.h"
+
 
 class UndergroundFactory: public Factory
 {


### PR DESCRIPTION
Reference: #138

Remove includes from header files that really didn't need to be there. Instead, they should generally be included from cpp files.
