### PR TITLE
Merge init to constructor

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -10,27 +10,6 @@ using namespace NAS2D;
 
 ComboBox::ComboBox()
 {
-	init();
-}
-
-
-ComboBox::~ComboBox()
-{
-	resized().disconnect(this, &ComboBox::resizedHandler);
-	moved().disconnect(this, &ComboBox::repositioned);
-	lstItems.selectionChanged().disconnect(this, &ComboBox::lstItemsSelectionChanged);
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
-	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
-}
-
-
-/**
- * Internal initializer.
- * 
- * Performs basic init'ing of internal components.
- */
-void ComboBox::init()
-{
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ComboBox::onMouseDown);
 	Utility<EventHandler>::get().mouseWheel().connect(this, &ComboBox::onMouseWheel);
 
@@ -44,6 +23,16 @@ void ComboBox::init()
 	resized().connect(this, &ComboBox::resizedHandler);
 	moved().connect(this, &ComboBox::repositioned);
 	lstItems.selectionChanged().connect(this, &ComboBox::lstItemsSelectionChanged);
+}
+
+
+ComboBox::~ComboBox()
+{
+	resized().disconnect(this, &ComboBox::resizedHandler);
+	moved().disconnect(this, &ComboBox::repositioned);
+	lstItems.selectionChanged().disconnect(this, &ComboBox::lstItemsSelectionChanged);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
+	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
 }
 
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -41,8 +41,6 @@ public:
 	const std::string& text() const;
 
 private:
-	void init();
-
 	void resizedHandler(Control* control);
 	void repositioned(int, int);
 	void lstItemsSelectionChanged();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -16,7 +16,16 @@ using namespace NAS2D;
 
 ListBoxBase::ListBoxBase()
 {
-	_init();
+	Utility<EventHandler>::get().mouseWheel().connect(this, &ListBoxBase::onMouseWheel);
+	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBoxBase::onMouseDown);
+	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBoxBase::onMouseMove);
+
+	mSlider.displayPosition(false);
+	mSlider.length(0);
+	mSlider.thumbPosition(0);
+	mSlider.change().connect(this, &ListBoxBase::slideChanged);
+
+	_update_item_display();
 }
 
 
@@ -29,24 +38,6 @@ ListBoxBase::~ListBoxBase()
 	Utility<EventHandler>::get().mouseMotion().disconnect(this, &ListBoxBase::onMouseMove);
 
 	for (auto item : mItems) { delete item; }
-}
-
-
-/**
- * Internal initializer function.
- */
-void ListBoxBase::_init()
-{
-	Utility<EventHandler>::get().mouseWheel().connect(this, &ListBoxBase::onMouseWheel);
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBoxBase::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBoxBase::onMouseMove);
-
-	mSlider.displayPosition(false);
-	mSlider.length(0);
-	mSlider.thumbPosition(0);
-	mSlider.change().connect(this, &ListBoxBase::slideChanged);
-
-	_update_item_display();
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -81,7 +81,6 @@ protected:
 	std::vector<ListBoxItem*> mItems; /**< List of Items. Pointers used for polymorphism. */
 
 private:
-	void _init();
 	void slideChanged(float newPosition);
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -28,7 +28,11 @@ Window::Window(std::string newTitle) :
 	}
 {
 	text(newTitle);
-	_init();
+
+	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Window::onMouseUp);
+	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMove);
+
+	WINDOW_TITLE_FONT = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
 
 
@@ -36,15 +40,6 @@ Window::~Window()
 {
 	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Window::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Window::onMouseMove);
-}
-
-
-void Window::_init()
-{
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Window::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMove);
-
-	WINDOW_TITLE_FONT = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
 
 

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -27,9 +27,6 @@ protected:
 	static inline constexpr int sWindowTitleBarHeight = 20;
 
 private:
-	void _init();
-
-private:
 	bool mMouseDrag = false;
 	bool mAnchored = false;
 

