### PR TITLE
Unify (mostly) list box base interface

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -147,7 +147,7 @@ void ComboBox::maxDisplayItems(std::size_t count)
  */
 void ComboBox::addItem(const std::string& item, int tag)
 {
-	lstItems.addItem(item, tag);
+	lstItems.add(item, tag);
 
 	if (lstItems.count() > mMaxDisplayItems) { return; }
 	lstItems.height(static_cast<int>(lstItems.count() * lstItems.lineHeight()));

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -98,21 +98,6 @@ void ListBox::addItem(const std::string& item, int tag)
 }
 
 
-/**
- * Removes a named item from the Menu.
- */
-void ListBox::removeItem(const std::string& item)
-{
-	auto it = std::find(mItems.begin(), mItems.end(), item);
-	if (it != mItems.end())
-	{
-		mItems.erase(it);
-		mSelectedIndex = constants::NO_SELECTION;
-		updateScrollLayout();
-	}
-}
-
-
 bool ListBox::isItemSelected() const
 {
 	return mSelectedIndex != constants::NO_SELECTION;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -122,12 +122,6 @@ void ListBox::removeItem(const std::string& item)
 }
 
 
-bool ListBox::itemExists(const std::string& item)
-{
-	return std::find(mItems.begin(), mItems.end(), item) != mItems.end();
-}
-
-
 bool ListBox::isItemSelected() const
 {
 	return mSelectedIndex != constants::NO_SELECTION;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -86,18 +86,6 @@ void ListBox::updateScrollLayout()
 }
 
 
