### PR TITLE
Allow robots and buildings to be placed at view edge

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -554,7 +554,7 @@ Tile* TileMap::getVisibleTile(NAS2D::Point<int> position, int level)
 
 bool TileMap::isVisibleTile(NAS2D::Point<int> position, int z) const
 {
-	if (!NAS2D::Rectangle{mMapViewLocation.x, mMapViewLocation.y, mEdgeLength - 1, mEdgeLength - 1}.contains(position))
+	if (!NAS2D::Rectangle{mMapViewLocation.x, mMapViewLocation.y, mEdgeLength, mEdgeLength}.contains(position))
 	{
 		return false;
 	}


### PR DESCRIPTION
Closes #788

Fix off by 1 error. Previously the lower left and lower right edges were not considered viewable, even though they were being visibly drawn. This prevented items from being placed on those tiles.