--- a/OPHD/UI/DiggerDirection.cpp
+++ b/OPHD/UI/DiggerDirection.cpp
@@ -3,9 +3,9 @@
 
 
 DiggerDirection::DiggerDirection() :
+	Window{"Direction"},
 	btnCancel{"Cancel"}
 {
-	text("Direction");
 	init();
 }
 

--- a/OPHD/UI/DiggerDirection.cpp
+++ b/OPHD/UI/DiggerDirection.cpp
@@ -6,16 +6,6 @@ DiggerDirection::DiggerDirection() :
 	Window{"Direction"},
 	btnCancel{"Cancel"}
 {
-	init();
-}
-
-
-DiggerDirection::~DiggerDirection()
-{}
-
-
-void DiggerDirection::init()
-{
 	position({0, 0});
 	size({74, 170});
 
@@ -49,6 +39,10 @@ void DiggerDirection::init()
 	btnCancel.size({64, 25});
 	btnCancel.click().connect(this, &DiggerDirection::btnCancelClicked);
 }
+
+
+DiggerDirection::~DiggerDirection()
+{}
 
 
 void DiggerDirection::setParameters(Tile* tile)

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -30,7 +30,6 @@ public:
 	void allEnabled();
 
 protected:
-	virtual void init();
 	void btnCancelClicked();
 
 private:

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -13,12 +13,6 @@ using namespace NAS2D;
 FactoryProduction::FactoryProduction() :
 	Window{constants::WINDOW_FACTORY_PRODUCTION}
 {
-	init();
-}
-
-
-void FactoryProduction::init()
-{
 	size({320, 162});
 
 	// Set up GUI Layout

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -10,9 +10,9 @@
 using namespace NAS2D;
 
 
-FactoryProduction::FactoryProduction()
+FactoryProduction::FactoryProduction() :
+	Window{constants::WINDOW_FACTORY_PRODUCTION}
 {
-	text(constants::WINDOW_FACTORY_PRODUCTION);
 	init();
 }
 

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -30,9 +30,6 @@ public:
 
 	void update() override;
 
-protected:
-	void init();
-
 private:
 	void btnOkayClicked();
 	void btnCancelClicked();

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -14,13 +14,13 @@ using namespace NAS2D;
 
 
 FileIo::FileIo() :
+	Window{"File I/O"},
 	btnClose{"Cancel"},
 	btnFileOp{"FileOp"}
 {
 	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &FileIo::onDoubleClick);
 	Utility<EventHandler>::get().keyDown().connect(this, &FileIo::onKeyDown);
 
-	text("File I/O");
 	init();
 }
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -21,19 +21,6 @@ FileIo::FileIo() :
 	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &FileIo::onDoubleClick);
 	Utility<EventHandler>::get().keyDown().connect(this, &FileIo::onKeyDown);
 
-	init();
-}
-
-
-FileIo::~FileIo()
-{
-	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &FileIo::onDoubleClick);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &FileIo::onKeyDown);
-}
-
-
-void FileIo::init()
-{
 	size({500, 350});
 
 	add(btnFileOp, {445, 325});
@@ -54,6 +41,13 @@ void FileIo::init()
 	mListBox.size({490, 273});
 	mListBox.visible(true);
 	mListBox.selectionChanged().connect(this, &FileIo::fileSelected);
+}
+
+
+FileIo::~FileIo()
+{
+	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &FileIo::onDoubleClick);
+	Utility<EventHandler>::get().keyDown().disconnect(this, &FileIo::onKeyDown);
 }
 
 

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -32,8 +32,6 @@ public:
 	void update() override;
 
 protected:
