### PR TITLE
Xml improvements

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -30,10 +30,12 @@ const std::map<Difficulty, std::string> DIFFICULTY_STRING_TABLE
 	{ Difficulty::Hard, constants::DIFFICULTY_HARD },
 };
 
+
 std::string StringFromDifficulty(const Difficulty& difficulty)
 {
 	return DIFFICULTY_STRING_TABLE.at(difficulty);
 }
+
 
 Difficulty DifficultyFromString(std::string difficultyStr)
 {
@@ -430,11 +432,13 @@ bool doYesNoMessage(const std::string& title, const std::string msg)
 	return yes;
 }
 
+
 void checkSavegameVersion(const std::string& filename)
 {
 	// openSavegame checks version number after opening file
 	openSavegame(filename);
 }
+
 
 /**
  * Open a saved game and validate version.

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -430,12 +430,18 @@ bool doYesNoMessage(const std::string& title, const std::string msg)
 	return yes;
 }
 
+void checkSavegameVersion(const std::string& filename)
+{
+	// openSavegame checks version number after opening file
+	openSavegame(filename);
+}
+
 /**
- * Checks a savegame version.
+ * Open a saved game and validate version.
  *
  * \throws	Throws a std::runtime_error if there are any errors with a savegame version, formation or missing root nodes.
  */
-void checkSavegameVersion(const std::string& filename)
+NAS2D::Xml::XmlDocument openSavegame(const std::string& filename)
 {
 	auto xmlDocument = openXmlFile(filename, constants::SAVE_GAME_ROOT_NODE);
 
@@ -445,6 +451,8 @@ void checkSavegameVersion(const std::string& filename)
 	{
 		throw std::runtime_error("Savegame version mismatch: '" + filename + "'. Expected " + constants::SAVE_GAME_VERSION + ", found " + savegameVersion + ".");
 	}
+
+	return xmlDocument;
 }
 
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -9,6 +9,10 @@
 #include <string>
 #include <vector>
 
+namespace NAS2D::Xml {
+	class XmlDocument;
+}
+
 enum class StructureState;
 
 enum class Difficulty
@@ -308,6 +312,7 @@ void doAlertMessage(const std::string& title, const std::string& msg);
 bool doYesNoMessage(const std::string& title, const std::string msg);
 
 void checkSavegameVersion(const std::string& filename);
+NAS2D::Xml::XmlDocument openSavegame(const std::string& filename);
 
 NAS2D::StringList split_string(const char *str, char delim);
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -156,15 +156,15 @@ void MapViewState::load(const std::string& filePath)
 		throw std::runtime_error("File '" + filePath + "' was not found.");
 	}
 
-	auto xmlDocument = openSavegame(filePath);
-	auto* root = xmlDocument.firstChildElement(constants::SAVE_GAME_ROOT_NODE);
-
 	scrubRobotList();
 	Utility<StructureManager>::get().dropAllStructures();
 	ccLocation() = CcNotPlaced;
 
 	delete mTileMap;
 	mTileMap = nullptr;
+
+	auto xmlDocument = openSavegame(filePath);
+	auto* root = xmlDocument.firstChildElement(constants::SAVE_GAME_ROOT_NODE);
 
 	XmlElement* map = root->firstChildElement("properties");
 	XmlAttribute* attribute = map->firstAttribute();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -12,6 +12,7 @@
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"
 #include "../Map/TileMap.h"
+#include "../XmlSerializer.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
@@ -155,28 +156,8 @@ void MapViewState::load(const std::string& filePath)
 		throw std::runtime_error("File '" + filePath + "' was not found.");
 	}
 
