### PR TITLE
Rename core UI events

### DIFF
--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -78,7 +78,7 @@ void CheckBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void CheckBox::onTextChanged()
+void CheckBox::onTextChange()
 {
 	const auto textWidth = mFont.width(text());
 	width((textWidth > 0) ? 20 + textWidth : 13);

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -28,7 +28,7 @@ protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
 	void onResize() override;
-	void onTextChanged() override;
+	void onTextChange() override;
 
 private:
 	const NAS2D::Font& mFont;

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -24,13 +24,13 @@ ComboBox::ComboBox()
 	lstItems.visible(false);
 	lstItems.height(300);
 
-	lstItems.selectionChanged().connect(this, &ComboBox::lstItemsSelectionChanged);
+	lstItems.selectionChanged().connect(this, &ComboBox::onListSelectionChange);
 }
 
 
 ComboBox::~ComboBox()
 {
-	lstItems.selectionChanged().disconnect(this, &ComboBox::lstItemsSelectionChanged);
+	lstItems.selectionChanged().disconnect(this, &ComboBox::onListSelectionChange);
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
 	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
 }
@@ -119,7 +119,7 @@ void ComboBox::clearSelected()
 /**
  * ListBox selection changed event handler.
  */
-void ComboBox::lstItemsSelectionChanged()
+void ComboBox::onListSelectionChange()
 {
 	txtField.text(selectionText());
 	lstItems.visible(false);

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -43,7 +43,7 @@ public:
 private:
 	void onResize() override;
 	void onMove(NAS2D::Vector<int> displacement) override;
-	void lstItemsSelectionChanged();
+	void onListSelectionChange();
 
 	void onMouseWheel(int x, int y);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -14,7 +14,7 @@
 class ComboBox : public Control
 {
 public:
-	using SelectionChanged = NAS2D::Signal<>;
+	using SelectionChangedCallback = NAS2D::Signal<>;
 
 	ComboBox();
 	~ComboBox() override;
@@ -26,7 +26,7 @@ public:
 
 	void clearSelected();
 
-	SelectionChanged& selectionChanged() { return mSelectionChanged; }
+	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 
 	const std::string& selectionText() const;
 	int selectionTag() const;
@@ -54,7 +54,7 @@ private:
 
 	NAS2D::Rectangle<int> mBaseArea;
 
-	SelectionChanged mSelectionChanged;
+	SelectionChangedCallback mSelectionChanged;
 
 	std::size_t mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
 };

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -14,7 +14,7 @@
 class ComboBox : public Control
 {
 public:
-	using SelectionChangedCallback = NAS2D::Signal<>;
+	using SelectionChangeCallback = NAS2D::Signal<>;
 
 	ComboBox();
 	~ComboBox() override;
@@ -26,7 +26,7 @@ public:
 
 	void clearSelected();
 
-	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeCallback& selectionChanged() { return mSelectionChanged; }
 
 	const std::string& selectionText() const;
 	int selectionTag() const;
@@ -54,7 +54,7 @@ private:
 
 	NAS2D::Rectangle<int> mBaseArea;
 
-	SelectionChangedCallback mSelectionChanged;
+	SelectionChangeCallback mSelectionChanged;
 
 	std::size_t mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
 };

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -57,7 +57,7 @@ template <typename ListBoxItem = ListBoxItemText>
 class ListBox : public Control
 {
 public:
-	using SelectionChangedCallback = NAS2D::Signal<>;
+	using SelectionChangeCallback = NAS2D::Signal<>;
 
 	ListBox() :
 		mContext{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
@@ -186,7 +186,7 @@ public:
 		mSlider.update();
 	}
 
-	SelectionChangedCallback& selectionChanged() {
+	SelectionChangeCallback& selectionChanged() {
 		return mSelectionChanged;
 	}
 
@@ -273,6 +273,6 @@ private:
 
 	NAS2D::Rectangle<int> mScrollArea;
 
-	SelectionChangedCallback mSelectionChanged; /**< Callback for selection changed callback. */
+	SelectionChangeCallback mSelectionChanged; /**< Callback for selection changed callback. */
 	Slider mSlider;
 };

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -27,7 +27,7 @@ public:
 	/**
 	 * Callback signal fired whenever the list selection changes.
 	 */
-	using SelectionChangedCallback = NAS2D::Signal<>;
+	using SelectionChangeCallback = NAS2D::Signal<>;
 
 	/**
 	 * Derived SpecialListBox types can inherit from this struct
@@ -59,7 +59,7 @@ public:
 
 	std::size_t currentHighlight() const;
 
-	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeCallback& selectionChanged() { return mSelectionChanged; }
 
 	void update() override = 0;
 
@@ -106,6 +106,6 @@ private:
 	NAS2D::Color mHighlightBg = NAS2D::Color::DarkGreen; /**< Highlight Background color. */
 	NAS2D::Color mHighlightText = NAS2D::Color::White; /**< Text Color for an item that is currently highlighted. */
 
-	SelectionChangedCallback mSelectionChanged; /**< Callback for selection changed callback. */
+	SelectionChangeCallback mSelectionChanged; /**< Callback for selection changed callback. */
 	Slider mSlider; /**< Slider control. */
 };

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -52,7 +52,7 @@ void RadioButton::parentContainer(UIContainer* parent)
 void RadioButton::text(const std::string& text)
 {
 	mLabel.text(text);
-	onTextChanged();
+	onTextChange();
 }
 
 const std::string& RadioButton::text() const
@@ -86,7 +86,7 @@ void RadioButton::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void RadioButton::onTextChanged()
+void RadioButton::onTextChange()
 {
 	const auto textWidth = mFont.width(text());
 	width((textWidth > 0) ? 20 + textWidth : 13);

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -35,7 +35,7 @@ protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
 	void onResize() override;
-	void onTextChanged() override;
+	void onTextChange() override;
 
 	void parentContainer(UIContainer* parent);
 

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -37,7 +37,7 @@ public:
 		NAS2D::RectangleSkin skinSlider;
 	};
 
-	using ValueChangedCallback = NAS2D::Signal<float>; /*!< type for Callback on value changed. */
+	using ValueChangeCallback = NAS2D::Signal<float>; /*!< type for Callback on value changed. */
 
 	Slider(SliderType sliderType = SliderType::Vertical);
 	Slider(Skins skins, SliderType sliderType = SliderType::Vertical);
@@ -61,7 +61,7 @@ public:
 
 	void update() override; /*!< Called to display the slider. */
 
-	ValueChangedCallback& change() { return mCallback; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
+	ValueChangeCallback& change() { return mCallback; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y); /*!< Event raised on mouse button down. */
@@ -81,7 +81,7 @@ private:
 
 	NAS2D::Timer mTimer;
 
-	ValueChangedCallback mCallback; /*!< Callback executed when the value is changed. */
+	ValueChangeCallback mCallback; /*!< Callback executed when the value is changed. */
 
 	SliderType mSliderType{SliderType::Vertical}; /*!< Type of the Slider. */
 

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -69,7 +69,7 @@ void TextArea::onResize()
 }
 
 
-void TextArea::onTextChanged()
+void TextArea::onTextChange()
 {
 	processString();
 }

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -75,7 +75,7 @@ void TextArea::onTextChange()
 }
 
 
