### PR TITLE
Update CircleCI build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,21 +19,21 @@ jobs:
       - build
   build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc:1.2
+      - image: outpostuniverse/nas2d-gcc:1.3
     environment:
       WARN_EXTRA: -Wsuggest-override
     steps:
       - build
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.1
+      - image: outpostuniverse/nas2d-clang:1.2
     environment:
       WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
       - build
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.5
+      - image: outpostuniverse/nas2d-mingw:1.6
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/


### PR DESCRIPTION
Closes #718

Note: The submodule update brings in dropping support for old style config files for the `options` element.
