### PR TITLE
Remove low value code

### DIFF
--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -20,10 +20,8 @@ public:
 		BUTTON_TOGGLE
 	};
 
-public:
 	using ClickCallback = NAS2D::Signals::Signal<>;
 
-public:
 	Button(std::string newText = "");
 	~Button() override;
 
@@ -53,10 +51,8 @@ private:
 		Pressed
 	};
 
-private:
 	void draw() override;
 
-private:
 	State mState = State::Normal; /**< Current state of the Button. */
 	Type mType = Type::BUTTON_NORMAL; /**< Modifies Button behavior. */
 

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -14,7 +14,6 @@ class CheckBox : public TextControl
 public:
 	using ClickCallback = NAS2D::Signals::Signal<>;
 
-public:
 	CheckBox(std::string newText = "");
 	~CheckBox() override;
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -16,7 +16,6 @@ class ComboBox : public Control
 public:
 	using SelectionChanged = NAS2D::Signals::Signal<>;
 
-public:
 	ComboBox();
 	~ComboBox() override;
 
@@ -48,7 +47,6 @@ private:
 	void onMouseWheel(int x, int y);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
-private:
 	Button btnDown;
 	ListBox lstItems;
 	TextField txtField;

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -81,12 +81,11 @@ protected:
 
 	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */
 
-private:
-	virtual void draw() {}
-
-protected:
 	bool mEnabled = true; /**< Flag indicating whether or not the Control is enabled. */
 	bool mHasFocus = false; /**< Flag indicating that the Control has input focus. */
 	bool mVisible = true; /**< Flag indicating visibility of the Control. */
 	bool mHighlight = false; /**< Flag indicating that this Control is highlighted. */
+
+private:
+	virtual void draw() {}
 };

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -19,7 +19,6 @@ public:
 	using ResizeCallback = NAS2D::Signals::Signal<Control*>;
 	using PositionChangedCallback = NAS2D::Signals::Signal<int, int>;
 
-public:
 	Control() = default;
 	virtual ~Control() = default;
 
@@ -77,7 +76,6 @@ protected:
 
 	virtual void onSizeChanged() { mResized(this); }
 
-protected:
 	PositionChangedCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
 	ResizeCallback mResized;
 

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -18,7 +18,6 @@ class RadioButton : public TextControl
 public:
 	using ClickCallback = NAS2D::Signals::Signal<>;
 
-public:
 	RadioButton(std::string newText = "");
 	~RadioButton() override;
 

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -38,7 +38,6 @@ public:
 
 	using ValueChangedCallback = NAS2D::Signals::Signal<float>; /*!< type for Callback on value changed. */
 
-public:
 	Slider(SliderType sliderType = SliderType::Vertical);
 	Slider(Skins skins, SliderType sliderType = SliderType::Vertical);
 	~Slider() override;
@@ -77,7 +76,6 @@ private:
 
 	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle<int>& rect, float value);
 
-private:
 	NAS2D::Timer mTimer;
 
 	ValueChangedCallback mCallback; /*!< Callback executed when the value is changed. */

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -22,7 +22,6 @@ public:
 private:
 	using StringList = std::vector<std::string>;
 
-private:
 	void onSizeChanged() override;
 	void onTextChanged() override;
 	virtual void onFontChanged();
@@ -30,7 +29,6 @@ private:
 	void draw() override;
 	void processString();
 
-private:
 	std::size_t mNumLines = 0;
 
 	StringList mFormattedList;

--- a/OPHD/UI/Core/TextControl.h
+++ b/OPHD/UI/Core/TextControl.h
@@ -14,7 +14,6 @@ class TextControl : public Control
 public:
 	using TextChangedCallback = NAS2D::Signals::Signal<TextControl*>;
 
-public:
 	void text(const std::string& text);
 	const std::string& text() const { return mText; }
 	TextChangedCallback& textChanged() { return mTextChanged; }

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -71,7 +71,6 @@ private:
 
 	void updateCursor();
 
