### PR TITLE
Use direct member calls

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -24,7 +24,6 @@ ComboBox::ComboBox()
 	lstItems.visible(false);
 	lstItems.height(300);
 
-	resized().connect(this, &ComboBox::resizedHandler);
 	moved().connect(this, &ComboBox::repositioned);
 	lstItems.selectionChanged().connect(this, &ComboBox::lstItemsSelectionChanged);
 }
@@ -32,7 +31,6 @@ ComboBox::ComboBox()
 
 ComboBox::~ComboBox()
 {
-	resized().disconnect(this, &ComboBox::resizedHandler);
 	moved().disconnect(this, &ComboBox::repositioned);
 	lstItems.selectionChanged().disconnect(this, &ComboBox::lstItemsSelectionChanged);
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
@@ -43,8 +41,10 @@ ComboBox::~ComboBox()
 /**
  * Resized event handler.
  */
-void ComboBox::resizedHandler(Control* /*control*/)
+void ComboBox::onSizeChanged()
 {
+	Control::onSizeChanged();
+
 	// Enforce minimum size
 	if (mRect.width < 50 || mRect.height < 20)
 	{

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -24,14 +24,12 @@ ComboBox::ComboBox()
 	lstItems.visible(false);
 	lstItems.height(300);
 
-	moved().connect(this, &ComboBox::repositioned);
 	lstItems.selectionChanged().connect(this, &ComboBox::lstItemsSelectionChanged);
 }
 
 
 ComboBox::~ComboBox()
 {
-	moved().disconnect(this, &ComboBox::repositioned);
 	lstItems.selectionChanged().disconnect(this, &ComboBox::lstItemsSelectionChanged);
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
 	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
@@ -64,8 +62,10 @@ void ComboBox::onSizeChanged()
 /**
  * Position changed event handler.
  */
-void ComboBox::repositioned(int, int)
+void ComboBox::positionChanged(int dX, int dY)
 {
+	Control::positionChanged(dX, dY);
+
 	txtField.position(position());
 	btnDown.position(txtField.rect().crossXPoint());
 	lstItems.position(rect().crossYPoint());

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -42,7 +42,7 @@ public:
 
 private:
 	void onSizeChanged() override;
-	void repositioned(int, int);
+	void positionChanged(int dX, int dY) override;
 	void lstItemsSelectionChanged();
 
 	void onMouseWheel(int x, int y);

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -41,7 +41,7 @@ public:
 	const std::string& text() const;
 
 private:
-	void resizedHandler(Control* control);
+	void onSizeChanged() override;
 	void repositioned(int, int);
 	void lstItemsSelectionChanged();
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -43,7 +43,6 @@ IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &IconGrid::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMove);
-	resized().connect(this, &IconGrid::sizeChanged);
 	hasFocus(true);
 }
 
@@ -146,8 +145,10 @@ std::size_t IconGrid::translateCoordsToIndex(NAS2D::Vector<int> relativeOffset)
 /**
  * Called whenever the size of the IconGrid is changed.
  */
-void IconGrid::sizeChanged(Control*)
+void IconGrid::onSizeChanged()
 {
+	Control::onSizeChanged();
+
 	updateGrid();
 }
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -92,7 +92,7 @@ protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	virtual void onMouseMove(int x, int y, int dX, int dY);
 
-	virtual void sizeChanged(Control*);
+	void onSizeChanged() override;
 
 private:
 	using IconItemList = std::vector<IconGridItem>;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -131,7 +131,6 @@ FactoryReport::FactoryReport() :
 	txtProductDescription.textColor(NAS2D::Color{0, 185, 0});
 	txtProductDescription.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
 
-	Control::resized().connect(this, &FactoryReport::resized);
 	fillLists();
 }
 
@@ -259,8 +258,10 @@ void FactoryReport::checkFactoryActionControls()
 }
 
 
-void FactoryReport::resized(Control* /*c*/)
+void FactoryReport::onSizeChanged()
 {
+	Control::onSizeChanged();
+
 	const auto comboEndPoint = cboFilterByProduct.rect().endPoint();
 
 	lstFactoryList.size({comboEndPoint.x - 10, mRect.height - 74});

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -58,7 +58,7 @@ private:
 
 	void checkFactoryActionControls();
 
-	void resized(Control*);
+	void onSizeChanged() override;
 
 	void drawDetailPane(NAS2D::Renderer&);
 	void drawProductPane(NAS2D::Renderer&);

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -111,7 +111,6 @@ MineReport::MineReport() :
 	btnRemoveTruck.size({ 140, 30 });
 	btnRemoveTruck.click().connect(this, &MineReport::btnRemoveTruckClicked);
 
-	Control::resized().connect(this, &MineReport::resized);
 	fillLists();
 }
 
@@ -160,8 +159,10 @@ void MineReport::fillLists()
 }
 
 
-void MineReport::resized(Control* /*c*/)
+void MineReport::onSizeChanged()
 {
+	Control::onSizeChanged();
+
 	lstMineFacilities.size({ rect().center().x - 20, rect().height - 51 });
 
 	int position_x = rect().width - 150;

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -59,7 +59,7 @@ private:
 
 	void updateManagementButtonsVisiblity();
 
-	void resized(Control*);
+	void onSizeChanged() override;
 
 	void drawMineFacilityPane(const NAS2D::Point<int>&);
 	void drawOreProductionPane(const NAS2D::Point<int>&);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -67,14 +67,12 @@ WarehouseReport::WarehouseReport() :
 
 	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &WarehouseReport::doubleClicked);
 
-	Control::resized().connect(this, &WarehouseReport::_resized);
 	fillLists();
 }
 
 
 WarehouseReport::~WarehouseReport()
 {
-	Control::resized().disconnect(this, &WarehouseReport::_resized);
 	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &WarehouseReport::doubleClicked);
 }
 
@@ -252,8 +250,10 @@ void WarehouseReport::selectStructure(Structure* structure)
 }
 
 
-void WarehouseReport::_resized(Control*)
+void WarehouseReport::onSizeChanged()
 {
+	Control::onSizeChanged();
+
 	lstStructures.size({(mRect.width / 2) - 20, mRect.height - 126});
 	lstProducts.size({(mRect.width / 2) - 20, mRect.height - 184});
 	lstProducts.position({Utility<Renderer>::get().center().x + 10, lstProducts.positionY()});

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -38,7 +38,7 @@ private:
 
 	void _fillListFromStructureList(const std::vector<Structure*>&);
 
-	void _resized(Control*);
+	void onSizeChanged() override;
 
 	void btnShowAllClicked();
 	void btnSpaceAvailableClicked();


### PR DESCRIPTION
Code structure changes for #855.

I believe these were all the cases of self dispatch using a `Signal` object. Doing a search for all strings of the form `.connect(` shows an explicit object is being used on the left hand side in all remaining cases, and those objects are not of the current class. That means there should be no more instances of self dispatch through a `Signal` object.