-	auto xmlFile = Utility<Filesystem>::get().open(filePath);
-
-	XmlDocument doc;
-
-	// Load the XML document and handle any errors if occuring
-	doc.parse(xmlFile.raw_bytes());
-	if (doc.error())
-	{
-		throw std::runtime_error("Malformed savegame ('" + filePath + "'). Error on Row " + std::to_string(doc.errorRow()) + ", Column " + std::to_string(doc.errorCol()) + ": " + doc.errorDesc());
-	}
-
-	XmlElement* root = doc.firstChildElement(constants::SAVE_GAME_ROOT_NODE);
-	if (root == nullptr)
-	{
-		throw std::runtime_error("Root element in '" + filePath + "' is not '" + constants::SAVE_GAME_ROOT_NODE + "'.");
-	}
-
-	std::string sg_version = root->attribute("version");
-	if (sg_version != constants::SAVE_GAME_VERSION)
-	{
-		throw std::runtime_error("Savegame version mismatch: '" + filePath + "'. Expected " + constants::SAVE_GAME_VERSION + ", found " + sg_version + ".");
-	}
+	auto xmlDocument = openSavegame(filePath);
+	auto* root = xmlDocument.firstChildElement(constants::SAVE_GAME_ROOT_NODE);
 
 	scrubRobotList();
 	Utility<StructureManager>::get().dropAllStructures();

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -17,21 +17,6 @@ namespace {
 	constexpr auto PlanetSize = NAS2D::Vector{PlanetRadius * 2, PlanetRadius * 2};
 }
 
-const std::unordered_map<std::string, Planet::PlanetType> Planet::planetTypeTable
-{
-	{"none", PlanetType::None},
-	{"mercury", PlanetType::Mercury},
-	{"mars", PlanetType::Mars},
-	{"ganymede", PlanetType::Ganymede}
-};
-
-const std::unordered_map<std::string, Planet::Hostility> Planet::hostilityTable
-{
-	{"none", Hostility::None},
-	{"low", Hostility::Low},
-	{"medium", Hostility::Medium},
-	{"high", Hostility::High}
-};
 
 Planet::Planet(const Attributes& attributes) :
 	mAttributes(attributes),
@@ -84,61 +69,42 @@ void Planet::update()
 	renderer.drawSubImage(mImage, mPosition, NAS2D::Rectangle<int>::Create(spriteFrameOffset, PlanetSize));
 }
 
-
-void parseElementValue(Planet::PlanetType& destination, const NAS2D::Xml::XmlElement* element)
+namespace
 {
-	destination = stringToEnum(Planet::planetTypeTable, element->getText());
-}
+	Planet::Attributes parsePlanet(const NAS2D::Xml::XmlElement* xmlNode);
 
+	void parseElementValue(Planet::PlanetType& destination, const NAS2D::Xml::XmlElement* element);
+	void parseElementValue(Planet::Hostility& destination, const NAS2D::Xml::XmlElement* element);
 
-void parseElementValue(Planet::Hostility& destination, const NAS2D::Xml::XmlElement* element)
-{
-	destination = stringToEnum(Planet::hostilityTable, element->getText());
-}
-
-
-Planet::Attributes parsePlanet(const NAS2D::Xml::XmlElement* xmlNode)
-{
-	Planet::Attributes attributes;
-
-	for (const auto* node = xmlNode->iterateChildren(nullptr);
-		node != nullptr;
-		node = xmlNode->iterateChildren(node))
+	const std::unordered_map<std::string, Planet::PlanetType> planetTypeTable
 	{
-		const auto* element = node->toElement();
+		{"none", Planet::PlanetType::None},
+		{"mercury", Planet::PlanetType::Mercury},
+		{"mars", Planet::PlanetType::Mars},
+		{"ganymede", Planet::PlanetType::Ganymede}
+	};
 
-		if (element->value() == "PlanetType")
-		{
-			parseElementValue(attributes.type, element);
-		}
-		else if (element->value() == "ImagePath") {
-			parseElementValue(attributes.imagePath, element);
-		}
-		else if (element->value() == "Hostility") {
-			parseElementValue(attributes.hostility, element);
-		}
-		else if (element->value() == "MaxDepth") {
-			parseElementValue(attributes.maxDepth, element);
-		}
-		else if (element->value() == "MaxMines") {
-			parseElementValue(attributes.maxMines, element);
-		}
-		else if (element->value() == "MapImagePath") {
-			parseElementValue(attributes.mapImagePath, element);
-		}
-		else if (element->value() == "TilesetPath") {
-			parseElementValue(attributes.tilesetPath, element);
-		}
-		else if (element->value() == "Name") {
-			parseElementValue(attributes.name, element);
-		}
-		else if (element->value() == "MeanSolarDistance") {
-			parseElementValue(attributes.meanSolarDistance, element);
-		}
+	const std::unordered_map<std::string, Planet::Hostility> hostilityTable
+	{
+		{"none", Planet::Hostility::None},
+		{"low", Planet::Hostility::Low},
+		{"medium", Planet::Hostility::Medium},
+		{"high", Planet::Hostility::High}
+	};
+
+
+	void parseElementValue(Planet::PlanetType& destination, const NAS2D::Xml::XmlElement* element)
+	{
+		destination = stringToEnum(planetTypeTable, element->getText());
 	}
 
-	return attributes;
+
+	void parseElementValue(Planet::Hostility& destination, const NAS2D::Xml::XmlElement* element)
+	{
+		destination = stringToEnum(hostilityTable, element->getText());
+	}
 }
