### PR TITLE
Rename Report events

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -49,24 +49,24 @@ void MainMenuState::initialize()
 
 	btnNewGame.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnNewGame.size({200, 30});
-	btnNewGame.click().connect(this, &MainMenuState::btnNewGameClicked);
+	btnNewGame.click().connect(this, &MainMenuState::onNewGame);
 
 	btnContinueGame.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnContinueGame.size({200, 30});
-	btnContinueGame.click().connect(this, &MainMenuState::btnContinueGameClicked);
+	btnContinueGame.click().connect(this, &MainMenuState::onContinueGame);
 
 	btnOptions.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnOptions.size({200, 30});
 	btnOptions.enabled(false);
-	btnOptions.click().connect(this, &MainMenuState::btnOptionsClicked);
+	btnOptions.click().connect(this, &MainMenuState::onOptions);
 
 	btnHelp.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnHelp.size({200, 30});
-	btnHelp.click().connect(this, &MainMenuState::btnHelpClicked);
+	btnHelp.click().connect(this, &MainMenuState::onHelp);
 
 	btnQuit.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnQuit.size({200, 30});
-	btnQuit.click().connect(this, &MainMenuState::btnQuitClicked);
+	btnQuit.click().connect(this, &MainMenuState::onQuit);
 
 	mFileIoDialog.setMode(FileIo::FileOperation::FILE_LOAD);
 	mFileIoDialog.fileOperation().connect(this, &MainMenuState::fileIoAction);
@@ -212,7 +212,7 @@ void MainMenuState::onFadeComplete()
 /**
  * Click handler for New Game button.
  */