-private:
 	const NAS2D::Font& mFont;
 	const NAS2D::RectangleSkin mSkinNormal;
 	const NAS2D::RectangleSkin mSkinFocus;

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -26,6 +26,7 @@ public:
 	void update() override;
 
 	std::vector<Control*> controls() const;
+
 protected:
 	void visibilityChanged(bool visible) override;
 	void positionChanged(int dX, int dY) override;

--- a/OPHD/UI/Core/WindowStack.h
+++ b/OPHD/UI/Core/WindowStack.h
@@ -32,6 +32,5 @@ public:
 private:
 	using WindowList = std::list<Window*>;
 
-private:
 	WindowList mWindowList;
 };

--- a/OPHD/UI/DiggerDirection.cpp
+++ b/OPHD/UI/DiggerDirection.cpp
@@ -41,10 +41,6 @@ DiggerDirection::DiggerDirection() :
 }
 
 
-DiggerDirection::~DiggerDirection()
-{}
-
-
 void DiggerDirection::setParameters(Tile* tile)
 {
 	mTile = tile;

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -15,7 +15,6 @@ public:
 
 public:
 	DiggerDirection();
-	~DiggerDirection() override;
 
 	void update() override;
 

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -13,7 +13,6 @@ class DiggerDirection: public Window
 public:
 	using Callback = NAS2D::Signals::Signal<Direction, Tile*>;
 
-public:
 	DiggerDirection();
 
 	void update() override;
@@ -38,7 +37,6 @@ private:
 	void btnDiggerEastClicked();
 	void btnDiggerWestClicked();
 
-private:
 	Button btnDown;
 	Button btnNorth;
 	Button btnEast;

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -39,10 +39,6 @@ private:
 	void btnDiggerWestClicked();
 
 private:
-	DiggerDirection(const DiggerDirection&) = delete; /**< Not allowed. */
-	DiggerDirection& operator=(const DiggerDirection&) = delete; /**< Not allowed. */
-
-private:
 	Button btnDown;
 	Button btnNorth;
 	Button btnEast;

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -39,7 +39,6 @@ private:
 
 	void productSelectionChanged(const IconGrid::IconGridItem*);
 
-private:
 	Factory* mFactory = nullptr;
 
 	ProductType mProduct = ProductType::PRODUCT_NONE;

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -20,8 +20,6 @@ class FactoryProduction : public Window
 {
 public:
 	FactoryProduction();
-	FactoryProduction(const FactoryProduction&) = delete;
-	FactoryProduction& operator=(const FactoryProduction&) = delete;
 
 	void factory(Factory* newFactory);
 	Factory* factory() { return mFactory; }

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -36,10 +36,6 @@ protected:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 
 private:
-	FileIo(const FileIo&) = delete;
-	FileIo& operator=(const FileIo&) = delete;
-
-private:
 	void btnCloseClicked();
 	void btnFileIoClicked();
 

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -20,7 +20,6 @@ public:
 
 	using FileOperationCallback = NAS2D::Signals::Signal<const std::string&, FileOperation>;
 
-public:
 	FileIo();
 	~FileIo() override;
 
@@ -42,7 +41,6 @@ private:
 	void fileSelected();
 	void fileNameModified(TextControl* control);
 
-private:
 	FileOperationCallback mCallback;
 
 	FileOperation mMode;

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -21,10 +21,6 @@ public:
 	ClickCallback& returnToMainMenu() { return mCallbackClose; }
 
 private:
-	GameOptionsDialog(const GameOptionsDialog&) = delete;
-	GameOptionsDialog& operator=(const GameOptionsDialog&) = delete;
-
-private:
 	void btnLoadClicked();
 	void btnSaveClicked();
 	void btnReturnClicked();

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -9,7 +9,6 @@ class GameOptionsDialog : public Window
 public:
 	using ClickCallback = NAS2D::Signals::Signal<>;
 
-public:
 	GameOptionsDialog();
 	~GameOptionsDialog() override;
 
@@ -28,7 +27,6 @@ private:
 
 	void enabledChanged() override;
 
-private:
 	Button btnSave;
 	Button btnLoad;
 	Button btnReturn;

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -24,10 +24,6 @@ GameOverDialog::GameOverDialog() :
 }
 
 
-GameOverDialog::~GameOverDialog()
-{}
-
-
 void GameOverDialog::btnCloseClicked()
 {
 	mCallback();

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -11,8 +11,6 @@ public:
 
 public:
 	GameOverDialog();
-	GameOverDialog(const GameOverDialog&) = delete;
-	GameOverDialog& operator=(const GameOverDialog&) = delete;
 
 	ClickCallback& returnToMainMenu() { return mCallback; }
 

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -11,14 +11,12 @@ public:
 
 public:
 	GameOverDialog();
+	GameOverDialog(const GameOverDialog&) = delete;
+	GameOverDialog& operator=(const GameOverDialog&) = delete;
 
 	ClickCallback& returnToMainMenu() { return mCallback; }
 
 	void update() override;
-
-private:
-	GameOverDialog(const GameOverDialog&) = delete;
-	GameOverDialog& operator=(const GameOverDialog&) = delete;
 
 private:
 	void btnCloseClicked();

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -19,7 +19,6 @@ public:
 private:
 	void btnCloseClicked();
 
-private:
 	const NAS2D::Image& mHeader;
 
 	Button btnClose;

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -11,7 +11,6 @@ public:
 
 public:
 	GameOverDialog();
-	~GameOverDialog() override;
 
 	ClickCallback& returnToMainMenu() { return mCallback; }
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -97,13 +97,11 @@ private:
 	using IconItemList = std::vector<IconGridItem>;
 	using Index = IconItemList::size_type;
 
-private:
 	void updateGrid();
 	std::size_t translateCoordsToIndex(NAS2D::Vector<int> relativeOffset);
 
 	void raiseChangedEvent();
 
-private:
 	Index mHighlightIndex = constants::NO_SELECTION; /**< Current highlight index. */
 	Index mCurrentSelection = constants::NO_SELECTION; /**< Currently selected item index. */
 

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -15,8 +15,6 @@ public:
 	};
 
 	MajorEventAnnouncement();
-	MajorEventAnnouncement(const MajorEventAnnouncement&) = delete;
-	MajorEventAnnouncement& operator=(const MajorEventAnnouncement&) = delete;
 
 	void announcement(AnnouncementType a);
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -86,10 +86,6 @@ MineOperationsWindow::MineOperationsWindow() :
 }
 
 
