### PR TITLE
minimal starting point for entity component system

### DIFF
--- a/OPHD/StructureComponent.h
+++ b/OPHD/StructureComponent.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <NAS2D/Utility.h>
+
+class Structure;
+class StructureManager;
+class StructureComponent;
+
+
+/**
+ * Key type for identifying a specific structure instance.
+ * The key for any given structure is guaranteed to remain unchanged for the lifetime of the structure.
+ * The key for any given structure is guaranteed to be unique during the lifetime of the structure.
+ *
+ * Every structure has a Structure instance. The Structure pointer is used as key to allow O(1) access
+ * to the Structure instance. This is an internal detail and should not be relied upon by code handling the key.
+ */
+class SKey
+{
+private:
+	Structure* mStructure;
+public:
+	SKey(Structure* structure) : mStructure(structure) {}
+
+	/** Comparison operators to allow using this type in ordered containers such as maps and sets. */
+	bool operator<(const SKey& rhs) const { return mStructure < rhs.mStructure; }
+
+	/** Do not call this function directly. It is intended only for GetComponent/TryGetComponent. */
+	Structure* getInternal() { return mStructure; }
+};
+
+
+/**
+ * Return a reference to the given StructureComponent type belonging to
+ * a structure. The structure is assumed to have the given component,
+ * and it is an error to try to get a component from a structure that
+ * does not have it.
+ */
+template<typename T>
+inline T& GetComponent(SKey s)
+{
+	return NAS2D::Utility<StructureManager>::get().get<T>(s);
+}
+
+/**
+ * Return a reference to the Structure type belonging to a structure.
+ * This allows writing code that's agnostic to the SKey type.
+ */
+template<>
+inline Structure& GetComponent<Structure>(SKey s)
+{
+	return *s.getInternal();
+}
+
+
+/**
+ * Return a pointer to the given StructureComponent type belonging
+ * to a structure, if it has the corresponding component type.
+ * Otherwise return nullptr.
+ */
+template<typename T>
+inline T* TryGetComponent(SKey s)
+{
+	return NAS2D::Utility<StructureManager>::get().tryGet<T>(s);
+}
+
+/**
+ * Return a pointer to the Structure type belonging to a structure.
+ * This allows writing code that's agnostic to the SKey type.
+ */
+template<>
+inline Structure* TryGetComponent<Structure>(SKey s)
+{
+	return s.getInternal();
+}
+
+
+/**
+ * Common base class for all structure components.
+ * Each structure is associated with a set of components that define the functional properties of the structure.
+ * A structure either has a given component or not - it can never have multiple instances of the same component type.
+ *
+ * The StructureComponent base class is abstract in the sense that it cannot be constructed or queried.
+ * Component classes deriving from StructureComponent must declare the following field:
+ * static constexpr ComponentTypeID componentTypeID = ...;
+ */
+class StructureComponent
+{
+public:
+	typedef int ComponentTypeID; // TODO: replace by enum class.
+
+private:
+	SKey mKey; /**< Key of the structure owning this component. */
+
+protected:
+	StructureComponent(SKey key) : mKey(key) {}
+
+public:
+	virtual ~StructureComponent() {}
+
+	SKey key() const { return mKey; }
+
+	/**
+	 * Obtain a reference to the Structure instance belonging to this structure.
+	 * It is guaranteed to exist.
+	 */
+	Structure& structure() const { return GetComponent<Structure>(mKey); }
+
+	/**
+	 * Convenience function to get a different component type from the same structure.
+	 */
+	template<typename T> T& Get() { return GetComponent<T>(mKey); }
+
+	/**
+	 * Convenience function to get a different component type from the same structure.
+	 */
+	template<typename T> T* TryGet() { return TryGetComponent<T>(mKey); }
+};

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -244,6 +244,18 @@ void StructureManager::addStructure(Structure* structure, Tile* tile)
  */
 void StructureManager::removeStructure(Structure* structure)
 {
+	// Destroy all components belonging to the structure.
+	SKey s = SKey(structure);
+	for (auto& [componentTypeID, table] : mComponents)
+	{
+		auto cit = table.find(s);
+		if (cit != table.end())
+		{
+			delete cit->second;
+			table.erase(cit);
+		}
+	}
+
 	StructureList& structures = mStructureLists[structure->structureClass()];
 
 	if (structures.empty())
@@ -251,14 +263,12 @@ void StructureManager::removeStructure(Structure* structure)
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
 
-	for (std::size_t i = 0; i < structures.size(); ++i)
+	auto structureIt = std::find(structures.begin(), structures.end(), structure);
+	if (structureIt == structures.end())
 	{
-		if (structures[i] == structure)
-		{
-			structures.erase(structures.begin() + static_cast<std::ptrdiff_t>(i));
-			break;
-		}
+		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
+	structures.erase(structureIt);
 
 	auto tileTableIt = mStructureTileTable.find(structure);
 	if (tileTableIt == mStructureTileTable.end())

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "StructureComponent.h"
 #include "Things/Structures/Structure.h"
 
 
@@ -52,6 +53,79 @@ public:
 
 	void serialize(NAS2D::Xml::XmlElement* element);
 
+	/**
+	 * Associate a StructureComponent with a structure.
+	 * This transfers ownership of the component instance to the
+	 * structure manager. The component will be destroyed when the
+	 * structure with which it is associated is removed.
+	 */
+	template<typename ComponentTy>
+	void attachComponent(SKey s, ComponentTy* component)
+	{
+		auto& table = mComponents[ComponentTy::componentTypeID];
+		bool success = table.insert(std::make_pair(s, static_cast<StructureComponent*>(component))).second;
+#if defined(_DEBUG)
+		if (!success)
+		{
+			throw std::runtime_error("Structure::Attach() was called on a Structure that already had the component!");
+		}
+#endif
+	}
+
+	/**
+	 * Return a reference to the given StructureComponent type belonging to
+	 * a structure. The structure is assumed to have the given component,
+	 * and it is an error to try to get a component from a structure that
+	 * does not have it.
+	 */
+	template<typename ComponentTy>
+	ComponentTy& get(SKey s)
+	{
+		ComponentTy* component = tryGet<ComponentTy>(s);
+#if defined(_DEBUG)
+		if (!component)
+		{
+			throw std::runtime_error("StructureManager::get() was called on a Structure without the requested component!");
+		}
+#endif
+		return *component;
+	}
+
+	/**
+	 * Return a reference to the Structure type belonging to a structure.
+	 * This allows writing code that's agnostic to the SKey type.
+	 */
+	template<>
+	Structure& get<Structure>(SKey s)
+	{
+		return *s.getInternal();
+	}
+
+	/**
+	 * Return a pointer to the given StructureComponent type belonging
+	 * to a structure, if it has the corresponding component type.
+	 * Otherwise return nullptr.
+	 */
+	template<typename ComponentTy>
+	ComponentTy* tryGet(SKey s)
+	{
+		auto& table = mComponents[ComponentTy::componentTypeID];
+		auto it = table.find(s);
+		if (it != table.end())
+			return reinterpret_cast<ComponentTy*>(it->second);
+		return nullptr;
+	}
+
+	/**
+	 * Return a pointer to the Structure type belonging to a structure.
+	 * This allows writing code that's agnostic to the SKey type.
+	 */
+	template<>
+	Structure* tryGet<Structure>(SKey s)
+	{
+		return s.getInternal();
+	}
+
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;
 	using StructureClassTable = std::map<Structure::StructureClass, StructureList>;
@@ -62,6 +136,15 @@ private:
 
 	StructureTileTable mStructureTileTable; /**< List mapping Structures to a particular tile. */
 	StructureClassTable mStructureLists; /**< Map containing all of the structure list types available. */
+
+	/**
+	 * Master table of all StructureComponent instances.
+	 * It is divided into one sub-table per StructureComponent type.
+	 * Each sub-table maps structure keys to a StructureComponent-derived instance.
+	 * Only keys to structures that actually have a given StructureComponent type
+	 * are present in the respective sub-tables.
+	 */
+	std::map<StructureComponent::ComponentTypeID, std::map<SKey, StructureComponent*>> mComponents;
 
 	int mTotalEnergyOutput = 0; /**< Total energy output of all energy producers in the structure list. */
 	int mTotalEnergyUsed = 0;

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -357,6 +357,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="States\SplashState.h" />
     <ClInclude Include="States\Wrapper.h" />
     <ClInclude Include="StructureCatalogue.h" />
+    <ClInclude Include="StructureComponent.h" />
     <ClInclude Include="StructureManager.h" />
     <ClInclude Include="Things\Robots\Robodigger.h" />
     <ClInclude Include="Things\Robots\Robodozer.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -671,6 +671,9 @@
     <ClInclude Include="XmlSerializer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="StructureComponent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ophd.rc">


### PR DESCRIPTION
Minimal starting point for the ECS system. Doesn't include any of the iteration utilities.
I don't really like the name SKey, but couldn't come up with something obviously better. StructureRef? Perhaps we should rename the existing StructureID or StructureTypeID and rename SKey to StructureID.