### PR TITLE
Inline StringList use in FileIo

### DIFF
--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -128,13 +128,13 @@ void FileIo::scanDirectory(const std::string& directory)
 
 	mListBox.dropAllItems();
 
-	for (std::size_t i = 0; i < dirList.size(); ++i)
+	for (auto& dir : dirList)
 	{
-		if (!f.isDirectory(directory + dirList[i]))
+		if (!f.isDirectory(directory + dir))
 		{
 			// FixMe: Naive approach: Assumes a file save extension of 3 characters.
-			dirList[i].resize(dirList[i].size() - 4);
-			mListBox.addItem(dirList[i]);
+			dir.resize(dir.size() - 4);
+			mListBox.addItem(dir);
 		}
 	}
 	mListBox.sort();

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -9,6 +9,9 @@
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/MathUtils.h>
 
+#include <string>
+#include <vector>
+
 
 using namespace NAS2D;
 
@@ -121,7 +124,7 @@ void FileIo::setMode(FileOperation fileOp)
 void FileIo::scanDirectory(const std::string& directory)
 {
 	Filesystem& f = Utility<Filesystem>::get();
-	StringList dirList = f.directoryList(directory);
+	std::vector<std::string> dirList = f.directoryList(directory);
 
 	mListBox.dropAllItems();
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -184,7 +184,7 @@ void FileIo::btnCloseClicked()
  */
 void FileIo::btnFileIoClicked()
 {
-	mCallback(txtFileName.text() , mMode);
+	mCallback(txtFileName.text(), mMode);
 	txtFileName.text("");
 	txtFileName.resetCursorPosition();
 	btnFileOp.enabled(false);


### PR DESCRIPTION
While cleaning up NAS2D headers, I noticed `FileIo` didn't properly include the header for `StringList`. I opted to inline the use of that type alias, rather than add the include.

Note that including the header for `StringList` would necessarily mean transitively including the headers for `<string>` and `<vector>`.

Reference: https://github.com/lairworks/nas2d-core/pull/801
