### PR TITLE
Mark StructureManager::structureList return value as const

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -212,7 +212,7 @@ void MapViewState::load(const std::string& filePath)
 			 * There should only ever be one structure if the turn count is 0, the
 			 * SEED Lander which at this point should not have been deployed.
 			 */
-			StructureList& list = Utility<StructureManager>::get().structureList(Structure::StructureClass::Lander);
+			const auto& list = Utility<StructureManager>::get().structureList(Structure::StructureClass::Lander);
 			if (list.size() != 1) { throw std::runtime_error("MapViewState::load(): Turn counter at 0 but more than one structure in list."); }
 
 			SeedLander* s = dynamic_cast<SeedLander*>(list[0]);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -88,7 +88,7 @@ void MapViewState::updatePopulation()
 	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, StructureState::Operational);
 	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::Operational);
 
-	StructureList &foodproducers = structureManager.structureList(Structure::StructureClass::FoodProduction);
+	const auto& foodproducers = structureManager.structureList(Structure::StructureClass::FoodProduction);
 	int remainder = mPopulation.update(mCurrentMorale, mFood, residences, universities, nurseries, hospitals);
 
 	for (auto structure : foodproducers)
@@ -106,8 +106,8 @@ void MapViewState::updateCommercial()
 {
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	StructureList& _warehouses = structureManager.structureList(Structure::StructureClass::Warehouse);
-	StructureList& _commercial = structureManager.structureList(Structure::StructureClass::Commercial);
+	const auto& _warehouses = structureManager.structureList(Structure::StructureClass::Warehouse);
+	const auto& _commercial = structureManager.structureList(Structure::StructureClass::Commercial);
 
 	// No need to do anything if there are no commercial structures.
 	if (_commercial.empty()) { return; }

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -273,7 +273,7 @@ void StructureManager::removeStructure(Structure* structure)
 }
 
 
-StructureList& StructureManager::structureList(Structure::StructureClass structureClass)
+const StructureList& StructureManager::structureList(Structure::StructureClass structureClass)
 {
 	return mStructureLists[structureClass];
 }

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -25,7 +25,7 @@ public:
 	void addStructure(Structure* structure, Tile* tile);
 	void removeStructure(Structure* structure);
 
-	StructureList& structureList(Structure::StructureClass structureClass);
+	const StructureList& structureList(Structure::StructureClass structureClass);
 	Tile& tileFromStructure(Structure* structure);
 
 	void disconnectAll();


### PR DESCRIPTION
To prevent accidental modification of the original structure lists, the return value should have `const` added, as below:
```cpp
const StructureList& structureList(Structure::StructureClass structureClass);
```
