### PR TITLE
Refactor ListBox interface

### DIFF
--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -223,9 +223,9 @@ void MainReportsUiState::_deactivate()
 		panel.Selected(false);
 	}
 
-	Panels[NavigationPanel::PANEL_PRODUCTION].UiPanel->clearSelection();
-	Panels[NavigationPanel::PANEL_WAREHOUSE].UiPanel->clearSelection();
-	Panels[NavigationPanel::PANEL_MINING].UiPanel->clearSelection();
+	Panels[NavigationPanel::PANEL_PRODUCTION].UiPanel->clearSelected();
+	Panels[NavigationPanel::PANEL_WAREHOUSE].UiPanel->clearSelected();
+	Panels[NavigationPanel::PANEL_MINING].UiPanel->clearSelected();
 }
 
 
@@ -273,7 +273,7 @@ void MainReportsUiState::exit()
 
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel) { panel.UiPanel->clearSelection(); }
+		if (panel.UiPanel) { panel.UiPanel->clearSelected(); }
 	}
 
 	mReportsUiCallback();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1165,7 +1165,7 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 		clearMode();
 		resetUi();
 
-		mStructures.dropAllItems();
+		mStructures.clear();
 		mBtnTurns.enabled(true);
 	}
 	else

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -219,8 +219,8 @@ void MapViewState::load(const std::string& filePath)
 
 			s->deployCallback().connect(this, &MapViewState::deploySeedLander);
 
-			mStructures.dropAllItems();
-			mConnections.dropAllItems();
+			mStructures.clear();
+			mConnections.clear();
 			mBtnTurns.enabled(true);
 		}
 	}
@@ -239,7 +239,7 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 {
 	mRobotPool.clear();
 	mRobotList.clear();
-	mRobots.dropAllItems();
+	mRobots.clear();
 
 	ROBOT_ID_COUNTER = 0;
 	int id = 0, type = 0, age = 0, production_time = 0, x = 0, y = 0, depth = 0, direction = 0;

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -241,8 +241,8 @@ void MapViewState::clearSelections()
  */
 void MapViewState::populateStructureMenu()
 {
-	mStructures.dropAllItems();
-	mConnections.dropAllItems();
+	mStructures.clear();
+	mConnections.clear();
 
 	// Above Ground structures only
 	if (NAS2D::Utility<StructureManager>::get().count() == 0)

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -194,7 +194,6 @@ void ComboBox::update()
 
 void ComboBox::text(const std::string& text) {
 	txtField.text(text);
-	txtField.textChanged();
 	lstItems.setSelectedByName(txtField.text());
 	mSelectionChanged();
 }

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -108,9 +108,9 @@ void ComboBox::onMouseWheel(int /*x*/, int /*y*/)
 }
 
 
-void ComboBox::clearSelection()
+void ComboBox::clearSelected()
 {
-	lstItems.clearSelection();
+	lstItems.clearSelected();
 	txtField.clear();
 }
 
@@ -151,7 +151,7 @@ void ComboBox::addItem(const std::string& item, int tag)
 	if (lstItems.count() > mMaxDisplayItems) { return; }
 	lstItems.height(static_cast<int>(lstItems.count() * lstItems.lineHeight()));
 
-	lstItems.clearSelection();
+	lstItems.clearSelected();
 }
 
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -173,6 +173,12 @@ int ComboBox::selectionTag() const
 }
 
 
+bool ComboBox::isItemSelected() const
+{
+	return lstItems.isItemSelected();
+}
+
+
 void ComboBox::currentSelection(std::size_t index) {
 	lstItems.currentSelection(index);
 	text(selectionText());

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -169,7 +169,7 @@ const std::string& ComboBox::selectionText() const
  */
 int ComboBox::selectionTag() const
 {
-	return lstItems.selectionTag();
+	return lstItems.isItemSelected() ? lstItems.selected().tag : 0;
 }
 
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -179,8 +179,8 @@ bool ComboBox::isItemSelected() const
 }
 
 
