### PR TITLE
Refactor StorableResources

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -269,12 +269,12 @@ void MapViewState::updatePlayerResources()
 	 */
 	auto& playerResources = const_cast<StorableResources&>(mPlayerResources);
 
-	playerResources.clear();
-
+	StorableResources resources;
 	for (auto structure : storage)
 	{
-		playerResources += structure->storage();
+		resources += structure->storage();
 	}
+	playerResources = resources;
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -249,9 +249,9 @@ int MapViewState::totalStorage(Structure::StructureClass structureClass, int cap
 int MapViewState::refinedResourcesInStorage()
 {
 	int total = 0;
-	for (size_t i = 0; i < mPlayerResources.resources.size(); ++i)
+	for (size_t i = 0; i < mResourcesCount.resources.size(); ++i)
 	{
-		total += mPlayerResources.resources[i];
+		total += mResourcesCount.resources[i];
 	}
 	return total;
 }
@@ -267,7 +267,7 @@ void MapViewState::updatePlayerResources()
 	{
 		resources += structure->storage();
 	}
-	mPlayerResources = resources;
+	mResourcesCount = resources;
 }
 
 
@@ -1115,9 +1115,9 @@ void MapViewState::placeStructure()
 		}
 
 		// Check build cost
-		if (!StructureCatalogue::canBuild(mPlayerResources, mCurrentStructure))
+		if (!StructureCatalogue::canBuild(mResourcesCount, mCurrentStructure))
 		{
-			resourceShortageMessage(mPlayerResources, mCurrentStructure);
+			resourceShortageMessage(mResourcesCount, mCurrentStructure);
 			return;
 		}
 
@@ -1130,7 +1130,7 @@ void MapViewState::placeStructure()
 		if (structure->isFactory())
 		{
 			static_cast<Factory*>(structure)->productionComplete().connect(this, &MapViewState::factoryProductionComplete);
-			static_cast<Factory*>(structure)->resourcePool(&mPlayerResources);
+			static_cast<Factory*>(structure)->resourcePool(&mResourcesCount);
 		}
 
 		auto cost = StructureCatalogue::costToBuild(mCurrentStructure);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -262,19 +262,12 @@ void MapViewState::updatePlayerResources()
 	StructureList storage = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
 	storage.insert(storage.begin(), mTileMap->getTile(ccLocation(), 0).structure());
 
-	/**
-	 * This at first looks heinous. However, mPlayerResources is declared const
-	 * to ensure that it is treated as a read-only object. This function is the
-	 * only one allowed to modify it.
-	 */
-	auto& playerResources = const_cast<StorableResources&>(mPlayerResources);
-
 	StorableResources resources;
 	for (auto structure : storage)
 	{
 		resources += structure->storage();
 	}
-	playerResources = resources;
+	mPlayerResources = resources;
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -891,7 +891,7 @@ void MapViewState::placeRobot()
 			/**
 			 * \todo	This could/should be some sort of alert message to the user instead of dumped to the console
 			 */
-			if (!recycledResources.empty()) { std::cout << "Resources wasted demolishing " << structure->name() << std::endl; }
+			if (!recycledResources.isEmpty()) { std::cout << "Resources wasted demolishing " << structure->name() << std::endl; }
 
 			updatePlayerResources();
 			updateStructuresAvailability();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -230,7 +230,7 @@ private:
 	int mFood{ 0 };
 
 	// POOLS
-	const StorableResources mPlayerResources; /**< Player's current refined resources. */
+	StorableResources mPlayerResources; /**< Player's current refined resources. */
 	RobotPool mRobotPool; /**< Robots that are currently available for use. */
 	PopulationPool mPopulationPool;
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -230,7 +230,7 @@ private:
 	int mFood{ 0 };
 
 	// POOLS
