### PR TITLE
Add MacOS build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,22 @@ commands:
       - run: make package
       - store_artifacts:
           path: .build/package/
+  brew-install:
+    description: "Brew install MacOS dependencies (or restore from cache)"
+    parameters:
+      packages:
+        type: string
+    steps:
+      - restore_cache:
+          name: Restoring brew dependencies
+          key: deps-OPHD-v1-{{ arch }}
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install << parameters.packages >>
+      - save_cache:
+          name: Caching brew dependencies
+          key: deps-OPHD-v1-{{ arch }}
+          paths:
+            - /usr/local/Cellar
+      - run: brew link << parameters.packages >>
 
 jobs:
   build-linux:
@@ -38,6 +54,15 @@ jobs:
       - checkout
       - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" intermediate
+  build-macos:
+    macos:
+      xcode: "12.3.0"
+    environment:
+      - WARN_EXTRA: "-Wno-double-promotion"
+    steps:
+      - brew-install:
+          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
+      - build
 
 workflows:
   build:
@@ -46,3 +71,4 @@ workflows:
       - build-linux-gcc
       - build-linux-clang
       - build-linux-mingw
+      - build-macos

--- a/makefile
+++ b/makefile
@@ -14,11 +14,16 @@ PACKAGEDIR := $(BUILDDIR)/package/
 CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
 
+Linux_OpenGL_LIBS := -lGLEW -lGL
+Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
+Windows_OpenGL_LIBS := -lglew32 -lopengl32
+OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
+
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
-LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
+LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs $(OpenGL_LIBS)
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)$*.Td
 


### PR DESCRIPTION
This attempt caught defects fixed in #738 and #739:
https://app.circleci.com/pipelines/github/OutpostUniverse/OPHD/1160/workflows/c46deafd-1c3f-4194-a0a0-6e578acb7948/jobs/4968

Still need to figure out how to support the OpenGL dependency on MacOS.