-void MainMenuState::btnNewGameClicked()
+void MainMenuState::onNewGame()
 {
 	if (mFileIoDialog.visible()) { return; }
 
@@ -241,7 +241,7 @@ void MainMenuState::newGameCancelled()
 /**
  * Click handler for Continue button.
  */
-void MainMenuState::btnContinueGameClicked()
+void MainMenuState::onContinueGame()
 {
 	if (mFileIoDialog.visible()) { return; }
 
@@ -253,7 +253,7 @@ void MainMenuState::btnContinueGameClicked()
 /**
  * Click handler for Options button.
  */
-void MainMenuState::btnOptionsClicked()
+void MainMenuState::onOptions()
 {
 	if (mFileIoDialog.visible()) { return; }
 }
@@ -262,7 +262,7 @@ void MainMenuState::btnOptionsClicked()
 /**
  * Click handler for the Help button.
  */
-void MainMenuState::btnHelpClicked()
+void MainMenuState::onHelp()
 {
 	if (mFileIoDialog.visible()) { return; }
 
@@ -282,7 +282,7 @@ void MainMenuState::btnHelpClicked()
 /**
  * Click handler for Quit button.
  */
-void MainMenuState::btnQuitClicked()
+void MainMenuState::onQuit()
 {
 	if (mFileIoDialog.visible()) { return; }
 

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -31,11 +31,11 @@ private:
 	void disableButtons();
 	void enableButtons();
 
-	void btnNewGameClicked();
-	void btnContinueGameClicked();
-	void btnOptionsClicked();
-	void btnHelpClicked();
-	void btnQuitClicked();
+	void onNewGame();
+	void onContinueGame();
+	void onOptions();
+	void onHelp();
+	void onQuit();
 
 	void wasDifficultyOkClicked();
 	void newGameCancelled();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -209,15 +209,15 @@ private:
 	void updateStructuresAvailability();
 
 	// UI EVENT HANDLERS
-	void btnTurnsClicked();
-	void btnToggleConnectednessClicked();
-	void btnToggleCommRangeOverlayClicked();
-	void btnToggleRouteOverlayClicked();
+	void onTurns();
+	void onToggleConnectedness();
+	void onToggleCommRangeOverlay();
+	void onToggleRouteOverlay();
 
-	void btnSaveGameClicked();
-	void btnLoadGameClicked();
-	void btnReturnToGameClicked();
-	void btnGameOverClicked();
+	void onSaveGame();
+	void onLoadGame();
+	void onReturnToGame();
+	void onGameOver();
 
 	void structuresSelectionChanged(const IconGrid::IconGridItem*);
 	void connectionsSelectionChanged(const IconGrid::IconGridItem*);

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -525,9 +525,9 @@ void MapViewState::nextTurn()
 
 	// Overlay Updates
 	checkCommRangeOverlay();
-	btnToggleConnectednessClicked();
-	btnToggleCommRangeOverlayClicked();
-	btnToggleRouteOverlayClicked();
+	onToggleConnectedness();
+	onToggleCommRangeOverlay();
+	onToggleRouteOverlay();
 
 	auto& factories = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory);
 	for (auto factory : factories)

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -70,13 +70,13 @@ void MapViewState::initUi()
 	mResourceBreakdownPanel.position({0, 22});
 	mResourceBreakdownPanel.playerResources(&mResourcesCount);
 
-	mGameOverDialog.returnToMainMenu().connect(this, &MapViewState::btnGameOverClicked);
+	mGameOverDialog.returnToMainMenu().connect(this, &MapViewState::onGameOver);
 	mGameOverDialog.hide();
 
-	mGameOptionsDialog.SaveGame().connect(this, &MapViewState::btnSaveGameClicked);
-	mGameOptionsDialog.LoadGame().connect(this, &MapViewState::btnLoadGameClicked);
-	mGameOptionsDialog.returnToGame().connect(this, &MapViewState::btnReturnToGameClicked);
-	mGameOptionsDialog.returnToMainMenu().connect(this, &MapViewState::btnGameOverClicked);
+	mGameOptionsDialog.SaveGame().connect(this, &MapViewState::onSaveGame);
+	mGameOptionsDialog.LoadGame().connect(this, &MapViewState::onLoadGame);
+	mGameOptionsDialog.returnToGame().connect(this, &MapViewState::onReturnToGame);
+	mGameOptionsDialog.returnToMainMenu().connect(this, &MapViewState::onGameOver);
 	mGameOptionsDialog.hide();
 
 	mAnnouncement.hide();
@@ -99,7 +99,7 @@ void MapViewState::initUi()
 	mBtnTurns.image("ui/icons/turns.png");
 	mBtnTurns.position(NAS2D::Point{mMiniMapBoundingBox.x - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT, size.y - constants::MARGIN - MAIN_BUTTON_SIZE});
 	mBtnTurns.size(constants::MAIN_BUTTON_SIZE);
-	mBtnTurns.click().connect(this, &MapViewState::btnTurnsClicked);
+	mBtnTurns.click().connect(this, &MapViewState::onTurns);
 	mBtnTurns.enabled(false);
 
 	mBtnToggleHeightmap.image("ui/icons/height.png");
@@ -109,17 +109,17 @@ void MapViewState::initUi()
 	mBtnToggleConnectedness.image("ui/icons/connection.png");
 	mBtnToggleConnectedness.size(constants::MAIN_BUTTON_SIZE);
 	mBtnToggleConnectedness.type(Button::Type::BUTTON_TOGGLE);
-	mBtnToggleConnectedness.click().connect(this, &MapViewState::btnToggleConnectednessClicked);
+	mBtnToggleConnectedness.click().connect(this, &MapViewState::onToggleConnectedness);
 
 	mBtnToggleCommRangeOverlay.image("ui/icons/comm_overlay.png");
 	mBtnToggleCommRangeOverlay.size(constants::MAIN_BUTTON_SIZE);
 	mBtnToggleCommRangeOverlay.type(Button::Type::BUTTON_TOGGLE);
-	mBtnToggleCommRangeOverlay.click().connect(this, &MapViewState::btnToggleCommRangeOverlayClicked);
+	mBtnToggleCommRangeOverlay.click().connect(this, &MapViewState::onToggleCommRangeOverlay);
 
 	mBtnToggleRouteOverlay.image("ui/icons/route.png");
 	mBtnToggleRouteOverlay.size(constants::MAIN_BUTTON_SIZE);
 	mBtnToggleRouteOverlay.type(Button::Type::BUTTON_TOGGLE);
-	mBtnToggleRouteOverlay.click().connect(this, &MapViewState::btnToggleRouteOverlayClicked);
+	mBtnToggleRouteOverlay.click().connect(this, &MapViewState::onToggleRouteOverlay);
 
 	// Menus
 	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
@@ -418,45 +418,45 @@ void MapViewState::drawUI()
 /**
  * Handles clicks of the Connectedness Overlay button.
  */
-void MapViewState::btnToggleConnectednessClicked()
+void MapViewState::onToggleConnectedness()
 {
 	if (mBtnToggleConnectedness.toggled())
 	{
 		mBtnToggleCommRangeOverlay.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 
-		btnToggleCommRangeOverlayClicked();
-		btnToggleRouteOverlayClicked();
+		onToggleCommRangeOverlay();
+		onToggleRouteOverlay();
 	}
 
 	setOverlay(mBtnToggleConnectedness, mConnectednessOverlay, Tile::Overlay::Connectedness);
 }
 
 
-void MapViewState::btnToggleCommRangeOverlayClicked()
+void MapViewState::onToggleCommRangeOverlay()
 {
 	if (mBtnToggleCommRangeOverlay.toggled())
 	{
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 
-		btnToggleConnectednessClicked();
-		btnToggleRouteOverlayClicked();
+		onToggleConnectedness();
+		onToggleRouteOverlay();
 	}
 
 	setOverlay(mBtnToggleCommRangeOverlay, mCommRangeOverlay, Tile::Overlay::Communications);
 }
 
 
-void MapViewState::btnToggleRouteOverlayClicked()
+void MapViewState::onToggleRouteOverlay()
 {
 	if (mBtnToggleRouteOverlay.toggled())
 	{
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleCommRangeOverlay.toggle(false);
 
-		btnToggleCommRangeOverlayClicked();
-		btnToggleConnectednessClicked();
+		onToggleCommRangeOverlay();
+		onToggleConnectedness();
 	}
 
 	setOverlay(mBtnToggleRouteOverlay, mTruckRouteOverlay, Tile::Overlay::TruckingRoutes);
@@ -572,7 +572,7 @@ void MapViewState::diggerSelectionDialog(Direction direction, Tile* tile)
 /**
  * Click handler for the main menu Save Game button.
  */
-void MapViewState::btnSaveGameClicked()
+void MapViewState::onSaveGame()
 {
 	mGameOptionsDialog.hide();
 	mFileIoDialog.scanDirectory(constants::SAVE_GAME_PATH);
@@ -584,7 +584,7 @@ void MapViewState::btnSaveGameClicked()
 /**
  * Click handler for the main menu Load Game button.
  */
-void MapViewState::btnLoadGameClicked()
+void MapViewState::onLoadGame()
 {
 	mGameOptionsDialog.hide();
 	mFileIoDialog.scanDirectory(constants::SAVE_GAME_PATH);
@@ -597,7 +597,7 @@ void MapViewState::btnLoadGameClicked()
 /**
  * Click handler for the main menu Return to Game button.
  */
-void MapViewState::btnReturnToGameClicked()
+void MapViewState::onReturnToGame()
 {
 	mGameOptionsDialog.hide();
 }
@@ -606,7 +606,7 @@ void MapViewState::btnReturnToGameClicked()
 /**
  * Click handler for the main menu Return to Main Menu Screen button.
  */
-void MapViewState::btnGameOverClicked()
+void MapViewState::onGameOver()
 {
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(static_cast<float>(constants::FADE_SPEED));
 	mQuitCallback();
@@ -642,7 +642,7 @@ void MapViewState::fileIoAction(const std::string& filePath, FileIo::FileOperati
 /**
  * Turns button clicked.
  */
-void MapViewState::btnTurnsClicked()
+void MapViewState::onTurns()
 {
 	nextTurn();
 }

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -75,7 +75,7 @@ void PlanetSelectState::initialize()
 
 	mQuit.size({100, 20});
 	mQuit.position({renderer.size().x - 105, 30});
-	mQuit.click().connect(this, &PlanetSelectState::btnQuitClicked);
+	mQuit.click().connect(this, &PlanetSelectState::onQuit);
 
 	mPlanetDescription.text("");
 	mPlanetDescription.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);
@@ -192,7 +192,7 @@ void PlanetSelectState::onWindowResized(int w, int h)
 }
 
 
-void PlanetSelectState::btnQuitClicked()
+void PlanetSelectState::onQuit()
 {
 	Utility<Renderer>::get().fadeOut(constants::FADE_SPEED);
 	mReturnState = new MainMenuState();

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -33,7 +33,7 @@ private:
 
 	void onWindowResized(int, int);
 
-	void btnQuitClicked();
+	void onQuit();
 
 private:
 	const NAS2D::Font& mFontBold;

--- a/OPHD/UI/DiggerDirection.cpp
+++ b/OPHD/UI/DiggerDirection.cpp
@@ -13,31 +13,31 @@ DiggerDirection::DiggerDirection() :
 	add(btnDown, {5, 25});
 	btnDown.image("ui/icons/arrow-down.png");
 	btnDown.size({64, 34});
-	btnDown.click().connect(this, &DiggerDirection::btnDiggerDownClicked);
+	btnDown.click().connect(this, &DiggerDirection::onDiggerDown);
 
 	add(btnWest, {5, 68});
 	btnWest.image("ui/icons/arrow-west.png");
 	btnWest.size({32, 32});
-	btnWest.click().connect(this, &DiggerDirection::btnDiggerWestClicked);
+	btnWest.click().connect(this, &DiggerDirection::onDiggerWest);
 
 	add(btnNorth, {38, 68});
 	btnNorth.image("ui/icons/arrow-north.png");
 	btnNorth.size({32, 32});
-	btnNorth.click().connect(this, &DiggerDirection::btnDiggerNorthClicked);
+	btnNorth.click().connect(this, &DiggerDirection::onDiggerNorth);
 
 	add(btnSouth, {5, 101});
 	btnSouth.image("ui/icons/arrow-south.png");
 	btnSouth.size({32, 32});
-	btnSouth.click().connect(this, &DiggerDirection::btnDiggerSouthClicked);
+	btnSouth.click().connect(this, &DiggerDirection::onDiggerSouth);
 
 	add(btnEast, {38, 101});
 	btnEast.image("ui/icons/arrow-east.png");
 	btnEast.size({32, 32});
-	btnEast.click().connect(this, &DiggerDirection::btnDiggerEastClicked);
+	btnEast.click().connect(this, &DiggerDirection::onDiggerEast);
 
 	add(btnCancel, {5, 140});
 	btnCancel.size({64, 25});
-	btnCancel.click().connect(this, &DiggerDirection::btnCancelClicked);
+	btnCancel.click().connect(this, &DiggerDirection::onCancel);
 }
 
 
@@ -79,7 +79,7 @@ void DiggerDirection::allEnabled()
 	btnEast.enabled(true);
 }
 
-void DiggerDirection::btnCancelClicked()
+void DiggerDirection::onCancel()
 {
 	visible(false);
 }
@@ -94,35 +94,35 @@ void DiggerDirection::update()
 
 void DiggerDirection::selectDown()
 {
-	btnDiggerDownClicked();
+	onDiggerDown();
 }
 
 
-void DiggerDirection::btnDiggerDownClicked()
+void DiggerDirection::onDiggerDown()
 {
 	mCallback(Direction::Down, mTile);
 }
 
 
-void DiggerDirection::btnDiggerNorthClicked()
+void DiggerDirection::onDiggerNorth()
 {
 	mCallback(Direction::North, mTile);
 }
 
 
-void DiggerDirection::btnDiggerSouthClicked()
+void DiggerDirection::onDiggerSouth()
 {
 	mCallback(Direction::South, mTile);
 }
 
 
-void DiggerDirection::btnDiggerEastClicked()
+void DiggerDirection::onDiggerEast()
 {
 	mCallback(Direction::East, mTile);
 }
 
 
-void DiggerDirection::btnDiggerWestClicked()
+void DiggerDirection::onDiggerWest()
 {
 	mCallback(Direction::West, mTile);
 }

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -28,14 +28,14 @@ public:
 	void allEnabled();
 
 protected:
-	void btnCancelClicked();
+	void onCancel();
 
 private:
-	void btnDiggerDownClicked();
-	void btnDiggerNorthClicked();
-	void btnDiggerSouthClicked();
-	void btnDiggerEastClicked();
-	void btnDiggerWestClicked();
+	void onDiggerDown();
+	void onDiggerNorth();
+	void onDiggerSouth();
+	void onDiggerEast();
+	void onDiggerWest();
 
 	Button btnDown;
 	Button btnNorth;

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -24,19 +24,19 @@ FactoryProduction::FactoryProduction() :
 
 	add(btnOkay, {233, 138});
 	btnOkay.size({40, 20});
-	btnOkay.click().connect(this, &FactoryProduction::btnOkayClicked);
+	btnOkay.click().connect(this, &FactoryProduction::onOkay);
 
 	add(btnCancel, {276, 138});
 	btnCancel.size({40, 20});
-	btnCancel.click().connect(this, &FactoryProduction::btnCancelClicked);
+	btnCancel.click().connect(this, &FactoryProduction::onCancel);
 
 	add(btnClearSelection, {5, 138});
 	btnClearSelection.size({mProductGrid.size().x, 20});
-	btnClearSelection.click().connect(this, &FactoryProduction::btnClearSelectionClicked);
+	btnClearSelection.click().connect(this, &FactoryProduction::onClearSelection);
 
 	add(btnApply, {mProductGrid.size().x + 12, btnClearSelection.positionY()});
 	btnApply.size({40, 20});
-	btnApply.click().connect(this, &FactoryProduction::btnApplyClicked);
+	btnApply.click().connect(this, &FactoryProduction::onApply);
 
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 	chkIdle.size({50, 20});
@@ -75,29 +75,29 @@ void FactoryProduction::productSelectionChanged(const IconGrid::IconGridItem* _i
 }
 
 
-void FactoryProduction::btnOkayClicked()
+void FactoryProduction::onOkay()
 {
 	mFactory->productType(mProduct);
 	hide();
 }
 
 
-void FactoryProduction::btnApplyClicked()
+void FactoryProduction::onApply()
 {
 	mFactory->productType(mProduct);
 }
 
 
-void FactoryProduction::btnCancelClicked()
+void FactoryProduction::onCancel()
 {
 	hide();
 }
 
 
-void FactoryProduction::btnClearSelectionClicked()
+void FactoryProduction::onClearSelection()
 {
 	clearProduct();
-	btnApplyClicked();
+	onApply();
 }
 
 

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -29,11 +29,11 @@ public:
 	void update() override;
 
 private:
-	void btnOkayClicked();
-	void btnCancelClicked();
-	void btnClearSelectionClicked();
+	void onOkay();
+	void onCancel();
+	void onClearSelection();
 	void chkIdleClicked();
-	void btnApplyClicked();
+	void onApply();
 
 	void clearProduct();
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -28,17 +28,17 @@ FileIo::FileIo() :
 
 	add(btnFileOp, {445, 325});
 	btnFileOp.size({50, 20});
-	btnFileOp.click().connect(this, &FileIo::btnFileIoClicked);
+	btnFileOp.click().connect(this, &FileIo::onFileIo);
 	btnFileOp.enabled(false);
 
 	add(btnFileDelete, {5, 325});
 	btnFileDelete.size({50, 20});
-	btnFileDelete.click().connect(this, &FileIo::btnFileDeleteClicked);
+	btnFileDelete.click().connect(this, &FileIo::onFileDelete);
 	btnFileDelete.enabled(false);
 
 	add(btnClose, {390, 325});
 	btnClose.size({50, 20});
-	btnClose.click().connect(this, &FileIo::btnCloseClicked);
+	btnClose.click().connect(this, &FileIo::onClose);
 
 	add(txtFileName, {5, 302});
 	txtFileName.size({490, 18});
@@ -70,7 +70,7 @@ void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
 	{
 		if (mListBox.currentHighlight() != constants::NO_SELECTION && !txtFileName.empty())
 		{
-			btnFileIoClicked();
+			onFileIo();
 		}
 	}
 }
@@ -87,12 +87,12 @@ void FileIo::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mo
 	{
 		if (!txtFileName.empty())
 		{
-			btnFileIoClicked();
+			onFileIo();
 		}
 	}
 	else if (key == EventHandler::KeyCode::KEY_ESCAPE)
 	{
-		btnCloseClicked();
+		onClose();
 	}
 }
 
@@ -154,7 +154,7 @@ void FileIo::fileNameModified(TextControl* control)
 }
 
 
-void FileIo::btnCloseClicked()
+void FileIo::onClose()
 {
 	visible(false);
 	txtFileName.text("");
@@ -162,7 +162,7 @@ void FileIo::btnCloseClicked()
 }
 
 
-void FileIo::btnFileIoClicked()
+void FileIo::onFileIo()
 {
 	mCallback(txtFileName.text(), mMode);
 	txtFileName.text("");
@@ -170,7 +170,7 @@ void FileIo::btnFileIoClicked()
 	btnFileOp.enabled(false);
 }
 
-void FileIo::btnFileDeleteClicked()
+void FileIo::onFileDelete()
 {
 	std::string filename = constants::SAVE_GAME_PATH + txtFileName.text() + ".xml";
 

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -35,9 +35,9 @@ protected:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 
 private:
-	void btnCloseClicked();
-	void btnFileIoClicked();
-	void btnFileDeleteClicked();
+	void onClose();
+	void onFileIo();
+	void onFileDelete();
 
 	void fileSelected();
 	void fileNameModified(TextControl* control);

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -15,19 +15,19 @@ GameOptionsDialog::GameOptionsDialog() :
 
 	add(btnSave, {5, 25});
 	btnSave.size({200, 25});
-	btnSave.click().connect(this, &GameOptionsDialog::btnSaveClicked);
+	btnSave.click().connect(this, &GameOptionsDialog::onSave);
 
 	add(btnLoad, {5, 53});
 	btnLoad.size({200, 25});
-	btnLoad.click().connect(this, &GameOptionsDialog::btnLoadClicked);
+	btnLoad.click().connect(this, &GameOptionsDialog::onLoad);
 
 	add(btnReturn, {5, 91});
 	btnReturn.size({200, 25});
-	btnReturn.click().connect(this, &GameOptionsDialog::btnReturnClicked);
+	btnReturn.click().connect(this, &GameOptionsDialog::onReturn);
 
 	add(btnClose, {5, 129});
 	btnClose.size({200, 25});
-	btnClose.click().connect(this, &GameOptionsDialog::btnCloseClicked);
+	btnClose.click().connect(this, &GameOptionsDialog::onClose);
 
 	anchored(true);
 }
@@ -35,10 +35,10 @@ GameOptionsDialog::GameOptionsDialog() :
 
 GameOptionsDialog::~GameOptionsDialog()
 {
-	btnSave.click().disconnect(this, &GameOptionsDialog::btnSaveClicked);
-	btnLoad.click().disconnect(this, &GameOptionsDialog::btnLoadClicked);
-	btnReturn.click().disconnect(this, &GameOptionsDialog::btnReturnClicked);
-	btnClose.click().disconnect(this, &GameOptionsDialog::btnCloseClicked);
+	btnSave.click().disconnect(this, &GameOptionsDialog::onSave);
+	btnLoad.click().disconnect(this, &GameOptionsDialog::onLoad);
+	btnReturn.click().disconnect(this, &GameOptionsDialog::onReturn);
+	btnClose.click().disconnect(this, &GameOptionsDialog::onClose);
 }
 
 
@@ -58,22 +58,22 @@ void GameOptionsDialog::update()
 	Window::update();
 }
 
-void GameOptionsDialog::btnSaveClicked()
+void GameOptionsDialog::onSave()
 {
 	mCallbackSave();
 }
 
-void GameOptionsDialog::btnLoadClicked()
+void GameOptionsDialog::onLoad()
 {
 	mCallbackLoad();
 }
 
-void GameOptionsDialog::btnReturnClicked()
+void GameOptionsDialog::onReturn()
 {
 	mCallbackReturn();
 }
 
-void GameOptionsDialog::btnCloseClicked()
+void GameOptionsDialog::onClose()
 {
 	mCallbackClose();
 }

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -20,10 +20,10 @@ public:
 	ClickCallback& returnToMainMenu() { return mCallbackClose; }
 
 private:
-	void btnLoadClicked();
-	void btnSaveClicked();
-	void btnReturnClicked();
-	void btnCloseClicked();
+	void onLoad();
+	void onSave();
+	void onReturn();
+	void onClose();
 
 	void onEnableChange() override;
 

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -19,13 +19,13 @@ GameOverDialog::GameOverDialog() :
 
 	add(btnClose, {5, 310});
 	btnClose.size({512, 25});
-	btnClose.click().connect(this, &GameOverDialog::btnCloseClicked);
+	btnClose.click().connect(this, &GameOverDialog::onClose);
 
 	anchored(true);
 }
 
 