-	StorableResources mPlayerResources; /**< Player's current refined resources. */
+	StorableResources mResourcesCount;
 	RobotPool mRobotPool; /**< Robots that are currently available for use. */
 	PopulationPool mPopulationPool;
 

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -155,10 +155,10 @@ void MapViewState::drawResourceInfo()
 	constexpr auto iconSize = constants::RESOURCE_ICON_SIZE;
 	const std::array resources
 	{
-		std::tuple{NAS2D::Rectangle{64, 16, iconSize, iconSize}, mPlayerResources.resources[0], offsetX},
-		std::tuple{NAS2D::Rectangle{80, 16, iconSize, iconSize}, mPlayerResources.resources[2], x + offsetX},
-		std::tuple{NAS2D::Rectangle{96, 16, iconSize, iconSize}, mPlayerResources.resources[1], x + offsetX},
-		std::tuple{NAS2D::Rectangle{112, 16, iconSize, iconSize}, mPlayerResources.resources[3], 0},
+		std::tuple{NAS2D::Rectangle{64, 16, iconSize, iconSize}, mResourcesCount.resources[0], offsetX},
+		std::tuple{NAS2D::Rectangle{80, 16, iconSize, iconSize}, mResourcesCount.resources[2], x + offsetX},
+		std::tuple{NAS2D::Rectangle{96, 16, iconSize, iconSize}, mResourcesCount.resources[1], x + offsetX},
+		std::tuple{NAS2D::Rectangle{112, 16, iconSize, iconSize}, mResourcesCount.resources[3], 0},
 	};
 
 	for (const auto& [imageRect, amount, spacing] : resources)

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -152,7 +152,7 @@ void MapViewState::deploySeedLander(NAS2D::Point<int> point)
 
 	// BOTTOM ROW
 	SeedFactory* sf = static_cast<SeedFactory*>(StructureCatalogue::get(StructureID::SID_SEED_FACTORY));
-	sf->resourcePool(&mPlayerResources);
+	sf->resourcePool(&mResourcesCount);
 	sf->productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 	sf->sprite().setFrame(7);
 	structureManager.addStructure(sf, &mTileMap->getTile(point + DirectionSouthWest));

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -463,7 +463,7 @@ void addRefinedResources(StorableResources& resourcesToAdd)
 
 	for (auto structure : storage)
 	{
-		if (resourcesToAdd.empty()) { break; }
+		if (resourcesToAdd.isEmpty()) { break; }
 
 		auto& storageTanksResources = structure->storage();
 
@@ -492,7 +492,7 @@ void removeRefinedResources(StorableResources& resourcesToRemove)
 
 	for (auto structure : storage)
 	{
-		if (resourcesToRemove.empty()) { break; }
+		if (resourcesToRemove.isEmpty()) { break; }
 
 		auto& resourcesInStorage = structure->storage().resources;
 		for (size_t i = 0; i < resourcesInStorage.size(); ++i)

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -436,7 +436,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			auto& factory = *static_cast<Factory*>(&structure);
 			factory.productType(static_cast<ProductType>(production_type));
 			factory.productionTurnsCompleted(production_completed);
-			factory.resourcePool(&mPlayerResources);
+			factory.resourcePool(&mResourcesCount);
 			factory.productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 		}
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -425,11 +425,11 @@ void MapViewState::nextTurn()
 
 	mPopulationPool.clear();
 
-	mResourceBreakdownPanel.previousResources(mPlayerResources);
+	mResourceBreakdownPanel.previousResources(mResourcesCount);
 
 	NAS2D::Utility<StructureManager>::get().disconnectAll();
 	checkConnectedness();
-	NAS2D::Utility<StructureManager>::get().update(mPlayerResources, mPopulationPool);
+	NAS2D::Utility<StructureManager>::get().update(mResourcesCount, mPopulationPool);
 
 	updateFood();
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -57,7 +57,7 @@ void MapViewState::initUi()
 	mPopulationPanel.old_morale(&mPreviousMorale);
 
 	mResourceBreakdownPanel.position({0, 22});
-	mResourceBreakdownPanel.playerResources(&mPlayerResources);
+	mResourceBreakdownPanel.playerResources(&mResourcesCount);
 
 	mGameOverDialog.returnToMainMenu().connect(this, &MapViewState::btnGameOverClicked);
 	mGameOverDialog.hide();
@@ -374,7 +374,7 @@ void MapViewState::structuresSelectionChanged(const IconGrid::IconGridItem* _ite
 	// Check availability
 	if (!_item->available)
 	{
-		resourceShortageMessage(mPlayerResources, static_cast<StructureID>(_item->meta));
+		resourceShortageMessage(mResourcesCount, static_cast<StructureID>(_item->meta));
 		mStructures.clearSelection();
 		return;
 	}
@@ -553,6 +553,6 @@ void MapViewState::updateStructuresAvailability()
 	for (int sid = 1; sid < StructureID::SID_COUNT; ++sid)
 	{
 		const StructureID id = static_cast<StructureID>(sid);
-		mStructures.itemAvailable(StructureName(id), StructureCatalogue::canBuild(mPlayerResources, id));
+		mStructures.itemAvailable(StructureName(id), StructureCatalogue::canBuild(mResourcesCount, id));
 	}
 }

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -36,7 +36,7 @@ struct StorableResources
 
 	bool operator>=(const StorableResources& other) const
 	{
-		return other.resources <= resources;
+		return other <= *this;
 	}
 
 	bool operator<(const StorableResources& other) const
@@ -49,7 +49,7 @@ struct StorableResources
 
 	bool operator>(const StorableResources& other) const
 	{
-		return other.resources < resources;
+		return other < *this;
 	}
 
 	StorableResources cap(int max) const

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -38,11 +38,6 @@ struct StorableResources
 		return true;
 	}
 