-/**
- * Adds an item to the Menu.
- *
- * \param	item	Item to add.
- */
-void ListBox::addItem(const std::string& item, int tag)
-{
-	mItems.push_back(ListBoxItem{item, tag});
-	updateScrollLayout();
-}
-
-
 bool ListBox::isItemSelected() const
 {
 	return mSelectedIndex != constants::NO_SELECTION;

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -93,12 +93,6 @@ void ListBox::_updateItemDisplay()
  * Adds an item to the Menu.
  *
  * \param	item	Item to add.
- *
- * \warning	Menu::font(Font& font) must have been called with a valid Font
- *			before this function can be safely called.
- *
- * \todo	Make this function safe to call regardless of whether a font
- *			has been defined or not.
  */
 void ListBox::addItem(const std::string& item, int tag)
 {

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -67,11 +67,12 @@ void ListBox::_updateItemDisplay()
 	// Account for border around control
 	mScrollArea = mRect.inset(1);
 
-	if ((mLineHeight * mItems.size()) > static_cast<std::size_t>(mRect.height))
+	const auto neededDisplaySize = mLineHeight * mItems.size();
+	if (neededDisplaySize > static_cast<std::size_t>(mRect.height))
 	{
 		mSlider.position({rect().x + mRect.width - 14, mRect.y});
 		mSlider.size({14, mRect.height});
-		mSlider.length(static_cast<float>(static_cast<int>(mLineHeight * mItems.size()) - mRect.height));
+		mSlider.length(static_cast<float>(static_cast<int>(neededDisplaySize) - mRect.height));
 		mScrollOffsetInPixels = static_cast<std::size_t>(mSlider.thumbPosition());
 		mScrollArea.width -= mSlider.size().x; // Remove scroll bar from scroll area
 		mSlider.visible(true);

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -27,7 +27,7 @@ ListBox::ListBox() :
 	mSlider.length(0);
 	mSlider.thumbPosition(0);
 	mSlider.change().connect(this, &ListBox::slideChanged);
-	_updateItemDisplay();
+	updateScrollLayout();
 }
 
 
@@ -52,17 +52,17 @@ bool ListBox::isEmpty() const
 
 void ListBox::onSizeChanged()
 {
-	_updateItemDisplay();
+	updateScrollLayout();
 }
 
 
 void ListBox::visibilityChanged(bool /*visible*/)
 {
-	_updateItemDisplay();
+	updateScrollLayout();
 }
 
 
-void ListBox::_updateItemDisplay()
+void ListBox::updateScrollLayout()
 {
 	// Account for border around control
 	mScrollArea = mRect.inset(1);
@@ -94,7 +94,7 @@ void ListBox::_updateItemDisplay()
 void ListBox::addItem(const std::string& item, int tag)
 {
 	mItems.push_back(ListBoxItem{item, tag});
-	_updateItemDisplay();
+	updateScrollLayout();
 }
 
 
@@ -108,7 +108,7 @@ void ListBox::removeItem(const std::string& item)
 	{
 		mItems.erase(it);
 		mSelectedIndex = constants::NO_SELECTION;
-		_updateItemDisplay();
+		updateScrollLayout();
 	}
 }
 
@@ -138,7 +138,7 @@ void ListBox::clear()
 	mItems.clear();
 	mSelectedIndex = constants::NO_SELECTION;
 	mHighlightIndex = constants::NO_SELECTION;
-	_updateItemDisplay();
+	updateScrollLayout();
 }
 
 
@@ -232,7 +232,7 @@ void ListBox::update()
 
 void ListBox::slideChanged(float newPosition)
 {
-	_updateItemDisplay();
+	updateScrollLayout();
 	// Intentional truncation of fractional value
 	const auto pos = std::floor(newPosition);
 	if (pos != newPosition)

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -69,16 +69,12 @@ void ListBox::_updateItemDisplay()
 
 	if ((mLineHeight * mItems.size()) > static_cast<std::size_t>(mRect.height))
 	{
-		const auto lineCount = static_cast<unsigned int>(mRect.height) / mLineHeight;
-		if (lineCount < mItems.size())
-		{
-			mSlider.position({rect().x + mRect.width - 14, mRect.y});
-			mSlider.size({14, mRect.height});
-			mSlider.length(static_cast<float>(static_cast<int>(mLineHeight * mItems.size()) - mRect.height));
-			mScrollOffsetInPixels = static_cast<std::size_t>(mSlider.thumbPosition());
-			mScrollArea.width -= mSlider.size().x; // Remove scroll bar from scroll area
-			mSlider.visible(true);
-		}
+		mSlider.position({rect().x + mRect.width - 14, mRect.y});
+		mSlider.size({14, mRect.height});
+		mSlider.length(static_cast<float>(static_cast<int>(mLineHeight * mItems.size()) - mRect.height));
+		mScrollOffsetInPixels = static_cast<std::size_t>(mSlider.thumbPosition());
+		mScrollArea.width -= mSlider.size().x; // Remove scroll bar from scroll area
+		mSlider.visible(true);
 	}
 	else
 	{

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -49,7 +49,6 @@ public:
 		updateScrollLayout();
 	}
 
-	void addItem(const std::string& item, int tag = 0);
 	void clear();
 	void sort();
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -43,7 +43,6 @@ public:
 	std::size_t count() const { return mItems.size(); }
 
 	void addItem(const std::string& item, int tag = 0);
-	void removeItem(const std::string& item);
 	void clear();
 	void sort();
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -44,7 +44,6 @@ public:
 
 	void addItem(const std::string& item, int tag = 0);
 	void removeItem(const std::string& item);
-	bool itemExists(const std::string& item);
 	void clear();
 	void sort();
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 #include <cstddef>
 
 
@@ -41,6 +42,12 @@ public:
 
 	bool isEmpty() const;
 	std::size_t count() const { return mItems.size(); }
+
+	template <typename... Args>
+	void add(Args&&... args) {
+		mItems.emplace_back(ListBoxItem{std::forward<Args>(args)...});
+		updateScrollLayout();
+	}
 
 	void addItem(const std::string& item, int tag = 0);
 	void clear();

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -81,8 +81,7 @@ protected:
 
 private:
 	void onSizeChanged() override;
-
-	void _updateItemDisplay();
+	void updateScrollLayout();
 
 
 	const NAS2D::Font& mFont;

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -74,16 +74,12 @@ void ListBoxBase::updateScrollLayout()
 
 	if ((mItemHeight * static_cast<int>(mItems.size())) > mRect.height)
 	{
-		auto lineCount = mRect.height / mItemHeight;
-		if (static_cast<std::size_t>(lineCount) < mItems.size())
-		{
-			mSlider.position({rect().x + mRect.width - 14, mRect.y});
-			mSlider.size({14, mRect.height});
-			mSlider.length(static_cast<float>(mItemHeight * static_cast<int>(mItems.size()) - mRect.height));
-			mScrollOffsetInPixels = static_cast<unsigned int>(mSlider.thumbPosition());
-			mItemWidth -= static_cast<unsigned int>(mSlider.size().x);
-			mSlider.visible(true);
-		}
+		mSlider.position({rect().x + mRect.width - 14, mRect.y});
+		mSlider.size({14, mRect.height});
+		mSlider.length(static_cast<float>(mItemHeight * static_cast<int>(mItems.size()) - mRect.height));
+		mScrollOffsetInPixels = static_cast<unsigned int>(mSlider.thumbPosition());
+		mItemWidth -= static_cast<unsigned int>(mSlider.size().x);
+		mSlider.visible(true);
 	}
 	else
 	{

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -25,7 +25,7 @@ ListBoxBase::ListBoxBase()
 	mSlider.thumbPosition(0);
 	mSlider.change().connect(this, &ListBoxBase::slideChanged);
 
-	_update_item_display();
+	updateScrollLayout();
 }
 
 
@@ -61,14 +61,14 @@ std::size_t ListBoxBase::count() const
 
 void ListBoxBase::visibilityChanged(bool)
 {
-	_update_item_display();
+	updateScrollLayout();
 }
 
 
 /**
  * Updates values required for properly displaying list items.
  */
-void ListBoxBase::_update_item_display()
+void ListBoxBase::updateScrollLayout()
 {
 	mItemWidth = mRect.width;
 
@@ -100,7 +100,7 @@ void ListBoxBase::_update_item_display()
  */
 void ListBoxBase::onSizeChanged()
 {
-	_update_item_display();
+	updateScrollLayout();
 }
 
 
@@ -184,7 +184,7 @@ void ListBoxBase::onMouseWheel(int /*x*/, int y)
  */
 void ListBoxBase::slideChanged(float newPosition)
 {
-	_update_item_display();
+	updateScrollLayout();
 	auto pos = std::floor(newPosition);
 	if (pos != newPosition)
 	{
@@ -230,7 +230,7 @@ void ListBoxBase::clear()
 	mItems.clear();
 	mSelectedIndex = constants::NO_SELECTION;
 	mHighlightIndex = constants::NO_SELECTION;
-	_update_item_display();
+	updateScrollLayout();
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -202,21 +202,6 @@ void ListBoxBase::addItem(ListBoxItem* item)
 
 
 /**
- * Removes a ListBoxItem.
- * 
- * \warning	Frees memory allocated for a ListBoxItem. All pointers
- *			and/or references will become invalidated.
- */
-void ListBoxBase::removeItem(ListBoxItem* item)
-{
-	auto it = std::find(mItems.begin(), mItems.end(), item);
-	if (it == mItems.end()) { return; }
-	delete (*it);
-	mItems.erase(it);
-}
-
-
-/**
  * Clears all items from the list.
  */
 void ListBoxBase::clear()

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -189,19 +189,6 @@ void ListBoxBase::slideChanged(float newPosition)
 
 
 /**
- * Adds a ListBoxItem.
- * 
- * \warning	Requires a pointer to a ListBoxItem -- memory is owned
- *			and managed by ListBoxBase.
- */
-void ListBoxBase::addItem(ListBoxItem* item)
-{
-	auto it = std::find(mItems.begin(), mItems.end(), item);
-	if (it == mItems.end()) { mItems.push_back(item); }
-}
-
-
-/**
  * Clears all items from the list.
  */
 void ListBoxBase::clear()

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -74,9 +74,8 @@ void ListBoxBase::updateScrollLayout()
 
 	if ((mItemHeight * static_cast<int>(mItems.size())) > mRect.height)
 	{
-		mLineCount = mRect.height / mItemHeight;
-
-		if (static_cast<std::size_t>(mLineCount) < mItems.size())
+		auto lineCount = mRect.height / mItemHeight;
+		if (static_cast<std::size_t>(lineCount) < mItems.size())
 		{
 			mSlider.position({rect().x + mRect.width - 14, mRect.y});
 			mSlider.size({14, mRect.height});

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -49,7 +49,6 @@ public:
 	bool isEmpty() const;
 	std::size_t count() const;
 
-	void addItem(ListBoxItem*);
 	void clear();
 
 	bool isItemSelected() const;

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -95,7 +95,6 @@ private:
 
 	int mItemHeight = 1; /**< Height of a ListBoxItem. */
 	int mItemWidth = 0; /**< Width of a ListBoxItem. */
-	int mLineCount = 0; /**< Number of lines that can be displayed. */
 
 	bool mHasFocus = false;
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -64,6 +64,12 @@ public:
 	void update() override = 0;
 
 protected:
+	template <typename ItemType, typename... Args>
+	void add(Args&&... args) {
+		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+		updateScrollLayout();
+	}
+
 	void updateScrollLayout();
 
 	unsigned int item_width() const { return static_cast<unsigned int>(mItemWidth); }

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -50,7 +50,6 @@ public:
 	std::size_t count() const;
 
 	void addItem(ListBoxItem*);
-	void removeItem(ListBoxItem*);
 	void clear();
 
 	bool isItemSelected() const;

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -66,7 +66,7 @@ public:
 	void update() override = 0;
 
 protected:
-	void _update_item_display();
+	void updateScrollLayout();
 
 	unsigned int item_width() const { return static_cast<unsigned int>(mItemWidth); }
 	unsigned int item_height() const { return static_cast<unsigned int>(mItemHeight); }

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -76,10 +76,7 @@ void FactoryListBox::addItem(Factory* factory)
 		(text == constants::UNDERGROUND_FACTORY) ? NAS2D::Point<int>{138, 276} :
 		(text == constants::SEED_FACTORY) ? NAS2D::Point<int>{460, 368} :
 		NAS2D::Point<int>{0, 46}; // Surface factory
-	mItems.push_back(new FactoryListBoxItem(factory));
-	FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems.back());
-	item->text = text;
-	item->icon_slice = iconPosition;
+	mItems.push_back(new FactoryListBoxItem{text, factory, iconPosition});
 
 	updateScrollLayout();
 }

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -76,9 +76,7 @@ void FactoryListBox::addItem(Factory* factory)
 		(text == constants::UNDERGROUND_FACTORY) ? NAS2D::Point<int>{138, 276} :
 		(text == constants::SEED_FACTORY) ? NAS2D::Point<int>{460, 368} :
 		NAS2D::Point<int>{0, 46}; // Surface factory
-	mItems.push_back(new FactoryListBoxItem{text, factory, iconPosition});
-
-	updateScrollLayout();
+	add<FactoryListBoxItem>(text, factory, iconPosition);
 }
 
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -75,11 +75,11 @@ void FactoryListBox::addItem(Factory* factory)
 	/// \fixme super sloppy
 	FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems.back());
 	item->text = factory->name();
-	if (item->text == constants::SURFACE_FACTORY) { item->icon_slice = {0, 46}; }
-	else if (item->text == constants::UNDERGROUND_FACTORY) { item->icon_slice = {138, 276}; }
-	else if (item->text == constants::SEED_FACTORY) { item->icon_slice = {460, 368}; }
+	item->icon_slice = (factory->state() == StructureState::Destroyed) ? NAS2D::Point<int>{414, 368} :
+		(item->text == constants::UNDERGROUND_FACTORY) ? NAS2D::Point<int>{138, 276} :
+		(item->text == constants::SEED_FACTORY) ? NAS2D::Point<int>{460, 368} :
+		NAS2D::Point<int>{0, 46}; // Surface factory
 
-	if (factory->state() == StructureState::Destroyed) { item->icon_slice = {414, 368}; }
 	updateScrollLayout();
 }
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -80,7 +80,7 @@ void FactoryListBox::addItem(Factory* factory)
 	else if (item->text == constants::SEED_FACTORY) { item->icon_slice = {460, 368}; }
 
 	if (factory->state() == StructureState::Destroyed) { item->icon_slice = {414, 368}; }
-	_update_item_display();
+	updateScrollLayout();
 }
 
 
@@ -96,7 +96,7 @@ void FactoryListBox::removeItem(Factory* factory)
 		if (static_cast<FactoryListBoxItem*>(*it)->factory == factory)
 		{
 			mItems.erase(it);
-			_update_item_display();
+			updateScrollLayout();
 			clearSelected();
 			return;
 		}

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -85,26 +85,6 @@ void FactoryListBox::addItem(Factory* factory)
 
 
 /**
- * Removes a Factory from the FactoryListBox.
- * 
- * Specialized version of the default addItem(ListBoxItem*) function.
- */
-void FactoryListBox::removeItem(Factory* factory)
-{
-	for (auto it = mItems.begin(); it != mItems.end(); ++it)
-	{
-		if (static_cast<FactoryListBoxItem*>(*it)->factory == factory)
-		{
-			mItems.erase(it);
-			updateScrollLayout();
-			clearSelected();
-			return;
-		}
-	}
-}
-
-
-/**
  * Sets the current selection.
  * 
  * \param f	Pointer to a Factory object. Safe to pass \c nullptr.

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -70,15 +70,16 @@ void FactoryListBox::addItem(Factory* factory)
 		}
 	}
 
-	mItems.push_back(new FactoryListBoxItem(factory));
-
 	/// \fixme super sloppy
-	FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems.back());
-	item->text = factory->name();
-	item->icon_slice = (factory->state() == StructureState::Destroyed) ? NAS2D::Point<int>{414, 368} :
-		(item->text == constants::UNDERGROUND_FACTORY) ? NAS2D::Point<int>{138, 276} :
-		(item->text == constants::SEED_FACTORY) ? NAS2D::Point<int>{460, 368} :
+	const auto& text = factory->name();
+	const auto iconPosition = (factory->state() == StructureState::Destroyed) ? NAS2D::Point<int>{414, 368} :
+		(text == constants::UNDERGROUND_FACTORY) ? NAS2D::Point<int>{138, 276} :
+		(text == constants::SEED_FACTORY) ? NAS2D::Point<int>{460, 368} :
 		NAS2D::Point<int>{0, 46}; // Surface factory
+	mItems.push_back(new FactoryListBoxItem(factory));
+	FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems.back());
+	item->text = text;
+	item->icon_slice = iconPosition;
 
 	updateScrollLayout();
 }

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -22,7 +22,11 @@ public:
 
 	struct FactoryListBoxItem : public ListBoxItem
 	{
-		FactoryListBoxItem(Factory* newFactory) : factory(newFactory) {}
+		FactoryListBoxItem(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition) :
+			ListBoxItem{textDescription},
+			factory{newFactory},
+			icon_slice{iconPosition}
+		{}
 
 		Factory* factory = nullptr;
 		NAS2D::Point<int> icon_slice;

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -32,7 +32,6 @@ public:
 	FactoryListBox();
 
 	void addItem(Factory* factory);
-	void removeItem(Factory* factory);
 	void setSelected(Factory*);
 
 	Factory* selectedFactory();

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -110,7 +110,7 @@ void FileIo::scanDirectory(const std::string& directory)
 		{
 			// FixMe: Naive approach: Assumes a file save extension of 3 characters.
 			dir.resize(dir.size() - 4);
-			mListBox.addItem(dir);
+			mListBox.add(dir);
 		}
 	}
 	mListBox.sort();

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -38,7 +38,7 @@ void ProductListBox::productPool(ProductPool& pool)
 		}
 	}
 
-	_update_item_display();
+	updateScrollLayout();
 }
 
 

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -28,12 +28,13 @@ void ProductListBox::productPool(ProductPool& pool)
 
 	for (std::size_t product_type = 0; product_type < static_cast<std::size_t>(ProductType::PRODUCT_COUNT); ++product_type)
 	{
-		if (pool.count(static_cast<ProductType>(product_type)) > 0)
+		const auto productCount = pool.count(static_cast<ProductType>(product_type));
+		if (productCount > 0)
 		{
 			ProductListBoxItem* item = new ProductListBoxItem();
 			item->text = productDescription(static_cast<ProductType>(product_type));
-			item->count = pool.count(static_cast<ProductType>(product_type));
-			item->usage = static_cast<float>(item->count) / static_cast<float>(pool.capacity());
+			item->count = productCount;
+			item->usage = static_cast<float>(productCount) / static_cast<float>(pool.capacity());
 			mItems.push_back(item);
 		}
 	}

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -416,7 +416,7 @@ void FactoryReport::lstFactoryListSelectionChanged()
 		const Factory::ProductionTypeList& _pl = selectedFactory->productList();
 		for (auto item : _pl)
 		{
-			lstProducts.addItem(productDescription(item), static_cast<int>(item));
+			lstProducts.add(productDescription(item), static_cast<int>(item));
 		}
 	}
 	lstProducts.selectIf([productType = selectedFactory->productType()](const auto& item){ return item.tag == productType; });

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -69,8 +69,7 @@ void StructureListBox::addItem(Structure* structure)
 		}
 	}
 
-	mItems.push_back(new StructureListBoxItem(structure));
-	updateScrollLayout();
+	add<StructureListBoxItem>(structure);
 }
 
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -75,26 +75,6 @@ void StructureListBox::addItem(Structure* structure)
 
 
 /**
- * Removes a Factory from the FactoryListBox.
- * 
- * Specialized version of the default addItem(ListBoxItem*) function.
- */
-void StructureListBox::removeItem(Structure* structure)
-{
-	for (auto it = mItems.begin(); it != mItems.end(); ++it)
-	{
-		if (static_cast<StructureListBoxItem*>(*it)->structure == structure)
-		{
-			mItems.erase(it);
-			updateScrollLayout();
-			clearSelected();
-			return;
-		}
-	}
-}
-
-
-/**
  * Sets the current selection.
  * 
  * \param structure		Pointer to a Structure object. Save to pass \c nullptr.

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -70,7 +70,7 @@ void StructureListBox::addItem(Structure* structure)
 	}
 
 	mItems.push_back(new StructureListBoxItem(structure));
-	_update_item_display();
+	updateScrollLayout();
 }
 
 
@@ -86,7 +86,7 @@ void StructureListBox::removeItem(Structure* structure)
 		if (static_cast<StructureListBoxItem*>(*it)->structure == structure)
 		{
 			mItems.erase(it);
-			_update_item_display();
+			updateScrollLayout();
 			clearSelected();
 			return;
 		}

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -31,7 +31,6 @@ public:
 	StructureListBox();
 
 	void addItem(Structure*);
-	void removeItem(Structure*);
 	void setSelected(Structure*);
 
 	Structure* selectedStructure();


### PR DESCRIPTION
Prep-work for: #479

This removes unused methods that would be problematic to maintain and unifies remaining public methods in `ListBoxBase` with `ListBox`. The public API of these base classes is now very similar such that users of either should not be able to tell the difference. Work is not quite done yet though, since the `ListBoxBase` derived classes add additional methods which are not yet accounted for. There are also still internal structural differences that prevent the two classes from being merged.
