### PR TITLE
Fix missing <string> include in UiConstants

### DIFF
--- a/OPHD/Constants/UiConstants.h
+++ b/OPHD/Constants/UiConstants.h
@@ -3,6 +3,7 @@
 #include <NAS2D/Renderer/Color.h>
 
 #include <limits>
+#include <string>
 
 
 namespace constants


### PR DESCRIPTION
Noticed while attempting a MacOS build, which gave an error here.