-	constexpr bool operator>=(const StorableResources& other) const
-	{
-		return other <= *this;
-	}
-
 	constexpr bool operator<(const StorableResources& other) const
 	{
 		for (size_t i = 0; i < resources.size(); ++i)
@@ -53,6 +48,11 @@ struct StorableResources
 			}
 		}
 		return true;
+	}
+
+	constexpr bool operator>=(const StorableResources& other) const
+	{
+		return other <= *this;
 	}
 
 	constexpr bool operator>(const StorableResources& other) const

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -63,11 +63,6 @@ struct StorableResources
 		return out;
 	}
 
-	void clear()
-	{
-		resources = { 0, 0, 0, 0 };
-	}
-
 	bool isEmpty() const
 	{
 		if (resources[0] > 0 ||

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -28,10 +28,14 @@ struct StorableResources
 
 	constexpr bool operator<=(const StorableResources& other) const
 	{
-		return resources[0] <= other.resources[0] &&
-			resources[1] <= other.resources[1] &&
-			resources[2] <= other.resources[2] &&
-			resources[3] <= other.resources[3];
+		for (size_t i = 0; i < resources.size(); ++i)
+		{
+			if (!(resources[i] <= other.resources[i]))
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 
 	constexpr bool operator>=(const StorableResources& other) const
@@ -41,10 +45,14 @@ struct StorableResources
 
 	constexpr bool operator<(const StorableResources& other) const
 	{
-		return resources[0] < other.resources[0] &&
-			resources[1] < other.resources[1] &&
-			resources[2] < other.resources[2] &&
-			resources[3] < other.resources[3];
+		for (size_t i = 0; i < resources.size(); ++i)
+		{
+			if (!(resources[i] < other.resources[i]))
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 
 	constexpr bool operator>(const StorableResources& other) const
@@ -65,14 +73,13 @@ struct StorableResources
 
 	constexpr bool isEmpty() const
 	{
-		if (resources[0] > 0 ||
-			resources[1] > 0 ||
-			resources[2] > 0 ||
-			resources[3] > 0)
+		for (size_t i = 0; i < resources.size(); ++i)
 		{
-			return false;
+			if (resources[i] > 0)
+			{
+				return false;
+			}
 		}
-
 		return true;
 	}
 

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -80,12 +80,12 @@ struct StorableResources
 };
 
 
-constexpr inline StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
+constexpr StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
 {
 	return lhs += rhs;
 }
 
-constexpr inline StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
+constexpr StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
 {
 	return lhs -= rhs;
 }

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 
+
 struct StorableResources
 {
 	StorableResources operator+(const StorableResources& other) const

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -81,7 +81,7 @@ struct StorableResources
 		return true;
 	}
 
-	std::array<int, 4> resources{ 0 };
+	std::array<int, 4> resources{};
 };
 
 

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -5,8 +5,6 @@
 
 struct StorableResources
 {
-	StorableResources() = default;
-
 	StorableResources operator+(const StorableResources& other) const
 	{
 		StorableResources out;

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -6,39 +6,23 @@
 
 struct StorableResources
 {
-	StorableResources operator+(const StorableResources& other) const
-	{
-		StorableResources out;
-
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			out.resources[i] = resources[i] + other.resources[i];
-		}
-
-		return out;
-	}
-
 	StorableResources& operator+=(const StorableResources& other)
 	{
-		*this = *this + other;
-		return *this;
-	}
-
-	StorableResources operator-(const StorableResources& other) const
-	{
-		StorableResources out;
-
 		for (size_t i = 0; i < resources.size(); ++i)
 		{
-			out.resources[i] = resources[i] - other.resources[i];
+			resources[i] += other.resources[i];
 		}
 
-		return out;
+		return *this;
 	}
 
 	StorableResources& operator-=(const StorableResources& other)
 	{
-		*this = *this - other;
+		for (size_t i = 0; i < resources.size(); ++i)
+		{
+			resources[i] -= other.resources[i];
+		}
+
 		return *this;
 	}
 
@@ -99,3 +83,14 @@ struct StorableResources
 
 	std::array<int, 4> resources{ 0 };
 };
+
+
+inline StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
+{
+	return lhs += rhs;
+}
+
+inline StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
+{
+	return lhs -= rhs;
+}

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -6,7 +6,7 @@
 
 struct StorableResources
 {
-	StorableResources& operator+=(const StorableResources& other)
+	constexpr StorableResources& operator+=(const StorableResources& other)
 	{
 		for (size_t i = 0; i < resources.size(); ++i)
 		{
@@ -16,7 +16,7 @@ struct StorableResources
 		return *this;
 	}
 
-	StorableResources& operator-=(const StorableResources& other)
+	constexpr StorableResources& operator-=(const StorableResources& other)
 	{
 		for (size_t i = 0; i < resources.size(); ++i)
 		{
@@ -26,7 +26,7 @@ struct StorableResources
 		return *this;
 	}
 
-	bool operator<=(const StorableResources& other) const
+	constexpr bool operator<=(const StorableResources& other) const
 	{
 		return resources[0] <= other.resources[0] &&
 			resources[1] <= other.resources[1] &&
@@ -34,12 +34,12 @@ struct StorableResources
 			resources[3] <= other.resources[3];
 	}
 
-	bool operator>=(const StorableResources& other) const
+	constexpr bool operator>=(const StorableResources& other) const
 	{
 		return other <= *this;
 	}
 
-	bool operator<(const StorableResources& other) const
+	constexpr bool operator<(const StorableResources& other) const
 	{
 		return resources[0] < other.resources[0] &&
 			resources[1] < other.resources[1] &&
@@ -47,12 +47,12 @@ struct StorableResources
 			resources[3] < other.resources[3];
 	}
 
-	bool operator>(const StorableResources& other) const
+	constexpr bool operator>(const StorableResources& other) const
 	{
 		return other < *this;
 	}
 
-	StorableResources cap(int max) const
+	constexpr StorableResources cap(int max) const
 	{
 		StorableResources out;
 		for (std::size_t i = 0; i < resources.size(); ++i)
@@ -63,7 +63,7 @@ struct StorableResources
 		return out;
 	}
 
-	bool isEmpty() const
+	constexpr bool isEmpty() const
 	{
 		if (resources[0] > 0 ||
 			resources[1] > 0 ||
@@ -80,12 +80,12 @@ struct StorableResources
 };
 
 
-inline StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
+constexpr inline StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
 {
 	return lhs += rhs;
 }
 
-inline StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
+constexpr inline StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
 {
 	return lhs -= rhs;
 }

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -68,7 +68,7 @@ struct StorableResources
 		resources = { 0, 0, 0, 0 };
 	}
 
-	bool empty()
+	bool isEmpty()
 	{
 		if (resources[0] > 0 ||
 			resources[1] > 0 ||

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -68,7 +68,7 @@ struct StorableResources
 		resources = { 0, 0, 0, 0 };
 	}
 
-	bool isEmpty()
+	bool isEmpty() const
 	{
 		if (resources[0] > 0 ||
 			resources[1] > 0 ||

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -135,7 +135,7 @@ void Factory::updateProduction()
 
 	removeRefinedResources(cost);
 
-	if (!cost.empty()) { throw std::runtime_error("Factory::updateProduction(): Production cost not empty"); }
+	if (!cost.isEmpty()) { throw std::runtime_error("Factory::updateProduction(): Production cost not empty"); }
 
 	++mTurnsCompleted;
 

--- a/OPHD/Things/Structures/OreRefining.h
+++ b/OPHD/Things/Structures/OreRefining.h
@@ -111,7 +111,7 @@ protected:
 
 		stored = capped;
 
-		if (!overflow.empty())
+		if (!overflow.isEmpty())
 		{
 			StorableResources deconvertedResources{ overflow.resources[0] * OreConversionDivisor[0],
 				overflow.resources[1] * OreConversionDivisor[1],


### PR DESCRIPTION
I was investigating using C++20, and the only problem seemed to be in `StorableResources`, so I refactored it a bit.

As we don't have unit tests covering that class, the changes may bear a little extra scrutiny.

For some background on re-writing the `operator` delegation (`<=`, `<`, `>=`, `>`), see:
https://stackoverflow.com/questions/38579088/c-why-implement-op-in-terms-of-op-and-not-the-other-way-around