-MineOperationsWindow::~MineOperationsWindow()
-{}
-
-
 void MineOperationsWindow::hide()
 {
 	Control::hide();

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -39,7 +39,6 @@ private:
 	void btnAssignTruckClicked();
 	void btnUnassignTruckClicked();
 
-private:
 	MineFacility* mFacility = nullptr;
 
 	const NAS2D::Image& mUiIcon;

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -17,7 +17,6 @@ class MineOperationsWindow final : public Window
 {
 public:
 	MineOperationsWindow();
-	~MineOperationsWindow() override;
 
 	void mineFacility(MineFacility* facility);
 	MineFacility* mineFacility() { return mFacility; }

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -27,10 +27,6 @@ public:
 	void hide() override;
 
 private:
-	MineOperationsWindow(const MineOperationsWindow&) = delete;
-	MineOperationsWindow& operator=(const MineOperationsWindow&) = delete;
-
-private:
 	void chkCommonMetalsClicked();
 	void chkCommonMineralsClicked();
 	void chkRareMetalsClicked();

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -27,8 +27,6 @@ public:
 
 	void update() override;
 
-protected:
-
 private:
 	const NAS2D::Image& mIcons;
 	NAS2D::RectangleSkin mSkin;

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -65,7 +65,6 @@ private:
 
 	void visibilityChanged(bool visible) override;
 
-private:
 	const NAS2D::Font& font;
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -67,7 +67,6 @@ private:
 	void drawTruckMangementPane(const NAS2D::Point<int>&);
 	void drawTruckHaulInfo(const NAS2D::Point<int>&);
 
-private:
 	const NAS2D::Font& font;
 	const NAS2D::Font& fontBold;
 	const NAS2D::Font& fontMedium;

--- a/OPHD/UI/Reports/ReportInterface.h
+++ b/OPHD/UI/Reports/ReportInterface.h
@@ -18,10 +18,8 @@ public:
 	 */
 	using TakeMeThere = NAS2D::Signals::Signal<Structure*>;
 
-public:
 	ReportInterface() {}
 
-public:
 	/**
 	 * Instructs the Report UI to clear any selections it may have.
 	 */

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -62,7 +62,6 @@ private:
 	void drawLeftPanel(NAS2D::Renderer&);
 	void drawRightPanel(NAS2D::Renderer&);
 
-private:
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;
 	const NAS2D::Font& fontBigBold;

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -33,10 +33,6 @@ StructureInspector::StructureInspector() :
 }
 
 
-StructureInspector::~StructureInspector()
-{}
-
-
 void StructureInspector::structure(Structure* structure)
 {
 	mStructure = structure;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -24,7 +24,6 @@ private:
 	void drawStructureSpecificTable(NAS2D::Point<int> position, NAS2D::Renderer& renderer);
 	std::string formatAge() const;
 
-private:
 	Button btnClose;
 	const NAS2D::Image& mIcons;
 	Structure* mStructure = nullptr;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -25,10 +25,6 @@ private:
 	std::string formatAge() const;
 
 private:
-	StructureInspector(const StructureInspector&) = delete;
-	StructureInspector& operator=(const StructureInspector&) = delete;
-
-private:
 	Button btnClose;
 	const NAS2D::Image& mIcons;
 	Structure* mStructure = nullptr;

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -12,7 +12,6 @@ class StructureInspector : public Window
 {
 public:
 	StructureInspector();
-	~StructureInspector() override;
 
 	void structure(Structure* structure);
 	Structure* structure() { return mStructure; }

--- a/OPHD/UI/TileInspector.h
+++ b/OPHD/UI/TileInspector.h
@@ -19,7 +19,6 @@ public:
 private:
 	void btnCloseClicked();
 
-private:
 	Button btnClose;
 	Tile* mTile = nullptr;
 };

--- a/OPHD/UI/TileInspector.h
+++ b/OPHD/UI/TileInspector.h
@@ -17,10 +17,6 @@ public:
 	void update() override;
 
 private:
-	TileInspector(const TileInspector&) = delete;
-	TileInspector& operator=(const TileInspector&) = delete;
-
-private:
 	void btnCloseClicked();
 
 private:

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -19,10 +19,6 @@ WarehouseInspector::WarehouseInspector() :
 }
 
 
-WarehouseInspector::~WarehouseInspector()
-{}
-
-
 void WarehouseInspector::warehouse(Warehouse* w)
 {
 	mWarehouse = w;

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -13,7 +13,6 @@ class WarehouseInspector : public Window
 {
 public:
 	WarehouseInspector();
-	~WarehouseInspector() override;
 
 	void warehouse(Warehouse* w);
 

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -23,10 +23,6 @@ private:
 	void btnCloseClicked();
 
 private:
-	WarehouseInspector(const WarehouseInspector&) = delete;
-	WarehouseInspector& operator=(const WarehouseInspector&) = delete;
-
-private:
 	Warehouse* mWarehouse = nullptr;
 	Button btnClose;
 };

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -22,7 +22,6 @@ public:
 private:
 	void btnCloseClicked();
 
-private:
 	Warehouse* mWarehouse = nullptr;
 	Button btnClose;
 };


### PR DESCRIPTION
Remove:
- Empty destructor overrides (`SomeClass::~SomeClass() {}`)
- Deletion of copy and assignment methods when they would be safe to use
- Duplicate access specifiers (`public`, `protected`, `private`)

Admittedly it might be a bit weird to copy or assign some of those classes, though not necessarily wrong. I think deleting those methods would be more of a temporary debugging tool to check if they were accidentally used somewhere, and you wanted the compiler to flag all such occurrences. That doesn't mean all such occurrences are necessarily wrong.
