### PR TITLE
added component enumeration function

### DIFF
--- a/OPHD/StructureComponent.h
+++ b/OPHD/StructureComponent.h
@@ -30,6 +30,17 @@ inline T* tryGetComponent(SKey s)
 
 
 /**
+ * Returns a range object that can be used to iterate over all instances of the
+ * given StructureComponent type. It is suitable for use in range-based for loops.
+ */
+template<typename ComponentTy>
+const ComponentRange<ComponentTy> enumerateComponent()
+{
+	return NAS2D::Utility<StructureManager>::get().enumerateComponent<ComponentTy>();
+}
+
+
+/**
  * Common base class for all structure components.
  * Each structure is associated with a set of components that define the functional properties of the structure.
  * A structure either has a given component or not - it can never have multiple instances of the same component type.

--- a/OPHD/StructureComponent.h
+++ b/OPHD/StructureComponent.h
@@ -1,44 +1,6 @@
 #pragma once
 
 #include "StructureManager.h"
-#include <NAS2D/Utility.h>
-
-
-/**
- * Return a reference to the given StructureComponent type belonging to
- * a structure. The structure is assumed to have the given component,
- * and it is an error to try to get a component from a structure that
- * does not have it.
- */
-template<typename T>
-inline T& getComponent(SKey s)
-{
-	return NAS2D::Utility<StructureManager>::get().get<T>(s);
-}
-
-
-/**
- * Return a pointer to the given StructureComponent type belonging
- * to a structure, if it has the corresponding component type.
- * Otherwise return nullptr.
- */
-template<typename T>
-inline T* tryGetComponent(SKey s)
-{
-	return NAS2D::Utility<StructureManager>::get().tryGet<T>(s);
-}
-
-
-/**
- * Returns a range object that can be used to iterate over all instances of the
- * given StructureComponent type. It is suitable for use in range-based for loops.
- */
-template<typename ComponentTy>
-const ComponentRange<ComponentTy> enumerateComponent()
-{
-	return NAS2D::Utility<StructureManager>::get().enumerateComponent<ComponentTy>();
-}
-
 
 /**
  * Common base class for all structure components.

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -140,9 +140,9 @@ public:
 			std::map<SKey, StructureComponent*>::iterator mIt;
 		public:
 			Iterator(std::map<SKey, StructureComponent*>::iterator it) : mIt(it) {}
-			bool operator!= (const Iterator& rhs) const { return mIt != rhs.mIt; }
+			bool operator!=(const Iterator& rhs) const { return mIt != rhs.mIt; }
 			Iterator& operator++() { ++mIt; return *this; }
-			operator ComponentTy* () const { return static_cast<ComponentTy*>(mIt->second); }
+			operator ComponentTy*() const { return static_cast<ComponentTy*>(mIt->second); }
 			ComponentTy* operator->() const { return static_cast<ComponentTy*>(mIt->second); }
 		};
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -38,6 +38,38 @@ public:
 
 
 /**
+ * Object suitable for range-based for loops.
+ * This class allows code to iterate over instances of a given component
+ * without exposing the internal component storage container type.
+ */
+template<typename ComponentTy>
+class ComponentRange
+{
+private:
+	class Iterator
+	{
+	private:
+		std::map<SKey, StructureComponent*>::iterator mIt;
+	public:
+		Iterator(std::map<SKey, StructureComponent*>::iterator it) : mIt(it) {}
+		bool operator!= (const Iterator& rhs) const { return mIt != rhs.mIt; }
+		Iterator& operator++() { ++mIt; return *this; }
+		operator ComponentTy* () const { return static_cast<ComponentTy*>(mIt->second); }
+		ComponentTy* operator->() const { return static_cast<ComponentTy*>(mIt->second); }
+	};
+
+	std::map<SKey, StructureComponent*>& mComponents;
+
+public:
+	ComponentRange(std::map<SKey, StructureComponent*>& components) : mComponents(components) {}
+
+	Iterator begin() const { return Iterator(mComponents.begin()); }
+	Iterator end() const { return Iterator(mComponents.end()); }
+	size_t size() const { return mComponents.size(); }
+};
+
+
+/**
  * Handles structure updating and resource management for structures.
  *
  * Keeps track of which structures are operational, idle and disabled.
@@ -122,6 +154,16 @@ public:
 		if (it != table.end())
 			return static_cast<ComponentTy*>(it->second);
 		return nullptr;
+	}
+
+	/**
+	 * Returns a range object that can be used to iterate over all instances of the
+	 * given StructureComponent type. It is suitable for use in range-based for loops.
+	 */
+	template<typename ComponentTy>
+	const ComponentRange<ComponentTy> enumerateComponent()
+	{
+		return ComponentRange<ComponentTy>(mComponents[ComponentTy::componentTypeID]);
 	}
 
 private:


### PR DESCRIPTION
This change adds a helper class suitable for range-based for-loops, as well as functions to obtain instances of the helper class from the structure manager.

Intended usage pattern is:
```
for ( auto& componentInstance : enumerateComponents<SomeComponentType>()) {
  componentInstance.someFunction();
}
```