### PR TITLE
Refactor RobotCommand

### DIFF
--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -11,16 +11,11 @@
 int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
 
 
-/**
- * C'tor
- */
 RobotPool::RobotPool()
 {}
 
 
 /**
- * D'tor.
- * 
  * Frees all resources from the robot pool so this class should be
  * freed after all pointers to robots attained from the pool have been
  * released.
@@ -31,9 +26,6 @@ RobotPool::~RobotPool()
 }
 
 
-/**
- * 
- */
 void RobotPool::clear()
 {
 	clearRobots(mDiggers);
@@ -197,9 +189,6 @@ void RobotPool::InitRobotCtrl(uint32_t maxRobotCtrl)
 }
 
 
-/**
- * 
- */
 void RobotPool::AddRobotCtrl()
 {
 	if (mRobotControlMax > mRobotControlCount)
@@ -209,9 +198,6 @@ void RobotPool::AddRobotCtrl()
 }
 
 
-/**
- * 
- */
 bool RobotPool::insertRobotIntoTable(RobotTileTable& robotMap, Robot* robot, Tile* tile)
 {
 	if (!tile) { return false; }

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -7,7 +7,8 @@
 
 #include <algorithm>
 
-extern int ROBOT_ID_COUNTER; /// \fixme	Kludge
+
+int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
 
 
 /**

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -150,9 +150,6 @@ bool RobotPool::robotAvailable(RobotType type)
 }
 
 
-/**
- * 
- */
 int RobotPool::getAvailableCount(RobotType type)
 {
 	switch (type)
@@ -172,9 +169,6 @@ int RobotPool::getAvailableCount(RobotType type)
 }
 
 
-/**
- * 
- */
 void RobotPool::InitRobotCtrl(uint32_t maxRobotCtrl)
 {
 	mRobotControlMax = maxRobotCtrl;

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -95,8 +95,7 @@ Robot* RobotPool::addRobot(RobotType type, int id /*= 0*/)
  */
 Robodigger* RobotPool::getDigger()
 {
-	Robodigger* _r = static_cast<Robodigger*>(getRobot(mDiggers));
-	return _r;
+	return static_cast<Robodigger*>(getRobot(mDiggers));
 }
 
 
@@ -107,8 +106,7 @@ Robodigger* RobotPool::getDigger()
  */
 Robodozer* RobotPool::getDozer()
 {
-	Robodozer* _r = static_cast<Robodozer*>(getRobot(mDozers));
-	return _r;
+	return static_cast<Robodozer*>(getRobot(mDozers));
 }
 
 
@@ -119,8 +117,7 @@ Robodozer* RobotPool::getDozer()
  */
 Robominer* RobotPool::getMiner()
 {
-	Robominer* _r = static_cast<Robominer*>(getRobot(mMiners));
-	return _r;
+	return static_cast<Robominer*>(getRobot(mMiners));
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -39,8 +39,6 @@ const std::string MAP_DISPLAY_EXTENSION = "_b.png";
 extern Point<int> MOUSE_COORDS;
 
 
-int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
-
 Rectangle<int> RESOURCE_PANEL_PIN{0, 1, 8, 19};
 Rectangle<int> POPULATION_PANEL_PIN{675, 1, 8, 19};
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -30,9 +30,6 @@ using namespace NAS2D;
 using namespace NAS2D::Xml;
 
 
-extern int ROBOT_ID_COUNTER; /// \fixme Kludge
-
-
 const NAS2D::Point<int> CcNotPlaced{-1, -1};
 static Point<int> commandCenterLocation = CcNotPlaced;
 
@@ -486,7 +483,6 @@ void checkRobotDeployment(XmlElement* _ti, RobotTileTable& _rm, Robot* _r, Robot
 void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTileTable& robotMap)
 {
 	XmlElement* robots = new XmlElement("robots");
-	robots->attribute("id_counter", ROBOT_ID_COUNTER);
 
 	RobotPool::DiggerList& diggers = robotPool.diggers();
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -225,7 +225,7 @@ bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position)
  */
 void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt, Tile* /*tile*/)
 {
-	if (rcc->commandedByThis(robotToDelete))
+	if (rcc->isControlling(robotToDelete))
 	{
 		std::cout << "Cannot bulldoze Robot Command Center by a Robot under its command." << std::endl;
 		return;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -261,11 +261,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 	mRobotList.clear();
 	mRobots.dropAllItems();
 
-	/**
-	 * \fixme	This is fragile and prone to break if the savegame file is malformed.
-	 */
-	element->firstAttribute()->queryIntValue(ROBOT_ID_COUNTER);
-
+	ROBOT_ID_COUNTER = 0;
 	int id = 0, type = 0, age = 0, production_time = 0, x = 0, y = 0, depth = 0, direction = 0;
 	XmlAttribute* attribute = nullptr;
 	for (XmlNode* robotNode = element->firstChild(); robotNode; robotNode = robotNode->nextSibling())
@@ -285,6 +281,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 
 			attribute = attribute->next();
 		}
+		ROBOT_ID_COUNTER = std::max(ROBOT_ID_COUNTER, id);
 
 		Robot* robot = nullptr;
 		switch (static_cast<RobotType>(type))

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -419,20 +419,20 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 	for (auto it = mStructureTileTable.begin(); it != mStructureTileTable.end(); ++it)
 	{
-		auto* structure = new NAS2D::Xml::XmlElement("structure");
-		serializeStructure(structure, it->first, it->second);
+		auto* structureElement = new NAS2D::Xml::XmlElement("structure");
+		serializeStructure(structureElement, it->first, it->second);
 
 		if (it->first->isFactory())
 		{
-			structure->attribute("production_completed", static_cast<Factory*>(it->first)->productionTurnsCompleted());
-			structure->attribute("production_type", static_cast<Factory*>(it->first)->productType());
+			structureElement->attribute("production_completed", static_cast<Factory*>(it->first)->productionTurnsCompleted());
+			structureElement->attribute("production_type", static_cast<Factory*>(it->first)->productType());
 		}
 
 		if (it->first->isWarehouse())
 		{
 			auto* warehouse_products = new NAS2D::Xml::XmlElement("warehouse_products");
 			static_cast<Warehouse*>(it->first)->products().serialize(warehouse_products);
-			structure->linkEndChild(warehouse_products);
+			structureElement->linkEndChild(warehouse_products);
 		}
 
 		if (it->first->isRobotCommand())
@@ -449,17 +449,17 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 			}
 
 			robotsElement->attribute("robots", str.str());
-			structure->linkEndChild(robotsElement);
+			structureElement->linkEndChild(robotsElement);
 		}
 
 		if (it->first->structureClass() == Structure::StructureClass::FoodProduction)
 		{
 			auto* food = new NAS2D::Xml::XmlElement("food");
 			food->attribute("level", static_cast<FoodProduction*>(it->first)->foodLevel());
-			structure->linkEndChild(food);
+			structureElement->linkEndChild(food);
 		}
 
-		structures->linkEndChild(structure);
+		structures->linkEndChild(structureElement);
 	}
 
 	element->linkEndChild(structures);

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -439,13 +439,13 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 		{
 			auto* robotsElement = new NAS2D::Xml::XmlElement("robots");
 
-			const RobotList& rl = static_cast<RobotCommand*>(it->first)->robots();
+			const RobotList& robots = static_cast<RobotCommand*>(it->first)->robots();
 
 			std::stringstream str;
-			for (std::size_t i = 0; i < rl.size(); ++i)
+			for (std::size_t i = 0; i < robots.size(); ++i)
 			{
-				str << rl[i]->id();
-				if (i != rl.size() - 1) { str << ","; } // kind of a kludge
+				str << robots[i]->id();
+				if (i != robots.size() - 1) { str << ","; } // kind of a kludge
 			}
 
 			robotsElement->attribute("robots", str.str());

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -437,7 +437,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 		if (it->first->isRobotCommand())
 		{
-			auto* robots = new NAS2D::Xml::XmlElement("robots");
+			auto* robotsElement = new NAS2D::Xml::XmlElement("robots");
 
 			const RobotList& rl = static_cast<RobotCommand*>(it->first)->robots();
 
@@ -448,8 +448,8 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 				if (i != rl.size() - 1) { str << ","; } // kind of a kludge
 			}
 
-			robots->attribute("robots", str.str());
-			structure->linkEndChild(robots);
+			robotsElement->attribute("robots", str.str());
+			structure->linkEndChild(robotsElement);
 		}
 
 		if (it->first->structureClass() == Structure::StructureClass::FoodProduction)

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -417,29 +417,29 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 {
 	auto* structures = new NAS2D::Xml::XmlElement("structures");
 
-	for (auto it = mStructureTileTable.begin(); it != mStructureTileTable.end(); ++it)
+	for (auto& [structure, tile] : mStructureTileTable)
 	{
 		auto* structureElement = new NAS2D::Xml::XmlElement("structure");
-		serializeStructure(structureElement, it->first, it->second);
+		serializeStructure(structureElement, structure, tile);
 
-		if (it->first->isFactory())
+		if (structure->isFactory())
 		{
-			structureElement->attribute("production_completed", static_cast<Factory*>(it->first)->productionTurnsCompleted());
-			structureElement->attribute("production_type", static_cast<Factory*>(it->first)->productType());
+			structureElement->attribute("production_completed", static_cast<Factory*>(structure)->productionTurnsCompleted());
+			structureElement->attribute("production_type", static_cast<Factory*>(structure)->productType());
 		}
 
-		if (it->first->isWarehouse())
+		if (structure->isWarehouse())
 		{
 			auto* warehouse_products = new NAS2D::Xml::XmlElement("warehouse_products");
-			static_cast<Warehouse*>(it->first)->products().serialize(warehouse_products);
+			static_cast<Warehouse*>(structure)->products().serialize(warehouse_products);
 			structureElement->linkEndChild(warehouse_products);
 		}
 
-		if (it->first->isRobotCommand())
+		if (structure->isRobotCommand())
 		{
 			auto* robotsElement = new NAS2D::Xml::XmlElement("robots");
 
-			const auto& robots = static_cast<RobotCommand*>(it->first)->robots();
+			const auto& robots = static_cast<RobotCommand*>(structure)->robots();
 
 			std::stringstream str;
 			for (std::size_t i = 0; i < robots.size(); ++i)
@@ -452,10 +452,10 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 			structureElement->linkEndChild(robotsElement);
 		}
 
-		if (it->first->structureClass() == Structure::StructureClass::FoodProduction)
+		if (structure->structureClass() == Structure::StructureClass::FoodProduction)
 		{
 			auto* food = new NAS2D::Xml::XmlElement("food");
-			food->attribute("level", static_cast<FoodProduction*>(it->first)->foodLevel());
+			food->attribute("level", static_cast<FoodProduction*>(structure)->foodLevel());
 			structureElement->linkEndChild(food);
 		}
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -439,7 +439,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 		{
 			auto* robotsElement = new NAS2D::Xml::XmlElement("robots");
 
-			const RobotList& robots = static_cast<RobotCommand*>(it->first)->robots();
+			const auto& robots = static_cast<RobotCommand*>(it->first)->robots();
 
 			std::stringstream str;
 			for (std::size_t i = 0; i < robots.size(); ++i)

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -21,7 +21,7 @@ bool RobotCommand::commandCapacityAvailable() const
 /**
  * \param	robot	Pointer to a Robot.
  */
-bool RobotCommand::commandedByThis(Robot* robot) const
+bool RobotCommand::isControlling(Robot* robot) const
 {
 	return find(mRobotList.begin(), mRobotList.end(), robot) != mRobotList.end();
 }
@@ -42,7 +42,7 @@ void RobotCommand::addRobot(Robot* robot)
 		throw std::runtime_error("RobotCommand::addRobot(): Facility is already at capacity.");
 	}
 
-	if (commandedByThis(robot))
+	if (isControlling(robot))
 	{
 		std::cout << "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. CURRENT ID: " << ROBOT_ID_COUNTER << std::endl;
 		std::cout << "RCC:ADD: _r addr: " << robot << " name: " << robot->name() << " id: " << robot->id() << std::endl;

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -45,7 +45,7 @@ void RobotCommand::addRobot(Robot* robot)
 
 	if (isControlling(robot))
 	{
-		const auto message = "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name() + " ID: " + std::to_string(robot->id());
+		const auto message = "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name();
 		std::cout << message << std::endl;
 		throw std::runtime_error(message);
 	}

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -63,15 +63,13 @@ void RobotCommand::removeRobot(Robot* robot)
 {
 	if (mRobotList.empty())
 	{
-		//throw std::runtime_error("RobotCommand::removeRobot(): Robot list empty.");
-		return;
+		throw std::runtime_error("RobotCommand::removeRobot(): Robot list empty.");
 	}
 
 	auto iter = find(mRobotList.begin(), mRobotList.end(), robot);
 	if (iter == mRobotList.end())
 	{
-		//throw std::runtime_error("RobotCommand::removeRobot(): Removing a robot that is not under the command of this Robot Command Facility.");
-		return;
+		throw std::runtime_error("RobotCommand::removeRobot(): Removing a robot that is not under the command of this Robot Command Facility.");
 	}
 
 	mRobotList.erase(iter);

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -10,8 +10,6 @@
 #include <algorithm>
 
 
-extern int ROBOT_ID_COUNTER; /// \fixme Kludge
-
 /**
  * Gets whether the command facility has additional command capacity remaining.
  */

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -67,12 +67,12 @@ void RobotCommand::removeRobot(Robot* robot)
 		return;
 	}
 
-	auto _it = find(mRobotList.begin(), mRobotList.end(), robot);
-	if (_it == mRobotList.end())
+	auto iter = find(mRobotList.begin(), mRobotList.end(), robot);
+	if (iter == mRobotList.end())
 	{
 		//throw std::runtime_error("RobotCommand::removeRobot(): Removing a robot that is not under the command of this Robot Command Facility.");
 		return;
 	}
 
-	mRobotList.erase(_it);
+	mRobotList.erase(iter);
 }

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -47,9 +47,9 @@ void RobotCommand::addRobot(Robot* robot)
 
 	if (isControlling(robot))
 	{
-		std::cout << "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. CURRENT ID: " << ROBOT_ID_COUNTER << std::endl;
-		std::cout << "RCC:ADD: _r addr: " << robot << " name: " << robot->name() << " id: " << robot->id() << std::endl;
-		throw std::runtime_error("RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name() + " ID: " + std::to_string(robot->id()));
+		const auto message = "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name() + " ID: " + std::to_string(robot->id());
+		std::cout << message << std::endl;
+		throw std::runtime_error(message);
 	}
 
 	mRobotList.push_back(robot);

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -5,7 +5,10 @@
 #include "../Robots/Robot.h"
 #include "../../Constants.h"
 
+#include <string>
+#include <stdexcept>
 #include <algorithm>
+
 
 extern int ROBOT_ID_COUNTER; /// \fixme Kludge
 
@@ -46,9 +49,7 @@ void RobotCommand::addRobot(Robot* robot)
 	{
 		std::cout << "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. CURRENT ID: " << ROBOT_ID_COUNTER << std::endl;
 		std::cout << "RCC:ADD: _r addr: " << robot << " name: " << robot->name() << " id: " << robot->id() << std::endl;
-		doAlertMessage("Invalid Robot Command", "Robot Command Center: Requested add of a robot already commanded by this RCC. Please submit log to developer and any steps to reproduce.");
-		return;
-		//throw std::runtime_error("RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility.");
+		throw std::runtime_error("RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name() + " ID: " + std::to_string(robot->id()));
 	}
 
 	mRobotList.push_back(robot);

--- a/OPHD/Things/Structures/RobotCommand.h
+++ b/OPHD/Things/Structures/RobotCommand.h
@@ -26,7 +26,7 @@ public:
 		requiresCHAP(false);
 	}
 
-	bool commandedByThis(Robot* robot) const;
+	bool isControlling(Robot* robot) const;
 
 	bool commandCapacityAvailable() const;
 	void addRobot(Robot* robot);


### PR DESCRIPTION
Reference: #138

Reduce use of global data `ROBOT_ID_COUNTER`, listed by `cppclean`.

This global can potentially be removed in the future. Internally the game links up robots and robot command structures using pointers. As pointers don't have much meaning when stored to data files, an ID based scheme is used instead. Potentially these IDs can be generated when saving, and then used and discarded during loading. Currently though, the `Robot` instances all store a long term ID value, using the global to keep track of the next available ID.

Potentially we can reduce extra data structures by putting the ID on the robot command structure instead. There is a many-to-one relationship between robots and robot command structures, so having the robots reference the robot command structure would allow a single field on each `Robot` to reference the robot command. There would be no need for additional parallel array structures to hold the mapping.
