### PR TITLE
Refactor ProductPool

### DIFF
--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -96,10 +96,11 @@ void ProductPool::transferAllTo(ProductPool& destination)
 	{
 		if (destination.availableStorage() == 0) { return; }
 
-		const bool canTransferAll = (destination.availableStorage() >= storageRequired(static_cast<ProductType>(i), mProducts[i]));
-		const int unitsToMove = canTransferAll ? mProducts[i] : destination.availableStorage() / storageRequiredPerUnit(static_cast<ProductType>(i));
-		destination.store(static_cast<ProductType>(i), unitsToMove);
-		pull(static_cast<ProductType>(i), unitsToMove);
+		const auto productType = static_cast<ProductType>(i);
+		const bool canTransferAll = (destination.availableStorage() >= storageRequired(productType, mProducts[i]));
+		const int unitsToMove = canTransferAll ? mProducts[i] : destination.availableStorage() / storageRequiredPerUnit(productType);
+		destination.store(productType, unitsToMove);
+		pull(productType, unitsToMove);
 	}
 }
 

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -10,7 +10,7 @@ namespace {
 	/**
 	 * Space required to store a Product.
 	 */
-	const std::map<ProductType, int> PRODUCT_STORAGE_VALUE =
+	const std::map<ProductType, int> productStorageSpace =
 	{
 		{ ProductType::PRODUCT_DIGGER, 10 },
 		{ ProductType::PRODUCT_DOZER, 10 },
@@ -31,7 +31,7 @@ namespace {
 	 */
 	inline int storageRequiredPerUnit(ProductType type)
 	{
-		return PRODUCT_STORAGE_VALUE.at(type);
+		return productStorageSpace.at(type);
 	}
 
 
@@ -40,7 +40,7 @@ namespace {
 	 */
 	inline int storageRequired(ProductType type, int count)
 	{
-		return PRODUCT_STORAGE_VALUE.at(type) * count;
+		return productStorageSpace.at(type) * count;
 	}
 
 

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -96,17 +96,10 @@ void ProductPool::transferAllTo(ProductPool& destination)
 	{
 		if (destination.availableStorage() == 0) { return; }
 
-		if (destination.availableStorage() >= storageRequired(static_cast<ProductType>(i), mProducts[i]))
-		{
-			destination.store(static_cast<ProductType>(i), mProducts[i]);
-			pull(static_cast<ProductType>(i), mProducts[i]);
-		}
-		else
-		{
-			int units_to_move = destination.availableStorage() / storageRequiredPerUnit(static_cast<ProductType>(i));
-			destination.store(static_cast<ProductType>(i), units_to_move);
-			pull(static_cast<ProductType>(i), units_to_move);
-		}
+		const bool canTransferAll = (destination.availableStorage() >= storageRequired(static_cast<ProductType>(i), mProducts[i]));
+		const int unitsToMove = canTransferAll ? mProducts[i] : destination.availableStorage() / storageRequiredPerUnit(static_cast<ProductType>(i));
+		destination.store(static_cast<ProductType>(i), unitsToMove);
+		pull(static_cast<ProductType>(i), unitsToMove);
 	}
 }
 

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -6,54 +6,53 @@
 #include <algorithm>
 
 
-/**
- * Space required to store a Product.
- */
-const std::map<ProductType, int> PRODUCT_STORAGE_VALUE =
-{
-	{ ProductType::PRODUCT_DIGGER, 10 },
-	{ ProductType::PRODUCT_DOZER, 10 },
-	{ ProductType::PRODUCT_MINER, 10 },
-	{ ProductType::PRODUCT_EXPLORER, 10 },
-	{ ProductType::PRODUCT_TRUCK, 10 },
-
-	{ ProductType::PRODUCT_ROAD_MATERIALS, 1 },
-	{ ProductType::PRODUCT_MAINTENANCE_PARTS, 1 },
-
-	{ ProductType::PRODUCT_CLOTHING, 1 },
-	{ ProductType::PRODUCT_MEDICINE, 1 }
-};
-
-
-/**
- * Gets the amount of storage required for one unit of a Product.
- */
-inline int storageRequiredPerUnit(ProductType type)
-{
-	return PRODUCT_STORAGE_VALUE.at(type);
-}
-
-
-/**
- * Gets the amount of storage required for a given number of Products.
- */
-inline int storageRequired(ProductType type, int count)
-{
-	return PRODUCT_STORAGE_VALUE.at(type) * count;
-}
-
-
-/**
- * Internal helper function.
- */
-static int computeCurrentStorage(const ProductPool::ProductTypeCount& products)
-{
-	int stored = 0;
-	for (std::size_t i = 0; i < static_cast<std::size_t>(ProductType::PRODUCT_COUNT); ++i)
+namespace {
+	/**
+	 * Space required to store a Product.
+	 */
+	const std::map<ProductType, int> PRODUCT_STORAGE_VALUE =
 	{
-		stored += storageRequired(static_cast<ProductType>(i), products[i]);
+		{ ProductType::PRODUCT_DIGGER, 10 },
+		{ ProductType::PRODUCT_DOZER, 10 },
+		{ ProductType::PRODUCT_MINER, 10 },
+		{ ProductType::PRODUCT_EXPLORER, 10 },
+		{ ProductType::PRODUCT_TRUCK, 10 },
+
+		{ ProductType::PRODUCT_ROAD_MATERIALS, 1 },
+		{ ProductType::PRODUCT_MAINTENANCE_PARTS, 1 },
+
+		{ ProductType::PRODUCT_CLOTHING, 1 },
+		{ ProductType::PRODUCT_MEDICINE, 1 }
+	};
+
+
+	/**
+	 * Gets the amount of storage required for one unit of a Product.
+	 */
+	inline int storageRequiredPerUnit(ProductType type)
+	{
+		return PRODUCT_STORAGE_VALUE.at(type);
 	}
-	return stored;
+
+
+	/**
+	 * Gets the amount of storage required for a given number of Products.
+	 */
+	inline int storageRequired(ProductType type, int count)
+	{
+		return PRODUCT_STORAGE_VALUE.at(type) * count;
+	}
+
+
+	int computeCurrentStorage(const ProductPool::ProductTypeCount& products)
+	{
+		int stored = 0;
+		for (std::size_t i = 0; i < static_cast<std::size_t>(ProductType::PRODUCT_COUNT); ++i)
+		{
+			stored += storageRequired(static_cast<ProductType>(i), products[i]);
+		}
+		return stored;
+	}
 }
 
 

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -87,6 +87,30 @@ bool ProductPool::atCapacity() const
 }
 
 
+// Attempts to transfer all or partial storage to another pool
+void ProductPool::transferAllTo(ProductPool& destination)
+{
+	if (empty() || destination.atCapacity()) { return; }
+
+	for (std::size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
+	{
+		if (destination.availableStorage() == 0) { return; }
+
+		if (destination.availableStorage() >= storageRequired(static_cast<ProductType>(i), mProducts[i]))
+		{
+			destination.store(static_cast<ProductType>(i), mProducts[i]);
+			pull(static_cast<ProductType>(i), mProducts[i]);
+		}
+		else
+		{
+			int units_to_move = destination.availableStorage() / storageRequiredPerUnit(static_cast<ProductType>(i));
+			destination.store(static_cast<ProductType>(i), units_to_move);
+			pull(static_cast<ProductType>(i), units_to_move);
+		}
+	}
+}
+
+
 /**
  * Stores a specified amount of a ProductType.
  * 

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -2,7 +2,6 @@
 
 #include "Common.h"
 #include "Constants.h"
-#include "Templates.h"
 
 #include <NAS2D/Xml/XmlElement.h>
 

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -8,10 +8,6 @@
 #include <array>
 
 
-int storageRequired(ProductType type, int count);
-int storageRequiredPerUnit(ProductType type);
-
-
 class ProductPool
 {
 public:

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -43,9 +43,6 @@ public:
 	void verifyCount();
 
 private:
-	friend void transferProductsPool(ProductPool&, ProductPool&);
-
-
 	ProductTypeCount mProducts = {{ 0 }};
 
 	int mCapacity = constants::BASE_PRODUCT_CAPACITY;

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -9,6 +9,10 @@
 #include <array>
 
 
+int storageRequired(ProductType type, int count);
+int storageRequiredPerUnit(ProductType type);
+
+
 class ProductPool
 {
 public:

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -30,6 +30,7 @@ public:
 	bool empty() const;
 	bool atCapacity() const;
 
+	void transferAllTo(ProductPool& destination);
 	void store(ProductType type, int count);
 	int pull(ProductType type, int count);
 	int count(ProductType type);

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -40,8 +40,6 @@ public:
 	void verifyCount();
 
 private:
-	template <class T>
-	friend void transferProductsStructure(T&, T&);
 	friend void transferProductsPool(ProductPool&, ProductPool&);
 
 private:

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -17,14 +17,13 @@ class ProductPool
 public:
 	using ProductTypeCount = std::array<int, ProductType::PRODUCT_COUNT>;
 
-public:
+
 	ProductPool() = default;
 	~ProductPool() = default;
 
 	ProductPool(const ProductPool&) = default;
 	ProductPool& operator=(const ProductPool&) = default;
 
-public:
 	int capacity() const;
 
 	bool canStore(ProductType type, int count);
@@ -45,7 +44,7 @@ public:
 private:
 	friend void transferProductsPool(ProductPool&, ProductPool&);
 
-private:
+
 	ProductTypeCount mProducts = {{ 0 }};
 
 	int mCapacity = constants::BASE_PRODUCT_CAPACITY;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -451,7 +451,7 @@ void moveProducts(Warehouse* sourceWarehouse)
 			Warehouse* warehouse = static_cast<Warehouse*>(structure);
 			if (warehouse != sourceWarehouse)
 			{
-				transferProductsStructure(sourceWarehouse, warehouse);
+				transferProductsPool(sourceWarehouse->products(), warehouse->products());
 			}
 		}
 	}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -420,7 +420,7 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
 			if (warehouse != sourceWarehouse)
 			{
 				ProductPool destinationPool = warehouse->products();
-				transferProductsPool(sourcePool, destinationPool);
+				sourcePool.transferAllTo(destinationPool);
 				if (sourcePool.empty())
 				{
 					return true;
@@ -451,7 +451,7 @@ void moveProducts(Warehouse* sourceWarehouse)
 			Warehouse* warehouse = static_cast<Warehouse*>(structure);
 			if (warehouse != sourceWarehouse)
 			{
-				transferProductsPool(sourceWarehouse->products(), warehouse->products());
+				sourceWarehouse->products().transferAllTo(warehouse->products());
 			}
 		}
 	}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -412,7 +412,7 @@ void transferProductsPool(ProductPool& source, ProductPool& destination)
  */
 bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
-	ProductPool _pool = sourceWarehouse->products();
+	ProductPool sourcePool = sourceWarehouse->products();
 
 	/** \fixme	This is a brute force approach. It works but it's not elegant. */
 	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
@@ -423,13 +423,13 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
 			Warehouse* warehouse = static_cast<Warehouse*>(structure);
 			if (warehouse != sourceWarehouse)
 			{
-				ProductPool _tfrPool = warehouse->products();
-				transferProductsPool(_pool, _tfrPool);
+				ProductPool destinationPool = warehouse->products();
+				transferProductsPool(sourcePool, destinationPool);
 			}
 		}
 	}
 
-	if (!_pool.empty()) { return doYesNoMessage(constants::PRODUCT_TRANSFER_TITLE, constants::PRODUCT_TRANSFER_MESSAGE); }
+	if (!sourcePool.empty()) { return doYesNoMessage(constants::PRODUCT_TRANSFER_TITLE, constants::PRODUCT_TRANSFER_MESSAGE); }
 
 	return true;
 }

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -425,9 +425,12 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
 		}
 	}
 
