### PR TITLE
Update CircleCI parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" intermediate
+      - run: make --keep-going --jobs 8 CXXFLAGS_EXTRA="-Werror" intermediate
   build-macos:
     macos:
       xcode: "12.3.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ commands:
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror" nas2d
-      - run: make --keep-going --jobs 2 CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" nas2d
+      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
       - run: make package
       - store_artifacts:
           path: .build/package/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ commands:
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - run: make --keep-going --jobs 8 CXXFLAGS_EXTRA="-Werror" nas2d
-      - run: make --keep-going --jobs 8 CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
       - run: make package
       - store_artifacts:
           path: .build/package/
@@ -53,7 +53,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - run: make --keep-going --jobs 8 CXXFLAGS_EXTRA="-Werror" intermediate
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" intermediate
   build-macos:
     macos:
       xcode: "12.3.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ commands:
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" nas2d
-      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs 8 CXXFLAGS_EXTRA="-Werror" nas2d
+      - run: make --keep-going --jobs 8 CXXFLAGS_EXTRA="-Werror"
       - run: make package
       - store_artifacts:
           path: .build/package/


### PR DESCRIPTION
Increase build speeds by updating parallelism.

Trying to run too much at once can cause failures due to memory exhaustion, so there is a limit to what is possible. There is also a point of diminishing returns, where increasing parallelism has comparatively little effect on reducing build times.