-void GameOverDialog::btnCloseClicked()
+void GameOverDialog::onClose()
 {
 	mCallback();
 }

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -17,7 +17,7 @@ public:
 	void update() override;
 
 private:
-	void btnCloseClicked();
+	void onClose();
 
 	const NAS2D::Image& mHeader;
 

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -18,13 +18,13 @@ MajorEventAnnouncement::MajorEventAnnouncement() :
 
 	add(btnClose, {5, 310});
 	btnClose.size({512, 25});
-	btnClose.click().connect(this, &MajorEventAnnouncement::btnCloseClicked);
+	btnClose.click().connect(this, &MajorEventAnnouncement::onClose);
 
 	anchored(true);
 }
 
 
-void MajorEventAnnouncement::btnCloseClicked()
+void MajorEventAnnouncement::onClose()
 {
 	hide();
 }

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -21,7 +21,7 @@ public:
 	void update() override;
 
 private:
-	void btnCloseClicked();
+	void onClose();
 
 	const NAS2D::Image& mHeader;
 	std::string mMessage;

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -50,23 +50,23 @@ MineOperationsWindow::MineOperationsWindow() :
 	add(btnIdle, {10, 230});
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({60, 30});
-	btnIdle.click().connect(this, &MineOperationsWindow::btnIdleClicked);
+	btnIdle.click().connect(this, &MineOperationsWindow::onIdle);
 
 	add(btnExtendShaft, {72, 230});
 	btnExtendShaft.size({100, 30});
