### PR TITLE
Remove redundant file exists check when loading saved games

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -160,12 +160,6 @@ void MainMenuState::fileIoAction(const std::string& filePath, FileIo::FileOperat
 
 	std::string filename = constants::SAVE_GAME_PATH + filePath + ".xml";
 
-	if (!Utility<Filesystem>::get().exists(filename))
-	{
-		doNonFatalErrorMessage("Load Failed", "File '" + filename + "' was not found.");
-		return;
-	}
-
 	try
 	{
 		checkSavegameVersion(filename);


### PR DESCRIPTION
The `Filesystem::open` code will already throw a clear exception if it fails to open a file.

Addresses comment:
https://github.com/OutpostUniverse/OPHD/pull/805#discussion_r582450711