-void ComboBox::currentSelection(std::size_t index) {
-	lstItems.currentSelection(index);
+void ComboBox::setSelected(std::size_t index) {
+	lstItems.setSelected(index);
 	text(selectionText());
 	mSelectionChanged();
 }

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -195,7 +195,7 @@ void ComboBox::update()
 void ComboBox::text(const std::string& text) {
 	txtField.text(text);
 	txtField.textChanged();
-	lstItems.setSelectionByName(txtField.text());
+	lstItems.setSelectedByName(txtField.text());
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -1,5 +1,7 @@
 #include "ComboBox.h"
 
+#include "../../Constants/Strings.h"
+
 #include <NAS2D/Utility.h>
 #include <NAS2D/MathUtils.h>
 
@@ -118,7 +120,7 @@ void ComboBox::clearSelection()
  */
 void ComboBox::lstItemsSelectionChanged()
 {
-	txtField.text(lstItems.selectionText());
+	txtField.text(selectionText());
 	lstItems.visible(false);
 	mRect = mBaseArea;
 	mSelectionChanged();
@@ -158,7 +160,7 @@ void ComboBox::addItem(const std::string& item, int tag)
  */
 const std::string& ComboBox::selectionText() const
 {
-	return lstItems.selectionText();
+	return lstItems.isItemSelected() ? lstItems.selected().text : constants::EMPTY_STR;
 }
 
 
@@ -173,7 +175,7 @@ int ComboBox::selectionTag() const
 
 void ComboBox::currentSelection(std::size_t index) {
 	lstItems.currentSelection(index);
-	text(lstItems.selectionText());
+	text(selectionText());
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -33,7 +33,7 @@ public:
 
 	bool isItemSelected() const;
 	std::size_t selectedIndex() { return lstItems.selectedIndex(); }
-	void currentSelection(std::size_t index);
+	void setSelected(std::size_t index);
 
 	void update() override;
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -31,6 +31,7 @@ public:
 	const std::string& selectionText() const;
 	int selectionTag() const;
 
+	bool isItemSelected() const;
 	std::size_t currentSelection() { return lstItems.currentSelection(); }
 	void currentSelection(std::size_t index);
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -24,7 +24,7 @@ public:
 	std::size_t maxDisplayItems() const { return mMaxDisplayItems; }
 	void maxDisplayItems(std::size_t count);
 
-	void clearSelection();
+	void clearSelected();
 
 	SelectionChanged& selectionChanged() { return mSelectionChanged; }
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -32,7 +32,7 @@ public:
 	int selectionTag() const;
 
 	bool isItemSelected() const;
-	std::size_t currentSelection() { return lstItems.currentSelection(); }
+	std::size_t selectedIndex() { return lstItems.selectedIndex(); }
 	void currentSelection(std::size_t index);
 
 	void update() override;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -160,6 +160,12 @@ void ListBox::setSelectionByName(const std::string& item)
 }
 
 
+bool ListBox::isItemSelected() const
+{
+	return mCurrentSelection != constants::NO_SELECTION;
+}
+
+
 /**
  * Drops all items from the list.
  */

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -166,6 +166,17 @@ bool ListBox::isItemSelected() const
 }
 
 
+const ListBox::ListBoxItem& ListBox::selected() const
+{
+	if (mCurrentSelection == constants::NO_SELECTION)
+	{
+		throw std::runtime_error("ListBox has no selected item");
+	}
+
+	return mItems[mCurrentSelection];
+}
+
+
 /**
  * Drops all items from the list.
  */

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -84,7 +84,7 @@ void ListBox::_updateItemDisplay()
 /**
  * Gets whether the menu is empty or not.
  */
-bool ListBox::empty() const
+bool ListBox::isEmpty() const
 {
 	return mItems.empty();
 }
@@ -117,7 +117,7 @@ void ListBox::addItem(const std::string& item, int tag)
  */
 void ListBox::removeItem(const std::string& item)
 {
-	if (empty()) { return; }
+	if (isEmpty()) { return; }
 
 	auto it = std::find(mItems.begin(), mItems.end(), item);
 
@@ -183,7 +183,7 @@ void ListBox::sort()
 void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	// Ignore if menu is empty or invisible
-	if (empty() || !visible()) { return; }
+	if (isEmpty() || !visible()) { return; }
 
 	const auto point = NAS2D::Point{x, y};
 
@@ -209,7 +209,7 @@ void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
 	// Ignore if menu is empty or invisible
-	if (empty() || !visible()) { return; }
+	if (isEmpty() || !visible()) { return; }
 
 	const auto point = NAS2D::Point{x, y};
 
@@ -232,7 +232,7 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
  */
 void ListBox::onMouseWheel(int /*x*/, int y)
 {
-	if (empty() || !visible()) { return; }
+	if (isEmpty() || !visible()) { return; }
 
 	mSlider.changeThumbPosition((y < 0 ? 16.0f : -16.0f));
 }

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -166,7 +166,7 @@ const ListBox::ListBoxItem& ListBox::selected() const
 /**
  * Drops all items from the list.
  */
-void ListBox::dropAllItems()
+void ListBox::clear()
 {
 	mItems.clear();
 	mSelectedIndex = 0;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -169,7 +169,7 @@ const ListBox::ListBoxItem& ListBox::selected() const
 void ListBox::clear()
 {
 	mItems.clear();
-	mSelectedIndex = 0;
+	mSelectedIndex = constants::NO_SELECTION;
 	_updateItemDisplay();
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -90,20 +90,6 @@ bool ListBox::empty() const
 }
 
 
-const std::string& ListBox::selectionText() const
-{
-	if (mCurrentSelection == constants::NO_SELECTION) { return constants::EMPTY_STR; }
-	return mItems[mCurrentSelection].text;
-}
-
-
-int ListBox::selectionTag() const
-{
-	if (mCurrentSelection == constants::NO_SELECTION) { return 0; }
-	return mItems[mCurrentSelection].tag;
-}
-
-
 /**
  * Adds an item to the Menu.
  *

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -202,7 +202,7 @@ void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 		return;
 	}
 
-	currentSelection(mHighlightIndex);
+	setSelected(mHighlightIndex);
 }
 
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -136,7 +136,7 @@ bool ListBox::itemExists(const std::string& item)
 }
 
 
-void ListBox::setSelectionByName(const std::string& item)
+void ListBox::setSelectedByName(const std::string& item)
 {
 	const auto target = toLowercase(item);
 	for (std::size_t i = 0; i < mItems.size(); i++)

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -170,6 +170,7 @@ void ListBox::clear()
 {
 	mItems.clear();
 	mSelectedIndex = constants::NO_SELECTION;
+	mHighlightIndex = constants::NO_SELECTION;
 	_updateItemDisplay();
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -187,7 +187,7 @@ void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 
 	const auto point = NAS2D::Point{x, y};
 
-	if (!rect().contains(point) || mCurrentHighlight == constants::NO_SELECTION)
+	if (!rect().contains(point) || mHighlightIndex == constants::NO_SELECTION)
 	{
 		return;
 	}
@@ -197,12 +197,12 @@ void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 		return; // if the mouse is on the slider then the slider should handle that
 	}
 
-	if (static_cast<std::size_t>(mCurrentHighlight) >= mItems.size())
+	if (static_cast<std::size_t>(mHighlightIndex) >= mItems.size())
 	{
 		return;
 	}
 
-	currentSelection(mCurrentHighlight);
+	currentSelection(mHighlightIndex);
 }
 
 
@@ -215,14 +215,14 @@ void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 
 	if (!mScrollArea.contains(point))
 	{
-		mCurrentHighlight = constants::NO_SELECTION;
+		mHighlightIndex = constants::NO_SELECTION;
 		return;
 	}
 
-	mCurrentHighlight = (static_cast<std::size_t>(y - mRect.y) + mScrollOffsetInPixels) / static_cast<std::size_t>(mLineHeight);
-	if (mCurrentHighlight >= mItems.size())
+	mHighlightIndex = (static_cast<std::size_t>(y - mRect.y) + mScrollOffsetInPixels) / static_cast<std::size_t>(mLineHeight);
+	if (mHighlightIndex >= mItems.size())
 	{
-		mCurrentHighlight = constants::NO_SELECTION;
+		mHighlightIndex = constants::NO_SELECTION;
 	}
 }
 
@@ -258,11 +258,11 @@ void ListBox::update()
 	renderer.drawBoxFilled(itemBounds, mBackgroundColorSelected);
 
 	// Highlight On mouse Over
-	if (mCurrentHighlight != constants::NO_SELECTION)
+	if (mHighlightIndex != constants::NO_SELECTION)
 	{
 		auto highlightBounds = mScrollArea;
 		highlightBounds.height = static_cast<int>(mLineHeight);
-		highlightBounds.y += static_cast<int>((mCurrentHighlight * mLineHeight) - mScrollOffsetInPixels);
+		highlightBounds.y += static_cast<int>((mHighlightIndex * mLineHeight) - mScrollOffsetInPixels);
 		renderer.drawBox(highlightBounds, mBackgroundColorMouseHover);
 	}
 
@@ -271,7 +271,7 @@ void ListBox::update()
 	textPosition += {constants::MARGIN_TIGHT, -static_cast<int>(mScrollOffsetInPixels)};
 	for(std::size_t i = 0; i < mItems.size(); i++)
 	{
-		const auto textColor = (i == mCurrentHighlight) ? mTextColorMouseHover : mTextColorNormal;
+		const auto textColor = (i == mHighlightIndex) ? mTextColorMouseHover : mTextColorNormal;
 		renderer.drawTextShadow(mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 		textPosition.y += mLineHeight;
 	}

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -42,6 +42,15 @@ ListBox::~ListBox()
 }
 
 
+/**
+ * Gets whether the menu is empty or not.
+ */
+bool ListBox::isEmpty() const
+{
+	return mItems.empty();
+}
+
+
 void ListBox::onSizeChanged()
 {
 	_updateItemDisplay();
@@ -78,15 +87,6 @@ void ListBox::_updateItemDisplay()
 		mSlider.length(0);
 		mSlider.visible(false);
 	}
-}
-
-
-/**
- * Gets whether the menu is empty or not.
- */
-bool ListBox::isEmpty() const
-{
-	return mItems.empty();
 }
 
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -124,7 +124,7 @@ void ListBox::removeItem(const std::string& item)
 	if (it != mItems.end())
 	{
 		mItems.erase(it);
-		mCurrentSelection = constants::NO_SELECTION;
+		mSelectedIndex = constants::NO_SELECTION;
 		_updateItemDisplay();
 	}
 }
@@ -141,25 +141,25 @@ void ListBox::setSelectionByName(const std::string& item)
 	const auto target = toLowercase(item);
 	for (std::size_t i = 0; i < mItems.size(); i++)
 	{
-		if (toLowercase(mItems[i].text) == target) { mCurrentSelection = i; return; }
+		if (toLowercase(mItems[i].text) == target) { mSelectedIndex = i; return; }
 	}
 }
 
 
 bool ListBox::isItemSelected() const
 {
-	return mCurrentSelection != constants::NO_SELECTION;
+	return mSelectedIndex != constants::NO_SELECTION;
 }
 
 
 const ListBox::ListBoxItem& ListBox::selected() const
 {
-	if (mCurrentSelection == constants::NO_SELECTION)
+	if (mSelectedIndex == constants::NO_SELECTION)
 	{
 		throw std::runtime_error("ListBox has no selected item");
 	}
 
-	return mItems[mCurrentSelection];
+	return mItems[mSelectedIndex];
 }
 
 
@@ -169,7 +169,7 @@ const ListBox::ListBoxItem& ListBox::selected() const
 void ListBox::dropAllItems()
 {
 	mItems.clear();
-	mCurrentSelection = 0;
+	mSelectedIndex = 0;
 	_updateItemDisplay();
 }
 
@@ -254,7 +254,7 @@ void ListBox::update()
 	// Highlight currently selected item
 	auto itemBounds = mScrollArea;
 	itemBounds.height = static_cast<int>(mLineHeight);
-	itemBounds.y += static_cast<int>((mCurrentSelection * mLineHeight) - mScrollOffsetInPixels);
+	itemBounds.y += static_cast<int>((mSelectedIndex * mLineHeight) - mScrollOffsetInPixels);
 	renderer.drawBoxFilled(itemBounds, mBackgroundColorSelected);
 
 	// Highlight On mouse Over

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -42,7 +42,7 @@ public:
 	void addItem(const std::string& item, int tag = 0);
 	void removeItem(const std::string& item);
 	bool itemExists(const std::string& item);
-	void dropAllItems();
+	void clear();
 	void sort();
 
 	std::size_t count() const { return mItems.size(); }

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -48,10 +48,10 @@ public:
 	std::size_t count() const { return mItems.size(); }
 	unsigned int lineHeight() const { return mLineHeight; }
 
-	std::size_t selectedIndex() const { return mCurrentSelection; }
-	void currentSelection(std::size_t selection) { mCurrentSelection = selection; mSelectionChanged(); }
+	std::size_t selectedIndex() const { return mSelectedIndex; }
+	void currentSelection(std::size_t selection) { mSelectedIndex = selection; mSelectionChanged(); }
 	void setSelectionByName(const std::string& item);
-	void clearSelection() { mCurrentSelection = constants::NO_SELECTION; }
+	void clearSelection() { mSelectedIndex = constants::NO_SELECTION; }
 
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;
@@ -81,7 +81,7 @@ private:
 	const NAS2D::Font& mFont;
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
-	std::size_t mCurrentSelection = 0; /**< Current selection index. */
+	std::size_t mSelectedIndex = 0; /**< Current selection index. */
 	std::size_t mScrollOffsetInPixels = 0;
 
 	unsigned int mLineHeight = 0; /**< Height of an item line. */

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -48,17 +48,16 @@ public:
 	void clear();
 	void sort();
 
-	unsigned int lineHeight() const { return mLineHeight; }
-
+	bool isItemSelected() const;
+	const ListBoxItem& selected() const;
 	std::size_t selectedIndex() const { return mSelectedIndex; }
 	void setSelected(std::size_t index) { mSelectedIndex = index; mSelectionChanged(); }
 	void setSelectedByName(const std::string& item);
 	void clearSelected() { mSelectedIndex = constants::NO_SELECTION; }
 
-	bool isItemSelected() const;
-	const ListBoxItem& selected() const;
-
 	std::size_t currentHighlight() const { return mHighlightIndex; }
+
+	unsigned int lineHeight() const { return mLineHeight; }
 
 	void update() override;
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -48,7 +48,7 @@ public:
 	std::size_t count() const { return mItems.size(); }
 	unsigned int lineHeight() const { return mLineHeight; }
 
-	std::size_t currentSelection() const { return mCurrentSelection; }
+	std::size_t selectedIndex() const { return mCurrentSelection; }
 	void currentSelection(std::size_t selection) { mCurrentSelection = selection; mSelectionChanged(); }
 	void setSelectionByName(const std::string& item);
 	void clearSelection() { mCurrentSelection = constants::NO_SELECTION; }

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -49,7 +49,7 @@ public:
 	unsigned int lineHeight() const { return mLineHeight; }
 
 	std::size_t selectedIndex() const { return mSelectedIndex; }
-	void currentSelection(std::size_t selection) { mSelectedIndex = selection; mSelectionChanged(); }
+	void setSelected(std::size_t index) { mSelectedIndex = index; mSelectionChanged(); }
 	void setSelectionByName(const std::string& item);
 	void clearSelection() { mSelectedIndex = constants::NO_SELECTION; }
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -48,16 +48,15 @@ public:
 	std::size_t count() const { return mItems.size(); }
 	unsigned int lineHeight() const { return mLineHeight; }
 
-	void setSelectionByName(const std::string& item);
-
 	std::size_t currentSelection() const { return mCurrentSelection; }
 	void currentSelection(std::size_t selection) { mCurrentSelection = selection; mSelectionChanged(); }
+	void setSelectionByName(const std::string& item);
 	void clearSelection() { mCurrentSelection = constants::NO_SELECTION; }
-
-	std::size_t currentHighlight() const { return mCurrentHighlight; }
 
 	const std::string& selectionText() const;
 	int selectionTag() const;
+
+	std::size_t currentHighlight() const { return mCurrentHighlight; }
 
 	void update() override;
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -60,7 +60,7 @@ public:
 
 	void update() override;
 
-	bool empty() const;
+	bool isEmpty() const;
 
 	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -80,7 +80,7 @@ private:
 
 	const NAS2D::Font& mFont;
 
-	std::size_t mHighlightIndex = constants::NO_SELECTION; /**< Currently highlighted selection index. */
+	std::size_t mHighlightIndex = constants::NO_SELECTION;
 	std::size_t mSelectedIndex = 0;
 	std::size_t mScrollOffsetInPixels = 0;
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -55,8 +55,6 @@ public:
 
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;
-	const std::string& selectionText() const;
-	int selectionTag() const;
 
 	std::size_t currentHighlight() const { return mCurrentHighlight; }
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -50,7 +50,7 @@ public:
 
 	std::size_t selectedIndex() const { return mSelectedIndex; }
 	void setSelected(std::size_t index) { mSelectedIndex = index; mSelectionChanged(); }
-	void setSelectionByName(const std::string& item);
+	void setSelectedByName(const std::string& item);
 	void clearSelected() { mSelectedIndex = constants::NO_SELECTION; }
 
 	bool isItemSelected() const;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -54,6 +54,7 @@ public:
 	void clearSelection() { mCurrentSelection = constants::NO_SELECTION; }
 
 	bool isItemSelected() const;
+	const ListBoxItem& selected() const;
 	const std::string& selectionText() const;
 	int selectionTag() const;
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -39,13 +39,15 @@ public:
 	ListBox();
 	~ListBox() override;
 
+	bool isEmpty() const;
+	std::size_t count() const { return mItems.size(); }
+
 	void addItem(const std::string& item, int tag = 0);
 	void removeItem(const std::string& item);
 	bool itemExists(const std::string& item);
 	void clear();
 	void sort();
 
-	std::size_t count() const { return mItems.size(); }
 	unsigned int lineHeight() const { return mLineHeight; }
 
 	std::size_t selectedIndex() const { return mSelectedIndex; }
@@ -59,8 +61,6 @@ public:
 	std::size_t currentHighlight() const { return mHighlightIndex; }
 
 	void update() override;
-
-	bool isEmpty() const;
 
 	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -81,7 +81,7 @@ private:
 	const NAS2D::Font& mFont;
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
-	std::size_t mSelectedIndex = 0; /**< Current selection index. */
+	std::size_t mSelectedIndex = 0;
 	std::size_t mScrollOffsetInPixels = 0;
 
 	unsigned int mLineHeight = 0; /**< Height of an item line. */

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -56,7 +56,7 @@ public:
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;
 
-	std::size_t currentHighlight() const { return mCurrentHighlight; }
+	std::size_t currentHighlight() const { return mHighlightIndex; }
 
 	void update() override;
 
@@ -80,7 +80,7 @@ private:
 
 	const NAS2D::Font& mFont;
 
-	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
+	std::size_t mHighlightIndex = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	std::size_t mSelectedIndex = 0;
 	std::size_t mScrollOffsetInPixels = 0;
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -53,6 +53,7 @@ public:
 	void setSelectionByName(const std::string& item);
 	void clearSelection() { mCurrentSelection = constants::NO_SELECTION; }
 
+	bool isItemSelected() const;
 	const std::string& selectionText() const;
 	int selectionTag() const;
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -51,7 +51,7 @@ public:
 	std::size_t selectedIndex() const { return mSelectedIndex; }
 	void setSelected(std::size_t index) { mSelectedIndex = index; mSelectionChanged(); }
 	void setSelectionByName(const std::string& item);
-	void clearSelection() { mSelectedIndex = constants::NO_SELECTION; }
+	void clearSelected() { mSelectedIndex = constants::NO_SELECTION; }
 
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -104,11 +104,11 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	}
 
 	// A few basic checks