-	btnExtendShaft.click().connect(this, &MineOperationsWindow::btnExtendShaftClicked);
+	btnExtendShaft.click().connect(this, &MineOperationsWindow::onExtendShaft);
 
 	add(btnOkay, {mRect.width - 70, 230});
 	btnOkay.size({60, 30});
-	btnOkay.click().connect(this, &MineOperationsWindow::btnOkayClicked);
+	btnOkay.click().connect(this, &MineOperationsWindow::onOkay);
 
 	add(btnAssignTruck, {mRect.width - 85, 115});
 	btnAssignTruck.size({ 80, 20 });
-	btnAssignTruck.click().connect(this, &MineOperationsWindow::btnAssignTruckClicked);
+	btnAssignTruck.click().connect(this, &MineOperationsWindow::onAssignTruck);
 
 	add(btnUnassignTruck, {mRect.width - 170, 115});
 	btnUnassignTruck.size({ 80, 20 });
-	btnUnassignTruck.click().connect(this, &MineOperationsWindow::btnUnassignTruckClicked);
+	btnUnassignTruck.click().connect(this, &MineOperationsWindow::onUnassignTruck);
 
 	// ORE TOGGLE BUTTONS
 	add(chkCommonMetals, {148, 140});
@@ -107,27 +107,27 @@ void MineOperationsWindow::mineFacility(MineFacility* facility)
 }
 
 
-void MineOperationsWindow::btnOkayClicked()
+void MineOperationsWindow::onOkay()
 {
 	hide();
 }
 
 
-void MineOperationsWindow::btnExtendShaftClicked()
+void MineOperationsWindow::onExtendShaft()
 {
 	mFacility->extend();
 	btnExtendShaft.enabled(false);
 }
 
 
-void MineOperationsWindow::btnIdleClicked()
+void MineOperationsWindow::onIdle()
 {
 	mFacility->forceIdle(btnIdle.toggled());
 }
 
 
 
-void MineOperationsWindow::btnAssignTruckClicked()
+void MineOperationsWindow::onAssignTruck()
 {
 	if (mFacility->assignedTrucks() == mFacility->maxTruckCount()) { return; }
 
@@ -139,7 +139,7 @@ void MineOperationsWindow::btnAssignTruckClicked()
 }
 
 
-void MineOperationsWindow::btnUnassignTruckClicked()
+void MineOperationsWindow::onUnassignTruck()
 {
 	if (mFacility->assignedTrucks() == 1) { return; }
 

--- a/OPHD/UI/MineOperationsWindow.h
+++ b/OPHD/UI/MineOperationsWindow.h
@@ -32,12 +32,12 @@ private:
 	void chkRareMetalsClicked();
 	void chkRareMineralsClicked();
 
-	void btnOkayClicked();
-	void btnExtendShaftClicked();
-	void btnIdleClicked();
+	void onOkay();
+	void onExtendShaft();
+	void onIdle();
 
-	void btnAssignTruckClicked();
-	void btnUnassignTruckClicked();
+	void onAssignTruck();
+	void onUnassignTruck();
 
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -64,50 +64,50 @@ FactoryReport::FactoryReport() :
 	btnShowAll.size({75, 20});
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
-	btnShowAll.click().connect(this, &FactoryReport::btnShowAllClicked);
+	btnShowAll.click().connect(this, &FactoryReport::onShowAll);
 
 	add(btnShowSurface, {87, 10});
 	btnShowSurface.size({75, 20});
 	btnShowSurface.type(Button::Type::BUTTON_TOGGLE);
-	btnShowSurface.click().connect(this, &FactoryReport::btnShowSurfaceClicked);
+	btnShowSurface.click().connect(this, &FactoryReport::onShowSurface);
 
 	add(btnShowUnderground, {164, 10});
 	btnShowUnderground.size({75, 20});
 	btnShowUnderground.type(Button::Type::BUTTON_TOGGLE);
-	btnShowUnderground.click().connect(this, &FactoryReport::btnShowUndergroundClicked);
+	btnShowUnderground.click().connect(this, &FactoryReport::onShowUnderground);
 
 	add(btnShowActive, {10, 33});
 	btnShowActive.size({75, 20});
 	btnShowActive.type(Button::Type::BUTTON_TOGGLE);
-	btnShowActive.click().connect(this, &FactoryReport::btnShowActiveClicked);
+	btnShowActive.click().connect(this, &FactoryReport::onShowActive);
 
 	add(btnShowIdle, {87, 33});
 	btnShowIdle.size({75, 20});
 	btnShowIdle.type(Button::Type::BUTTON_TOGGLE);
-	btnShowIdle.click().connect(this, &FactoryReport::btnShowIdleClicked);
+	btnShowIdle.click().connect(this, &FactoryReport::onShowIdle);
 
 	add(btnShowDisabled, {164, 33});
 	btnShowDisabled.size({75, 20});
 	btnShowDisabled.type(Button::Type::BUTTON_TOGGLE);
-	btnShowDisabled.click().connect(this, &FactoryReport::btnShowDisabledClicked);
+	btnShowDisabled.click().connect(this, &FactoryReport::onShowDisabled);
 
 	int position_x = Utility<Renderer>::get().size().x - 110;
 	add(btnIdle, {position_x, 35});
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({140, 30});
-	btnIdle.click().connect(this, &FactoryReport::btnIdleClicked);
+	btnIdle.click().connect(this, &FactoryReport::onIdle);
 
 	add(btnClearProduction, {position_x, 75});
 	btnClearProduction.size({140, 30});
-	btnClearProduction.click().connect(this, &FactoryReport::btnClearProductionClicked);
+	btnClearProduction.click().connect(this, &FactoryReport::onClearProduction);
 
 	add(btnTakeMeThere, {position_x, 115});
 	btnTakeMeThere.size({140, 30});
-	btnTakeMeThere.click().connect(this, &FactoryReport::btnTakeMeThereClicked);
+	btnTakeMeThere.click().connect(this, &FactoryReport::onTakeMeThere);
 
 	add(btnApply, {0, 0});
 	btnApply.size({140, 30});
-	btnApply.click().connect(this, &FactoryReport::btnApplyClicked);
+	btnApply.click().connect(this, &FactoryReport::onApply);
 
 	add(cboFilterByProduct, {250, 33});
 	cboFilterByProduct.size({200, 20});
@@ -158,7 +158,7 @@ void FactoryReport::clearSelected()
  */
 void FactoryReport::refresh()
 {
-	btnShowAllClicked();
+	onShowAll();
 }
 
 
@@ -315,7 +315,7 @@ void FactoryReport::filterButtonClicked(bool clearCbo)
 }
 
 
