### PR TITLE
Use consistent line spacing in file headers of UI code

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -8,6 +8,7 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/MathUtils.h>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -28,6 +28,7 @@ using namespace NAS2D;
 
 static const Font* CBOX_FONT = nullptr;
 
+
 CheckBox::CheckBox(std::string newText) :
 	mSkin{imageCache.load("ui/skin/checkbox.png")}
 {

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -8,6 +8,7 @@
 
 using namespace NAS2D;
 
+
 ComboBox::ComboBox()
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ComboBox::onMouseDown);

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -1,5 +1,6 @@
 #include "Control.h"
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/Core/Label.h
+++ b/OPHD/UI/Core/Label.h
@@ -8,7 +8,9 @@
 #pragma once
 
 #include "TextControl.h"
+
 #include <NAS2D/Renderer/Color.h>
+
 #include <string>
 
 
@@ -16,6 +18,7 @@ namespace NAS2D
 {
 	class Font;
 }
+
 
 /**
  * \class Label

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -15,6 +15,7 @@ using namespace NAS2D;
 
 static const Font* CBOX_FONT = nullptr;
 
+
 RadioButton::RadioButton(std::string newText) :
 	mSkin{imageCache.load("ui/skin/checkbox.png")},
 	mLabel{newText}

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -7,6 +7,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/Core/TextControl.h
+++ b/OPHD/UI/Core/TextControl.h
@@ -1,13 +1,17 @@
 #pragma once
 
 #include "Control.h"
+
 #include <NAS2D/Signal.h>
+
 #include <string>
+
 
 namespace NAS2D 
 {
 	class Font;
 }
+
 
 class TextControl : public Control
 {

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -16,6 +16,7 @@
 
 #include <locale>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -1,7 +1,6 @@
 #include "UIContainer.h"
 
 #include "RadioButton.h"
-
 #include "../../Common.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+
 /**
  * UI Object that contains other UI Controls.
  * 

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -7,9 +7,11 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+
 using namespace NAS2D;
 
 static const Font* WINDOW_TITLE_FONT;
+
 
 Window::Window(std::string newTitle) :
 	mTitleBarLeft{imageCache.load("ui/skin/window_title_left.png")},

--- a/OPHD/UI/Core/WindowStack.cpp
+++ b/OPHD/UI/Core/WindowStack.cpp
@@ -1,6 +1,6 @@
 #include "WindowStack.h"
-#include "Window.h"
 
+#include "Window.h"
 #include "../../Common.h"
 
 #include <algorithm>

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -6,6 +6,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -16,6 +16,7 @@ using namespace NAS2D;
 
 static const Font* FONT = nullptr;
 
+
 IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 	mIconSize{iconEdgeSize},
 	mIconMargin{margin},

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -12,8 +12,8 @@
 #include <NAS2D/Renderer/RectangleSkin.h>
 #include <NAS2D/Resources/Image.h>
 
-
 #include <algorithm>
+
 
 /**
  * \class IconGrid

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -6,7 +6,9 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+
 using namespace NAS2D;
+
 
 MajorEventAnnouncement::MajorEventAnnouncement() :
 	mHeader{imageCache.load("ui/interface/colony_ship_crash.png")}

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -7,9 +7,11 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+
 using namespace NAS2D;
 
 static const Font* FONT = nullptr;
+
 
 PopulationPanel::PopulationPanel() :
 	mIcons{imageCache.load("ui/icons.png")},

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -18,7 +18,6 @@ namespace NAS2D
 	class Image;
 }
 
-
 class MineFacility;
 
 

--- a/OPHD/UI/Reports/ReportInterface.h
+++ b/OPHD/UI/Reports/ReportInterface.h
@@ -2,7 +2,9 @@
 
 #include "../Core/UIContainer.h"
 
+
 class Structure;
+
 
 /**
  * Provides an abstract interface for Report UIs used in the MainReportsUiState.

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -1,11 +1,16 @@
 #include "StringTable.h"
+
 #include "../Cache.h"
 #include "../Constants/UiConstants.h"
+
 #include <NAS2D/Utility.h>
+
 #include <stdexcept>
 #include <algorithm>
 
+
 const NAS2D::Color StringTable::Cell::ColorEmpty = NAS2D::Color::NoAlpha;
+
 
 StringTable::Cell& StringTable::operator[](const CellCoordinate& coordinate)
 {

--- a/OPHD/UI/StringTable.h
+++ b/OPHD/UI/StringTable.h
@@ -6,9 +6,11 @@
 #include <NAS2D/Renderer/Rectangle.h>
 #include <NAS2D/Renderer/Vector.h>
 #include <NAS2D/StringValue.h>
+
 #include <string>
 #include <vector>
 #include <cstddef>
+
 
 // Draw a 2 dimensional table of text. Determine cell size based on inserted text, font, and padding. Only allows one line of text per cell.
 class StringTable

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -2,8 +2,10 @@
 
 #include "Core/Window.h"
 #include "Core/Button.h"
+
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Point.h>
+
 
 class Structure;
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -11,7 +11,6 @@
 
 using namespace NAS2D;
 
-
 const int LIST_ITEM_HEIGHT = 30;
 
 static const Font* MAIN_FONT = nullptr;

--- a/OPHD/UI/TextRender.h
+++ b/OPHD/UI/TextRender.h
@@ -2,6 +2,7 @@
 
 #include <NAS2D/Renderer/Point.h>
 #include <NAS2D/Renderer/Color.h>
+
 #include <string>
 
 

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <sstream>
 
+
 using namespace NAS2D;
 
 

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -5,7 +5,9 @@
 
 #include "../Things/Structures/Warehouse.h"
 
+
 using namespace NAS2D;
+
 
 WarehouseInspector::WarehouseInspector() :
 	Window{constants::WINDOW_WH_INSPECTOR},

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -6,6 +6,7 @@
 
 class Warehouse;
 
+
 /**
 * \brief Implements a Factory Production dialog interface.
 */


### PR DESCRIPTION
Adjust blocking of header includes.
Adjust spacing after includes.
Adjust spacing before opening class declaration.