-	if (!rect().contains(point) || mCurrentHighlight == constants::NO_SELECTION) { return; }
+	if (!rect().contains(point) || mHighlightIndex == constants::NO_SELECTION) { return; }
 	if (mSlider.visible() && mSlider.rect().contains(point)) { return; }
-	if (mCurrentHighlight >= mItems.size()) { return; }
+	if (mHighlightIndex >= mItems.size()) { return; }
 
-	setSelection(mCurrentHighlight);
+	setSelection(mHighlightIndex);
 }
 
 
@@ -125,22 +125,22 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 	// Ignore mouse motion events if the pointer isn't within the menu rect.
 	if (!mHasFocus)
 	{
-		mCurrentHighlight = constants::NO_SELECTION;
+		mHighlightIndex = constants::NO_SELECTION;
 		return;
 	}
 
 	// if the mouse is on the slider then the slider should handle that
 	if (mSlider.visible() && mSlider.rect().contains(mousePosition))
 	{
-		mCurrentHighlight = constants::NO_SELECTION;
+		mHighlightIndex = constants::NO_SELECTION;
 		return;
 	}
 
-	mCurrentHighlight = (static_cast<unsigned int>(y - positionY()) + mCurrentOffset) / static_cast<unsigned int>(mItemHeight);
+	mHighlightIndex = (static_cast<unsigned int>(y - positionY()) + mCurrentOffset) / static_cast<unsigned int>(mItemHeight);
 