-void TextArea::onFontChanged()
+void TextArea::onFontChange()
 {
 	processString();
 }

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -23,7 +23,7 @@ private:
 	using StringList = std::vector<std::string>;
 
 	void onResize() override;
-	void onTextChanged() override;
+	void onTextChange() override;
 	virtual void onFontChanged();
 
 	void draw() override;

--- a/OPHD/UI/Core/TextArea.h
+++ b/OPHD/UI/Core/TextArea.h
@@ -24,7 +24,7 @@ private:
 
 	void onResize() override;
 	void onTextChange() override;
-	virtual void onFontChanged();
+	virtual void onFontChange();
 
 	void draw() override;
 	void processString();

--- a/OPHD/UI/Core/TextControl.cpp
+++ b/OPHD/UI/Core/TextControl.cpp
@@ -6,5 +6,5 @@
 void TextControl::text(const std::string& text)
 {
 	mText = text;
-	onTextChanged();
+	onTextChange();
 }

--- a/OPHD/UI/Core/TextControl.h
+++ b/OPHD/UI/Core/TextControl.h
@@ -16,16 +16,16 @@ namespace NAS2D
 class TextControl : public Control
 {
 public:
-	using TextChangedCallback = NAS2D::Signal<TextControl*>;
+	using TextChangeCallback = NAS2D::Signal<TextControl*>;
 
 	void text(const std::string& text);
 	const std::string& text() const { return mText; }
-	TextChangedCallback& textChanged() { return mTextChanged; }
+	TextChangeCallback& textChanged() { return mTextChanged; }
 
 	virtual void onTextChange() { mTextChanged(this); }
 
 protected:
-	TextChangedCallback mTextChanged;
+	TextChangeCallback mTextChanged;
 
 	std::string mText; /**< Internal text string. */
 };

--- a/OPHD/UI/Core/TextControl.h
+++ b/OPHD/UI/Core/TextControl.h
@@ -22,7 +22,7 @@ public:
 	const std::string& text() const { return mText; }
 	TextChangedCallback& textChanged() { return mTextChanged; }
 
-	virtual void onTextChanged() { mTextChanged(this); }
+	virtual void onTextChange() { mTextChanged(this); }
 
 protected:
 	TextChangedCallback mTextChanged;

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -145,7 +145,7 @@ void TextField::onTextInput(const std::string& newTextInput)
 
 	if (text().length() - prvLen != 0u)
 	{
-		onTextChanged();
+		onTextChange();
 		mCursorPosition++;
 	}
 }
@@ -163,7 +163,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			{
 				mCursorPosition--;
 				mText.erase(mCursorPosition, 1);
-				onTextChanged();
+				onTextChange();
 			}
 			break;
 
@@ -179,7 +179,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			if (text().length() > 0)
 			{
 				mText = mText.erase(mCursorPosition, 1);
-				onTextChanged();
+				onTextChange();
 			}
 			break;
 

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -20,11 +20,11 @@ public:
 	void show() override;
 	void update() override;
 
-	using TitleChangedCallback = NAS2D::Signal<Window*>;
+	using TitleChangeCallback = NAS2D::Signal<Window*>;
 
 	void title(const std::string& title);
 	const std::string& title() const { return mTitle; }
-	TitleChangedCallback& titleChanged() { return mTitleChanged; }
+	TitleChangeCallback& titleChanged() { return mTitleChanged; }
 
 	virtual void onTitleChanged() { mTitleChanged(this); }
 
@@ -45,7 +45,7 @@ private:
 	const NAS2D::Image& mTitleBarRight;
 	NAS2D::RectangleSkin mBody;
 
-	TitleChangedCallback mTitleChanged;
+	TitleChangeCallback mTitleChanged;
 
 	std::string mTitle;
 };


### PR DESCRIPTION
Rename Core UI events to match convention suggested in #855.
