### PR TITLE
Null derefernce guard in rcc read

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -55,6 +55,26 @@ static void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, Storabl
 }
 
 
+static void readRccRobots(NAS2D::Xml::XmlAttribute* attr, Structure& structure, RobotPool& pool)
+{
+	if (!attr) { return; }
+
+	for (const auto& string : NAS2D::split(attr->value(), ','))
+	{
+		const auto robotId = NAS2D::stringTo<int>(string);
+		for (auto* robot : pool.robots())
+		{
+			if (robot->id() == robotId)
+			{
+				static_cast<RobotCommand*>(&structure)->addRobot(robot);
+				break;
+			}
+		}
+	}
+}
+
+
+
 /*****************************************************************************
  * CLASS FUNCTIONS
  *****************************************************************************/
@@ -445,22 +465,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			auto robotsElement = structureNode->firstChildElement("robots");
 			if (robotsElement)
 			{
-				auto robotsAttribute = robotsElement->firstAttribute();
-				if (robotsAttribute)
-				{
-					for (const auto& string : NAS2D::split(robotsAttribute->value(), ','))
-					{
-						const auto robotId = NAS2D::stringTo<int>(string);
-						for (auto* robot : mRobotPool.robots())
-						{
-							if (robot->id() == robotId)
-							{
-								static_cast<RobotCommand*>(&structure)->addRobot(robot);
-								break;
-							}
-						}
-					}
-				}
+				readRccRobots(robotsElement->firstAttribute(), structure, mRobotPool);
 			}
 		}
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -440,25 +440,25 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			factory.productionComplete().connect(this, &MapViewState::factoryProductionComplete);
 		}
 
-		/**
-		 * This is a little fragile in that it assumes that everything it expects is
-		 * encoded in the XML savegame. While there are some basic guards in place when
-		 * loading the code doesn't do any checking for garbage for the sake of brevity.
-		 */
 		if (structure.isRobotCommand())
 		{
-			auto& rcc = *static_cast<RobotCommand*>(&structure);
-			XmlAttribute* robotsAttribute = structureNode->firstChildElement("robots")->firstAttribute();
-
-			for (const auto& string : NAS2D::split(robotsAttribute->value(), ','))
+			auto robotsElement = structureNode->firstChildElement("robots");
+			if (robotsElement)
 			{
-				const auto robotId = NAS2D::stringTo<int>(string);
-				for (auto* robot : mRobotPool.robots())
+				auto robotsAttribute = robotsElement->firstAttribute();
+				if (robotsAttribute)
 				{
-					if (robot->id() == robotId)
+					for (const auto& string : NAS2D::split(robotsAttribute->value(), ','))
 					{
-						rcc.addRobot(robot);
-						break;
+						const auto robotId = NAS2D::stringTo<int>(string);
+						for (auto* robot : mRobotPool.robots())
+						{
+							if (robot->id() == robotId)
+							{
+								static_cast<RobotCommand*>(&structure)->addRobot(robot);
+								break;
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Small refactor of the RCC xml read code that adds in some basic guards so things aren't crashy if a user decides to make changes in a save game file.