### PR TITLE
Fix bug where Tile Inspector can't be opened on edge tiles

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -289,7 +289,7 @@ void TileMap::centerMapOnTile(Tile* _t)
  */
 bool TileMap::tileHighlightVisible() const
 {
-	return NAS2D::Rectangle<int>::Create(mMapViewLocation, NAS2D::Vector{mEdgeLength - 1, mEdgeLength - 1}).contains(mMapHighlight);
+	return isVisibleTile(mMapHighlight, mCurrentDepth);
 }
 
 


### PR DESCRIPTION
Closes #794

Delegate to `isTileVisible` to reduce code duplication.
