### PR TITLE
Fix for 792

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Introduces communcations range overlays, additional GUI quality of life improvem
 
 ### Changed
 - FileIO Window now has a 'delete' button so save games can be deleted from within the game
+- Change order of food counting and population update so that landing cargo/colonist landers at the same time doesn't result in an immediate game over
 
 ### Fixed
 - Fixed some computations in the population simulation that caused subtle behavior issues

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -506,8 +506,8 @@ void MapViewState::nextTurn()
 	transferFoodToCommandCenter();
 	updateResidentialCapacity();
 
-	updatePopulation();
 	countFood();
+	updatePopulation();
 
 	updateCommercial();
 	updateBiowasteRecycling();


### PR DESCRIPTION
Closes #792

---

In MapViewStateTurn.cpp, I noticed the order of the following functions seem to trigger the death of my colony.
I always wait until my Command Center is completely built, and then I place both Cargo Landers and both Colonist Landers and end my turn.


```
void MapViewState::nextTurn()
{
        ...

	updatePopulation();
	countFood();
        
        ...
}
```
The above will kill all the population because they don't have food.

But when I replaced it by the below order:

```
void MapViewState::nextTurn()
{
        ...

	countFood();
	updatePopulation();
        
        ...
}
```
Then my population doesn't starve and the four landers appear.
Using the above switching of function order, the mass death no longer occurred (given that the Command Center is fully built).
If the Colony Landers and Cargo Landers are brought down before the Command Center is built, it still triggers a Game Over, which I think is correct.

_Originally posted by @belgianguy in https://github.com/OutpostUniverse/OPHD/issues/792#issuecomment-791798267_

Noted by @belgianguy

Thanks for looking into it! This was a far simpler fix than I was expecting.