### PR TITLE
Fix release configuration log file redirect

### DIFF
--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -29,14 +29,13 @@ using namespace NAS2D;
 
 int main(int argc, char *argv[])
 {
-	//Crude way of redirecting stream buffer when building in release (no console)
+	// Crude way of redirecting stream buffer when building in release (no console)
 	#ifdef NDEBUG
-	std::streambuf *backup;
-	std::ofstream filestr;
-	filestr.open("ophd.log");
-
-	backup = std::cout.rdbuf();
-	std::cout.rdbuf(filestr.rdbuf());
+	// Save for later
+	std::streambuf* originalCoutBuffer = std::cout.rdbuf();
+	// Redirect output to log file
+	std::ofstream logFile("ophd.log");
+	std::cout.rdbuf(logFile.rdbuf());
 	#endif
 
 	std::cout << "OutpostHD " << constants::VERSION << std::endl << std::endl;
@@ -172,7 +171,8 @@ int main(int argc, char *argv[])
 	imageCache.clear();
 
 	#ifdef NDEBUG
-	filestr.close();
+	// Reset to stdout again (prevents crashes on exit)
+	std::cout.rdbuf(originalCoutBuffer);
 	#endif
 
 	SDL_Quit();


### PR DESCRIPTION
Apply crash fixes from OP2-Landlord to OPHD for release configuration log redirect. Old code did not restore the old `rdbuf` before exiting, which caused crashes when exiting.

To see the crash on Linux with the old code, compile with:
```sh
make CXXFLAGS_EXTRA=-DNDEBUG
```

As the Linux environment doesn't normally define `NDEBUG` (MSVC specific define), this was not normally seen for Linux builds.

This was noticed while reviewing pre-processor directives for #845.
