### PR TITLE
Fix linux build of entityComponentSystem branch

### DIFF
--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -366,3 +366,8 @@ const auto formatDiff = [](int diff)
 {
 	return ((diff > 0) ? "+" : "") + std::to_string(diff);
 };
+
+/**
+ * Silence compiler warnings about unused variable
+ */
+#define UNUSED(x) (void)(x)

--- a/OPHD/StructureComponent.h
+++ b/OPHD/StructureComponent.h
@@ -1,33 +1,7 @@
 #pragma once
 
+#include "StructureManager.h"
 #include <NAS2D/Utility.h>
-
-class Structure;
-class StructureManager;
-class StructureComponent;
-
-
-/**
- * Key type for identifying a specific structure instance.
- * The key for any given structure is guaranteed to remain unchanged for the lifetime of the structure.
- * The key for any given structure is guaranteed to be unique during the lifetime of the structure.
- *
- * Every structure has a Structure instance. The Structure pointer is used as key to allow O(1) access
- * to the Structure instance. This is an internal detail and should not be relied upon by code handling the key.
- */
-class SKey
-{
-private:
-	Structure* mStructure;
-public:
-	SKey(Structure* structure) : mStructure(structure) {}
-
-	/** Comparison operators to allow using this type in ordered containers such as maps and sets. */
-	bool operator<(const SKey& rhs) const { return mStructure < rhs.mStructure; }
-
-	/** Do not call this function directly. It is intended only for GetComponent/TryGetComponent. */
-	Structure* getInternal() { return mStructure; }
-};
 
 
 /**
@@ -86,9 +60,6 @@ inline Structure* TryGetComponent<Structure>(SKey s)
  */
 class StructureComponent
 {
-public:
-	typedef int ComponentTypeID; // TODO: replace by enum class.
-
 private:
 	SKey mKey; /**< Key of the structure owning this component. */
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -4,6 +4,7 @@
 #include "ProductPool.h"
 #include "IOHelper.h"
 #include "PopulationPool.h"
+#include "StructureComponent.h"
 #include "Map/Tile.h"
 #include "Things/Robots/Robot.h"
 #include "Things/Structures/Structures.h"
@@ -248,6 +249,7 @@ void StructureManager::removeStructure(Structure* structure)
 	SKey s = SKey(structure);
 	for (auto& [componentTypeID, table] : mComponents)
 	{
+		UNUSED(componentTypeID);
 		auto cit = table.find(s);
 		if (cit != table.end())
 		{


### PR DESCRIPTION
Improved definition sequence to satisfy GCC.

SKey is now defined in StructureManager.h, which makes sense anyway - it defines an instance of a structure, which is not directly related to StructureComponent.

Template specialization of member function is now done in the enclosing namespace since only MSVC allows specialization within the class definition.

Added UNUSED macro to common.h to silence compiler warnings about unused variables.