+
 
 std::vector<Planet::Attributes> parsePlanetAttributes()
 {
@@ -161,4 +127,51 @@ std::vector<Planet::Attributes> parsePlanetAttributes()
 	}
 
 	return planetAttributes;
+}
+
+
+namespace 
+{
+	Planet::Attributes parsePlanet(const NAS2D::Xml::XmlElement* xmlNode)
+	{
+		Planet::Attributes attributes;
+
+		for (const auto* node = xmlNode->iterateChildren(nullptr);
+			node != nullptr;
+			node = xmlNode->iterateChildren(node))
+		{
+			const auto* element = node->toElement();
+
+			if (element->value() == "PlanetType")
+			{
+				parseElementValue(attributes.type, element);
+			}
+			else if (element->value() == "ImagePath") {
+				::parseElementValue(attributes.imagePath, element);
+			}
+			else if (element->value() == "Hostility") {
+				parseElementValue(attributes.hostility, element);
+			}
+			else if (element->value() == "MaxDepth") {
+				::parseElementValue(attributes.maxDepth, element);
+			}
+			else if (element->value() == "MaxMines") {
+				::parseElementValue(attributes.maxMines, element);
+			}
+			else if (element->value() == "MapImagePath") {
+				::parseElementValue(attributes.mapImagePath, element);
+			}
+			else if (element->value() == "TilesetPath") {
+				::parseElementValue(attributes.tilesetPath, element);
+			}
+			else if (element->value() == "Name") {
+				::parseElementValue(attributes.name, element);
+			}
+			else if (element->value() == "MeanSolarDistance") {
+				::parseElementValue(attributes.meanSolarDistance, element);
+			}
+		}
+
+		return attributes;
+	}
 }

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -146,28 +146,36 @@ namespace
 			{
 				parseElementValue(attributes.type, element);
 			}
