### PR TITLE
Add biowaste recycling logic

### DIFF
--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -157,6 +157,7 @@ private:
 	void updateCommercial();
 	void updateMorale();
 	void updateResidentialCapacity();
+	void updateBiowasteRecycling();
 	void updateResources();
 	void updateRoads();
 	void updateRobots();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -336,7 +336,27 @@ void MapViewState::updateResidentialCapacity()
 
 void MapViewState::updateBiowasteRecycling()
 {
+	auto& residences = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Residence);
+	auto& recyclingFacilities = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Recycling);
 
+	if (residences.empty() || recyclingFacilities.empty()) { return; }
+
+	auto residenceIterator = residences.begin();
+	for (auto recyclingFacility : recyclingFacilities)
+	{
+		int count = 0;
+
+		// Consider a different control path
+		if (!recyclingFacility->operational()) { continue; }
+
+		for (; residenceIterator != residences.end(); ++residenceIterator)
+		{
+			Residence* residence = static_cast<Residence*>(*residenceIterator);
+			residence->pullWaste(30);
+			++count;
+			if (count >= 10) { break; }
+		}
+	}
 }
 
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -185,6 +185,13 @@ void MapViewState::updateMorale()
 	// Ensure that there is always a morale hit if residential capacity is more than 100%.
 	if (mPopulationPanel.capacity() > 100 && residentialMoraleHit < constants::MINIMUM_RESIDENCE_OVERCAPACITY_HIT) { residentialMoraleHit = constants::MINIMUM_RESIDENCE_OVERCAPACITY_HIT; }
 
+	auto& residences = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Residence);
+	for (auto residence : residences)
+	{
+		Residence* unit = static_cast<Residence*>(residence);
+		if (unit->wasteOverflow() > 0) { mCurrentMorale -= 2; } /// \fixme magic number
+	}
+
 	mCurrentMorale -= residentialMoraleHit;
 
 	mCurrentMorale = std::clamp(mCurrentMorale, 0, 1000);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -345,17 +345,27 @@ void MapViewState::updateBiowasteRecycling()
 	for (auto recyclingFacility : recyclingFacilities)
 	{
 		int count = 0;
+		
+		if (!recyclingFacility->operational()) { continue; } // Consider a different control structure
 
-		// Consider a different control path
-		if (!recyclingFacility->operational()) { continue; }
+		Recycling* recycling = static_cast<Recycling*>(recyclingFacility);
 
 		for (; residenceIterator != residences.end(); ++residenceIterator)
 		{
 			Residence* residence = static_cast<Residence*>(*residenceIterator);
-			residence->pullWaste(30);
+			residence->pullWaste(recycling->wasteProcessingCapacity());
+			
 			++count;
-			if (count >= 10) { break; }
+			
+			if (count >= recycling->residentialSupportCount())
+			{
+				break;
+			}
 		}
+
+		// We got to the end of the residence list, don't waste time iterating over
+		// any remaining recycling facilities.
+		if (residenceIterator == residences.end()) { break; }
 	}
 }
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -334,6 +334,12 @@ void MapViewState::updateResidentialCapacity()
 }
 
 
+void MapViewState::updateBiowasteRecycling()
+{
+
+}
+
+
 void MapViewState::updateFood()
 {
 	mFood = 0;
@@ -405,6 +411,7 @@ void MapViewState::nextTurn()
 
 	updatePopulation();
 	updateCommercial();
+	updateBiowasteRecycling();
 	updateMorale();
 	updateRobots();
 	updateResources();

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -65,6 +65,7 @@ void StructureManager::update(const StorableResources& resources, PopulationPool
 	updateStructures(resources, population, mStructureLists[Structure::StructureClass::SurfacePolice]);
 	updateStructures(resources, population, mStructureLists[Structure::StructureClass::UndergroundPolice]);
 	updateStructures(resources, population, mStructureLists[Structure::StructureClass::RecreationCenter]);
+	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Recycling]);
 	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Residence]);
 	updateStructures(resources, population, mStructureLists[Structure::StructureClass::RobotCommand]);
 	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Warehouse]);

--- a/OPHD/Things/Structures/Recycling.h
+++ b/OPHD/Things/Structures/Recycling.h
@@ -6,6 +6,10 @@
 
 class Recycling : public Structure
 {
+private:
+	const int WasteProcessingCapacity = 30;
+	const int ResidentialSupportCount = 10;
+
 public:
 	Recycling() : Structure(constants::RECYCLING,
 		"structures/recycling.sprite",
@@ -17,6 +21,26 @@ public:
 
 		requiresCHAP(true);
 	}
+
+
+	/**
+	 * Amount of waste the facility can process per turn.
+	 */
+	virtual int wasteProcessingCapacity() const
+	{
+		return WasteProcessingCapacity;
+	}
+	
+	
+	/**
+	 * Number of residential units the facility can support
+	 * each turn.
+	 */
+	virtual int residentialSupportCount() const
+	{
+	return ResidentialSupportCount;
+	}
+
 
 protected:
 	void defineResourceInput() override

--- a/OPHD/Things/Structures/Recycling.h
+++ b/OPHD/Things/Structures/Recycling.h
@@ -7,9 +7,9 @@
 class Recycling : public Structure
 {
 public:
-	Recycling() : Structure(constants::RECREATION_CENTER,
+	Recycling() : Structure(constants::RECYCLING,
 		"structures/recycling.sprite",
-		StructureClass::RecreationCenter,
+		StructureClass::Recycling,
 		StructureID::SID_RECYCLING)
 	{
 		maxAge(500);


### PR DESCRIPTION
Closes #750

Adds biowaste processing logic when player builds recycling structures and adds a morale hit when waste is overflowing at residences.