### PR TITLE
Remove ListBox::sort

### DIFF
--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -139,12 +139,6 @@ void ListBox::clear()
 }
 
 
-void ListBox::sort()
-{
-	std::sort(mItems.begin(), mItems.end());
-}
-
-
 void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	if (!visible() || mHighlightIndex == constants::NO_SELECTION || mHighlightIndex >= mItems.size() || !mScrollArea.contains({x, y}))

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -46,7 +46,6 @@ struct ListBoxItemText
 	void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
 
 	bool operator==(const std::string& rhs) { return text == rhs; }
-	bool operator<(const ListBoxItemText& lhs) { return text < lhs.text; }
 };
 
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -44,8 +44,6 @@ struct ListBoxItemText
 	};
 
 	void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawArea, const Context& context, bool isSelected, bool isHighlighted);
-
-	bool operator==(const std::string& rhs) { return text == rhs; }
 };
 
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -72,7 +72,6 @@ public:
 	}
 
 	void clear();
-	void sort();
 
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 
 using namespace NAS2D;
@@ -101,9 +102,9 @@ void FileIo::scanDirectory(const std::string& directory)
 {
 	Filesystem& f = Utility<Filesystem>::get();
 	std::vector<std::string> dirList = f.directoryList(directory);
+	std::sort(dirList.begin(), dirList.end());
 
 	mListBox.clear();
-
 	for (auto& dir : dirList)
 	{
 		if (!f.isDirectory(directory + dir))
@@ -113,7 +114,6 @@ void FileIo::scanDirectory(const std::string& directory)
 			mListBox.add(dir);
 		}
 	}
-	mListBox.sort();
 }
 
 


### PR DESCRIPTION
Cleanup to help with #479

Pre-sort filenames in `FileIo` before adding them to `ListBox`. Remove now unused `ListBox::sort` method. Simplify `ListBoxItem` struct.
