### PR TITLE
Make UIControl extend from Control and give Window a title property

### DIFF
--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -13,7 +13,7 @@
  * 
  * Generally not intended to be used by itself.
  */
-class UIContainer: public TextControl
+class UIContainer: public Control
 {
 public:
 	UIContainer();

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -28,7 +28,7 @@ Window::Window(std::string newTitle) :
 		imageCache.load("ui/skin/window_bottom_right.png")
 	}
 {
-	text(newTitle);
+	title(newTitle);
 
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Window::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMove);
@@ -94,7 +94,13 @@ void Window::update()
 
 	mBody.draw(renderer, NAS2D::Rectangle{mRect.x, mRect.y + 20, mRect.width, mRect.height - 20});
 
-	renderer.drawText(mTitleFont, text(), NAS2D::Point{mRect.x + 5, mRect.y + 2}, NAS2D::Color::White);
+	renderer.drawText(mTitleFont, title(), NAS2D::Point{mRect.x + 5, mRect.y + 2}, NAS2D::Color::White);
 
 	UIContainer::update();
+}
+
+void Window::title(const std::string& title)
+{
+	mTitle = title;
+	onTitleChanged();
 }

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -20,6 +20,14 @@ public:
 	void show() override;
 	void update() override;
 
+	using TitleChangedCallback = NAS2D::Signals::Signal<Window*>;
+
+	void title(const std::string& title);
+	const std::string& title() const { return mTitle; }
+	TitleChangedCallback& textChanged() { return mTitleChanged; }
+
+	virtual void onTitleChanged() { mTitleChanged(this); }
+
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
@@ -36,4 +44,8 @@ private:
 	const NAS2D::Image& mTitleBarCenter;
 	const NAS2D::Image& mTitleBarRight;
 	NAS2D::RectangleSkin mBody;
+
+	TitleChangedCallback mTitleChanged;
+
+	std::string mTitle;
 };

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -100,7 +100,7 @@ void FileIo::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mo
 void FileIo::setMode(FileOperation fileOp)
 {
 	mMode = fileOp; 
-	text(mMode == FileOperation::FILE_LOAD ? constants::WINDOW_FILEIO_TITLE_LOAD : constants::WINDOW_FILEIO_TITLE_SAVE);
+	title(mMode == FileOperation::FILE_LOAD ? constants::WINDOW_FILEIO_TITLE_LOAD : constants::WINDOW_FILEIO_TITLE_SAVE);
 	btnFileOp.text(mMode == FileOperation::FILE_LOAD ? constants::WINDOW_FILEIO_LOAD : constants::WINDOW_FILEIO_SAVE);
 }
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -82,7 +82,7 @@ void RobotInspector::focusOnRobot(Robot* robot)
 	if (!robot) { throw std::runtime_error("RobotInspector::focusOnRobot(): nullptr passed "); }
 
 	mRobot = robot;
-	text(robot->name());
+	title(robot->name());
 }
 
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -114,7 +114,7 @@ void StructureInspector::update()
 	{
 		throw std::runtime_error("Null pointer to structure within StructureInspector");
 	}
-	text(mStructure->name());
+	title(mStructure->name());
 
 	auto stringTable = buildStringTable();
 	stringTable.draw(renderer);


### PR DESCRIPTION
I did have to reload the submodules as my game would crash on "route.png" at:

```
mBtnToggleRouteOverlay.image("ui/icons/route.png");
```
And the asset was not available on my system. When I tried to check the git status in this directory, I was greeted with the "Detached HEAD" error message. So I looked up how to update them to the latest version. It seems by default it uses a --checkout option, which points to a commit, which then causes a detached HEAD. The below command is different and I hope it no longer causes the detached head issue.

```
git submodule update --remote --rebase
```
This allowed me to start the game and not get the "route.png" error.

I reloaded my submodules, but now I have uncommitted changes of which I don't know if I need to commit and push them.

![image](https://user-images.githubusercontent.com/3091512/110693255-885a9b80-81e7-11eb-8fe4-8292bf3a1bac.png)
