### PR TITLE
ListBox Context

### DIFF
--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -17,7 +17,7 @@ using namespace NAS2D;
 
 ListBox::ListBox() :
 	mContext{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
-	mLineHeight{static_cast<unsigned int>(mContext.mFont.height() + constants::MARGIN_TIGHT)}
+	mLineHeight{static_cast<unsigned int>(mContext.font.height() + constants::MARGIN_TIGHT)}
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
@@ -166,7 +166,7 @@ void ListBox::update()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	const auto borderColor = hasFocus() ? mContext.mBorderColorActive : mContext.mBorderColorNormal;
+	const auto borderColor = hasFocus() ? mContext.borderColorActive : mContext.borderColorNormal;
 	renderer.drawBox(mRect, borderColor);
 
 	renderer.clipRect(mRect);
@@ -183,27 +183,27 @@ void ListBox::update()
 		const auto isSelected = (i == mSelectedIndex);
 		const auto isHighlighted = (i == mHighlightIndex);
 		const auto textPosition = itemDrawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
-		const auto textColor = isHighlighted ? mContext.mTextColorMouseHover : mContext.mTextColorNormal;
+		const auto textColor = isHighlighted ? mContext.textColorMouseHover : mContext.textColorNormal;
 
 		// Draw background rect
-		const auto backgroundColor = isSelected ? mContext.mBackgroundColorSelected : mContext.mBackgroundColorNormal;
+		const auto backgroundColor = isSelected ? mContext.backgroundColorSelected : mContext.backgroundColorNormal;
 		renderer.drawBoxFilled(itemDrawArea, backgroundColor);
 
 		// Draw highlight on mouse over
 		if (isHighlighted)
 		{
-			renderer.drawBox(itemDrawArea, mContext.mItemBorderColorMouseHover);
+			renderer.drawBox(itemDrawArea, mContext.itemBorderColorMouseHover);
 		}
 
 		// Draw item contents
-		renderer.drawTextShadow(mContext.mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+		renderer.drawTextShadow(mContext.font, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 
 		itemDrawArea.y += mLineHeight;
 	}
 
 	// Paint remaining section of scroll area not covered by items
 	itemDrawArea.height = mScrollArea.endPoint().y - itemDrawArea.startPoint().y;
-	renderer.drawBoxFilled(itemDrawArea, mContext.mBackgroundColorNormal);
+	renderer.drawBoxFilled(itemDrawArea, mContext.backgroundColorNormal);
 
 	renderer.clipRectClear();
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -15,6 +15,26 @@
 using namespace NAS2D;
 
 
+void ListBox::ListBoxItem::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, const Context& context, bool isSelected, bool isHighlighted)
+{
+	const auto textPosition = drawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
+	const auto textColor = isHighlighted ? context.textColorMouseHover : context.textColorNormal;
+
+	// Draw background rect
+	const auto backgroundColor = isSelected ? context.backgroundColorSelected : context.backgroundColorNormal;
+	renderer.drawBoxFilled(drawArea, backgroundColor);
+
+	// Draw highlight on mouse over
+	if (isHighlighted)
+	{
+		renderer.drawBox(drawArea, context.itemBorderColorMouseHover);
+	}
+
+	// Draw item contents
+	renderer.drawTextShadow(context.font, text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+}
+
+
 ListBox::ListBox() :
 	mContext{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
 	mLineHeight{static_cast<unsigned int>(mContext.font.height() + constants::MARGIN_TIGHT)}
@@ -182,21 +202,8 @@ void ListBox::update()
 	{
 		const auto isSelected = (i == mSelectedIndex);
 		const auto isHighlighted = (i == mHighlightIndex);
-		const auto textPosition = itemDrawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
-		const auto textColor = isHighlighted ? mContext.textColorMouseHover : mContext.textColorNormal;
 
-		// Draw background rect
-		const auto backgroundColor = isSelected ? mContext.backgroundColorSelected : mContext.backgroundColorNormal;
-		renderer.drawBoxFilled(itemDrawArea, backgroundColor);
-
-		// Draw highlight on mouse over
-		if (isHighlighted)
-		{
-			renderer.drawBox(itemDrawArea, mContext.itemBorderColorMouseHover);
-		}
-
-		// Draw item contents
-		renderer.drawTextShadow(mContext.font, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+		mItems[i].draw(renderer, itemDrawArea, mContext, isSelected, isHighlighted);
 
 		itemDrawArea.y += mLineHeight;
 	}

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -15,13 +15,13 @@
 using namespace NAS2D;
 
 
-unsigned int ListBox::ListBoxItem::Context::itemHeight() const
+unsigned int ListBoxItem::Context::itemHeight() const
 {
 	return font.height() + constants::MARGIN_TIGHT;
 }
 
 
-void ListBox::ListBoxItem::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, const Context& context, bool isSelected, bool isHighlighted)
+void ListBoxItem::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, const Context& context, bool isSelected, bool isHighlighted)
 {
 	// Draw background rect
 	const auto backgroundColor = isSelected ? context.backgroundColorSelected : context.backgroundColorNormal;
@@ -116,7 +116,7 @@ bool ListBox::isItemSelected() const
 }
 
 
-const ListBox::ListBoxItem& ListBox::selected() const
+const ListBoxItem& ListBox::selected() const
 {
 	if (mSelectedIndex == constants::NO_SELECTION)
 	{

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -168,7 +168,6 @@ void ListBox::update()
 
 	const auto borderColor = hasFocus() ? mBorderColorActive : mBorderColorNormal;
 	renderer.drawBox(mRect, borderColor);
-	renderer.drawBoxFilled(mScrollArea, mBackgroundColorNormal);
 
 	renderer.clipRect(mRect);
 
@@ -187,10 +186,8 @@ void ListBox::update()
 		const auto textColor = isHighlighted ? mTextColorMouseHover : mTextColorNormal;
 
 		// Draw background rect
-		if (isSelected)
-		{
-			renderer.drawBoxFilled(itemDrawArea, mBackgroundColorSelected);
-		}
+		const auto backgroundColor = isSelected ? mBackgroundColorSelected : mBackgroundColorNormal;
+		renderer.drawBoxFilled(itemDrawArea, backgroundColor);
 
 		// Draw highlight on mouse over
 		if (isHighlighted)
@@ -203,6 +200,10 @@ void ListBox::update()
 
 		itemDrawArea.y += mLineHeight;
 	}
+
+	// Paint remaining section of scroll area not covered by items
+	itemDrawArea.height = mScrollArea.endPoint().y - itemDrawArea.startPoint().y;
+	renderer.drawBoxFilled(itemDrawArea, mBackgroundColorNormal);
 
 	renderer.clipRectClear();
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -17,9 +17,6 @@ using namespace NAS2D;
 
 void ListBox::ListBoxItem::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, const Context& context, bool isSelected, bool isHighlighted)
 {
-	const auto textPosition = drawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
-	const auto textColor = isHighlighted ? context.textColorMouseHover : context.textColorNormal;
-
 	// Draw background rect
 	const auto backgroundColor = isSelected ? context.backgroundColorSelected : context.backgroundColorNormal;
 	renderer.drawBoxFilled(drawArea, backgroundColor);
@@ -31,6 +28,8 @@ void ListBox::ListBoxItem::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int>
 	}
 
 	// Draw item contents
+	const auto textPosition = drawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
+	const auto textColor = isHighlighted ? context.textColorMouseHover : context.textColorNormal;
 	renderer.drawTextShadow(context.font, text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -192,7 +192,7 @@ void ListBox::update()
 		// Draw highlight on mouse over
 		if (isHighlighted)
 		{
-			renderer.drawBox(itemDrawArea, mBackgroundColorMouseHover);
+			renderer.drawBox(itemDrawArea, mItemBorderColorMouseHover);
 		}
 
 		// Draw item contents

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -178,15 +178,6 @@ void ListBox::update()
 	itemBounds.y += static_cast<int>((mSelectedIndex * mLineHeight) - mScrollOffsetInPixels);
 	renderer.drawBoxFilled(itemBounds, mBackgroundColorSelected);
 
-	// Highlight On mouse Over
-	if (mHighlightIndex != constants::NO_SELECTION)
-	{
-		auto highlightBounds = mScrollArea;
-		highlightBounds.height = static_cast<int>(mLineHeight);
-		highlightBounds.y += static_cast<int>((mHighlightIndex * mLineHeight) - mScrollOffsetInPixels);
-		renderer.drawBox(highlightBounds, mBackgroundColorMouseHover);
-	}
-
 	// display actuals values that are meant to be
 	const auto firstVisibleIndex = mScrollOffsetInPixels / mLineHeight;
 	const auto lastVisibleIndex = (mScrollOffsetInPixels + mScrollArea.height + (mLineHeight - 1)) / mLineHeight;
@@ -196,8 +187,13 @@ void ListBox::update()
 	itemDrawArea.height = static_cast<int>(mLineHeight);
 	for(std::size_t i = firstVisibleIndex; i < endVisibleIndex; i++)
 	{
+		const auto isHighlighted = (i == mHighlightIndex);
 		const auto textPosition = itemDrawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
-		const auto textColor = (i == mHighlightIndex) ? mTextColorMouseHover : mTextColorNormal;
+		const auto textColor = isHighlighted ? mTextColorMouseHover : mTextColorNormal;
+		if (isHighlighted)
+		{
+			renderer.drawBox(itemDrawArea, mBackgroundColorMouseHover);
+		}
 		renderer.drawTextShadow(mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 		itemDrawArea.y += mLineHeight;
 	}

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -16,8 +16,8 @@ using namespace NAS2D;
 
 
 ListBox::ListBox() :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
-	mLineHeight{static_cast<unsigned int>(mFont.height() + constants::MARGIN_TIGHT)}
+	mContext{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
+	mLineHeight{static_cast<unsigned int>(mContext.mFont.height() + constants::MARGIN_TIGHT)}
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
@@ -166,7 +166,7 @@ void ListBox::update()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	const auto borderColor = hasFocus() ? mBorderColorActive : mBorderColorNormal;
+	const auto borderColor = hasFocus() ? mContext.mBorderColorActive : mContext.mBorderColorNormal;
 	renderer.drawBox(mRect, borderColor);
 
 	renderer.clipRect(mRect);
@@ -183,27 +183,27 @@ void ListBox::update()
 		const auto isSelected = (i == mSelectedIndex);
 		const auto isHighlighted = (i == mHighlightIndex);
 		const auto textPosition = itemDrawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
-		const auto textColor = isHighlighted ? mTextColorMouseHover : mTextColorNormal;
+		const auto textColor = isHighlighted ? mContext.mTextColorMouseHover : mContext.mTextColorNormal;
 
 		// Draw background rect
-		const auto backgroundColor = isSelected ? mBackgroundColorSelected : mBackgroundColorNormal;
+		const auto backgroundColor = isSelected ? mContext.mBackgroundColorSelected : mContext.mBackgroundColorNormal;
 		renderer.drawBoxFilled(itemDrawArea, backgroundColor);
 
 		// Draw highlight on mouse over
 		if (isHighlighted)
 		{
-			renderer.drawBox(itemDrawArea, mItemBorderColorMouseHover);
+			renderer.drawBox(itemDrawArea, mContext.mItemBorderColorMouseHover);
 		}
 
 		// Draw item contents
-		renderer.drawTextShadow(mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+		renderer.drawTextShadow(mContext.mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 
 		itemDrawArea.y += mLineHeight;
 	}
 
 	// Paint remaining section of scroll area not covered by items
 	itemDrawArea.height = mScrollArea.endPoint().y - itemDrawArea.startPoint().y;
-	renderer.drawBoxFilled(itemDrawArea, mBackgroundColorNormal);
+	renderer.drawBoxFilled(itemDrawArea, mContext.mBackgroundColorNormal);
 
 	renderer.clipRectClear();
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -172,12 +172,6 @@ void ListBox::update()
 
 	renderer.clipRect(mRect);
 
-	// Highlight currently selected item
-	auto itemBounds = mScrollArea;
-	itemBounds.height = static_cast<int>(mLineHeight);
-	itemBounds.y += static_cast<int>((mSelectedIndex * mLineHeight) - mScrollOffsetInPixels);
-	renderer.drawBoxFilled(itemBounds, mBackgroundColorSelected);
-
 	// display actuals values that are meant to be
 	const auto firstVisibleIndex = mScrollOffsetInPixels / mLineHeight;
 	const auto lastVisibleIndex = (mScrollOffsetInPixels + mScrollArea.height + (mLineHeight - 1)) / mLineHeight;
@@ -187,14 +181,26 @@ void ListBox::update()
 	itemDrawArea.height = static_cast<int>(mLineHeight);
 	for(std::size_t i = firstVisibleIndex; i < endVisibleIndex; i++)
 	{
+		const auto isSelected = (i == mSelectedIndex);
 		const auto isHighlighted = (i == mHighlightIndex);
 		const auto textPosition = itemDrawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
 		const auto textColor = isHighlighted ? mTextColorMouseHover : mTextColorNormal;
+
+		// Draw background rect
+		if (isSelected)
+		{
+			renderer.drawBoxFilled(itemDrawArea, mBackgroundColorSelected);
+		}
+
+		// Draw highlight on mouse over
 		if (isHighlighted)
 		{
 			renderer.drawBox(itemDrawArea, mBackgroundColorMouseHover);
 		}
+
+		// Draw item contents
 		renderer.drawTextShadow(mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
+
 		itemDrawArea.y += mLineHeight;
 	}
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -15,13 +15,13 @@
 using namespace NAS2D;
 
 
-unsigned int ListBoxItem::Context::itemHeight() const
+unsigned int ListBoxItemText::Context::itemHeight() const
 {
 	return font.height() + constants::MARGIN_TIGHT;
 }
 
 
-void ListBoxItem::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, const Context& context, bool isSelected, bool isHighlighted)
+void ListBoxItemText::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, const Context& context, bool isSelected, bool isHighlighted)
 {
 	// Draw background rect
 	const auto backgroundColor = isSelected ? context.backgroundColorSelected : context.backgroundColorNormal;
@@ -116,7 +116,7 @@ bool ListBox::isItemSelected() const
 }
 
 
-const ListBoxItem& ListBox::selected() const
+const ListBox::ListBoxItem& ListBox::selected() const
 {
 	if (mSelectedIndex == constants::NO_SELECTION)
 	{

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -191,13 +191,15 @@ void ListBox::update()
 	const auto firstVisibleIndex = mScrollOffsetInPixels / mLineHeight;
 	const auto lastVisibleIndex = (mScrollOffsetInPixels + mScrollArea.height + (mLineHeight - 1)) / mLineHeight;
 	const auto endVisibleIndex = std::min(lastVisibleIndex, mItems.size());
-	auto textPosition = mScrollArea.startPoint();
-	textPosition += {constants::MARGIN_TIGHT, -static_cast<int>(mScrollOffsetInPixels % mLineHeight)};
+	auto itemDrawArea = mScrollArea;
+	itemDrawArea.y += -static_cast<int>(mScrollOffsetInPixels % mLineHeight);
+	itemDrawArea.height = static_cast<int>(mLineHeight);
 	for(std::size_t i = firstVisibleIndex; i < endVisibleIndex; i++)
 	{
+		const auto textPosition = itemDrawArea.startPoint() + NAS2D::Vector{constants::MARGIN_TIGHT, 0};
 		const auto textColor = (i == mHighlightIndex) ? mTextColorMouseHover : mTextColorNormal;
 		renderer.drawTextShadow(mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
-		textPosition.y += mLineHeight;
+		itemDrawArea.y += mLineHeight;
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -188,9 +188,12 @@ void ListBox::update()
 	}
 
 	// display actuals values that are meant to be
+	const auto firstVisibleIndex = mScrollOffsetInPixels / mLineHeight;
+	const auto lastVisibleIndex = (mScrollOffsetInPixels + mScrollArea.height + (mLineHeight - 1)) / mLineHeight;
+	const auto endVisibleIndex = std::min(lastVisibleIndex, mItems.size());
 	auto textPosition = mScrollArea.startPoint();
-	textPosition += {constants::MARGIN_TIGHT, -static_cast<int>(mScrollOffsetInPixels)};
-	for(std::size_t i = 0; i < mItems.size(); i++)
+	textPosition += {constants::MARGIN_TIGHT, -static_cast<int>(mScrollOffsetInPixels % mLineHeight)};
+	for(std::size_t i = firstVisibleIndex; i < endVisibleIndex; i++)
 	{
 		const auto textColor = (i == mHighlightIndex) ? mTextColorMouseHover : mTextColorNormal;
 		renderer.drawTextShadow(mFont, mItems[i].text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -32,6 +32,22 @@ public:
 		std::string text; /**< Text of the ListBoxItem. */
 		int tag = 0; /**< User defined int data attached to the item. */
 
+		struct Context
+		{
+			const NAS2D::Font& font;
+
+			NAS2D::Color borderColorNormal = NAS2D::Color{75, 75, 75};
+			NAS2D::Color borderColorActive = NAS2D::Color{0, 185, 0};
+
+			NAS2D::Color itemBorderColorMouseHover = NAS2D::Color::DarkGreen;
+
+			NAS2D::Color backgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
+			NAS2D::Color backgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
+
+			NAS2D::Color textColorNormal = NAS2D::Color::White;
+			NAS2D::Color textColorMouseHover = NAS2D::Color::White;
+		};
+
 		bool operator==(const std::string& rhs) { return text == rhs; }
 		bool operator<(const ListBoxItem& lhs) { return text < lhs.text; }
 	};
@@ -88,23 +104,7 @@ private:
 	void onSizeChanged() override;
 	void updateScrollLayout();
 
-	struct Context
-	{
-		const NAS2D::Font& font;
-
-		NAS2D::Color borderColorNormal = NAS2D::Color{75, 75, 75};
-		NAS2D::Color borderColorActive = NAS2D::Color{0, 185, 0};
-
-		NAS2D::Color itemBorderColorMouseHover = NAS2D::Color::DarkGreen;
-
-		NAS2D::Color backgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
-		NAS2D::Color backgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
-
-		NAS2D::Color textColorNormal = NAS2D::Color::White;
-		NAS2D::Color textColorMouseHover = NAS2D::Color::White;
-	};
-
-	Context mContext;
+	ListBoxItem::Context mContext;
 
 	std::size_t mHighlightIndex = constants::NO_SELECTION;
 	std::size_t mSelectedIndex = 0;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -20,6 +20,36 @@ namespace NAS2D {
 }
 
 
+struct ListBoxItem
+{
+	std::string text; /**< Text of the ListBoxItem. */
+	int tag = 0; /**< User defined int data attached to the item. */
+
+	struct Context
+	{
+		const NAS2D::Font& font;
+
+		NAS2D::Color borderColorNormal = NAS2D::Color{75, 75, 75};
+		NAS2D::Color borderColorActive = NAS2D::Color{0, 185, 0};
+
+		NAS2D::Color itemBorderColorMouseHover = NAS2D::Color::DarkGreen;
+
+		NAS2D::Color backgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
+		NAS2D::Color backgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
+
+		NAS2D::Color textColorNormal = NAS2D::Color::White;
+		NAS2D::Color textColorMouseHover = NAS2D::Color::White;
+
+		unsigned int itemHeight() const;
+	};
+
+	void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
+
+	bool operator==(const std::string& rhs) { return text == rhs; }
+	bool operator<(const ListBoxItem& lhs) { return text < lhs.text; }
+};
+
+
 /**
  * Implements a ListBox control.
  */
@@ -27,36 +57,6 @@ class ListBox: public Control
 {
 public:
 	using SelectionChangedCallback = NAS2D::Signals::Signal<>;
-
-	struct ListBoxItem
-	{
-		std::string text; /**< Text of the ListBoxItem. */
-		int tag = 0; /**< User defined int data attached to the item. */
-
-		struct Context
-		{
-			const NAS2D::Font& font;
-
-			NAS2D::Color borderColorNormal = NAS2D::Color{75, 75, 75};
-			NAS2D::Color borderColorActive = NAS2D::Color{0, 185, 0};
-
-			NAS2D::Color itemBorderColorMouseHover = NAS2D::Color::DarkGreen;
-
-			NAS2D::Color backgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
-			NAS2D::Color backgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
-
-			NAS2D::Color textColorNormal = NAS2D::Color::White;
-			NAS2D::Color textColorMouseHover = NAS2D::Color::White;
-
-			unsigned int itemHeight() const;
-		};
-
-		void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
-
-		bool operator==(const std::string& rhs) { return text == rhs; }
-		bool operator<(const ListBoxItem& lhs) { return text < lhs.text; }
-	};
-
 
 	ListBox();
 	~ListBox() override;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -53,7 +53,7 @@ struct ListBoxItem
 /**
  * Implements a ListBox control.
  */
-class ListBox: public Control
+class ListBox : public Control
 {
 public:
 	using SelectionChangedCallback = NAS2D::Signals::Signal<>;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -88,8 +88,23 @@ private:
 	void onSizeChanged() override;
 	void updateScrollLayout();
 
+	struct Context
+	{
+		const NAS2D::Font& mFont;
 
-	const NAS2D::Font& mFont;
+		NAS2D::Color mBorderColorNormal = NAS2D::Color{75, 75, 75};
+		NAS2D::Color mBorderColorActive = NAS2D::Color{0, 185, 0};
+
+		NAS2D::Color mItemBorderColorMouseHover = NAS2D::Color::DarkGreen;
+
+		NAS2D::Color mBackgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
+		NAS2D::Color mBackgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
+
+		NAS2D::Color mTextColorNormal = NAS2D::Color::White;
+		NAS2D::Color mTextColorMouseHover = NAS2D::Color::White;
+	};
+
+	Context mContext;
 
 	std::size_t mHighlightIndex = constants::NO_SELECTION;
 	std::size_t mSelectedIndex = 0;
@@ -100,17 +115,6 @@ private:
 	std::vector<ListBoxItem> mItems; /**< List of items preserved in the order in which they're added. */
 
 	NAS2D::Rectangle<int> mScrollArea;
-
-	NAS2D::Color mBorderColorNormal = NAS2D::Color{75, 75, 75};
-	NAS2D::Color mBorderColorActive = NAS2D::Color{0, 185, 0};
-
-	NAS2D::Color mItemBorderColorMouseHover = NAS2D::Color::DarkGreen;
-
-	NAS2D::Color mBackgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
-	NAS2D::Color mBackgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
-
-	NAS2D::Color mTextColorNormal = NAS2D::Color::White;
-	NAS2D::Color mTextColorMouseHover = NAS2D::Color::White;
 
 	SelectionChangedCallback mSelectionChanged; /**< Callback for selection changed callback. */
 	Slider mSlider;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -47,6 +47,8 @@ public:
 
 			NAS2D::Color textColorNormal = NAS2D::Color::White;
 			NAS2D::Color textColorMouseHover = NAS2D::Color::White;
+
+			unsigned int itemHeight() const;
 		};
 
 		void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
@@ -89,7 +91,7 @@ public:
 
 	std::size_t currentHighlight() const { return mHighlightIndex; }
 
-	unsigned int lineHeight() const { return mLineHeight; }
+	unsigned int lineHeight() const { return mContext.itemHeight(); }
 
 	void update() override;
 
@@ -112,8 +114,6 @@ private:
 	std::size_t mHighlightIndex = constants::NO_SELECTION;
 	std::size_t mSelectedIndex = 0;
 	std::size_t mScrollOffsetInPixels = 0;
-
-	unsigned int mLineHeight = 0; /**< Height of an item line. */
 
 	std::vector<ListBoxItem> mItems; /**< List of items preserved in the order in which they're added. */
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -104,8 +104,9 @@ private:
 	NAS2D::Color mBorderColorNormal = NAS2D::Color{75, 75, 75};
 	NAS2D::Color mBorderColorActive = NAS2D::Color{0, 185, 0};
 
+	NAS2D::Color mItemBorderColorMouseHover = NAS2D::Color::DarkGreen;
+
 	NAS2D::Color mBackgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
-	NAS2D::Color mBackgroundColorMouseHover = NAS2D::Color::DarkGreen;
 	NAS2D::Color mBackgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
 
 	NAS2D::Color mTextColorNormal = NAS2D::Color::White;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -90,18 +90,18 @@ private:
 
 	struct Context
 	{
-		const NAS2D::Font& mFont;
+		const NAS2D::Font& font;
 
-		NAS2D::Color mBorderColorNormal = NAS2D::Color{75, 75, 75};
-		NAS2D::Color mBorderColorActive = NAS2D::Color{0, 185, 0};
+		NAS2D::Color borderColorNormal = NAS2D::Color{75, 75, 75};
+		NAS2D::Color borderColorActive = NAS2D::Color{0, 185, 0};
 
-		NAS2D::Color mItemBorderColorMouseHover = NAS2D::Color::DarkGreen;
+		NAS2D::Color itemBorderColorMouseHover = NAS2D::Color::DarkGreen;
 
-		NAS2D::Color mBackgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
-		NAS2D::Color mBackgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
+		NAS2D::Color backgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
+		NAS2D::Color backgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
 
-		NAS2D::Color mTextColorNormal = NAS2D::Color::White;
-		NAS2D::Color mTextColorMouseHover = NAS2D::Color::White;
+		NAS2D::Color textColorNormal = NAS2D::Color::White;
+		NAS2D::Color textColorMouseHover = NAS2D::Color::White;
 	};
 
 	Context mContext;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -106,7 +106,7 @@ private:
 
 	NAS2D::Color mBackgroundColorNormal = NAS2D::Color{0, 85, 0, 220};
 	NAS2D::Color mBackgroundColorMouseHover = NAS2D::Color::DarkGreen;
-	NAS2D::Color mBackgroundColorSelected = NAS2D::Color::DarkGreen.alphaFade(80);
+	NAS2D::Color mBackgroundColorSelected = NAS2D::Color{0, 100, 0, 231};
 
 	NAS2D::Color mTextColorNormal = NAS2D::Color::White;
 	NAS2D::Color mTextColorMouseHover = NAS2D::Color::White;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -16,6 +16,7 @@
 
 namespace NAS2D {
 	class Font;
+	class Renderer;
 }
 
 
@@ -47,6 +48,8 @@ public:
 			NAS2D::Color textColorNormal = NAS2D::Color::White;
 			NAS2D::Color textColorMouseHover = NAS2D::Color::White;
 		};
+
+		void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
 
 		bool operator==(const std::string& rhs) { return text == rhs; }
 		bool operator<(const ListBoxItem& lhs) { return text < lhs.text; }

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -20,7 +20,7 @@ namespace NAS2D {
 }
 
 
-struct ListBoxItem
+struct ListBoxItemText
 {
 	std::string text; /**< Text of the ListBoxItem. */
 	int tag = 0; /**< User defined int data attached to the item. */
@@ -46,7 +46,7 @@ struct ListBoxItem
 	void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
 
 	bool operator==(const std::string& rhs) { return text == rhs; }
-	bool operator<(const ListBoxItem& lhs) { return text < lhs.text; }
+	bool operator<(const ListBoxItemText& lhs) { return text < lhs.text; }
 };
 
 
@@ -57,6 +57,7 @@ class ListBox : public Control
 {
 public:
 	using SelectionChangedCallback = NAS2D::Signals::Signal<>;
+	using ListBoxItem = ListBoxItemText;
 
 	ListBox();
 	~ListBox() override;


### PR DESCRIPTION
Prep-work for: #479

Extract draw parameters to a `Context` struct. Delegate drawing of `ListBoxItem` structs to `ListBoxItem::draw`. This allows the draw code to be tied to the available fields for any given type of list box. Tie the `Context` struct to the associated `ListBoxItem` struct.
