### PR TITLE
Use `auto` for Filesystem::open return values

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -440,7 +440,7 @@ bool doYesNoMessage(const std::string& title, const std::string msg)
  */
 void checkSavegameVersion(const std::string& filename)
 {
-	File xmlFile = Utility<Filesystem>::get().open(filename);
+	auto xmlFile = Utility<Filesystem>::get().open(filename);
 
 	NAS2D::Xml::XmlDocument doc;
 	doc.parse(xmlFile.raw_bytes());

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -155,7 +155,7 @@ void MapViewState::load(const std::string& filePath)
 		throw std::runtime_error("File '" + filePath + "' was not found.");
 	}
 
-	File xmlFile = Utility<Filesystem>::get().open(filePath);
+	auto xmlFile = Utility<Filesystem>::get().open(filePath);
 
 	XmlDocument doc;
 


### PR DESCRIPTION
Small stylistic update. No significant benefit, though it corresponds with a recent change done to NAS2D:
https://github.com/lairworks/nas2d-core/pull/833

Actually, these changes were done when updating NAS2D, without realizing the changes had overflowed into OPHD code. Noticed the changed files sitting around a few days later.
