### PR TITLE
Ecs staging

### DIFF
--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -366,8 +366,3 @@ const auto formatDiff = [](int diff)
 {
 	return ((diff > 0) ? "+" : "") + std::to_string(diff);
 };
-
-/**
- * Silence compiler warnings about unused variable
- */
-#define UNUSED(x) (void)(x)

--- a/OPHD/StructureComponent.h
+++ b/OPHD/StructureComponent.h
@@ -16,16 +16,6 @@ inline T& getComponent(SKey s)
 	return NAS2D::Utility<StructureManager>::get().get<T>(s);
 }
 
-/**
- * Return a reference to the Structure type belonging to a structure.
- * This allows writing code that's agnostic to the SKey type.
- */
-template<>
-inline Structure& getComponent<Structure>(SKey s)
-{
-	return *s.getInternal();
-}
-
 
 /**
  * Return a pointer to the given StructureComponent type belonging
@@ -36,16 +26,6 @@ template<typename T>
 inline T* tryGetComponent(SKey s)
 {
 	return NAS2D::Utility<StructureManager>::get().tryGet<T>(s);
-}
-
-/**
- * Return a pointer to the Structure type belonging to a structure.
- * This allows writing code that's agnostic to the SKey type.
- */
-template<>
-inline Structure* tryGetComponent<Structure>(SKey s)
-{
-	return s.getInternal();
 }
 
 

--- a/OPHD/StructureComponent.h
+++ b/OPHD/StructureComponent.h
@@ -11,7 +11,7 @@
  * does not have it.
  */
 template<typename T>
-inline T& GetComponent(SKey s)
+inline T& getComponent(SKey s)
 {
 	return NAS2D::Utility<StructureManager>::get().get<T>(s);
 }
@@ -21,7 +21,7 @@ inline T& GetComponent(SKey s)
  * This allows writing code that's agnostic to the SKey type.
  */
 template<>
-inline Structure& GetComponent<Structure>(SKey s)
+inline Structure& getComponent<Structure>(SKey s)
 {
 	return *s.getInternal();
 }
@@ -33,7 +33,7 @@ inline Structure& GetComponent<Structure>(SKey s)
  * Otherwise return nullptr.
  */
 template<typename T>
-inline T* TryGetComponent(SKey s)
+inline T* tryGetComponent(SKey s)
 {
 	return NAS2D::Utility<StructureManager>::get().tryGet<T>(s);
 }
@@ -43,7 +43,7 @@ inline T* TryGetComponent(SKey s)
  * This allows writing code that's agnostic to the SKey type.
  */
 template<>
-inline Structure* TryGetComponent<Structure>(SKey s)
+inline Structure* tryGetComponent<Structure>(SKey s)
 {
 	return s.getInternal();
 }
@@ -75,15 +75,15 @@ public:
 	 * Obtain a reference to the Structure instance belonging to this structure.
 	 * It is guaranteed to exist.
 	 */
-	Structure& structure() const { return GetComponent<Structure>(mKey); }
+	Structure& structure() const { return getComponent<Structure>(mKey); }
 
 	/**
 	 * Convenience function to get a different component type from the same structure.
 	 */
-	template<typename T> T& Get() { return GetComponent<T>(mKey); }
+	template<typename T> T& get() { return getComponent<T>(mKey); }
 
 	/**
 	 * Convenience function to get a different component type from the same structure.
 	 */
-	template<typename T> T* TryGet() { return TryGetComponent<T>(mKey); }
+	template<typename T> T* tryGet() { return tryGetComponent<T>(mKey); }
 };

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -247,9 +247,9 @@ void StructureManager::removeStructure(Structure* structure)
 {
 	// Destroy all components belonging to the structure.
 	SKey s = SKey(structure);
-	for (auto& [componentTypeID, table] : mComponents)
+	for (auto& kv : mComponents)
 	{
-		UNUSED(componentTypeID);
+		auto& table = kv.second;
 		auto cit = table.find(s);
 		if (cit != table.end())
 		{

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -88,14 +88,10 @@ public:
 	{
 		auto& table = mComponents[ComponentTy::componentTypeID];
 		bool success = table.insert(std::make_pair(s, static_cast<StructureComponent*>(component))).second;
-#if defined(_DEBUG)
 		if (!success)
 		{
 			throw std::runtime_error("Structure::Attach() was called on a Structure that already had the component!");
 		}
-#else
-		UNUSED(success);
-#endif
 	}
 
 	/**
@@ -108,12 +104,10 @@ public:
 	ComponentTy& get(SKey s)
 	{
 		ComponentTy* component = tryGet<ComponentTy>(s);
-#if defined(_DEBUG)
 		if (!component)
 		{
 			throw std::runtime_error("StructureManager::get() was called on a Structure without the requested component!");
 		}
-#endif
 		return *component;
 	}
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -27,15 +27,13 @@ typedef int ComponentTypeID; // TODO: replace by enum class?
 class SKey
 {
 private:
+	friend class StructureManager;
 	Structure* mStructure;
 public:
 	SKey(Structure* structure) : mStructure(structure) {}
 
 	/** Comparison operators to allow using this type in ordered containers such as maps and sets. */
 	bool operator<(const SKey& rhs) const { return mStructure < rhs.mStructure; }
-
-	/** Do not call this function directly. It is intended only for GetComponent/TryGetComponent. */
-	Structure* getInternal() { return mStructure; }
 };
 
 
@@ -157,7 +155,7 @@ private:
 template<>
 inline Structure& StructureManager::get<Structure>(SKey s)
 {
-	return *s.getInternal();
+	return *s.mStructure;
 }
 
 /**
@@ -167,6 +165,5 @@ inline Structure& StructureManager::get<Structure>(SKey s)
 template<>
 inline Structure* StructureManager::tryGet<Structure>(SKey s)
 {
-	return s.getInternal();
+	return s.mStructure;
 }
-


### PR DESCRIPTION
Fix most review comments in PR #836 and PR ##839. Some notable points that I did not address:

`StructureManager` is still using raw `StructureComponent` pointers in its backing store. Using `unique_ptr` would be challenging because of the dependency between classes:
`StructureComponent` uses `StructureManager`, and `StructureManager` has `StructureComponent` pointers. `StructureManager` can have `StructureComponent` raw pointers since it's sufficient to forward-declare the type. `unique_ptr` on the other hand references the destructor and requires the type to be fully declared.

I kept the `getComponent` functions. Looking closer at my fork, I see that I actually do use them a fair bit, when porting code like this over to the ECL:
```
if (structure->isRobotCommand())
{
	deleteRobotsInRCC(robot, &GetComponent<RobotCommand>(structure), mRobotPool, mRobotList, &tile);
}
```

Longer term we should eliminate as much of such code as possible, and we may be able to remove the getters in the end. But we should keep them for now until they're no longer necessary at some point in the future.

I still have an `SKey` class. In an attempt to make it less ugly, I removed the getter and gave friend access to `StructureManager`, which is the only class that should be using the key anyway. Let me know if I should rather just erase the `SKey` class and use `Structure*` directly, I don't mind either way.

I considered adding `static_assert` to check that `ComponentTy` actually inherits `StructureComponent` in various places, but the use of `static_cast` makes the compiler already complain if you attempt to pass an unexpected type. If you want we can still add `static_assert` just to make the compiler's error message slightly more obvious.