-	void init();
-
 	void onDoubleClick(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -10,21 +10,6 @@ GameOptionsDialog::GameOptionsDialog() :
 	btnReturn{"Return to current game"},
 	btnClose{"Return to Main Menu"}
 {
-	init();
-}
-
-
-GameOptionsDialog::~GameOptionsDialog()
-{
-	btnSave.click().disconnect(this, &GameOptionsDialog::btnSaveClicked);
-	btnLoad.click().disconnect(this, &GameOptionsDialog::btnLoadClicked);
-	btnReturn.click().disconnect(this, &GameOptionsDialog::btnReturnClicked);
-	btnClose.click().disconnect(this, &GameOptionsDialog::btnCloseClicked);
-}
-
-
-void GameOptionsDialog::init()
-{
 	position({0, 0});
 	size({210, 160});
 
@@ -45,6 +30,15 @@ void GameOptionsDialog::init()
 	btnClose.click().connect(this, &GameOptionsDialog::btnCloseClicked);
 
 	anchored(true);
+}
+
+
+GameOptionsDialog::~GameOptionsDialog()
+{
+	btnSave.click().disconnect(this, &GameOptionsDialog::btnSaveClicked);
+	btnLoad.click().disconnect(this, &GameOptionsDialog::btnLoadClicked);
+	btnReturn.click().disconnect(this, &GameOptionsDialog::btnReturnClicked);
+	btnClose.click().disconnect(this, &GameOptionsDialog::btnCloseClicked);
 }
 
 

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -20,10 +20,6 @@ public:
 	ClickCallback& returnToGame() { return mCallbackReturn; }
 	ClickCallback& returnToMainMenu() { return mCallbackClose; }
 
-
-protected:
-	virtual void init();
-
 private:
 	GameOptionsDialog(const GameOptionsDialog&) = delete;
 	GameOptionsDialog& operator=(const GameOptionsDialog&) = delete;

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -13,16 +13,6 @@ GameOverDialog::GameOverDialog() :
 	mHeader{imageCache.load("ui/interface/game_over.png")},
 	btnClose{"Return to Main Menu"}
 {
-	init();
-}
-
-
-GameOverDialog::~GameOverDialog()
-{}
-
-
-void GameOverDialog::init()
-{
 	position({0, 0});
 	size({522, 340});
 
@@ -32,6 +22,10 @@ void GameOverDialog::init()
 
 	anchored(true);
 }
+
+
+GameOverDialog::~GameOverDialog()
+{}
 
 
 void GameOverDialog::btnCloseClicked()

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -17,9 +17,6 @@ public:
 
 	void update() override;
 
-protected:
-	virtual void init();
-
 private:
 	GameOverDialog(const GameOverDialog&) = delete;
 	GameOverDialog& operator=(const GameOverDialog&) = delete;

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -11,12 +11,6 @@ using namespace NAS2D;
 MajorEventAnnouncement::MajorEventAnnouncement() :
 	mHeader{imageCache.load("ui/interface/colony_ship_crash.png")}
 {
-	init();
-}
-
-
-void MajorEventAnnouncement::init()
-{
 	position({0, 0});
 	size({522, 340});
 

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -22,9 +22,6 @@ public:
 
 	void update() override;
 
-protected:
-	virtual void init();
-
 private:
 	void btnCloseClicked();
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -20,6 +20,7 @@ static const Font* FONT_BOLD = nullptr;
 
 
 MineOperationsWindow::MineOperationsWindow() :
+	Window{constants::WINDOW_MINE_OPERATIONS},
 	mUiIcon{imageCache.load("ui/interface/mine.png")},
 	mIcons{imageCache.load("ui/icons.png")},
 	mPanel{
@@ -43,7 +44,6 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck{"Add Truck"},
 	btnUnassignTruck{"Remove Truck"}
 {
-	text(constants::WINDOW_MINE_OPERATIONS);
 	init();
 }
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -44,16 +44,6 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck{"Add Truck"},
 	btnUnassignTruck{"Remove Truck"}
 {
-	init();
-}
-
-
-MineOperationsWindow::~MineOperationsWindow()
-{}
-
-
-void MineOperationsWindow::init()
-{
 	size({375, 270});
 
 	// Set up GUI Layout
@@ -94,6 +84,10 @@ void MineOperationsWindow::init()
 	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
+
+
+MineOperationsWindow::~MineOperationsWindow()
+{}
 
 
 void MineOperationsWindow::hide()

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -27,9 +27,6 @@ public:
 	void update() override;
 	void hide() override;
 
-protected:
-	void init();
-
 private:
 	MineOperationsWindow(const MineOperationsWindow&) = delete;
 	MineOperationsWindow& operator=(const MineOperationsWindow&) = delete;

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -18,10 +18,10 @@ static const Font* FONT_BOLD = nullptr;
 
 
 StructureInspector::StructureInspector() :
+	Window{constants::WINDOW_STRUCTURE_INSPECTOR},
 	btnClose{"Close"},
 	mIcons{imageCache.load("ui/icons.png")}
 {
-	text(constants::WINDOW_STRUCTURE_INSPECTOR);
 	init();
 }
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -22,16 +22,6 @@ StructureInspector::StructureInspector() :
 	btnClose{"Close"},
 	mIcons{imageCache.load("ui/icons.png")}
 {
-	init();
-}
-
-
-StructureInspector::~StructureInspector()
-{}
-
-
-void StructureInspector::init()
-{
 	size({350, 200});
 
 	add(btnClose, {295, 175});
@@ -41,6 +31,10 @@ void StructureInspector::init()
 	FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 }
+
+
+StructureInspector::~StructureInspector()
+{}
 
 
 void StructureInspector::structure(Structure* structure)

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -19,9 +19,6 @@ public:
 
 	void update() override;
 
-protected:
-	void init();
-
 private:
 	void btnCloseClicked();
 	std::string getDisabledReason() const;

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -11,9 +11,9 @@ using namespace NAS2D;
 
 
 TileInspector::TileInspector() :
+	Window{constants::WINDOW_TILE_INSPECTOR},
 	btnClose{"Close"}
 {
-	text(constants::WINDOW_TILE_INSPECTOR);
 	init();
 }
 

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -14,22 +14,16 @@ TileInspector::TileInspector() :
 	Window{constants::WINDOW_TILE_INSPECTOR},
 	btnClose{"Close"}
 {
-	init();
-}
-
-
-TileInspector::~TileInspector()
-{
-}
-
-
-void TileInspector::init()
-{
 	size({200, 88});
 
 	add(btnClose, {145, 63});
 	btnClose.size({50, 20});
 	btnClose.click().connect(this, &TileInspector::btnCloseClicked);
+}
+
+
+TileInspector::~TileInspector()
+{
 }
 
 

--- a/OPHD/UI/TileInspector.h
+++ b/OPHD/UI/TileInspector.h
@@ -16,9 +16,6 @@ public:
 
 	void update() override;
 
-protected:
-	void init();
-
 private:
 	TileInspector(const TileInspector&) = delete;
 	TileInspector& operator=(const TileInspector&) = delete;

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -8,9 +8,9 @@
 using namespace NAS2D;
 
 WarehouseInspector::WarehouseInspector() :
+	Window{constants::WINDOW_WH_INSPECTOR},
 	btnClose{"Okay"}
 {
-	text(constants::WINDOW_WH_INSPECTOR);
 	init();
 }
 

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -11,22 +11,16 @@ WarehouseInspector::WarehouseInspector() :
 	Window{constants::WINDOW_WH_INSPECTOR},
 	btnClose{"Okay"}
 {
-	init();
-}
-
-
-WarehouseInspector::~WarehouseInspector()
-{}
-
-
-void WarehouseInspector::init()
-{
 	size({250, 350});
 
 	add(btnClose, {105, 325});
 	btnClose.size({40, 20});
 	btnClose.click().connect(this, &WarehouseInspector::btnCloseClicked);
 }
+
+
+WarehouseInspector::~WarehouseInspector()
+{}
 
 
 void WarehouseInspector::warehouse(Warehouse* w)

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -20,9 +20,6 @@ public:
 	void hide() override;
 	void update() override;
 
-protected:
-	void init();
-
 private:
 	void btnCloseClicked();
 


### PR DESCRIPTION
Merge `init()` methods into constructors in UI code.

Use initializer list to set `Window` title bar text.