-	if (mCurrentHighlight >= mItems.size())
+	if (mHighlightIndex >= mItems.size())
 	{
-		mCurrentHighlight = constants::NO_SELECTION;
+		mHighlightIndex = constants::NO_SELECTION;
 	}
 }
 
@@ -211,7 +211,7 @@ void ListBoxBase::clearItems()
 	for (auto item : mItems) { delete item; }
 	mItems.clear();
 	mSelectedIndex = constants::NO_SELECTION;
-	mCurrentHighlight = constants::NO_SELECTION;
+	mHighlightIndex = constants::NO_SELECTION;
 	_update_item_display();
 }
 
@@ -239,7 +239,7 @@ bool ListBoxBase::empty() const
  */
 std::size_t ListBoxBase::currentHighlight() const
 {
-	return mCurrentHighlight;
+	return mHighlightIndex;
 }
 
 
@@ -308,7 +308,7 @@ void ListBoxBase::update()
 	renderer.clipRect(mRect);
 
 	// MOUSE HIGHLIGHT
-	int highlight_y = positionY() + (static_cast<int>(mCurrentHighlight) * mItemHeight) - static_cast<int>(mCurrentOffset);
+	int highlight_y = positionY() + (static_cast<int>(mHighlightIndex) * mItemHeight) - static_cast<int>(mCurrentOffset);
 	renderer.drawBoxFilled(NAS2D::Rectangle{positionX(), highlight_y, mItemWidth, mItemHeight}, NAS2D::Color{0, 185, 0, 50});
 
 	mSlider.update();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -63,14 +63,14 @@ void ListBoxBase::_update_item_display()
 			mSlider.position({rect().x + mRect.width - 14, mRect.y});
 			mSlider.size({14, mRect.height});
 			mSlider.length(static_cast<float>(mItemHeight * static_cast<int>(mItems.size()) - mRect.height));
-			mCurrentOffset = static_cast<unsigned int>(mSlider.thumbPosition());
+			mScrollOffsetInPixels = static_cast<unsigned int>(mSlider.thumbPosition());
 			mItemWidth -= static_cast<unsigned int>(mSlider.size().x);
 			mSlider.visible(true);
 		}
 	}
 	else
 	{
-		mCurrentOffset = 0;
+		mScrollOffsetInPixels = 0;
 		mSlider.length(0);
 		mSlider.visible(false);
 	}
@@ -136,7 +136,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 		return;
 	}
 
-	mHighlightIndex = (static_cast<unsigned int>(y - positionY()) + mCurrentOffset) / static_cast<unsigned int>(mItemHeight);
+	mHighlightIndex = (static_cast<unsigned int>(y - positionY()) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemHeight);
 
 	if (mHighlightIndex >= mItems.size())
 	{
@@ -308,7 +308,7 @@ void ListBoxBase::update()
 	renderer.clipRect(mRect);
 
 	// MOUSE HIGHLIGHT
-	int highlight_y = positionY() + (static_cast<int>(mHighlightIndex) * mItemHeight) - static_cast<int>(mCurrentOffset);
+	int highlight_y = positionY() + (static_cast<int>(mHighlightIndex) * mItemHeight) - static_cast<int>(mScrollOffsetInPixels);
 	renderer.drawBoxFilled(NAS2D::Rectangle{positionX(), highlight_y, mItemWidth, mItemHeight}, NAS2D::Color{0, 185, 0, 50});
 
 	mSlider.update();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -210,7 +210,7 @@ void ListBoxBase::clearItems()
 {
 	for (auto item : mItems) { delete item; }
 	mItems.clear();
-	mCurrentSelection = constants::NO_SELECTION;
+	mSelectedIndex = constants::NO_SELECTION;
 	mCurrentHighlight = constants::NO_SELECTION;
 	_update_item_display();
 }
@@ -248,7 +248,7 @@ std::size_t ListBoxBase::currentHighlight() const
  */
 std::size_t ListBoxBase::selectedIndex() const
 {
-	return mCurrentSelection;
+	return mSelectedIndex;
 }
 
 
@@ -259,7 +259,7 @@ std::size_t ListBoxBase::selectedIndex() const
  */
 void ListBoxBase::setSelection(std::size_t selection)
 {
-	mCurrentSelection = (selection < mItems.size()) ? selection : constants::NO_SELECTION;
+	mSelectedIndex = (selection < mItems.size()) ? selection : constants::NO_SELECTION;
 	mSelectionChanged();
 }
 
@@ -276,7 +276,7 @@ const std::string& ListBoxBase::selectionText() const
  */
 void ListBoxBase::clearSelection()
 {
-	mCurrentSelection = constants::NO_SELECTION;
+	mSelectedIndex = constants::NO_SELECTION;
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -252,6 +252,23 @@ std::size_t ListBoxBase::selectedIndex() const
 }
 
 
+bool ListBoxBase::isItemSelected() const
+{
+	return mSelectedIndex != constants::NO_SELECTION;
+}
+
+
+const ListBoxBase::ListBoxItem& ListBoxBase::selected() const
+{
+	if (mSelectedIndex == constants::NO_SELECTION)
+	{
+		throw std::runtime_error("ListBox has no selected item");
+	}
+
+	return *mItems[mSelectedIndex];
+}
+
+
 /**
  * Sets the current selection index.
  * 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -274,7 +274,7 @@ const std::string& ListBoxBase::selectionText() const
 /**
  * Clears the current selection.
  */
-void ListBoxBase::clearSelection()
+void ListBoxBase::clearSelected()
 {
 	mSelectedIndex = constants::NO_SELECTION;
 }

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -281,13 +281,6 @@ void ListBoxBase::setSelection(std::size_t selection)
 }
 
 
