### PR TITLE
Fix an out of bounds issue in the StructureInspector window that...

### DIFF
--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -52,7 +52,7 @@ void StructureInspector::update()
 	}
 	text(mStructure->name());
 
-	StringTable stringTable(4, 3);
+	StringTable stringTable(4, 4);
 	stringTable.position(mRect.startPoint() + NAS2D::Vector{ 5, 25 });
 	stringTable.setVerticalPadding(5);
 	stringTable.setColumnFont(2, stringTable.GetDefaultTitleFont());


### PR DESCRIPTION
... attempts to access a row in StringTable that isn't allocated.

Not sure how this one was missed? Realized it when it came to structures that employ Scientists.