### PR TITLE
Improve remove robot function

### DIFF
--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -28,11 +28,6 @@ bool RobotCommand::isControlling(Robot* robot) const
 
 /**
  * Adds a robot to the management pool of the Robot Command structure.
- * 
- * \param	robot	Pointer to a Robot to add to command list.
- * 
- * \note	Performs some basic sanity checking. Will throw if list is full or
- *			the given pointer to a Robot is already in the list.
  */
 void RobotCommand::addRobot(Robot* robot)
 {
@@ -43,9 +38,7 @@ void RobotCommand::addRobot(Robot* robot)
 
 	if (isControlling(robot))
 	{
-		const auto message = "RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name();
-		std::cout << message << std::endl;
-		throw std::runtime_error(message);
+		throw std::runtime_error("RobotCommand::addRobot(): Adding a robot that is already under the command of this Robot Command Facility. Robot name: " + robot->name());
 	}
 
 	mRobotList.push_back(robot);

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -57,11 +57,5 @@ void RobotCommand::addRobot(Robot* robot)
  */
 void RobotCommand::removeRobot(Robot* robot)
 {
-	if (!robot) { throw std::runtime_error("RobotCommand::removeRobot() called with nullptr"); }
-	if (mRobotList.empty()) { return; }
-
-	auto iter = find(mRobotList.begin(), mRobotList.end(), robot);
-	if (iter == mRobotList.end()) { return; }
-
-	mRobotList.erase(iter);
+	mRobotList.erase(std::remove_if(mRobotList.begin(), mRobotList.end(), [robot](Robot* r1) { return r1 == robot; }), mRobotList.end());
 }

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -50,5 +50,5 @@ void RobotCommand::addRobot(Robot* robot)
  */
 void RobotCommand::removeRobot(Robot* robot)
 {
-	mRobotList.erase(std::remove_if(mRobotList.begin(), mRobotList.end(), [robot](Robot* r1) { return r1 == robot; }), mRobotList.end());
+	mRobotList.erase(std::remove(mRobotList.begin(), mRobotList.end(), robot), mRobotList.end());
 }


### PR DESCRIPTION
>Perhaps we should make use of [`std::remove_if`](https://en.cppreference.com/w/cpp/algorithm/remove). One method call should be able to replace this block of code.

```cpp
remove_if(mRobotList.begin(), mRobotList.end(), robot);
```

>Edit: It also runs in a way that enables us to remove the `empty()` check.

_Originally posted by @DanRStevens in https://github.com/OutpostUniverse/OPHD/pull/764#discussion_r572463784_

Implements this suggestion.