-			else if (element->value() == "ImagePath") {
+			else if (element->value() == "ImagePath")
+			{
 				::parseElementValue(attributes.imagePath, element);
 			}
-			else if (element->value() == "Hostility") {
+			else if (element->value() == "Hostility")
+			{
 				parseElementValue(attributes.hostility, element);
 			}
-			else if (element->value() == "MaxDepth") {
+			else if (element->value() == "MaxDepth")
+			{
 				::parseElementValue(attributes.maxDepth, element);
 			}
-			else if (element->value() == "MaxMines") {
+			else if (element->value() == "MaxMines")
+			{
 				::parseElementValue(attributes.maxMines, element);
 			}
-			else if (element->value() == "MapImagePath") {
+			else if (element->value() == "MapImagePath")
+			{
 				::parseElementValue(attributes.mapImagePath, element);
 			}
-			else if (element->value() == "TilesetPath") {
+			else if (element->value() == "TilesetPath")
+			{
 				::parseElementValue(attributes.tilesetPath, element);
 			}
-			else if (element->value() == "Name") {
+			else if (element->value() == "Name")
+			{
 				::parseElementValue(attributes.name, element);
 			}
-			else if (element->value() == "MeanSolarDistance") {
+			else if (element->value() == "MeanSolarDistance")
+			{
 				::parseElementValue(attributes.meanSolarDistance, element);
 			}
 		}

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -78,18 +78,18 @@ namespace
 
 	const std::unordered_map<std::string, Planet::PlanetType> planetTypeTable
 	{
-		{"none", Planet::PlanetType::None},
-		{"mercury", Planet::PlanetType::Mercury},
-		{"mars", Planet::PlanetType::Mars},
-		{"ganymede", Planet::PlanetType::Ganymede}
+		{"None", Planet::PlanetType::None},
+		{"Mercury", Planet::PlanetType::Mercury},
+		{"Mars", Planet::PlanetType::Mars},
+		{"Ganymede", Planet::PlanetType::Ganymede}
 	};
 
 	const std::unordered_map<std::string, Planet::Hostility> hostilityTable
 	{
-		{"none", Planet::Hostility::None},
-		{"low", Planet::Hostility::Low},
-		{"medium", Planet::Hostility::Medium},
-		{"high", Planet::Hostility::High}
+		{"None", Planet::Hostility::None},
+		{"Low", Planet::Hostility::Low},
+		{"Medium", Planet::Hostility::Medium},
+		{"High", Planet::Hostility::High}
 	};
 
 

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -17,14 +17,16 @@ namespace {
 	constexpr auto PlanetSize = NAS2D::Vector{PlanetRadius * 2, PlanetRadius * 2};
 }
 
-const std::unordered_map<std::string, Planet::PlanetType> Planet::planetTypeTable{
+const std::unordered_map<std::string, Planet::PlanetType> Planet::planetTypeTable
+{
 	{"none", PlanetType::None},
 	{"mercury", PlanetType::Mercury},
 	{"mars", PlanetType::Mars},
 	{"ganymede", PlanetType::Ganymede}
 };
 
-const std::unordered_map<std::string, Planet::Hostility> Planet::hostilityTable{
+const std::unordered_map<std::string, Planet::Hostility> Planet::hostilityTable
+{
 	{"none", Hostility::None},
 	{"low", Hostility::Low},
 	{"medium", Hostility::Medium},
@@ -105,7 +107,8 @@ Planet::Attributes parsePlanet(const NAS2D::Xml::XmlElement* xmlNode)
 	{
 		const auto* element = node->toElement();
 
-		if (element->value() == "PlanetType") {
+		if (element->value() == "PlanetType")
+		{
 			parseElementValue(attributes.type, element);
 		}
 		else if (element->value() == "ImagePath") {
@@ -150,7 +153,8 @@ std::vector<Planet::Attributes> parsePlanetAttributes()
 		node = rootElement->iterateChildren(node))
 	{
 		std::string elementName("Planet");
-		if (node->value() != elementName) {
+		if (node->value() != elementName)
+		{
 			throw std::runtime_error(xmlDocument.value() + " missing " + elementName + " tag");
 		}
 		planetAttributes.push_back(parsePlanet(node->toElement()));

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <string>
+#include <unordered_map>
 
 
 class Planet
@@ -31,6 +32,9 @@ public:
 		Medium,
 		High
 	};
+
+	static const std::unordered_map<std::string, PlanetType> planetTypeTable;
+	static const std::unordered_map<std::string, Hostility> hostilityTable;
 
 	struct Attributes
 	{
@@ -91,3 +95,13 @@ private:
 
 	NAS2D::Timer mTimer;
 };
+
+namespace NAS2D::Xml {
+	class XmlElement;
+}
+
+void parseElementValue(Planet::PlanetType& destination, const NAS2D::Xml::XmlElement* element);
+void parseElementValue(Planet::Hostility& destination, const NAS2D::Xml::XmlElement* element);
+
+std::vector<Planet::Attributes> parsePlanetAttributes();
+Planet::Attributes parsePlanet(const NAS2D::Xml::XmlElement* xmlNode);

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -33,9 +33,6 @@ public:
 		High
 	};
 
-	static const std::unordered_map<std::string, PlanetType> planetTypeTable;
-	static const std::unordered_map<std::string, Hostility> hostilityTable;
-
 	struct Attributes
 	{
 		PlanetType type = PlanetType::None;
@@ -96,12 +93,4 @@ private:
 	NAS2D::Timer mTimer;
 };
 
-namespace NAS2D::Xml {
-	class XmlElement;
-}
-
-void parseElementValue(Planet::PlanetType& destination, const NAS2D::Xml::XmlElement* element);
-void parseElementValue(Planet::Hostility& destination, const NAS2D::Xml::XmlElement* element);
-
 std::vector<Planet::Attributes> parsePlanetAttributes();
-Planet::Attributes parsePlanet(const NAS2D::Xml::XmlElement* xmlNode);

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -1,12 +1,12 @@
 #include "PlanetSelectState.h"
 
-#include "Planet.h"
 #include "GameState.h"
 #include "MapViewState.h"
 #include "MainMenuState.h"
 
 #include "../Constants.h"
 #include "../Cache.h"
+#include "../XmlSerializer.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Mixer/Mixer.h>
@@ -19,17 +19,6 @@
 using namespace NAS2D;
 
 
-namespace
-{
-	std::vector<Planet::Attributes> PlanetAttributes =
-	{
-		{ Planet::Attributes{Planet::PlanetType::Mercury, "planets/planet_d.png", Planet::Hostility::High, 1, 10, "maps/merc_01", "tsets/mercury.png", "Mercury Type", 0.4f} },
-		{ Planet::Attributes{Planet::PlanetType::Mars, "planets/planet_c.png", Planet::Hostility::Low, 4, 30, "maps/mars_04", "tsets/mars.png", "Mars Type", 1.524f} },
-		{ Planet::Attributes{Planet::PlanetType::Ganymede, "planets/planet_e.png", Planet::Hostility::Medium, 2, 15, "maps/ganymede_01", "tsets/ganymede.png", "Ganymede Type", 5.2f} }
-	};
-}
-
-
 PlanetSelectState::PlanetSelectState() :
 	mFontBold{ fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM) },
 	mTinyFont{ fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL) },
@@ -40,7 +29,8 @@ PlanetSelectState::PlanetSelectState() :
 	mSelect{"sfx/click.ogg"},
 	mHover{"sfx/menu4.ogg"},
 	mQuit{"Main Menu"},
-	mReturnState{this}
+	mReturnState{this},
+	PlanetAttributes(parsePlanetAttributes())
 {}
 
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Planet.h"
 #include "../UI/UI.h"
 
 #include <NAS2D/State.h>
@@ -11,9 +12,6 @@
 #include <NAS2D/Renderer/Point.h>
 
 #include <vector>
-
-
-class Planet;
 
 
 class PlanetSelectState : public NAS2D::State
@@ -63,4 +61,6 @@ private:
 	NAS2D::Timer mTimer;
 
 	NAS2D::State* mReturnState = this;
+
+	std::vector<Planet::Attributes> PlanetAttributes;
 };

--- a/OPHD/XmlSerializer.cpp
+++ b/OPHD/XmlSerializer.cpp
@@ -23,21 +23,3 @@ Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
 
 	return xmlDocument;
 }
-
-
-int elementToInt(const NAS2D::Xml::XmlElement* element)
-{
-	try
-	{
-		return std::stoi(element->getText());
-	}
-	catch (const std::invalid_argument&)
-	{
-		throw std::runtime_error("Unable to convert value " + element->getText() +
-			" from XML element " + element->value() + " into an integer");
-	}
-	catch (const std::out_of_range&)
-	{
-		throw std::runtime_error("Value from XML element " + element->value() + " is out of range for an integer");
-	}
-}

--- a/OPHD/XmlSerializer.cpp
+++ b/OPHD/XmlSerializer.cpp
@@ -4,6 +4,7 @@
 
 using namespace NAS2D;
 
+
 Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
 {
 	Xml::XmlDocument xmlDocument;
@@ -22,6 +23,7 @@ Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
 
 	return xmlDocument;
 }
+
 
 int elementToInt(const NAS2D::Xml::XmlElement* element)
 {

--- a/OPHD/XmlSerializer.cpp
+++ b/OPHD/XmlSerializer.cpp
@@ -1,0 +1,24 @@
+#include "XmlSerializer.h"
+#include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
+
+using namespace NAS2D;
+
+Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
+{
+	Xml::XmlDocument xmlDocument;
+	xmlDocument.parse(Utility<Filesystem>::get().open(filename).raw_bytes());
+
+	if (xmlDocument.error())
+	{
+		throw std::runtime_error(filename + " has malformed XML: Row: " + std::to_string(xmlDocument.errorRow()) +
+			" Column: " + std::to_string(xmlDocument.errorCol()) + " : " + xmlDocument.errorDesc());
+	}
+
+	const auto* xmlRootElement = xmlDocument.firstChildElement(rootElementName);
+	if (!xmlRootElement) {
+		throw std::runtime_error(filename + " does not contain required root tag of <" + rootElementName + ">");
+	}
+
+	return xmlDocument;
+}

--- a/OPHD/XmlSerializer.cpp
+++ b/OPHD/XmlSerializer.cpp
@@ -22,3 +22,20 @@ Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
 
 	return xmlDocument;
 }
+
+int elementToInt(const NAS2D::Xml::XmlElement* element)
+{
+	try
+	{
+		return std::stoi(element->getText());
+	}
+	catch (const std::invalid_argument&)
+	{
+		throw std::runtime_error("Unable to convert value " + element->getText() +
+			" from XML element " + element->value() + " into an integer");
+	}
+	catch (const std::out_of_range&)
+	{
+		throw std::runtime_error("Value from XML element " + element->value() + " is out of range for an integer");
+	}
+}

--- a/OPHD/XmlSerializer.h
+++ b/OPHD/XmlSerializer.h
@@ -1,9 +1,49 @@
 #pragma once
 
+#include <NAS2D/StringUtils.h>
 #include <NAS2D/Xml/Xml.h>
 #include <string>
+#include <unordered_map>
+#include <typeinfo>
+#include <type_traits>
+#include <stdexcept>
 
 
 // Open an xml document
 // Throws a runtime_error if the xml is ill formed or the root element name is incorrect
 NAS2D::Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName);
+
+int elementToInt(const NAS2D::Xml::XmlElement* element);
+
+template<typename T>
+T stringToEnum(const std::unordered_map<std::string, T>& table, std::string value)
+{
+	auto it = table.find(NAS2D::toLowercase(value));
+	if (it != table.end()) {
+		return it->second;
+	}
+
+	throw std::runtime_error("Unable to parse enum with value of " + value);
+}
+
+
+// Create an overload to parse specific enums
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+void parseElementValue(T& destination, const NAS2D::Xml::XmlElement* element)
+{
+	if constexpr (std::is_same_v<T, int>) {
+		destination = elementToInt(element);
+	}
+	else if constexpr (std::is_same_v<T, float>) {
+		destination = static_cast<float>(std::atof(element->getText().c_str()));
+	}
+	else if constexpr (std::is_same_v<T, double>) {
+		destination = std::atof(element->getText().c_str());
+	}
+	else if constexpr (std::is_same_v<T, std::string>) {
+		destination = element->getText();
+	}
+	else {
+		throw std::logic_error("Unable to parse type " + std::string(typeid(T).name()) + " from XML");
+	}
+}

--- a/OPHD/XmlSerializer.h
+++ b/OPHD/XmlSerializer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <NAS2D/StringUtils.h>
 #include <NAS2D/Xml/Xml.h>
 #include <string>
 #include <unordered_map>
@@ -12,7 +13,6 @@
 // Throws a runtime_error if the xml is ill formed or the root element name is incorrect
 NAS2D::Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName);
 
-int elementToInt(const NAS2D::Xml::XmlElement* element);
 
 template<typename T>
 T stringToEnum(const std::unordered_map<std::string, T>& table, std::string value)
@@ -31,24 +31,14 @@ T stringToEnum(const std::unordered_map<std::string, T>& table, std::string valu
 template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
 void parseElementValue(T& destination, const NAS2D::Xml::XmlElement* element)
 {
-	if constexpr (std::is_same_v<T, int>)
+	try 
 	{
-		destination = elementToInt(element);
+		destination = NAS2D::stringTo<T>(element->getText());
 	}
-	else if constexpr (std::is_same_v<T, float>)
+	catch (const std::exception& e)
 	{
-		destination = static_cast<float>(std::atof(element->getText().c_str()));
-	}
-	else if constexpr (std::is_same_v<T, double>)
-	{
-		destination = std::atof(element->getText().c_str());
-	}
-	else if constexpr (std::is_same_v<T, std::string>)
-	{
-		destination = element->getText();
-	}
-	else
-	{
-		throw std::logic_error("Unable to parse type " + std::string(typeid(T).name()) + " from XML");
+		throw std::logic_error("Unable to parse the value of " + element->getText() + 
+			" from XML element " + element->value() + " as type of " + std::string(typeid(T).name()) + 
+			". " + std::string(e.what()));
 	}
 }

--- a/OPHD/XmlSerializer.h
+++ b/OPHD/XmlSerializer.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <NAS2D/Xml/Xml.h>
+#include <string>
+
+
+// Open an xml document
+// Throws a runtime_error if the xml is ill formed or the root element name is incorrect
+NAS2D::Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName);

--- a/OPHD/XmlSerializer.h
+++ b/OPHD/XmlSerializer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <NAS2D/StringUtils.h>
 #include <NAS2D/Xml/Xml.h>
 #include <string>
 #include <unordered_map>
@@ -18,7 +17,7 @@ int elementToInt(const NAS2D::Xml::XmlElement* element);
 template<typename T>
 T stringToEnum(const std::unordered_map<std::string, T>& table, std::string value)
 {
-	auto it = table.find(NAS2D::toLowercase(value));
+	auto it = table.find(value);
 	if (it != table.end())
 	{
 		return it->second;

--- a/OPHD/XmlSerializer.h
+++ b/OPHD/XmlSerializer.h
@@ -19,7 +19,8 @@ template<typename T>
 T stringToEnum(const std::unordered_map<std::string, T>& table, std::string value)
 {
 	auto it = table.find(NAS2D::toLowercase(value));
-	if (it != table.end()) {
+	if (it != table.end())
+	{
 		return it->second;
 	}
 
@@ -31,19 +32,24 @@ T stringToEnum(const std::unordered_map<std::string, T>& table, std::string valu
 template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
 void parseElementValue(T& destination, const NAS2D::Xml::XmlElement* element)
 {
-	if constexpr (std::is_same_v<T, int>) {
+	if constexpr (std::is_same_v<T, int>)
+	{
 		destination = elementToInt(element);
 	}
-	else if constexpr (std::is_same_v<T, float>) {
+	else if constexpr (std::is_same_v<T, float>)
+	{
 		destination = static_cast<float>(std::atof(element->getText().c_str()));
 	}
-	else if constexpr (std::is_same_v<T, double>) {
+	else if constexpr (std::is_same_v<T, double>)
+	{
 		destination = std::atof(element->getText().c_str());
 	}
-	else if constexpr (std::is_same_v<T, std::string>) {
+	else if constexpr (std::is_same_v<T, std::string>)
+	{
 		destination = element->getText();
 	}
-	else {
+	else
+	{
 		throw std::logic_error("Unable to parse type " + std::string(typeid(T).name()) + " from XML");
 	}
 }

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -323,6 +323,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="UI\TileInspector.cpp" />
     <ClCompile Include="UI\WarehouseInspector.cpp" />
     <ClCompile Include="WindowEventWrapper.h" />
+    <ClCompile Include="XmlSerializer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h" />
@@ -447,6 +448,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="UI\UI.h" />
     <ClInclude Include="UI\WarehouseInspector.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="XmlSerializer.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ophd.rc" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -297,6 +297,9 @@
     <ClCompile Include="UI\RobotInspector.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
+    <ClCompile Include="XmlSerializer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -664,6 +667,9 @@
     </ClInclude>
     <ClInclude Include="UI\RobotInspector.h">
       <Filter>Header Files\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="XmlSerializer.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Must be paired with assets update to compile: https://github.com/OutpostUniverse/ophd-assets/pull/1

It looks like the assets are a submodule of this repo, but I had trouble linking them on my machine for some reason.

Related to #830. Not quite a string dictionary but tried to consolidate some of the xml related code.

The last commit is pretty big. I had trouble teasing it into smaller chunks due to the serialization involved. I was experimenting with template functions and enum lookups. Hopefully it looks ok...

This PR will allow someone to change the planet attributes without recompiling the source code.