### PR TITLE
Add ListBox::selectIf template method

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -4,6 +4,7 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/MathUtils.h>
+#include <NAS2D/StringUtils.h>
 
 #include <algorithm>
 
@@ -194,7 +195,7 @@ void ComboBox::update()
 
 void ComboBox::text(const std::string& text) {
 	txtField.text(text);
-	lstItems.setSelectedByName(txtField.text());
+	lstItems.selectIf([target = toLowercase(txtField.text())](const auto& item){ return toLowercase(item.text) == target; });
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -5,7 +5,6 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/MathUtils.h>
-#include <NAS2D/StringUtils.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Point.h>
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -136,16 +136,6 @@ bool ListBox::itemExists(const std::string& item)
 }
 
 
-void ListBox::setSelectedByName(const std::string& item)
-{
-	const auto target = toLowercase(item);
-	for (std::size_t i = 0; i < mItems.size(); i++)
-	{
-		if (toLowercase(mItems[i].text) == target) { mSelectedIndex = i; return; }
-	}
-}
-
-
 bool ListBox::isItemSelected() const
 {
 	return mSelectedIndex != constants::NO_SELECTION;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -52,7 +52,6 @@ public:
 	const ListBoxItem& selected() const;
 	std::size_t selectedIndex() const { return mSelectedIndex; }
 	void setSelected(std::size_t index) { mSelectedIndex = index; mSelectionChanged(); }
-	void setSelectedByName(const std::string& item);
 	void clearSelected() { mSelectedIndex = constants::NO_SELECTION; }
 
 	template <typename UnaryPredicate>

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -55,6 +55,16 @@ public:
 	void setSelectedByName(const std::string& item);
 	void clearSelected() { mSelectedIndex = constants::NO_SELECTION; }
 
+	template <typename UnaryPredicate>
+	void selectIf(UnaryPredicate predicate) {
+		for (std::size_t i = 0; i < mItems.size(); ++i) {
+			if (predicate(mItems[i])) {
+				mSelectedIndex = i;
+				return;
+			}
+		}
+	}
+
 	std::size_t currentHighlight() const { return mHighlightIndex; }
 
 	unsigned int lineHeight() const { return mLineHeight; }

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -419,7 +419,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 			lstProducts.addItem(productDescription(item), static_cast<int>(item));
 		}
 	}
-	lstProducts.setSelectedByName(productDescription(selectedFactory->productType()));
+	lstProducts.selectIf([productType = selectedFactory->productType()](const auto& item){ return item.tag == productType; });
 	selectedProductType = selectedFactory->productType();
 
 	StructureState _state = selectedFactory->state();


### PR DESCRIPTION
Add `ListBox::selectIf` template method, taking a unary predicate used to check items in the `ListBox`.

Use new method to improve efficiency, and to remove old public API method `ListBox::setSelectedByName`. The old method made assumptions about the contents of `ListBoxItem`, and so was not portable between the `ListBox` and `ListBoxBase`.

Prep-work for #479.
