### PR TITLE
Use SignalSource

### DIFF
--- a/OPHD/States/MainReportsUiState.h
+++ b/OPHD/States/MainReportsUiState.h
@@ -27,7 +27,7 @@ public:
 
 	void clearLists();
 
-	ReportsUiCallback& hideReports() { return mReportsUiCallback; }
+	ReportsUiCallback::Source& hideReports() { return mReportsUiCallback; }
 	TakeMeThereList takeMeThere();
 
 protected:

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -82,9 +82,9 @@ public:
 
 	void setPopulationLevel(PopulationLevel popLevel);
 
-	ReportsUiCallback& showReporstUi() { return mReportsUiCallback; }
-	QuitCallback& quit() { return mQuitCallback; }
-	MapChangedCallback& mapChanged() { return mMapChangedCallback; }
+	ReportsUiCallback::Source& showReporstUi() { return mReportsUiCallback; }
+	QuitCallback::Source& quit() { return mQuitCallback; }
+	MapChangedCallback::Source& mapChanged() { return mMapChangedCallback; }
 
 	void focusOnStructure(Structure* s);
 

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -65,8 +65,8 @@ public:
 
 	bool mouseHovering() const { return mMouseInArea; }
 
-	MouseCallback& mouseEnter() { return mMouseEnterCallback; }
-	MouseCallback& mouseExit() { return mMouseExitCallback; }
+	MouseCallback::Source& mouseEnter() { return mMouseEnterCallback; }
+	MouseCallback::Source& mouseExit() { return mMouseExitCallback; }
 
 	void update();
 

--- a/OPHD/Things/Robots/Robot.h
+++ b/OPHD/Things/Robots/Robot.h
@@ -37,7 +37,7 @@ public:
 
 	Type type() const { return mType; }
 
-	TaskCallback& taskComplete() { return mTaskCompleteCallback; }
+	TaskCallback::Source& taskComplete() { return mTaskCompleteCallback; }
 
 	void id(int newId) { mId = newId; }
 	int id() const { return mId; }

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -26,7 +26,7 @@ public:
 		enable();
 	}
 
-	Callback& deployCallback() { return mDeploy; }
+	Callback::Source& deployCallback() { return mDeploy; }
 
 protected:
 	void think() override

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -27,7 +27,7 @@ public:
 		enable();
 	}
 
-	Callback& deployCallback() { return mDeploy; }
+	Callback::Source& deployCallback() { return mDeploy; }
 
 protected:
 	void think() override

--- a/OPHD/Things/Structures/Factory.h
+++ b/OPHD/Things/Structures/Factory.h
@@ -54,7 +54,7 @@ public:
 
 	virtual void initFactory() = 0;
 
-	ProductionCallback& productionComplete() { return mProductionComplete; }
+	ProductionCallback::Source& productionComplete() { return mProductionComplete; }
 
 protected:
 	void clearProduction();

--- a/OPHD/Things/Structures/MineFacility.h
+++ b/OPHD/Things/Structures/MineFacility.h
@@ -34,7 +34,7 @@ public:
 	 */
 	Mine* mine() { return mMine; }
 
-	ExtensionCompleteCallback& extensionComplete() { return mExtensionComplete; }
+	ExtensionCompleteCallback::Source& extensionComplete() { return mExtensionComplete; }
 
 protected:
 	void think() override;

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -33,7 +33,7 @@ public:
 		mPosition = position;
 	}
 
-	Callback& deployCallback() { return mDeploy; }
+	Callback::Source& deployCallback() { return mDeploy; }
 
 protected:
 	void think() override

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -46,7 +46,7 @@ public:
 	virtual void die() { mIsDead = true; mDieCallback(this); }
 	bool dead() const { return mIsDead; }
 
-	DieCallback& onDie() { return mDieCallback; }
+	DieCallback::Source& onDie() { return mDieCallback; }
 
 private:
 	// No default copy constructor, or copy operator

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -35,7 +35,7 @@ public:
 	void image(const std::string& path);
 	bool hasImage() const;
 
-	ClickCallback& click() { return mCallback; }
+	ClickCallback::Source& click() { return mCallback; }
 
 	void update() override;
 

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -60,7 +60,7 @@ bool CheckBox::checked() const
 }
 
 
-CheckBox::ClickCallback& CheckBox::click()
+CheckBox::ClickCallback::Source& CheckBox::click()
 {
 	return mCallback;
 }

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -20,7 +20,7 @@ public:
 	void checked(bool toggle);
 	bool checked() const;
 
-	ClickCallback& click();
+	ClickCallback::Source& click();
 
 	void update() override;
 

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -26,7 +26,7 @@ public:
 
 	void clearSelected();
 
-	SelectionChangeCallback& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeCallback::Source& selectionChanged() { return mSelectionChanged; }
 
 	const std::string& selectionText() const;
 	int selectionTag() const;

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -38,7 +38,7 @@ int Control::positionY()
 /**
  * Callback fired whenever the Control's position changes.
  */
