### PR TITLE
Fix stability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Introduces biowaste produced by residential units and some quality of life impro
 - Fix crash when right-clicking a Robot Command Center
 - Fix a mistake that tallied food totals before population consumption which resulted in incorrect value displayed in the HUD
 - Fix Mine full-screen UI showing "no routes" when loading a game
+- Fix for phantom mine routes being drawn on the Mini Map if you quit to the main menu from an active game and start a new game
 
 
 ## [0.8.0] - 2021-01-01

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -96,6 +96,8 @@ MapViewState::~MapViewState()
 	e.windowResized().disconnect(this, &MapViewState::onWindowResized);
 
 	e.textInputMode(false);
+
+	NAS2D::Utility<std::map<class MineFacility*, Route>>::get().clear();
 }
 
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -319,8 +319,8 @@ void MineReport::updateManagementButtonsVisiblity()
 	btnAddTruck.visible(mSelectedFacility);
 	btnRemoveTruck.visible(mSelectedFacility);
 
-	if (mSelectedFacility->destroyed() ||
-		mSelectedFacility->underConstruction())
+	if (mSelectedFacility &&
+		(mSelectedFacility->destroyed() || mSelectedFacility->underConstruction()))
 	{
 		btnAddTruck.visible(false);
 		btnRemoveTruck.visible(false);


### PR DESCRIPTION
Noticed that the game was suddenly crashy if a new game was started. There's a case in MineReport where a nullptr dereference can occur if there are no mines in the game yet.

I also discovered that the mine route table wasn't getting cleared when the MapViewState was destroyed so fixed that while I was at it.