### PR TITLE
Use Vector::lengthSquared in Tile::distanceTo

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -157,5 +157,5 @@ float Tile::distanceTo(Tile* tile)
 float Tile::distanceTo(NAS2D::Point<int> point)
 {
 	const auto direction = point - position();
-	return static_cast<float>(std::sqrt((direction.x * direction.x) + (direction.y * direction.y)));
+	return static_cast<float>(std::sqrt(direction.lengthSquared()));
 }


### PR DESCRIPTION
Use one of the somewhat newer methods `Vector::lengthSquared()` to simplify `Tile::distanceTo`.

Relates to #806.