-Control::OnMoveCallback& Control::moved()
+Control::OnMoveCallback::Source& Control::moved()
 {
 	return mOnMoveSignal;
 }
@@ -83,7 +83,7 @@ void Control::height(int h)
 }
 
 
-Control::ResizeCallback& Control::resized()
+Control::ResizeCallback::Source& Control::resized()
 {
 	return mOnResizeSignal;
 }

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -28,7 +28,7 @@ public:
 	int positionX();
 	int positionY();
 
-	OnMoveCallback& moved();
+	OnMoveCallback::Source& moved();
 
 	void highlight(bool highlight);
 	bool highlight() const;
@@ -54,7 +54,7 @@ public:
 	void width(int w);
 	void height(int h);
 
-	ResizeCallback& resized();
+	ResizeCallback::Source& resized();
 
 	virtual void update() {}
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -186,7 +186,7 @@ public:
 		mSlider.update();
 	}
 
-	SelectionChangeCallback& selectionChanged() {
+	SelectionChangeCallback::Source& selectionChanged() {
 		return mSelectionChanged;
 	}
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -59,7 +59,7 @@ public:
 
 	std::size_t currentHighlight() const;
 
-	SelectionChangeCallback& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeCallback::Source& selectionChanged() { return mSelectionChanged; }
 
 	void update() override = 0;
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -60,7 +60,7 @@ const std::string& RadioButton::text() const
 	return mLabel.text();
 }
 
-RadioButton::ClickCallback& RadioButton::click()
+RadioButton::ClickCallback::Source& RadioButton::click()
 {
 	for (auto* sibling : mParentContainer->controls())
 	{

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -27,7 +27,7 @@ public:
 	void text(const std::string& text);
 	const std::string& text() const;
 
-	ClickCallback& click();
+	ClickCallback::Source& click();
 
 	void update() override;
 

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -61,7 +61,7 @@ public:
 
 	void update() override; /*!< Called to display the slider. */
 
-	ValueChangeCallback& change() { return mCallback; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
+	ValueChangeCallback::Source& change() { return mCallback; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y); /*!< Event raised on mouse button down. */

--- a/OPHD/UI/Core/TextControl.h
+++ b/OPHD/UI/Core/TextControl.h
@@ -20,7 +20,7 @@ public:
 
 	void text(const std::string& text);
 	const std::string& text() const { return mText; }
-	TextChangeCallback& textChanged() { return mTextChanged; }
+	TextChangeCallback::Source& textChanged() { return mTextChanged; }
 
 	virtual void onTextChange() { mTextChanged(this); }
 

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -24,7 +24,7 @@ public:
 
 	void title(const std::string& title);
 	const std::string& title() const { return mTitle; }
-	TitleChangeCallback& titleChanged() { return mTitleChanged; }
+	TitleChangeCallback::Source& titleChanged() { return mTitleChanged; }
 
 	virtual void onTitleChanged() { mTitleChanged(this); }
 

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -17,7 +17,7 @@ public:
 
 	void update() override;
 
-	Callback& directionSelected() { return mCallback; }
+	Callback::Source& directionSelected() { return mCallback; }
 
 	void setParameters(Tile* tile);
 

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -26,7 +26,7 @@ public:
 	void setMode(FileOperation fileOp);
 	void scanDirectory(const std::string& directory);
 
-	FileOperationCallback& fileOperation() { return mCallback; }
+	FileOperationCallback::Source& fileOperation() { return mCallback; }
 
 	void update() override;
 

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -14,10 +14,10 @@ public:
 
 	void update() override;
 
-	ClickCallback& SaveGame() { return mCallbackSave; }
-	ClickCallback& LoadGame() { return mCallbackLoad; }
-	ClickCallback& returnToGame() { return mCallbackReturn; }
-	ClickCallback& returnToMainMenu() { return mCallbackClose; }
+	ClickCallback::Source& SaveGame() { return mCallbackSave; }
+	ClickCallback::Source& LoadGame() { return mCallbackLoad; }
+	ClickCallback::Source& returnToGame() { return mCallbackReturn; }
+	ClickCallback::Source& returnToMainMenu() { return mCallbackClose; }
 
 private:
 	void onLoad();

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -12,7 +12,7 @@ public:
 public:
 	GameOverDialog();
 
-	ClickCallback& returnToMainMenu() { return mCallback; }
+	ClickCallback::Source& returnToMainMenu() { return mCallback; }
 
 	void update() override;
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -79,7 +79,7 @@ public:
 	void incrementSelection();
 	void decrementSelection();
 
-	Callback& selectionChanged() { return mCallback; }
+	Callback::Source& selectionChanged() { return mCallback; }
 
 	void hide() override;
 


### PR DESCRIPTION
Closes #853.

Updates `Signal` accessor methods to instead return a reference to `SignalSource`. This protects the original `Signal` object from misbehaved clients that may want to call `emit`.
