### PR TITLE
Added check to IconGrid to suppress changed event when the same item …

### DIFF
--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -86,7 +86,10 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		return;
 	}
 
+	auto previousIndex = mSelectedIndex;
 	mSelectedIndex = translateCoordsToIndex(mousePoint - startPoint);
+
+	if (previousIndex == mSelectedIndex) { return; }
 
 	if (mSelectedIndex >= mIconItemList.size())
 	{

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -89,8 +89,6 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	auto previousIndex = mSelectedIndex;
 	mSelectedIndex = translateCoordsToIndex(mousePoint - startPoint);
 
-	if (previousIndex == mSelectedIndex) { return; }
-
 	if (mSelectedIndex >= mIconItemList.size())
 	{
 		mSelectedIndex = constants::NO_SELECTION;
@@ -102,7 +100,10 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		return;
 	} */
 
-	raiseChangedEvent();
+	if (previousIndex != mSelectedIndex)
+	{
+		raiseChangedEvent();
+	}
 }
 
 


### PR DESCRIPTION
Closes #820 

At first I thought this could cause issues when it would be desirable to click an icon multiple times, say when you have two RoboDozers and you have to click the RoboDozer icon once for placing the first one, and click the RoboDozer icon again for when placing the second one. But this did not cause any problems.

Feel free to suggest other test cases that might need to be reviewed for this change to be accepted.