### PR TITLE
Add tile overlay color

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -159,9 +159,3 @@ float Tile::distanceTo(NAS2D::Point<int> point)
 	const auto direction = point - position();
 	return static_cast<float>(std::sqrt((direction.x * direction.x) + (direction.y * direction.y)));
 }
-
-
-void Tile::overlay(Overlay overlay)
-{
-	mOverlay = overlay;
-}

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -7,6 +7,33 @@
 #include <cmath>
 
 
+std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
+{
+	{ Tile::Overlay::None, NAS2D::Color::Normal },
+	{ Tile::Overlay::Communications, { 125, 200, 255 } },
+	{ Tile::Overlay::Connectedness, NAS2D::Color::Green }
+};
+
+std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
+{
+	{ Tile::Overlay::None, NAS2D::Color{ 125, 200, 255 } },
+	{ Tile::Overlay::Communications, { 100, 180, 230 } },
+	{ Tile::Overlay::Connectedness, NAS2D::Color{ 71, 224, 146 } }
+};
+
+
+const NAS2D::Color& overlayColor(Tile::Overlay overlay)
+{
+	return OverlayColorTable.at(overlay);
+}
+
+
+const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay)
+{
+	return OverlayHighlightColorTable.at(overlay);
+}
+
+
 Tile::Tile(NAS2D::Point<int> position, int depth, TerrainType index) :
 	mIndex{index},
 	mPosition{position},
@@ -120,4 +147,10 @@ float Tile::distanceTo(NAS2D::Point<int> point)
 {
 	const auto direction = point - position();
 	return static_cast<float>(std::sqrt((direction.x * direction.x) + (direction.y * direction.y)));
+}
+
+
+void Tile::overlay(Overlay overlay)
+{
+	mColor = overlayColor(overlay);
 }

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -22,6 +22,17 @@ std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
 };
 
 
