### PR TITLE
Added Yes/No dialog option when a user clicks delete in Load/Save dia…

### DIFF
--- a/OPHD/Constants/Strings.h
+++ b/OPHD/Constants/Strings.h
@@ -189,6 +189,7 @@ namespace constants
 
 	const std::string WINDOW_FILEIO_TITLE_LOAD = "Load Game";
 	const std::string WINDOW_FILEIO_TITLE_SAVE = "Save Game";
+	const std::string WINDOW_FILEIO_TITLE_DELETE = "Delete Game";
 	const std::string WINDOW_FILEIO_LOAD = "Load";
 	const std::string WINDOW_FILEIO_SAVE = "Save";
 	const std::string WINDOW_FILEIO_DELETE = "Delete";

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -172,11 +172,13 @@ void FileIo::btnFileIoClicked()
 
 void FileIo::btnFileDeleteClicked()
 {
-	std::string filename = constants::SAVE_GAME_PATH + txtFileName.text()+ ".xml";
+	std::string filename = constants::SAVE_GAME_PATH + txtFileName.text() + ".xml";
 
 	try
 	{
-		Utility<Filesystem>::get().del(filename);
+		if(doYesNoMessage(constants::WINDOW_FILEIO_TITLE_DELETE, "Are you sure you want to delete " + txtFileName.text() + "?")) {
+			Utility<Filesystem>::get().del(filename);
+		}
 	}
 	catch(const std::exception& e)
 	{

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -176,7 +176,8 @@ void FileIo::btnFileDeleteClicked()
 
 	try
 	{
-		if(doYesNoMessage(constants::WINDOW_FILEIO_TITLE_DELETE, "Are you sure you want to delete " + txtFileName.text() + "?")) {
+		if(doYesNoMessage(constants::WINDOW_FILEIO_TITLE_DELETE, "Are you sure you want to delete " + txtFileName.text() + "?"))
+		{
 			Utility<Filesystem>::get().del(filename);
 		}
 	}


### PR DESCRIPTION
I found out there is actually already a Yes/No prompt available.
I've added it in the "Delete Game" flow to prompt a user before he/she deletes a game.
If they click yes, the deletion is carried out, if they click no, the user is returned to the Load or Save dialog without deletion taking place.

What I'm not sure about is the way to pass strings, I do want to keep them in Strings.h as much as possible, but is there a way to setup strings that have parameter placeholders in them?

E.g.: I now have the following:

```
if(doYesNoMessage(constants::WINDOW_FILEIO_TITLE_DELETE, "Are you sure you want to delete " + txtFileName.text() + "?")) {
			Utility<Filesystem>::get().del(filename);
}
```
Is there a way to have the string in Strings.h but have some sort of placeholder text that will be filled in with the actual save game name?

And I messed up the curly brace, it should go on the next line.