### PR TITLE
Packed move event

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -62,9 +62,9 @@ void ComboBox::onSizeChanged()
 /**
  * Position changed event handler.
  */
-void ComboBox::positionChanged(int dX, int dY)
+void ComboBox::positionChanged(NAS2D::Vector<int> displacement)
 {
-	Control::positionChanged(dX, dY);
+	Control::positionChanged(displacement);
 
 	txtField.position(position());
 	btnDown.position(txtField.rect().crossXPoint());

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -42,7 +42,7 @@ public:
 
 private:
 	void onSizeChanged() override;
-	void positionChanged(int dX, int dY) override;
+	void positionChanged(NAS2D::Vector<int> displacement) override;
 	void lstItemsSelectionChanged();
 
 	void onMouseWheel(int x, int y);

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -62,10 +62,8 @@ protected:
 	/**
 	 * Called whenever the Control's position is changed.
 	 * 
-	 * \param	dX	Difference in X Position.
-	 * \param	dY	Difference in Y Position.
+	 * \param	displacement	Difference in position.
 	 */
-	void positionChanged(int dX, int dY) { positionChanged({dX, dY}); }
 	virtual void positionChanged(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -17,7 +17,7 @@ class Control
 {
 public:
 	using ResizeCallback = NAS2D::Signal<Control*>;
-	using PositionChangedCallback = NAS2D::Signal<int, int>;
+	using PositionChangedCallback = NAS2D::Signal<NAS2D::Vector<int>>;
 
 	Control() = default;
 	virtual ~Control() = default;
@@ -65,7 +65,7 @@ protected:
 	 * \param	dX	Difference in X Position.
 	 * \param	dY	Difference in Y Position.
 	 */
-	virtual void positionChanged(int dX, int dY) { mPositionChanged(dX, dY); }
+	virtual void positionChanged(int dX, int dY) { mPositionChanged({dX, dY}); }
 	void positionChanged(NAS2D::Vector<int> displacement) { positionChanged(displacement.x, displacement.y); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -65,8 +65,8 @@ protected:
 	 * \param	dX	Difference in X Position.
 	 * \param	dY	Difference in Y Position.
 	 */
-	virtual void positionChanged(int dX, int dY) { mPositionChanged({dX, dY}); }
-	void positionChanged(NAS2D::Vector<int> displacement) { positionChanged(displacement.x, displacement.y); }
+	virtual void positionChanged(int dX, int dY) { positionChanged({dX, dY}); }
+	void positionChanged(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -65,8 +65,8 @@ protected:
 	 * \param	dX	Difference in X Position.
 	 * \param	dY	Difference in Y Position.
 	 */
-	virtual void positionChanged(int dX, int dY) { positionChanged({dX, dY}); }
-	void positionChanged(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
+	void positionChanged(int dX, int dY) { positionChanged({dX, dY}); }
+	virtual void positionChanged(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}
 

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -77,13 +77,13 @@ void UIContainer::visibilityChanged(bool visible)
 }
 
 
-void UIContainer::positionChanged(int dX, int dY)
+void UIContainer::positionChanged(NAS2D::Vector<int> displacement)
 {
-	Control::positionChanged(dX, dY);
+	Control::positionChanged(displacement);
 
 	for (auto control : mControls)
 	{
-		control->position(control->position() + NAS2D::Vector{dX, dY});
+		control->position(control->position() + displacement);
 	}
 }
 

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -30,7 +30,7 @@ public:
 
 protected:
 	void visibilityChanged(bool visible) override;
-	void positionChanged(int dX, int dY) override;
+	void positionChanged(NAS2D::Vector<int> displacement) override;
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 


### PR DESCRIPTION
Convert `Control` move event to packed parameters (#217). Noticed while working on #857.
