### PR TITLE
Use reference for DirectionScan range-for loop

### DIFF
--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -242,7 +242,7 @@ void MapViewState::diggerTaskFinished(Robot* robot)
 	 *			a digger gets in the way (or should diggers be smarter than
 	 *			puncturing a fusion reactor containment vessel?)
 	 */
-	for (const auto offset : DirectionScan3x3)
+	for (const auto& offset : DirectionScan3x3)
 	{
 		mTileMap->getTile(origin + offset, newDepth).excavated(true);
 	}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -186,7 +186,7 @@ bool validLanderSite(Tile& tile)
  */
 bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position)
 {
-	for (const auto offset : DirectionScan3x3)
+	for (const auto& offset : DirectionScan3x3)
 	{
 		auto& tile = tilemap->getTile(position + offset);
 


### PR DESCRIPTION
Technically `Vector` structs are cheap to copy, so it shouldn't matter, though the MacOS compiler was complaining about it.