### PR TITLE
Misc UI font cleanup

### DIFF
--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -25,7 +25,7 @@ protected:
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseMove(int x, int y, int dX, int dY);
 
-	static inline constexpr int sWindowTitleBarHeight = 20;
+	static constexpr int sWindowTitleBarHeight = 20;
 
 private:
 	const NAS2D::Font& mTitleFont;

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -41,7 +41,6 @@ void GameOverDialog::update()
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
-	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
 	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	renderer.drawText(font, "You have failed. Your colony is dead.", position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -42,6 +42,6 @@ void GameOverDialog::update()
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
-	const auto& font = *&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	renderer.drawText(font, "You have failed. Your colony is dead.", position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -56,7 +56,6 @@ void MajorEventAnnouncement::update()
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
-	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
 	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	renderer.drawText(font, mMessage, position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -57,6 +57,6 @@ void MajorEventAnnouncement::update()
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	// Yeah, I know. I hate it too but it made more sense than holding onto a static pointer.
-	const auto& font = *&fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
+	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	renderer.drawText(font, mMessage, position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -27,7 +27,7 @@ namespace
 	/**
 	 * Convenience function for setting a resource trend.
 	 */
-	static ResourceTrend compareResources(int src, int dst)
+	ResourceTrend compareResources(int src, int dst)
 	{
 		return
 			(src > dst) ? ResourceTrend::Up :


### PR DESCRIPTION
A bit of miscellaneous cleanup related to the font handling in UI code.

Removes uses of `static`, `inline`, pointless address of and indirection operators, and obsolete comments.