-void FactoryReport::btnShowAllClicked()
+void FactoryReport::onShowAll()
 {
 	filterButtonClicked(true);
 	btnShowAll.toggle(true);
@@ -324,7 +324,7 @@ void FactoryReport::btnShowAllClicked()
 }
 
 
-void FactoryReport::btnShowSurfaceClicked()
+void FactoryReport::onShowSurface()
 {
 	filterButtonClicked(true);
 	btnShowSurface.toggle(true);
@@ -332,7 +332,7 @@ void FactoryReport::btnShowSurfaceClicked()
 }
 
 
-void FactoryReport::btnShowUndergroundClicked()
+void FactoryReport::onShowUnderground()
 {
 	filterButtonClicked(true);
 	btnShowUnderground.toggle(true);
@@ -340,7 +340,7 @@ void FactoryReport::btnShowUndergroundClicked()
 }
 
 
-void FactoryReport::btnShowActiveClicked()
+void FactoryReport::onShowActive()
 {
 	filterButtonClicked(true);
 	btnShowActive.toggle(true);
@@ -348,7 +348,7 @@ void FactoryReport::btnShowActiveClicked()
 }
 
 
-void FactoryReport::btnShowIdleClicked()
+void FactoryReport::onShowIdle()
 {
 	filterButtonClicked(true);
 	btnShowIdle.toggle(true);
@@ -356,7 +356,7 @@ void FactoryReport::btnShowIdleClicked()
 }
 
 
-void FactoryReport::btnShowDisabledClicked()
+void FactoryReport::onShowDisabled()
 {
 	filterButtonClicked(true);
 	btnShowDisabled.toggle(true);
@@ -364,13 +364,13 @@ void FactoryReport::btnShowDisabledClicked()
 }
 
 
-void FactoryReport::btnIdleClicked()
+void FactoryReport::onIdle()
 {
 	selectedFactory->forceIdle(btnIdle.toggled());
 }
 
 
-void FactoryReport::btnClearProductionClicked()
+void FactoryReport::onClearProduction()
 {
 	selectedFactory->productType(ProductType::PRODUCT_NONE);
 	lstProducts.clearSelected();
@@ -378,13 +378,13 @@ void FactoryReport::btnClearProductionClicked()
 }
 
 
-void FactoryReport::btnTakeMeThereClicked()
+void FactoryReport::onTakeMeThere()
 {
 	takeMeThereCallback()(selectedFactory);
 }
 
 
-void FactoryReport::btnApplyClicked()
+void FactoryReport::onApply()
 {
 	selectedFactory->productType(selectedProductType);
 	cboFilterByProductSelectionChanged();

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -281,7 +281,7 @@ void FactoryReport::onResize()
 	btnApply.position({position_x, mRect.height + 8});
 
 	lstProducts.size({detailPanelRect.width / 3, detailPanelRect.height - 219});
-	lstProducts.selectionChanged().connect(this, &FactoryReport::lstProductsSelectionChanged);
+	lstProducts.selectionChanged().connect(this, &FactoryReport::onProductSelectionChange);
 
 	txtProductDescription.position(lstProducts.rect().crossXPoint() + NAS2D::Vector{158, 0});
 	txtProductDescription.width(mRect.width - txtProductDescription.positionX() - 30);
@@ -428,7 +428,7 @@ void FactoryReport::onListSelectionChange()
 }
 
 
-void FactoryReport::lstProductsSelectionChanged()
+void FactoryReport::onProductSelectionChange()
 {
 	selectedProductType = static_cast<ProductType>(lstProducts.isItemSelected() ? lstProducts.selected().tag : 0);
 }

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -58,7 +58,7 @@ FactoryReport::FactoryReport() :
 	btnApply{"Apply"}
 {
 	add(lstFactoryList, {10, 63});
-	lstFactoryList.selectionChanged().connect(this, &FactoryReport::lstFactoryListSelectionChanged);
+	lstFactoryList.selectionChanged().connect(this, &FactoryReport::onListSelectionChange);
 
 	add(btnShowAll, {10, 10});
 	btnShowAll.size({75, 20});
@@ -391,7 +391,7 @@ void FactoryReport::onApply()
 }
 
 
-void FactoryReport::lstFactoryListSelectionChanged()
+void FactoryReport::onListSelectionChange()
 {
 	selectedFactory = lstFactoryList.selectedFactory();
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -122,7 +122,7 @@ FactoryReport::FactoryReport() :
 	cboFilterByProduct.addItem(constants::ROBOMINER, ProductType::PRODUCT_MINER);
 	cboFilterByProduct.addItem(constants::TRUCK, ProductType::PRODUCT_TRUCK);
 
-	cboFilterByProduct.selectionChanged().connect(this, &FactoryReport::cboFilterByProductSelectionChanged);
+	cboFilterByProduct.selectionChanged().connect(this, &FactoryReport::onProductFilterSelectionChange);
 
 	add(lstProducts, {cboFilterByProduct.rect().x + cboFilterByProduct.rect().width + 20, mRect.y + 230});
 
@@ -374,7 +374,7 @@ void FactoryReport::onClearProduction()
 {
 	selectedFactory->productType(ProductType::PRODUCT_NONE);
 	lstProducts.clearSelected();
-	cboFilterByProductSelectionChanged();
+	onProductFilterSelectionChange();
 }
 
 
@@ -387,7 +387,7 @@ void FactoryReport::onTakeMeThere()
 void FactoryReport::onApply()
 {
 	selectedFactory->productType(selectedProductType);
-	cboFilterByProductSelectionChanged();
+	onProductFilterSelectionChange();
 }
 
 
@@ -434,7 +434,7 @@ void FactoryReport::lstProductsSelectionChanged()
 }
 
 
