### PR TITLE
Remove dead code

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -232,12 +232,6 @@ void MainMenuState::wasDifficultyOkClicked()
 }
 
 
-void MainMenuState::newGameCancelled()
-{
-	enableButtons();
-}
-
-
 /**
  * Click handler for Continue button.
  */

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -218,7 +218,6 @@ void MainMenuState::onNewGame()
 
 	disableButtons();
 
-	//dlgNewGame.show();
 	wasDifficultyOkClicked();
 }
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -218,12 +218,6 @@ void MainMenuState::onNewGame()
 
 	disableButtons();
 
-	wasDifficultyOkClicked();
-}
-
-
-void MainMenuState::wasDifficultyOkClicked()
-{
 	mReturnState = new PlanetSelectState();
 
 	Utility<Renderer>::get().fadeOut(static_cast<float>(constants::FADE_SPEED));

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -38,7 +38,6 @@ private:
 	void onQuit();
 
 	void wasDifficultyOkClicked();
-	void newGameCancelled();
 
 	void onFileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -37,8 +37,6 @@ private:
 	void onHelp();
 	void onQuit();
 
-	void wasDifficultyOkClicked();
-
 	void onFileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
 private:


### PR DESCRIPTION
Noticed this while working on #864.

Remove a couple of obsolete event handler methods. One unused, and another that should probably be merged with an existing event handler. The existing event handler appears to have been split for a UI change which was later undone (#187 which added a difficulty select screen). We should probably undo the function split as well, since it doesn't make much sense without the corresponding UI change.
