### PR TITLE
Rename Control events

### DIFF
--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -88,7 +88,7 @@ void CheckBox::onTextChanged()
 /**
  * Enforces minimum and maximum sizes.
  */
-void CheckBox::onSizeChanged()
+void CheckBox::onResize()
 {
 	mRect.size({std::max(mRect.width, 13), 13});
 }

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -27,7 +27,7 @@ public:
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
-	void onSizeChanged() override;
+	void onResize() override;
 	void onTextChanged() override;
 
 private:

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -39,9 +39,9 @@ ComboBox::~ComboBox()
 /**
  * Resized event handler.
  */
-void ComboBox::onSizeChanged()
+void ComboBox::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 
 	// Enforce minimum size
 	if (mRect.width < 50 || mRect.height < 20)

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -62,9 +62,9 @@ void ComboBox::onSizeChanged()
 /**
  * Position changed event handler.
  */
-void ComboBox::positionChanged(NAS2D::Vector<int> displacement)
+void ComboBox::onMove(NAS2D::Vector<int> displacement)
 {
-	Control::positionChanged(displacement);
+	Control::onMove(displacement);
 
 	txtField.position(position());
 	btnDown.position(txtField.rect().crossXPoint());

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -41,7 +41,7 @@ public:
 	const std::string& text() const;
 
 private:
-	void onSizeChanged() override;
+	void onResize() override;
 	void onMove(NAS2D::Vector<int> displacement) override;
 	void lstItemsSelectionChanged();
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -42,7 +42,7 @@ public:
 
 private:
 	void onSizeChanged() override;
-	void positionChanged(NAS2D::Vector<int> displacement) override;
+	void onMove(NAS2D::Vector<int> displacement) override;
 	void lstItemsSelectionChanged();
 
 	void onMouseWheel(int x, int y);

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -38,7 +38,7 @@ int Control::positionY()
 /**
  * Callback fired whenever the Control's position changes.
  */
-Control::PositionChangedCallback& Control::moved()
+Control::OnMoveCallback& Control::moved()
 {
 	return mPositionChanged;
 }

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -13,7 +13,7 @@ void Control::position(Point<int> pos)
 {
 	const auto displacement = pos - mRect.startPoint();
 	mRect.startPoint(pos);
-	positionChanged(displacement);
+	onMove(displacement);
 }
 
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -85,7 +85,7 @@ void Control::height(int h)
 
 Control::ResizeCallback& Control::resized()
 {
-	return mResized;
+	return mOnResizeSignal;
 }
 
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -106,7 +106,7 @@ const Rectangle<int>& Control::rect() const
 void Control::hasFocus(bool focus)
 {
 	mHasFocus = focus;
-	onFocusChanged();
+	onFocusChange();
 }
 
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -151,7 +151,7 @@ bool Control::highlight() const
 void Control::enabled(bool enabled)
 {
 	mEnabled = enabled;
-	enabledChanged();
+	onEnableChange();
 }
 
 
@@ -174,7 +174,7 @@ bool Control::enabled() const
 void Control::visible(bool visible)
 {
 	mVisible = visible;
-	visibilityChanged(mVisible);
+	onVisibilityChange(mVisible);
 }
 
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -47,7 +47,7 @@ Control::PositionChangedCallback& Control::moved()
 void Control::size(NAS2D::Vector<int> newSize)
 {
 	mRect.size(newSize);
-	onSizeChanged();
+	onResize();
 }
 
 
@@ -66,7 +66,7 @@ void Control::size(int newSize)
 void Control::width(int w)
 {
 	mRect.width = w;
-	onSizeChanged();
+	onResize();
 }
 
 
@@ -79,7 +79,7 @@ void Control::width(int w)
 void Control::height(int h)
 {
 	mRect.height = h;
-	onSizeChanged();
+	onResize();
 }
 
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -40,7 +40,7 @@ int Control::positionY()
  */
 Control::OnMoveCallback& Control::moved()
 {
-	return mPositionChanged;
+	return mOnMoveSignal;
 }
 
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -68,9 +68,9 @@ protected:
 
 	virtual void onResize() { mResized(this); }
 
-	virtual void visibilityChanged(bool /*visible*/) {}
+	virtual void onVisibilityChange(bool /*visible*/) {}
 
-	virtual void enabledChanged() {}
+	virtual void onEnableChange() {}
 
 	virtual void onFocusChanged() {}
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -66,13 +66,13 @@ protected:
 	 */
 	virtual void onMove(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
 
+	virtual void onSizeChanged() { mResized(this); }
+
 	virtual void visibilityChanged(bool /*visible*/) {}
 
 	virtual void enabledChanged() {}
 
 	virtual void onFocusChanged() {}
-
-	virtual void onSizeChanged() { mResized(this); }
 
 	PositionChangedCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
 	ResizeCallback mResized;

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -64,7 +64,7 @@ protected:
 	 * 
 	 * \param	displacement	Difference in position.
 	 */
-	virtual void onMove(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
+	virtual void onMove(NAS2D::Vector<int> displacement) { mOnMoveSignal(displacement); }
 
 	virtual void onResize() { mResized(this); }
 
@@ -74,7 +74,7 @@ protected:
 
 	virtual void onFocusChange() {}
 
-	OnMoveCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
+	OnMoveCallback mOnMoveSignal; /**< Callback fired whenever the position of the Control changes. */
 	ResizeCallback mResized;
 
 	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -72,7 +72,7 @@ protected:
 
 	virtual void onEnableChange() {}
 
-	virtual void onFocusChanged() {}
+	virtual void onFocusChange() {}
 
 	PositionChangedCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
 	ResizeCallback mResized;

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -66,7 +66,7 @@ protected:
 	 */
 	virtual void onMove(NAS2D::Vector<int> displacement) { mOnMoveSignal(displacement); }
 
-	virtual void onResize() { mResized(this); }
+	virtual void onResize() { mOnResizeSignal(this); }
 
 	virtual void onVisibilityChange(bool /*visible*/) {}
 
@@ -75,7 +75,7 @@ protected:
 	virtual void onFocusChange() {}
 
 	OnMoveCallback mOnMoveSignal; /**< Callback fired whenever the position of the Control changes. */
-	ResizeCallback mResized;
+	ResizeCallback mOnResizeSignal;
 
 	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -66,7 +66,7 @@ protected:
 	 */
 	virtual void onMove(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
 
-	virtual void onSizeChanged() { mResized(this); }
+	virtual void onResize() { mResized(this); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -64,7 +64,7 @@ protected:
 	 * 
 	 * \param	displacement	Difference in position.
 	 */
-	virtual void positionChanged(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
+	virtual void onMove(NAS2D::Vector<int> displacement) { mPositionChanged(displacement); }
 
 	virtual void visibilityChanged(bool /*visible*/) {}
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -17,7 +17,7 @@ class Control
 {
 public:
 	using ResizeCallback = NAS2D::Signal<Control*>;
-	using PositionChangedCallback = NAS2D::Signal<NAS2D::Vector<int>>;
+	using OnMoveCallback = NAS2D::Signal<NAS2D::Vector<int>>;
 
 	Control() = default;
 	virtual ~Control() = default;
@@ -28,7 +28,7 @@ public:
 	int positionX();
 	int positionY();
 
-	PositionChangedCallback& moved();
+	OnMoveCallback& moved();
 
 	void highlight(bool highlight);
 	bool highlight() const;
@@ -74,7 +74,7 @@ protected:
 
 	virtual void onFocusChange() {}
 
-	PositionChangedCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
+	OnMoveCallback mPositionChanged; /**< Callback fired whenever the position of the Control changes. */
 	ResizeCallback mResized;
 
 	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -231,7 +231,7 @@ protected:
 	}
 
 
-	void visibilityChanged(bool /*visible*/) override {
+	void onVisibilityChange(bool /*visible*/) override {
 		updateScrollLayout();
 	}
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -236,7 +236,7 @@ protected:
 	}
 
 private:
-	void onSizeChanged() override {
+	void onResize() override {
 		updateScrollLayout();
 	}
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -93,7 +93,7 @@ void ListBoxBase::updateScrollLayout()
 /**
  * Resized event handler.
  */
-void ListBoxBase::onSizeChanged()
+void ListBoxBase::onResize()
 {
 	updateScrollLayout();
 }

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -59,7 +59,7 @@ std::size_t ListBoxBase::count() const
 }
 
 
-void ListBoxBase::visibilityChanged(bool)
+void ListBoxBase::onVisibilityChange(bool)
 {
 	updateScrollLayout();
 }

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -78,7 +78,7 @@ protected:
 
 	unsigned int draw_offset() const { return mScrollOffsetInPixels; }
 
-	void visibilityChanged(bool) override;
+	void onVisibilityChange(bool) override;
 
 
 	std::vector<ListBoxItem*> mItems; /**< List of Items. Pointers used for polymorphism. */

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -90,7 +90,7 @@ private:
 	void onMouseMove(int x, int y, int relX, int relY);
 	void onMouseWheel(int x, int y);
 
-	void onSizeChanged() override;
+	void onResize() override;
 
 
 	std::size_t mHighlightIndex = constants::NO_SELECTION;

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -96,7 +96,7 @@ void RadioButton::onTextChanged()
 /**
  * Enforces minimum and maximum sizes.
  */
-void RadioButton::onSizeChanged()
+void RadioButton::onResize()
 {
 	mRect.size({std::max(mRect.width, 13), 13});
 }

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -34,7 +34,7 @@ public:
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
-	void onSizeChanged() override;
+	void onResize() override;
 	void onTextChanged() override;
 
 	void parentContainer(UIContainer* parent);

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -62,9 +62,9 @@ void TextArea::processString()
 }
 
 
-void TextArea::onSizeChanged()
+void TextArea::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 	processString();
 }
 

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -22,7 +22,7 @@ public:
 private:
 	using StringList = std::vector<std::string>;
 
-	void onSizeChanged() override;
+	void onResize() override;
 	void onTextChanged() override;
 	virtual void onFontChanged();
 

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -71,7 +71,7 @@ void UIContainer::bringToFront(Control* control)
 }
 
 
-void UIContainer::visibilityChanged(bool visible)
+void UIContainer::onVisibilityChange(bool visible)
 {
 	for (auto control : mControls) { control->visible(visible); }
 }

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -77,9 +77,9 @@ void UIContainer::visibilityChanged(bool visible)
 }
 
 
-void UIContainer::positionChanged(NAS2D::Vector<int> displacement)
+void UIContainer::onMove(NAS2D::Vector<int> displacement)
 {
-	Control::positionChanged(displacement);
+	Control::onMove(displacement);
 
 	for (auto control : mControls)
 	{

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -29,7 +29,7 @@ public:
 	std::vector<Control*> controls() const;
 
 protected:
-	void visibilityChanged(bool visible) override;
+	void onVisibilityChange(bool visible) override;
 	void onMove(NAS2D::Vector<int> displacement) override;
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -30,7 +30,7 @@ public:
 
 protected:
 	void visibilityChanged(bool visible) override;
-	void positionChanged(NAS2D::Vector<int> displacement) override;
+	void onMove(NAS2D::Vector<int> displacement) override;
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -42,7 +42,7 @@ GameOptionsDialog::~GameOptionsDialog()
 }
 
 
-void GameOptionsDialog::enabledChanged()
+void GameOptionsDialog::onEnableChange()
 {
 	btnSave.enabled(enabled());
 	btnLoad.enabled(enabled());

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -25,7 +25,7 @@ private:
 	void btnReturnClicked();
 	void btnCloseClicked();
 
-	void enabledChanged() override;
+	void onEnableChange() override;
 
 	Button btnSave;
 	Button btnLoad;

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -145,9 +145,9 @@ std::size_t IconGrid::translateCoordsToIndex(NAS2D::Vector<int> relativeOffset)
 /**
  * Called whenever the size of the IconGrid is changed.
  */
-void IconGrid::onSizeChanged()
+void IconGrid::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 
 	updateGrid();
 }

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -92,7 +92,7 @@ protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	virtual void onMouseMove(int x, int y, int dX, int dY);
 
-	void onSizeChanged() override;
+	void onResize() override;
 
 private:
 	using IconItemList = std::vector<IconGridItem>;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -258,9 +258,9 @@ void FactoryReport::checkFactoryActionControls()
 }
 
 
-void FactoryReport::onSizeChanged()
+void FactoryReport::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 
 	const auto comboEndPoint = cboFilterByProduct.rect().endPoint();
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -292,7 +292,7 @@ void FactoryReport::onResize()
  * This has been overridden to handle some UI elements that need
  * special handling.
  */
-void FactoryReport::visibilityChanged(bool visible)
+void FactoryReport::onVisibilityChange(bool visible)
 {
 	if (!selectedFactory) { return; }
 

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -63,7 +63,7 @@ private:
 	void drawDetailPane(NAS2D::Renderer&);
 	void drawProductPane(NAS2D::Renderer&);
 
-	void visibilityChanged(bool visible) override;
+	void onVisibilityChange(bool visible) override;
 
 	const NAS2D::Font& font;
 	const NAS2D::Font& fontMedium;

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -58,7 +58,7 @@ private:
 
 	void checkFactoryActionControls();
 
-	void onSizeChanged() override;
+	void onResize() override;
 
 	void drawDetailPane(NAS2D::Renderer&);
 	void drawProductPane(NAS2D::Renderer&);

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -159,9 +159,9 @@ void MineReport::fillLists()
 }
 
 
-void MineReport::onSizeChanged()
+void MineReport::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 
 	lstMineFacilities.size({ rect().center().x - 20, rect().height - 51 });
 

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -59,7 +59,7 @@ private:
 
 	void updateManagementButtonsVisiblity();
 
-	void onSizeChanged() override;
+	void onResize() override;
 
 	void drawMineFacilityPane(const NAS2D::Point<int>&);
 	void drawOreProductionPane(const NAS2D::Point<int>&);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -250,9 +250,9 @@ void WarehouseReport::selectStructure(Structure* structure)
 }
 
 
-void WarehouseReport::onSizeChanged()
+void WarehouseReport::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 
 	lstStructures.size({(mRect.width / 2) - 20, mRect.height - 126});
 	lstProducts.size({(mRect.width / 2) - 20, mRect.height - 184});

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -38,7 +38,7 @@ private:
 
 	void _fillListFromStructureList(const std::vector<Structure*>&);
 
-	void onSizeChanged() override;
+	void onResize() override;
 
 	void btnShowAllClicked();
 	void btnSpaceAvailableClicked();


### PR DESCRIPTION
Rename base class `Control` events to match convention suggested in #855.