-void FactoryReport::cboFilterByProductSelectionChanged()
+void FactoryReport::onProductFilterSelectionChange()
 {
 	if (!cboFilterByProduct.isItemSelected()) { return; }
 	filterButtonClicked(false);

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -54,7 +54,7 @@ private:
 
 	void onListSelectionChange();
 	void lstProductsSelectionChanged();
-	void cboFilterByProductSelectionChanged();
+	void onProductFilterSelectionChange();
 
 	void checkFactoryActionControls();
 

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -37,18 +37,18 @@ private:
 	void fillFactoryList(bool);
 	void fillFactoryList(StructureState);
 
-	void btnShowAllClicked();
-	void btnShowSurfaceClicked();
-	void btnShowUndergroundClicked();
-	void btnShowActiveClicked();
-	void btnShowIdleClicked();
-	void btnShowDisabledClicked();
+	void onShowAll();
+	void onShowSurface();
+	void onShowUnderground();
+	void onShowActive();
+	void onShowIdle();
+	void onShowDisabled();
 
-	void btnIdleClicked();
-	void btnClearProductionClicked();
-	void btnTakeMeThereClicked();
+	void onIdle();
+	void onClearProduction();
+	void onTakeMeThere();
 
-	void btnApplyClicked();
+	void onApply();
 
 	void filterButtonClicked(bool clearCbo);
 

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -53,7 +53,7 @@ private:
 	void filterButtonClicked(bool clearCbo);
 
 	void onListSelectionChange();
-	void lstProductsSelectionChanged();
+	void onProductSelectionChange();
 	void onProductFilterSelectionChange();
 
 	void checkFactoryActionControls();

--- a/OPHD/UI/Reports/FactoryReport.h
+++ b/OPHD/UI/Reports/FactoryReport.h
@@ -52,7 +52,7 @@ private:
 
 	void filterButtonClicked(bool clearCbo);
 
-	void lstFactoryListSelectionChanged();
+	void onListSelectionChange();
 	void lstProductsSelectionChanged();
 	void cboFilterByProductSelectionChanged();
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -50,27 +50,27 @@ MineReport::MineReport() :
 	btnShowAll.size({ 75, 20 });
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
-	btnShowAll.click().connect(this, &MineReport::btnShowAllClicked);
+	btnShowAll.click().connect(this, &MineReport::onShowAll);
 
 	add(btnShowActive, {87, 10});
 	btnShowActive.size({ 75, 20 });
 	btnShowActive.type(Button::Type::BUTTON_TOGGLE);
-	btnShowActive.click().connect(this, &MineReport::btnShowActiveClicked);
+	btnShowActive.click().connect(this, &MineReport::onShowActive);
 
 	add(btnShowIdle, {164, 10});
 	btnShowIdle.size({ 75, 20 });
 	btnShowIdle.type(Button::Type::BUTTON_TOGGLE);
-	btnShowIdle.click().connect(this, &MineReport::btnShowIdleClicked);
+	btnShowIdle.click().connect(this, &MineReport::onShowIdle);
 
 	add(btnShowTappedOut, {241, 10});
 	btnShowTappedOut.size({ 75, 20 });
 	btnShowTappedOut.type(Button::Type::BUTTON_TOGGLE);
-	btnShowTappedOut.click().connect(this, &MineReport::btnShowTappedOutClicked);
+	btnShowTappedOut.click().connect(this, &MineReport::onShowTappedOut);
 
 	add(btnShowDisabled, {318, 10});
 	btnShowDisabled.size({ 75, 20 });
 	btnShowDisabled.type(Button::Type::BUTTON_TOGGLE);
-	btnShowDisabled.click().connect(this, &MineReport::btnShowDisabledClicked);
+	btnShowDisabled.click().connect(this, &MineReport::onShowDisabled);
 
 	add(lstMineFacilities, {10, 40});
 	lstMineFacilities.selectionChanged().connect(this, &MineReport::lstMineFacilitySelectionChanged);
@@ -79,15 +79,15 @@ MineReport::MineReport() :
 	add(btnIdle, {0, 40});
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({ 140, 30 });
-	btnIdle.click().connect(this, &MineReport::btnIdleClicked);
+	btnIdle.click().connect(this, &MineReport::onIdle);
 
 	add(btnDigNewLevel, {0, 75});
 	btnDigNewLevel.size({ 140, 30 });
-	btnDigNewLevel.click().connect(this, &MineReport::btnDigNewLevelClicked);
+	btnDigNewLevel.click().connect(this, &MineReport::onDigNewLevel);
 
 	add(btnTakeMeThere, {0, 110});
 	btnTakeMeThere.size({ 140, 30 });
-	btnTakeMeThere.click().connect(this, &MineReport::btnTakeMeThereClicked);
+	btnTakeMeThere.click().connect(this, &MineReport::onTakeMeThere);
 
 	// Ore Management Pane
 	add(chkCommonMetals, {0, 210});
@@ -105,11 +105,11 @@ MineReport::MineReport() :
 	// Truck Management Pane
 	add(btnAddTruck, {0, 215});
 	btnAddTruck.size({ 140, 30 });
-	btnAddTruck.click().connect(this, &MineReport::btnAddTruckClicked);
+	btnAddTruck.click().connect(this, &MineReport::onAddTruck);
 
 	add(btnRemoveTruck, {0, 250});
 	btnRemoveTruck.size({ 140, 30 });
-	btnRemoveTruck.click().connect(this, &MineReport::btnRemoveTruckClicked);
+	btnRemoveTruck.click().connect(this, &MineReport::onRemoveTruck);
 
 	fillLists();
 }
@@ -130,7 +130,7 @@ void MineReport::clearSelected()
 
 void MineReport::refresh()
 {
-	btnShowAllClicked();
+	onShowAll();
 }
 
 
@@ -192,7 +192,7 @@ void MineReport::filterButtonClicked()
 }
 
 
-void MineReport::btnShowAllClicked()
+void MineReport::onShowAll()
 {
 	filterButtonClicked();
 	btnShowAll.toggle(true);
@@ -201,41 +201,41 @@ void MineReport::btnShowAllClicked()
 }
 
 
-void MineReport::btnShowActiveClicked()
+void MineReport::onShowActive()
 {
 	filterButtonClicked();
 	btnShowActive.toggle(true);
 }
 
 
-void MineReport::btnShowIdleClicked()
+void MineReport::onShowIdle()
 {
 	filterButtonClicked();
 	btnShowIdle.toggle(true);
 }
 
 
-void MineReport::btnShowTappedOutClicked()
+void MineReport::onShowTappedOut()
 {
 	filterButtonClicked();
 	btnShowTappedOut.toggle(true);
 }
 
 
-void MineReport::btnShowDisabledClicked()
+void MineReport::onShowDisabled()
 {
 	filterButtonClicked();
 	btnShowDisabled.toggle(true);
 }
 
 
-void MineReport::btnIdleClicked()
+void MineReport::onIdle()
 {
 	mSelectedFacility->forceIdle(btnIdle.toggled());
 }
 
 
-void MineReport::btnDigNewLevelClicked()
+void MineReport::onDigNewLevel()
 {
 	auto facility = static_cast<MineFacility*>(mSelectedFacility);
 	facility->extend();
@@ -245,13 +245,13 @@ void MineReport::btnDigNewLevelClicked()
 }
 
 
-void MineReport::btnTakeMeThereClicked()
+void MineReport::onTakeMeThere()
 {
 	takeMeThereCallback()(mSelectedFacility);
 }
 
 
-void MineReport::btnAddTruckClicked()
+void MineReport::onAddTruck()
 {
 	if (!mSelectedFacility) { return; }
 
@@ -267,7 +267,7 @@ void MineReport::btnAddTruckClicked()
 }
 
 
-void MineReport::btnRemoveTruckClicked()
+void MineReport::onRemoveTruck()
 {
 	auto mFacility = static_cast<MineFacility*>(mSelectedFacility);
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -73,7 +73,7 @@ MineReport::MineReport() :
 	btnShowDisabled.click().connect(this, &MineReport::onShowDisabled);
 
 	add(lstMineFacilities, {10, 40});
-	lstMineFacilities.selectionChanged().connect(this, &MineReport::lstMineFacilitySelectionChanged);
+	lstMineFacilities.selectionChanged().connect(this, &MineReport::onMineFacilitySelectionChange);
 
 	// DETAIL PANE
 	add(btnIdle, {0, 40});
@@ -334,7 +334,7 @@ void MineReport::updateManagementButtonsVisiblity()
 }
 
 