+const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
+{
+	if (isHighlighted)
+	{
+		return overlayHighlightColor(overlay);
+	}
+		
+	return overlayColor(overlay);
+}
+
+
 const NAS2D::Color& overlayColor(Tile::Overlay overlay)
 {
 	return OverlayColorTable.at(overlay);
@@ -47,7 +58,6 @@ Tile::Tile(Tile&& other) noexcept :
 	mDepth{other.mDepth},
 	mThing{other.mThing},
 	mMine{other.mMine},
-	mColor{other.mColor},
 	mOverlay{other.mOverlay},
 	mExcavated{other.mExcavated}
 {
@@ -63,7 +73,6 @@ Tile& Tile::operator=(Tile&& other) noexcept
 	mDepth = other.mDepth;
 	mThing = other.mThing;
 	mMine = other.mMine;
-	mColor = other.mColor;
 	mOverlay = other.mOverlay;
 	mExcavated = other.mExcavated;
 
@@ -155,5 +164,4 @@ float Tile::distanceTo(NAS2D::Point<int> point)
 void Tile::overlay(Overlay overlay)
 {
 	mOverlay = overlay;
-	mColor = overlayColor(overlay);
 }

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -48,6 +48,7 @@ Tile::Tile(Tile&& other) noexcept :
 	mThing{other.mThing},
 	mMine{other.mMine},
 	mColor{other.mColor},
+	mOverlay{other.mOverlay},
 	mExcavated{other.mExcavated}
 {
 	other.mThing = nullptr;
@@ -63,6 +64,7 @@ Tile& Tile::operator=(Tile&& other) noexcept
 	mThing = other.mThing;
 	mMine = other.mMine;
 	mColor = other.mColor;
+	mOverlay = other.mOverlay;
 	mExcavated = other.mExcavated;
 
 	other.mThing = nullptr;
@@ -152,5 +154,6 @@ float Tile::distanceTo(NAS2D::Point<int> point)
 
 void Tile::overlay(Overlay overlay)
 {
+	mOverlay = overlay;
 	mColor = overlayColor(overlay);
 }

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -71,7 +71,7 @@ public:
 	float distanceTo(Tile* tile);
 	float distanceTo(NAS2D::Point<int> point);
 
-	void overlay(Overlay overlay);
+	void overlay(Overlay overlay) { mOverlay = overlay; }
 	Overlay overlay() const { return mOverlay; }
 
 private:

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -71,8 +71,6 @@ public:
 	float distanceTo(Tile* tile);
 	float distanceTo(NAS2D::Point<int> point);
 
-
-	const NAS2D::Color& color() const { return mColor; }
 	void overlay(Overlay overlay);
 	Overlay overlay() const { return mOverlay; }
 
@@ -85,13 +83,12 @@ private:
 	Thing* mThing = nullptr;
 	Mine* mMine = nullptr;
 
-	NAS2D::Color mColor = NAS2D::Color::Normal;
-	
 	Overlay mOverlay{ Overlay::None };
 
 	bool mExcavated = true; /**< Used when a Digger uncovers underground tiles. */
 	bool mConnected = false; /**< Flag indicating that this tile is connected to the Command Center. */
 };
 
-const NAS2D::Color& overlayColor(Tile::Overlay overlay);
-const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay);
+const NAS2D::Color& overlayColor(Tile::Overlay, bool);
+const NAS2D::Color& overlayColor(Tile::Overlay);
+const NAS2D::Color& overlayHighlightColor(Tile::Overlay);

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -71,9 +71,10 @@ public:
 	float distanceTo(Tile* tile);
 	float distanceTo(NAS2D::Point<int> point);
 
-	//void color(const NAS2D::Color& c) { mColor = c; }
+
 	const NAS2D::Color& color() const { return mColor; }
 	void overlay(Overlay overlay);
+	Overlay overlay() const { return mOverlay; }
 
 private:
 	TerrainType mIndex = TerrainType::Dozed;
@@ -85,6 +86,8 @@ private:
 	Mine* mMine = nullptr;
 
 	NAS2D::Color mColor = NAS2D::Color::Normal;
+	
+	Overlay mOverlay{ Overlay::None };
 
 	bool mExcavated = true; /**< Used when a Digger uncovers underground tiles. */
 	bool mConnected = false; /**< Flag indicating that this tile is connected to the Command Center. */

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -15,6 +15,15 @@ class Structure;
 class Tile
 {
 public:
+	enum class Overlay
+	{
+		Communications,
+		Connectedness,
+
+		None
+	};
+
+public:
 	Tile() = default;
 	Tile(NAS2D::Point<int> position, int depth, TerrainType index);
 	Tile(const Tile& other) = delete;
@@ -62,8 +71,9 @@ public:
 	float distanceTo(Tile* tile);
 	float distanceTo(NAS2D::Point<int> point);
 
-	void color(const NAS2D::Color& c) { mColor = c; }
+	//void color(const NAS2D::Color& c) { mColor = c; }
 	const NAS2D::Color& color() const { return mColor; }
+	void overlay(Overlay overlay);
 
 private:
 	TerrainType mIndex = TerrainType::Dozed;
@@ -79,3 +89,6 @@ private:
 	bool mExcavated = true; /**< Used when a Digger uncovers underground tiles. */
 	bool mConnected = false; /**< Flag indicating that this tile is connected to the Command Center. */
 };
+
+const NAS2D::Color& overlayColor(Tile::Overlay overlay);
+const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay);

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -312,9 +312,7 @@ void TileMap::draw()
 				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 
-				const NAS2D::Color tileColor = isTileHighlighted ? overlayHighlightColor(tile.overlay()) : overlayColor(tile.overlay());
-				
-				renderer.drawSubImage(mTileset, position, subImageRect, tileColor);
+				renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
 
 				// Draw a beacon on an unoccupied tile with a mine
 				if (tile.mine() != nullptr && !tile.thing())

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -311,12 +311,10 @@ void TileMap::draw()
 				const auto position = mMapPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
 				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
-				const bool isConnectionHighlighted = mShowConnections && tile.connected();
-				const NAS2D::Color highlightColor =
-					isTileHighlighted ?
-						isConnectionHighlighted ? NAS2D::Color{71, 224, 146} : NAS2D::Color{125, 200, 255} :
-						isConnectionHighlighted ? NAS2D::Color::Green : NAS2D::Color::Normal;
-				renderer.drawSubImage(mTileset, position, subImageRect, highlightColor);
+
+				const NAS2D::Color tileColor = isTileHighlighted ? overlayHighlightColor(tile.overlay()) : overlayColor(tile.overlay());
+				
+				renderer.drawSubImage(mTileset, position, subImageRect, tileColor);
 
 				// Draw a beacon on an unoccupied tile with a mine
 				if (tile.mine() != nullptr && !tile.thing())


### PR DESCRIPTION
Closes #114

Also mostly addresses #115 <-- this will be closed when the MapViewState maintains lists of tile overlays and uses the new Tile::overlay() functions to switch between overlay modes.