-	if (!sourcePool.empty()) { return doYesNoMessage(constants::PRODUCT_TRANSFER_TITLE, constants::PRODUCT_TRANSFER_MESSAGE); }
+	if (sourcePool.empty())
+	{
+		return true;
+	}
 
-	return true;
+	return doYesNoMessage(constants::PRODUCT_TRANSFER_TITLE, constants::PRODUCT_TRANSFER_MESSAGE);
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -410,9 +410,9 @@ void transferProductsPool(ProductPool& source, ProductPool& destination)
  * \return	True if all products can be moved or if the user selects "yes"
  *			if bulldozing will result in lost products.
  */
-bool simulateMoveProducts(Warehouse* wh)
+bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
-	ProductPool _pool = wh->products();
+	ProductPool _pool = sourceWarehouse->products();
 
 	/** \fixme	This is a brute force approach. It works but it's not elegant. */
 	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
@@ -421,7 +421,7 @@ bool simulateMoveProducts(Warehouse* wh)
 		if (structure->operational())
 		{
 			Warehouse* warehouse = static_cast<Warehouse*>(structure);
-			if (warehouse != wh)
+			if (warehouse != sourceWarehouse)
 			{
 				ProductPool _tfrPool = warehouse->products();
 				transferProductsPool(_pool, _tfrPool);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -373,34 +373,6 @@ RobotCommand* getAvailableRobotCommand()
 
 
 /**
- * Used in the product move simulation. Very brute force.
- */
-void transferProductsPool(ProductPool& source, ProductPool& destination)
-{
-	if (source.empty() || destination.atCapacity()) { return; }
-
-	auto& src = source.mProducts;
-
-	for (std::size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
-	{
-		if (destination.availableStorage() == 0) { return; }
-
-		if (destination.availableStorage() >= storageRequired(static_cast<ProductType>(i), src[i]))
-		{
-			destination.store(static_cast<ProductType>(i), src[i]);
-			source.pull(static_cast<ProductType>(i), src[i]);
-		}
-		else
-		{
-			int units_to_move = destination.availableStorage() / storageRequiredPerUnit(static_cast<ProductType>(i));
-			destination.store(static_cast<ProductType>(i), units_to_move);
-			source.pull(static_cast<ProductType>(i), units_to_move);
-		}
-	}
-}
-
-
-/**
  * Simulates moving the products out of a specified warehouse and raises
  * an alert to the user if not all products can be moved out of the
  * warehouse.

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -421,6 +421,10 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
 			{
 				ProductPool destinationPool = warehouse->products();
 				transferProductsPool(sourcePool, destinationPool);
+				if (sourcePool.empty())
+				{
+					return true;
+				}
 			}
 		}
 	}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -438,7 +438,7 @@ bool simulateMoveProducts(Warehouse* wh)
 /**
  * Attempts to move all products from a Warehouse into any remaining warehouses.
  */
-void moveProducts(Warehouse* wh)
+void moveProducts(Warehouse* sourceWarehouse)
 {
 	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
 	for (auto structure : structures)
@@ -446,9 +446,9 @@ void moveProducts(Warehouse* wh)
 		if (structure->operational())
 		{
 			Warehouse* warehouse = static_cast<Warehouse*>(structure);
-			if (warehouse != wh)
+			if (warehouse != sourceWarehouse)
 			{
-				transferProductsStructure(wh, warehouse);
+				transferProductsStructure(sourceWarehouse, warehouse);
 			}
 		}
 	}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -400,8 +400,6 @@ void transferProductsPool(ProductPool& source, ProductPool& destination)
 }
 
 
-
-
 /**
  * Simulates moving the products out of a specified warehouse and raises
  * an alert to the user if not all products can be moved out of the

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -411,8 +411,6 @@ void transferProductsPool(ProductPool& source, ProductPool& destination)
 bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
 	ProductPool sourcePool = sourceWarehouse->products();
-
-	/** \fixme	This is a brute force approach. It works but it's not elegant. */
 	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
 	for (auto structure : structures)
 	{

--- a/OPHD/Templates.h
+++ b/OPHD/Templates.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#include "Constants.h"
-

--- a/OPHD/Templates.h
+++ b/OPHD/Templates.h
@@ -4,35 +4,3 @@
 
 int storageRequired(ProductType type, int count);
 int storageRequiredPerUnit(ProductType type);
-
-/**
- * Transfers products from source to destination.
- * 
- * \note	Expects that the source/destination have an interface to
- *			ProductPool& products();
- */
-template <class T>
-void transferProductsStructure(T& source, T& destination)
-{
-	if (source->products().empty() || destination->products().atCapacity()) { return; }
-
-	auto& src = source->products().mProducts;
-	auto& dest = destination->products();
-
-	for (std::size_t i = 0; i < ProductType::PRODUCT_COUNT; ++i)
-	{
-		if (dest.availableStorage() == 0) { return; }
-
-		if (dest.availableStorage() >= storageRequired(static_cast<ProductType>(i), src[i]))
-		{
-			dest.store(static_cast<ProductType>(i), src[i]);
-			source->products().pull(static_cast<ProductType>(i), src[i]);
-		}
-		else
-		{
-			int units_to_move = dest.availableStorage() / storageRequiredPerUnit(static_cast<ProductType>(i));
-			dest.store(static_cast<ProductType>(i), units_to_move);
-			source->products().pull(static_cast<ProductType>(i), units_to_move);
-		}
-	}
-}

--- a/OPHD/Templates.h
+++ b/OPHD/Templates.h
@@ -2,5 +2,3 @@
 
 #include "Constants.h"
 
-int storageRequired(ProductType type, int count);
-int storageRequiredPerUnit(ProductType type);

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -353,7 +353,6 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="States\Wrapper.h" />
     <ClInclude Include="StructureCatalogue.h" />
     <ClInclude Include="StructureManager.h" />
-    <ClInclude Include="Templates.h" />
     <ClInclude Include="Things\Robots\Robodigger.h" />
     <ClInclude Include="Things\Robots\Robodozer.h" />
     <ClInclude Include="Things\Robots\Robominer.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -548,9 +548,6 @@
     <ClInclude Include="UI\MineOperationsWindow.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
-    <ClInclude Include="Templates.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="States\Wrapper.h">
       <Filter>Header Files\States</Filter>
     </ClInclude>


### PR DESCRIPTION
Reference: #138

Cleans up function "not found in expected header" messages shown by `cppclean`. This was solved by wrapping helper methods in an unnamed namespace. A bit of refactoring to make methods private was needed before this could be done.