-void MineReport::lstMineFacilitySelectionChanged()
+void MineReport::onMineFacilitySelectionChange()
 {
 	mSelectedFacility = lstMineFacilities.selectedStructure();
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -91,16 +91,16 @@ MineReport::MineReport() :
 
 	// Ore Management Pane
 	add(chkCommonMetals, {0, 210});
-	chkCommonMetals.click().connect(this, &MineReport::chkCommonMetalsClicked);
+	chkCommonMetals.click().connect(this, &MineReport::onCheckBoxCommonMetalsChange);
 
 	add(chkCommonMinerals, {0, 280});
-	chkCommonMinerals.click().connect(this, &MineReport::chkCommonMineralsClicked);
+	chkCommonMinerals.click().connect(this, &MineReport::onCheckBoxCommonMineralsChange);
 
 	add(chkRareMetals, {0, 350});
-	chkRareMetals.click().connect(this, &MineReport::chkRareMetalsClicked);
+	chkRareMetals.click().connect(this, &MineReport::onCheckBoxRareMetalsChange);
 
 	add(chkRareMinerals, {0, 420});
-	chkRareMinerals.click().connect(this, &MineReport::chkRareMineralsClicked);
+	chkRareMinerals.click().connect(this, &MineReport::onCheckBoxRareMineralsChange);
 
 	// Truck Management Pane
 	add(btnAddTruck, {0, 215});
@@ -283,28 +283,28 @@ void MineReport::onRemoveTruck()
 }
 
 
-void MineReport::chkCommonMetalsClicked()
+void MineReport::onCheckBoxCommonMetalsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
 	facility->mine()->miningCommonMetals(chkCommonMetals.checked());
 }
 
 
-void MineReport::chkCommonMineralsClicked()
+void MineReport::onCheckBoxCommonMineralsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
 	facility->mine()->miningCommonMinerals(chkCommonMinerals.checked());
 }
 
 
-void MineReport::chkRareMetalsClicked()
+void MineReport::onCheckBoxRareMetalsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
 	facility->mine()->miningRareMetals(chkRareMetals.checked());
 }
 
 
-void MineReport::chkRareMineralsClicked()
+void MineReport::onCheckBoxRareMineralsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
 	facility->mine()->miningRareMinerals(chkRareMinerals.checked());

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -35,18 +35,18 @@ public:
 	void update() override;
 
 private:
-	void btnShowAllClicked();
-	void btnShowActiveClicked();
-	void btnShowIdleClicked();
-	void btnShowTappedOutClicked();
-	void btnShowDisabledClicked();
+	void onShowAll();
+	void onShowActive();
+	void onShowIdle();
+	void onShowTappedOut();
+	void onShowDisabled();
 
-	void btnIdleClicked();
-	void btnDigNewLevelClicked();
-	void btnTakeMeThereClicked();
+	void onIdle();
+	void onDigNewLevel();
+	void onTakeMeThere();
 
-	void btnAddTruckClicked();
-	void btnRemoveTruckClicked();
+	void onAddTruck();
+	void onRemoveTruck();
 
 	void chkCommonMetalsClicked();
 	void chkCommonMineralsClicked();

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -55,7 +55,7 @@ private:
 
 	void filterButtonClicked();
 
-	void lstMineFacilitySelectionChanged();
+	void onMineFacilitySelectionChange();
 
 	void updateManagementButtonsVisiblity();
 

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -48,10 +48,10 @@ private:
 	void onAddTruck();
 	void onRemoveTruck();
 
-	void chkCommonMetalsClicked();
-	void chkCommonMineralsClicked();
-	void chkRareMetalsClicked();
-	void chkRareMineralsClicked();
+	void onCheckBoxCommonMetalsChange();
+	void onCheckBoxCommonMineralsChange();
+	void onCheckBoxRareMetalsChange();
+	void onCheckBoxRareMineralsChange();
 
 	void filterButtonClicked();
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -65,7 +65,7 @@ WarehouseReport::WarehouseReport() :
 
 	add(lstProducts, {Utility<Renderer>::get().center().x + 10, mRect.y + 173});
 
-	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &WarehouseReport::doubleClicked);
+	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &WarehouseReport::onDoubleClick);
 
 	fillLists();
 }
@@ -73,7 +73,7 @@ WarehouseReport::WarehouseReport() :
 
 WarehouseReport::~WarehouseReport()
 {
-	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &WarehouseReport::doubleClicked);
+	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &WarehouseReport::onDoubleClick);
 }
 
 
@@ -218,7 +218,7 @@ void WarehouseReport::fillListDisabled()
 }
 
 
-void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int y)
+void WarehouseReport::onDoubleClick(EventHandler::MouseButton button, int x, int y)
 {
 	if (!visible()) { return; }
 	if (button != EventHandler::MouseButton::Left) { return; }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -30,35 +30,35 @@ WarehouseReport::WarehouseReport() :
 	btnShowAll.size({75, 20});
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
-	btnShowAll.click().connect(this, &WarehouseReport::btnShowAllClicked);
+	btnShowAll.click().connect(this, &WarehouseReport::onShowAll);
 
 	add(btnSpaceAvailable, {90, 10});
 	btnSpaceAvailable.size({100, 20});
 	btnSpaceAvailable.type(Button::Type::BUTTON_TOGGLE);
 	btnSpaceAvailable.toggle(false);
-	btnSpaceAvailable.click().connect(this, &WarehouseReport::btnSpaceAvailableClicked);
+	btnSpaceAvailable.click().connect(this, &WarehouseReport::onSpaceAvailable);
 
 	add(btnFull, {195, 10});
 	btnFull.size({75, 20});
 	btnFull.type(Button::Type::BUTTON_TOGGLE);
 	btnFull.toggle(false);
-	btnFull.click().connect(this, &WarehouseReport::btnFullClicked);
+	btnFull.click().connect(this, &WarehouseReport::onFull);
 
 	add(btnEmpty, {275, 10});
 	btnEmpty.size({75, 20});
 	btnEmpty.type(Button::Type::BUTTON_TOGGLE);
 	btnEmpty.toggle(false);
-	btnEmpty.click().connect(this, &WarehouseReport::btnEmptyClicked);
+	btnEmpty.click().connect(this, &WarehouseReport::onEmpty);
 
 	add(btnDisabled, {355, 10});
 	btnDisabled.size({75, 20});
 	btnDisabled.type(Button::Type::BUTTON_TOGGLE);
 	btnDisabled.toggle(false);
-	btnDisabled.click().connect(this, &WarehouseReport::btnDisabledClicked);
+	btnDisabled.click().connect(this, &WarehouseReport::onDisabled);
 
 	add(btnTakeMeThere, {10, 10});
 	btnTakeMeThere.size({140, 30});
-	btnTakeMeThere.click().connect(this, &WarehouseReport::btnTakeMeThereClicked);
+	btnTakeMeThere.click().connect(this, &WarehouseReport::onTakeMeThere);
 
 	add(lstStructures, {10, mRect.y + 115});
 	lstStructures.selectionChanged().connect(this, &WarehouseReport::lstStructuresSelectionChanged);
@@ -239,7 +239,7 @@ void WarehouseReport::clearSelected()
 
 void WarehouseReport::refresh()
 {
-	btnShowAllClicked();
+	onShowAll();
 }
 
 
@@ -272,7 +272,7 @@ void WarehouseReport::filterButtonClicked()
 }
 
 
-void WarehouseReport::btnShowAllClicked()
+void WarehouseReport::onShowAll()
 {
 	filterButtonClicked();
 	btnShowAll.toggle(true);
@@ -281,7 +281,7 @@ void WarehouseReport::btnShowAllClicked()
 }
 
 