-const std::string& ListBoxBase::selectionText() const
-{
-	if (selectedIndex() == constants::NO_SELECTION) { return constants::EMPTY_STR; }
-	return mItems[selectedIndex()]->text;
-}
-
-
 /**
  * Clears the current selection.
  */

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -41,6 +41,24 @@ ListBoxBase::~ListBoxBase()
 }
 
 
+/**
+ * True if no items are in the list.
+ */
+bool ListBoxBase::isEmpty() const
+{
+	return mItems.empty();
+}
+
+
+/**
+ * Number of items in the ListBoxBase.
+ */
+std::size_t ListBoxBase::count() const
+{
+	return mItems.size();
+}
+
+
 void ListBoxBase::visibilityChanged(bool)
 {
 	_update_item_display();
@@ -213,24 +231,6 @@ void ListBoxBase::clear()
 	mSelectedIndex = constants::NO_SELECTION;
 	mHighlightIndex = constants::NO_SELECTION;
 	_update_item_display();
-}
-
-
-/**
- * Number of items in the ListBoxBase.
- */
-std::size_t ListBoxBase::count() const
-{
-	return mItems.size();
-}
-
-
-/**
- * True if no items are in the list.
- */
-bool ListBoxBase::isEmpty() const
-{
-	return mItems.empty();
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -206,7 +206,7 @@ void ListBoxBase::removeItem(ListBoxItem* item)
 /**
  * Clears all items from the list.
  */
-void ListBoxBase::clearItems()
+void ListBoxBase::clear()
 {
 	for (auto item : mItems) { delete item; }
 	mItems.clear();

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -95,7 +95,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if (!visible() || !hasFocus()) { return; }
 
-	if (empty() || button == EventHandler::MouseButton::BUTTON_MIDDLE) { return; }
+	if (isEmpty() || button == EventHandler::MouseButton::BUTTON_MIDDLE) { return; }
 
 	if (button == EventHandler::MouseButton::BUTTON_RIGHT && mRect.contains(point))
 	{
@@ -117,7 +117,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
  */
 void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
-	if (!visible() || empty()) { return; }
+	if (!visible() || isEmpty()) { return; }
 
 	const auto mousePosition = NAS2D::Point{x, y};
 	mHasFocus = rect().contains(mousePosition);
@@ -228,7 +228,7 @@ std::size_t ListBoxBase::count() const
 /**
  * True if no items are in the list.
  */
-bool ListBoxBase::empty() const
+bool ListBoxBase::isEmpty() const
 {
 	return mItems.empty();
 }

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -246,7 +246,7 @@ std::size_t ListBoxBase::currentHighlight() const
 /**
  * Index of the current selection.
  */
-std::size_t ListBoxBase::currentSelection() const
+std::size_t ListBoxBase::selectedIndex() const
 {
 	return mCurrentSelection;
 }
@@ -266,8 +266,8 @@ void ListBoxBase::setSelection(std::size_t selection)
 
 const std::string& ListBoxBase::selectionText() const
 {
-	if (currentSelection() == constants::NO_SELECTION) { return constants::EMPTY_STR; }
-	return mItems[currentSelection()]->text;
+	if (selectedIndex() == constants::NO_SELECTION) { return constants::EMPTY_STR; }
+	return mItems[selectedIndex()]->text;
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -59,7 +59,7 @@ public:
 
 	const std::string& selectionText() const;
 
-	void clearSelection();
+	void clearSelected();
 
 	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -90,7 +90,7 @@ private:
 	void onSizeChanged() override;
 
 
-	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
+	std::size_t mHighlightIndex = constants::NO_SELECTION; /**< Currently highlighted selection index. */
 	std::size_t mSelectedIndex = constants::NO_SELECTION;
 	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -91,7 +91,7 @@ private:
 
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
-	std::size_t mCurrentSelection = constants::NO_SELECTION; /**< Current selection index. */
+	std::size_t mSelectedIndex = constants::NO_SELECTION; /**< Current selection index. */
 	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
 
 	int mItemHeight = 1; /**< Height of a ListBoxItem. */

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -51,7 +51,7 @@ public:
 	void clear();
 
 	std::size_t count() const;
-	bool empty() const;
+	bool isEmpty() const;
 
 	std::size_t currentHighlight() const;
 	std::size_t selectedIndex() const;

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -90,7 +90,7 @@ private:
 	void onSizeChanged() override;
 
 
-	std::size_t mHighlightIndex = constants::NO_SELECTION; /**< Currently highlighted selection index. */
+	std::size_t mHighlightIndex = constants::NO_SELECTION;
 	std::size_t mSelectedIndex = constants::NO_SELECTION;
 	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -55,7 +55,6 @@ public:
 
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;
-	const std::string& selectionText() const;
 	std::size_t selectedIndex() const;
 	void setSelection(std::size_t selection);
 	void clearSelected();

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -53,6 +53,8 @@ public:
 	void removeItem(ListBoxItem*);
 	void clear();
 
+	bool isItemSelected() const;
+	const ListBoxItem& selected() const;
 	const std::string& selectionText() const;
 	std::size_t selectedIndex() const;
 	void setSelection(std::size_t selection);

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -46,12 +46,12 @@ public:
 	ListBoxBase();
 	~ListBoxBase() override;
 
+	bool isEmpty() const;
+	std::size_t count() const;
+
 	void addItem(ListBoxItem*);
 	void removeItem(ListBoxItem*);
 	void clear();
-
-	std::size_t count() const;
-	bool isEmpty() const;
 
 	std::size_t currentHighlight() const;
 	std::size_t selectedIndex() const;

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -54,7 +54,7 @@ public:
 	bool empty() const;
 
 	std::size_t currentHighlight() const;
-	std::size_t currentSelection() const;
+	std::size_t selectedIndex() const;
 	void setSelection(std::size_t selection);
 
 	const std::string& selectionText() const;

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -53,18 +53,16 @@ public:
 	void removeItem(ListBoxItem*);
 	void clear();
 
-	std::size_t currentHighlight() const;
+	const std::string& selectionText() const;
 	std::size_t selectedIndex() const;
 	void setSelection(std::size_t selection);
-
-	const std::string& selectionText() const;
-
 	void clearSelected();
+
+	std::size_t currentHighlight() const;
 
 	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 
 	void update() override = 0;
-
 
 protected:
 	void _update_item_display();

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -48,7 +48,7 @@ public:
 
 	void addItem(ListBoxItem*);
 	void removeItem(ListBoxItem*);
-	void clearItems();
+	void clear();
 
 	std::size_t count() const;
 	bool empty() const;

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -91,7 +91,7 @@ private:
 
 
 	std::size_t mCurrentHighlight = constants::NO_SELECTION; /**< Currently highlighted selection index. */
-	std::size_t mSelectedIndex = constants::NO_SELECTION; /**< Current selection index. */
+	std::size_t mSelectedIndex = constants::NO_SELECTION;
 	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
 
 	int mItemHeight = 1; /**< Height of a ListBoxItem. */

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -73,7 +73,7 @@ protected:
 	unsigned int item_height() const { return static_cast<unsigned int>(mItemHeight); }
 	void item_height(int);
 
-	unsigned int draw_offset() const { return mCurrentOffset; }
+	unsigned int draw_offset() const { return mScrollOffsetInPixels; }
 
 	void visibilityChanged(bool) override;
 
@@ -92,7 +92,7 @@ private:
 
 	std::size_t mHighlightIndex = constants::NO_SELECTION;
 	std::size_t mSelectedIndex = constants::NO_SELECTION;
-	unsigned int mCurrentOffset = 0; /**< Draw Offset. */
+	unsigned int mScrollOffsetInPixels = 0;
 
 	int mItemHeight = 1; /**< Height of a ListBoxItem. */
 	int mItemWidth = 0; /**< Width of a ListBoxItem. */

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -109,7 +109,7 @@ void FactoryListBox::removeItem(Factory* factory)
  * 
  * \param f	Pointer to a Factory object. Safe to pass \c nullptr.
  */
-void FactoryListBox::currentSelection(Factory* f)
+void FactoryListBox::setSelected(Factory* f)
 {
 	if (mItems.empty() || f == nullptr) { return; }
 	for (std::size_t i = 0; i < mItems.size(); ++i)

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -97,7 +97,7 @@ void FactoryListBox::removeItem(Factory* factory)
 		{
 			mItems.erase(it);
 			_update_item_display();
-			clearSelection();
+			clearSelected();
 			return;
 		}
 	}

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -126,7 +126,7 @@ void FactoryListBox::currentSelection(Factory* f)
 
 Factory* FactoryListBox::selectedFactory()
 {
-	return (currentSelection() == constants::NO_SELECTION) ? nullptr : static_cast<FactoryListBoxItem*>(mItems[currentSelection()])->factory;
+	return (selectedIndex() == constants::NO_SELECTION) ? nullptr : static_cast<FactoryListBoxItem*>(mItems[selectedIndex()])->factory;
 }
 
 
@@ -150,7 +150,7 @@ void FactoryListBox::update()
 			positionY() + (static_cast<int>(i) * LIST_ITEM_HEIGHT),
 			static_cast<int>(item_width()),
 			static_cast<int>(draw_offset()),
-			i == currentSelection());
+			i == selectedIndex());
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -33,7 +33,7 @@ public:
 
 	void addItem(Factory* factory);
 	void removeItem(Factory* factory);
-	void currentSelection(Factory*);
+	void setSelected(Factory*);
 
 	Factory* selectedFactory();
 

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -34,7 +34,6 @@ public:
 	void addItem(Factory* factory);
 	void removeItem(Factory* factory);
 	void currentSelection(Factory*);
-	using ListBoxBase::currentSelection;
 
 	Factory* selectedFactory();
 

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -115,7 +115,7 @@ void FactoryProduction::factory(Factory* newFactory)
 
 	if (!mFactory) { return; }
 
-	mProductGrid.dropAllItems();
+	mProductGrid.clear();
 	clearProduct();
 
 	// destroyed factories can't produce anything at all ever.

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -102,7 +102,7 @@ void FileIo::scanDirectory(const std::string& directory)
 	Filesystem& f = Utility<Filesystem>::get();
 	std::vector<std::string> dirList = f.directoryList(directory);
 
-	mListBox.dropAllItems();
+	mListBox.clear();
 
 	for (auto& dir : dirList)
 	{

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -119,7 +119,7 @@ void FileIo::scanDirectory(const std::string& directory)
 
 void FileIo::fileSelected()
 {
-	txtFileName.text(mListBox.selectionText());
+	txtFileName.text(mListBox.isItemSelected() ? mListBox.selected().text : "");
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -259,7 +259,7 @@ bool IconGrid::itemExists(const std::string& item)
 /**
  * Drops all items from the IconGrid.
  */
-void IconGrid::dropAllItems()
+void IconGrid::clear()
 {
 	mIconItemList.clear();
 	clearSelection();

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -86,16 +86,16 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		return;
 	}
 
-	mCurrentSelection = translateCoordsToIndex(mousePoint - startPoint);
+	mSelectedIndex = translateCoordsToIndex(mousePoint - startPoint);
 
-	if (mCurrentSelection >= mIconItemList.size())
+	if (mSelectedIndex >= mIconItemList.size())
 	{
-		mCurrentSelection = constants::NO_SELECTION;
+		mSelectedIndex = constants::NO_SELECTION;
 	}
-	/* else if (!mIconItemList[mCurrentSelection].available)
+	/* else if (!mIconItemList[mSelectedIndex].available)
 	{
 		cout << "Insufficient resources" <<endl;
-		mCurrentSelection = constants::NO_SELECTION;
+		mSelectedIndex = constants::NO_SELECTION;
 		return;
 	} */
 
@@ -272,7 +272,7 @@ void IconGrid::dropAllItems()
 void IconGrid::clearSelection()
 {
 	mHighlightIndex = constants::NO_SELECTION;
-	mCurrentSelection = constants::NO_SELECTION;
+	mSelectedIndex = constants::NO_SELECTION;
 }
 
 
@@ -281,7 +281,7 @@ void IconGrid::clearSelection()
  */
 void IconGrid::selection(std::size_t newSelection)
 {
-	mCurrentSelection = (newSelection < mIconItemList.size()) ? newSelection : constants::NO_SELECTION;
+	mSelectedIndex = (newSelection < mIconItemList.size()) ? newSelection : constants::NO_SELECTION;
 }
 
 
@@ -302,7 +302,7 @@ void IconGrid::selection_meta(int selectionMetaValue)
 	{
 		if (mIconItemList[i].meta == selectionMetaValue)
 		{
-			mCurrentSelection = i;
+			mSelectedIndex = i;
 			return;
 		}
 	}
@@ -311,15 +311,15 @@ void IconGrid::selection_meta(int selectionMetaValue)
 
 void IconGrid::incrementSelection()
 {
-	++mCurrentSelection;
-	if (mCurrentSelection >= mIconItemList.size())
+	++mSelectedIndex;
+	if (mSelectedIndex >= mIconItemList.size())
 	{
-		mCurrentSelection = 0;
+		mSelectedIndex = 0;
 	}
 
 	if (mIconItemList.empty())
 	{
-		mCurrentSelection = constants::NO_SELECTION;
+		mSelectedIndex = constants::NO_SELECTION;
 	}
 
 	raiseChangedEvent();
@@ -328,15 +328,15 @@ void IconGrid::incrementSelection()
 
 void IconGrid::decrementSelection()
 {
-	if (mCurrentSelection == 0)
+	if (mSelectedIndex == 0)
 	{
-		mCurrentSelection = mIconItemList.size();
+		mSelectedIndex = mIconItemList.size();
 	}
-	--mCurrentSelection;
+	--mSelectedIndex;
 
 	if (mIconItemList.empty())
 	{
-		mCurrentSelection = constants::NO_SELECTION;
+		mSelectedIndex = constants::NO_SELECTION;
 	}
 
 	raiseChangedEvent();
@@ -345,9 +345,9 @@ void IconGrid::decrementSelection()
 
 void IconGrid::raiseChangedEvent()
 {
-	if (mCurrentSelection != constants::NO_SELECTION)
+	if (mSelectedIndex != constants::NO_SELECTION)
 	{
-		mCallback(&mIconItemList[mCurrentSelection]);
+		mCallback(&mIconItemList[mSelectedIndex]);
 	}
 	else
 	{
@@ -390,9 +390,9 @@ void IconGrid::update()
 		renderer.drawSubImage(mIconSheet, position, NAS2D::Rectangle{mIconItemList[i].pos.x, mIconItemList[i].pos.y, mIconSize, mIconSize}, highlightColor);
 	}
 
-	if (mCurrentSelection != constants::NO_SELECTION)
+	if (mSelectedIndex != constants::NO_SELECTION)
 	{
-		const auto position = indexToGridPosition(mCurrentSelection) + NAS2D::Vector{mIconMargin, mIconMargin};
+		const auto position = indexToGridPosition(mSelectedIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
 		renderer.drawBox(NAS2D::Rectangle<int>::Create(position, NAS2D::Vector{mIconSize, mIconSize}), NAS2D::Color{0, 100, 255});
 	}
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -63,7 +63,7 @@ public:
 	void addItem(const std::string& name, int sheetIndex, int meta);
 	void removeItem(const std::string& item);
 	bool itemExists(const std::string& item);
-	void dropAllItems();
+	void clear();
 
 	// Setter
 	void itemAvailable(const std::string& item, bool isItemAvailable);

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -55,7 +55,7 @@ public:
 
 	const std::string& itemName(std::size_t index) const { return mIconItemList[index].name; }
 
-	int selectionIndex() const { return static_cast<int>(mCurrentSelection); }
+	int selectionIndex() const { return static_cast<int>(mSelectedIndex); }
 
 	bool empty() const { return mIconItemList.empty(); }
 
@@ -106,7 +106,7 @@ private:
 	const NAS2D::Font& mFont;
 
 	Index mHighlightIndex = constants::NO_SELECTION; /**< Current highlight index. */
-	Index mCurrentSelection = constants::NO_SELECTION; /**< Currently selected item index. */
+	Index mSelectedIndex = constants::NO_SELECTION; /**< Currently selected item index. */
 
 	int mIconSize = 1; /**< Size of the icons. */
 	int mIconMargin = 0; /**< Spacing between icons and edges of the IconGrid. */

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -24,7 +24,7 @@ ProductListBox::ProductListBox() :
  */
 void ProductListBox::productPool(ProductPool& pool)
 {
-	clearItems();
+	clear();
 
 	for (std::size_t product_type = 0; product_type < static_cast<std::size_t>(ProductType::PRODUCT_COUNT); ++product_type)
 	{

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -67,7 +67,7 @@ void ProductListBox::update()
 	{
 		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
 		const auto y = positionY() + (static_cast<int>(i) * itemSize.y);
-		const auto highlight = i == currentSelection();
+		const auto highlight = i == selectedIndex();
 
 		// Draw highlight rect so as not to tint/hue colors of everything else
 		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{x, y - offset, itemSize.x, itemSize.y}, highlightColor); }

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -419,7 +419,6 @@ void FactoryReport::lstFactoryListSelectionChanged()
 			lstProducts.addItem(productDescription(item), static_cast<int>(item));
 		}
 	}
-	lstProducts.clearSelected();
 	lstProducts.setSelectedByName(productDescription(selectedFactory->productType()));
 	selectedProductType = selectedFactory->productType();
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -143,7 +143,7 @@ FactoryReport::FactoryReport() :
  */
 void FactoryReport::selectStructure(Structure* structure)
 {
-	lstFactoryList.currentSelection(dynamic_cast<Factory*>(structure));
+	lstFactoryList.setSelected(dynamic_cast<Factory*>(structure));
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -420,7 +420,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 		}
 	}
 	lstProducts.clearSelected();
-	lstProducts.setSelectionByName(productDescription(selectedFactory->productType()));
+	lstProducts.setSelectedByName(productDescription(selectedFactory->productType()));
 	selectedProductType = selectedFactory->productType();
 
 	StructureState _state = selectedFactory->state();

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -436,7 +436,7 @@ void FactoryReport::lstProductsSelectionChanged()
 
 void FactoryReport::cboFilterByProductSelectionChanged()
 {
-	if (cboFilterByProduct.currentSelection() == constants::NO_SELECTION) { return; }
+	if (!cboFilterByProduct.isItemSelected()) { return; }
 	filterButtonClicked(false);
 	fillFactoryList(static_cast<ProductType>(cboFilterByProduct.selectionTag()));
 }

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -147,9 +147,9 @@ void FactoryReport::selectStructure(Structure* structure)
 }
 
 
-void FactoryReport::clearSelection()
+void FactoryReport::clearSelected()
 {
-	lstFactoryList.clearSelection();
+	lstFactoryList.clearSelected();
 	selectedFactory = nullptr;
 }
 
@@ -310,7 +310,7 @@ void FactoryReport::filterButtonClicked(bool clearCbo)
 	btnShowIdle.toggle(false);
 	btnShowDisabled.toggle(false);
 
-	if (clearCbo) { cboFilterByProduct.clearSelection(); }
+	if (clearCbo) { cboFilterByProduct.clearSelected(); }
 }
 
 
@@ -372,7 +372,7 @@ void FactoryReport::btnIdleClicked()
 void FactoryReport::btnClearProductionClicked()
 {
 	selectedFactory->productType(ProductType::PRODUCT_NONE);
-	lstProducts.clearSelection();
+	lstProducts.clearSelected();
 	cboFilterByProductSelectionChanged();
 }
 
@@ -419,7 +419,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 			lstProducts.addItem(productDescription(item), static_cast<int>(item));
 		}
 	}
-	lstProducts.clearSelection();
+	lstProducts.clearSelected();
 	lstProducts.setSelectionByName(productDescription(selectedFactory->productType()));
 	selectedProductType = selectedFactory->productType();
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -410,7 +410,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 
 	btnClearProduction.enabled(selectedFactory->state() == StructureState::Operational || selectedFactory->state() == StructureState::Idle);
 
-	lstProducts.dropAllItems();
+	lstProducts.clear();
 	if (selectedFactory->state() != StructureState::Destroyed)
 	{
 		const Factory::ProductionTypeList& _pl = selectedFactory->productList();

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -169,7 +169,7 @@ void FactoryReport::refresh()
 void FactoryReport::fillLists()
 {
 	selectedFactory = nullptr;
-	lstFactoryList.clearItems();
+	lstFactoryList.clear();
 	for (auto factory : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
 		lstFactoryList.addItem(static_cast<Factory*>(factory));
@@ -184,7 +184,7 @@ void FactoryReport::fillLists()
 void FactoryReport::fillFactoryList(ProductType type)
 {
 	selectedFactory = nullptr;
-	lstFactoryList.clearItems();
+	lstFactoryList.clear();
 	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
 		Factory* factory = static_cast<Factory*>(f);
@@ -204,7 +204,7 @@ void FactoryReport::fillFactoryList(ProductType type)
 void FactoryReport::fillFactoryList(bool surface)
 {
 	selectedFactory = nullptr;
-	lstFactoryList.clearItems();
+	lstFactoryList.clear();
 	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
 		Factory* factory = static_cast<Factory*>(f);
@@ -228,7 +228,7 @@ void FactoryReport::fillFactoryList(bool surface)
 void FactoryReport::fillFactoryList(StructureState state)
 {
 	selectedFactory = nullptr;
-	lstFactoryList.clearItems();
+	lstFactoryList.clear();
 	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
 	{
 		if (f->state() == state)

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -430,7 +430,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 
 void FactoryReport::lstProductsSelectionChanged()
 {
-	selectedProductType = static_cast<ProductType>(lstProducts.selectionTag());
+	selectedProductType = static_cast<ProductType>(lstProducts.isItemSelected() ? lstProducts.selected().tag : 0);
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -247,7 +247,7 @@ void FactoryReport::fillFactoryList(StructureState state)
  */
 void FactoryReport::checkFactoryActionControls()
 {
-	bool actionControlVisible = !lstFactoryList.empty();
+	bool actionControlVisible = !lstFactoryList.isEmpty();
 
 	btnIdle.visible(actionControlVisible);
 	btnClearProduction.visible(actionControlVisible);

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -28,7 +28,7 @@ public:
 	void refresh() override;
 
 	void fillLists() override;
-	void clearSelection() override;
+	void clearSelected() override;
 
 	void update() override;
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -118,7 +118,7 @@ MineReport::MineReport() :
 
 void MineReport::selectStructure(Structure* structure)
 {
-	lstMineFacilities.currentSelection(structure);
+	lstMineFacilities.setSelected(structure);
 }
 
 
@@ -154,7 +154,7 @@ void MineReport::fillLists()
 		++id;
 	}
 
-	selectedFacility == nullptr ? lstMineFacilities.setSelection(0) : lstMineFacilities.currentSelection(selectedFacility);
+	selectedFacility == nullptr ? lstMineFacilities.setSelection(0) : lstMineFacilities.setSelected(selectedFacility);
 	mAvailableTrucks = getTruckAvailability();
 	updateManagementButtonsVisiblity();
 }

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -355,7 +355,8 @@ void MineReport::drawMineFacilityPane(const NAS2D::Point<int>& origin)
 	const auto textColor = NAS2D::Color{ 0, 185, 0 };
 
 	r.drawImage(mineFacility, origin);
-	r.drawText(fontBigBold, lstMineFacilities.selectionText(), origin + NAS2D::Vector{ 0, -33 }, textColor);
+	const auto text = lstMineFacilities.isItemSelected() ? lstMineFacilities.selected().text : "";
+	r.drawText(fontBigBold, text, origin + NAS2D::Vector{ 0, -33 }, textColor);
 
 	r.drawText(fontMediumBold, "Status", origin + NAS2D::Vector{ 138, 0 }, textColor);
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -122,9 +122,9 @@ void MineReport::selectStructure(Structure* structure)
 }
 
 
-void MineReport::clearSelection()
+void MineReport::clearSelected()
 {
-	lstMineFacilities.clearSelection();
+	lstMineFacilities.clearSelected();
 	selectedFacility = nullptr;
 }
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -137,7 +137,7 @@ void MineReport::refresh()
 
 void MineReport::fillLists()
 {
-	lstMineFacilities.clearItems();
+	lstMineFacilities.clear();
 	std::size_t id = 1;
 	for (auto facility : NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Mine))
 	{

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -30,7 +30,7 @@ public:
 	void refresh() override;
 
 	void fillLists() override;
-	void clearSelection() override;
+	void clearSelected() override;
 
 	void update() override;
 

--- a/OPHD/UI/Reports/ReportInterface.h
+++ b/OPHD/UI/Reports/ReportInterface.h
@@ -25,7 +25,7 @@ public:
 	/**
 	 * Instructs the Report UI to clear any selections it may have.
 	 */
-	virtual void clearSelection() = 0;
+	virtual void clearSelected() = 0;
 
 	/**
 	 * Instructs the Report UI that it should fill any lists it needs to (the

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -246,7 +246,7 @@ void WarehouseReport::refresh()
 
 void WarehouseReport::selectStructure(Structure* structure)
 {
-	lstStructures.currentSelection(structure);
+	lstStructures.setSelected(structure);
 	selectedWarehouse = static_cast<Warehouse*>(structure);
 }
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -126,7 +126,7 @@ void WarehouseReport::_fillListFromStructureList(const std::vector<Structure*>& 
  */
 void WarehouseReport::fillLists()
 {
-	lstStructures.clearItems();
+	lstStructures.clear();
 
 	_fillListFromStructureList(Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse));
 
@@ -137,7 +137,7 @@ void WarehouseReport::fillLists()
 
 void WarehouseReport::fillListSpaceAvailable()
 {
-	lstStructures.clearItems();
+	lstStructures.clear();
 
 	StructureList list;
 	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
@@ -159,7 +159,7 @@ void WarehouseReport::fillListSpaceAvailable()
 
 void WarehouseReport::fillListFull()
 {
-	lstStructures.clearItems();
+	lstStructures.clear();
 
 	StructureList list;
 	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
@@ -180,7 +180,7 @@ void WarehouseReport::fillListFull()
 
 void WarehouseReport::fillListEmpty()
 {
-	lstStructures.clearItems();
+	lstStructures.clear();
 
 	StructureList list;
 	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
@@ -201,7 +201,7 @@ void WarehouseReport::fillListEmpty()
 
 void WarehouseReport::fillListDisabled()
 {
-	lstStructures.clearItems();
+	lstStructures.clear();
 
 	StructureList list;
 	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -231,9 +231,9 @@ void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int
 }
 
 
-void WarehouseReport::clearSelection()
+void WarehouseReport::clearSelected()
 {
-	lstStructures.clearSelection();
+	lstStructures.clearSelected();
 	selectedWarehouse = nullptr;
 }
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -26,7 +26,7 @@ public:
 	~WarehouseReport() override;
 
 	void fillLists() override;
-	void clearSelection() override;
+	void clearSelected() override;
 
 	void refresh() override;
 	void selectStructure(Structure*) override;

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -117,7 +117,7 @@ void StructureListBox::currentSelection(Structure* structure)
 
 Structure* StructureListBox::selectedStructure()
 {
-	return (currentSelection() == constants::NO_SELECTION) ? nullptr : static_cast<StructureListBoxItem*>(mItems[currentSelection()])->structure;
+	return (selectedIndex() == constants::NO_SELECTION) ? nullptr : static_cast<StructureListBoxItem*>(mItems[selectedIndex()])->structure;
 }
 
 
@@ -150,7 +150,7 @@ void StructureListBox::update()
 			positionY() + (static_cast<int>(i) * LIST_ITEM_HEIGHT),
 			static_cast<int>(item_width()),
 			static_cast<int>(draw_offset()),
-			i == currentSelection());
+			i == selectedIndex());
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -99,7 +99,7 @@ void StructureListBox::removeItem(Structure* structure)
  * 
  * \param structure		Pointer to a Structure object. Save to pass \c nullptr.
  */
-void StructureListBox::currentSelection(Structure* structure)
+void StructureListBox::setSelected(Structure* structure)
 {
 	if (mItems.empty() || structure == nullptr) { return; }
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -87,7 +87,7 @@ void StructureListBox::removeItem(Structure* structure)
 		{
 			mItems.erase(it);
 			_update_item_display();
-			clearSelection();
+			clearSelected();
 			return;
 		}
 	}

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -33,7 +33,6 @@ public:
 	void addItem(Structure*);
 	void removeItem(Structure*);
 	void currentSelection(Structure*);
-	using ListBoxBase::currentSelection;
 
 	Structure* selectedStructure();
 

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -32,7 +32,7 @@ public:
 
 	void addItem(Structure*);
 	void removeItem(Structure*);
-	void currentSelection(Structure*);
+	void setSelected(Structure*);
 
 	Structure* selectedStructure();
 


### PR DESCRIPTION
Pre-work making `ListBox` interface changes to help address #479. This tries to make the interfaces a little more similar between `ListBox` and `ListBoxBase`, and perhaps hopefully easier to use.

The big difference between `ListBox` and `ListBoxBase` is the different fields supported by the `ListBoxItem` struct. Methods in the `ListBox` class that directly touch those fields are less portable between the two classes. To work around this, direct read-only access to `ListBoxItem` structs is provided, pushing those differences out of the `ListBox` classes. In particular, the caller will know which type of `ListBox` it is using, and so it will know which fields should be present in a `ListBoxItem` struct. Eventually that `ListBoxItem` struct could become a template parameter.

One area I haven't yet touched is selecting an item by name. This of course touches the `ListBoxItem` fields directly, and so will not be portable between class types. An update to make that method generic will likely involve lambdas. A change I figure I'll make in a separate pull request.