-void WarehouseReport::btnSpaceAvailableClicked()
+void WarehouseReport::onSpaceAvailable()
 {
 	filterButtonClicked();
 	btnSpaceAvailable.toggle(true);
@@ -290,7 +290,7 @@ void WarehouseReport::btnSpaceAvailableClicked()
 }
 
 
-void WarehouseReport::btnFullClicked()
+void WarehouseReport::onFull()
 {
 	filterButtonClicked();
 	btnFull.toggle(true);
@@ -299,7 +299,7 @@ void WarehouseReport::btnFullClicked()
 }
 
 
-void WarehouseReport::btnEmptyClicked()
+void WarehouseReport::onEmpty()
 {
 	filterButtonClicked();
 	btnEmpty.toggle(true);
@@ -308,7 +308,7 @@ void WarehouseReport::btnEmptyClicked()
 }
 
 
-void WarehouseReport::btnDisabledClicked()
+void WarehouseReport::onDisabled()
 {
 	filterButtonClicked();
 	btnDisabled.toggle(true);
@@ -317,7 +317,7 @@ void WarehouseReport::btnDisabledClicked()
 }
 
 
-void WarehouseReport::btnTakeMeThereClicked()
+void WarehouseReport::onTakeMeThere()
 {
 	takeMeThereCallback()(selectedWarehouse);
 }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -61,7 +61,7 @@ WarehouseReport::WarehouseReport() :
 	btnTakeMeThere.click().connect(this, &WarehouseReport::onTakeMeThere);
 
 	add(lstStructures, {10, mRect.y + 115});
-	lstStructures.selectionChanged().connect(this, &WarehouseReport::lstStructuresSelectionChanged);
+	lstStructures.selectionChanged().connect(this, &WarehouseReport::onStructureSelectionChange);
 
 	add(lstProducts, {Utility<Renderer>::get().center().x + 10, mRect.y + 173});
 
@@ -323,7 +323,7 @@ void WarehouseReport::onTakeMeThere()
 }
 
 
-void WarehouseReport::lstStructuresSelectionChanged()
+void WarehouseReport::onStructureSelectionChange()
 {
 	selectedWarehouse = static_cast<Warehouse*>(lstStructures.selectedStructure());
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -40,13 +40,13 @@ private:
 
 	void onResize() override;
 
-	void btnShowAllClicked();
-	void btnSpaceAvailableClicked();
-	void btnFullClicked();
-	void btnEmptyClicked();
-	void btnDisabledClicked();
+	void onShowAll();
+	void onSpaceAvailable();
+	void onFull();
+	void onEmpty();
+	void onDisabled();
 
-	void btnTakeMeThereClicked();
+	void onTakeMeThere();
 
 	void fillListSpaceAvailable();
 	void fillListFull();

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -53,7 +53,7 @@ private:
 	void fillListEmpty();
 	void fillListDisabled();
 
-	void doubleClicked(NAS2D::EventHandler::MouseButton, int, int);
+	void onDoubleClick(NAS2D::EventHandler::MouseButton, int, int);
 
 	void onStructureSelectionChange();
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -55,7 +55,7 @@ private:
 
 	void doubleClicked(NAS2D::EventHandler::MouseButton, int, int);
 
-	void lstStructuresSelectionChanged();
+	void onStructureSelectionChange();
 
 	void filterButtonClicked();
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -71,9 +71,9 @@ void RobotInspector::init()
 
 	size({ size().x, buttonPosition.y + buttonHeight + constants::MARGIN });
 
-	btnCancelOrders.click().connect(this, &RobotInspector::btnCancelOrdersClicked);
-	btnSelfDestruct.click().connect(this, &RobotInspector::btnSelfDestructClicked);
-	btnCancel.click().connect(this, &RobotInspector::btnCancelClicked);
+	btnCancelOrders.click().connect(this, &RobotInspector::onCancelOrders);
+	btnSelfDestruct.click().connect(this, &RobotInspector::onSelfDestruct);
+	btnCancel.click().connect(this, &RobotInspector::onCancel);
 }
 
 
@@ -86,21 +86,21 @@ void RobotInspector::focusOnRobot(Robot* robot)
 }
 
 
-void RobotInspector::btnCancelOrdersClicked()
+void RobotInspector::onCancelOrders()
 {
 	mRobot->cancelTask();
 	hide();
 }
 
 
-void RobotInspector::btnSelfDestructClicked()
+void RobotInspector::onSelfDestruct()
 {
 	mRobot->seldDestruct(true);
 	hide();
 }
 
 
-void RobotInspector::btnCancelClicked()
+void RobotInspector::onCancel()
 {
 	hide();
 }

--- a/OPHD/UI/RobotInspector.h
+++ b/OPHD/UI/RobotInspector.h
@@ -26,9 +26,9 @@ public:
 private:
 	void init();
 
-	void btnCancelOrdersClicked();
-	void btnSelfDestructClicked();
-	void btnCancelClicked();
+	void onCancelOrders();
+	void onSelfDestruct();
+	void onCancel();
 
 private:
 	Button btnCancelOrders;

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -23,7 +23,7 @@ StructureInspector::StructureInspector() :
 
 	add(btnClose, { 295, 195 });
 	btnClose.size({ 50, 20 });
-	btnClose.click().connect(this, &StructureInspector::btnCloseClicked);
+	btnClose.click().connect(this, &StructureInspector::onClose);
 }
 
 
@@ -42,7 +42,7 @@ void StructureInspector::structure(Structure* structure)
 }
 
 
-void StructureInspector::btnCloseClicked()
+void StructureInspector::onClose()
 {
 	visible(false);
 }

--- a/OPHD/UI/StructureInspector.h
+++ b/OPHD/UI/StructureInspector.h
@@ -23,7 +23,7 @@ public:
 	void update() override;
 
 private:
-	void btnCloseClicked();
+	void onClose();
 	std::string getDisabledReason() const;
 	void drawStructureSpecificTable(NAS2D::Point<int> position, NAS2D::Renderer& renderer);
 	std::string formatAge() const;

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -19,7 +19,7 @@ TileInspector::TileInspector() :
 
 	add(btnClose, {145, 63});
 	btnClose.size({50, 20});
-	btnClose.click().connect(this, &TileInspector::btnCloseClicked);
+	btnClose.click().connect(this, &TileInspector::onClose);
 }
 
 
@@ -61,7 +61,7 @@ void TileInspector::update()
 }
 
 
-void TileInspector::btnCloseClicked()
+void TileInspector::onClose()
 {
 	visible(false);
 }

--- a/OPHD/UI/TileInspector.h
+++ b/OPHD/UI/TileInspector.h
@@ -17,7 +17,7 @@ public:
 	void update() override;
 
 private:
-	void btnCloseClicked();
+	void onClose();
 
 	Button btnClose;
 	Tile* mTile = nullptr;

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -17,7 +17,7 @@ WarehouseInspector::WarehouseInspector() :
 
 	add(btnClose, {105, 325});
 	btnClose.size({40, 20});
-	btnClose.click().connect(this, &WarehouseInspector::btnCloseClicked);
+	btnClose.click().connect(this, &WarehouseInspector::onClose);
 }
 
 
@@ -27,7 +27,7 @@ void WarehouseInspector::warehouse(Warehouse* w)
 }
 
 
-void WarehouseInspector::btnCloseClicked()
+void WarehouseInspector::onClose()
 {
 	hide();
 }

--- a/OPHD/UI/WarehouseInspector.h
+++ b/OPHD/UI/WarehouseInspector.h
@@ -21,7 +21,7 @@ public:
 	void update() override;
 
 private:
-	void btnCloseClicked();
+	void onClose();
 
 	Warehouse* mWarehouse = nullptr;
 	Button btnClose;


### PR DESCRIPTION
Rename `Report` events to match convention suggested in #855.
