### PR TITLE
Rename Callback to Signal

### DIFF
--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -276,7 +276,7 @@ void MainReportsUiState::exit()
 		if (panel.UiPanel) { panel.UiPanel->clearSelected(); }
 	}
 
-	mReportsUiCallback();
+	mReportsUiSignal();
 }
 
 
@@ -360,7 +360,7 @@ MainReportsUiState::TakeMeThereList MainReportsUiState::takeMeThere()
 	TakeMeThereList takeMeThereList;
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel) { takeMeThereList.push_back(&panel.UiPanel->takeMeThereCallback()); }
+		if (panel.UiPanel) { takeMeThereList.push_back(&panel.UiPanel->takeMeThereSignal()); }
 	}
 	return takeMeThereList;
 }

--- a/OPHD/States/MainReportsUiState.h
+++ b/OPHD/States/MainReportsUiState.h
@@ -13,7 +13,7 @@ class Structure;
 class MainReportsUiState : public Wrapper
 {
 public:
-	using ReportsUiCallback = NAS2D::Signal<>;
+	using ReportsUiSignal = NAS2D::Signal<>;
 	using TakeMeThere = NAS2D::Signal<Structure*>;
 	using TakeMeThereList = std::vector<TakeMeThere*>;
 
@@ -27,7 +27,7 @@ public:
 
 	void clearLists();
 
-	ReportsUiCallback::Source& hideReports() { return mReportsUiCallback; }
+	ReportsUiSignal::Source& hideReports() { return mReportsUiSignal; }
 	TakeMeThereList takeMeThere();
 
 protected:
@@ -48,5 +48,5 @@ private:
 	void exit();
 
 private:
-	ReportsUiCallback mReportsUiCallback;
+	ReportsUiSignal mReportsUiSignal;
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -357,7 +357,7 @@ void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifie
 
 	if (key == EventHandler::KeyCode::KEY_F1)
 	{
-		mReportsUiCallback();
+		mReportsUiSignal();
 		return;
 	}
 
@@ -645,7 +645,7 @@ void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int /*x*
 			else if (structure->isMineFacility() || structure->structureClass() == Structure::StructureClass::Smelter) { mMainReportsState.selectMinePanel(structure); }
 			else { return; } // avoids showing the full-screen UI on unhandled structures.
 
-			mReportsUiCallback();
+			mReportsUiSignal();
 		}
 	}
 }
@@ -1165,7 +1165,7 @@ void MapViewState::placeStructure()
 		if (!validLanderSite(*tile)) { return; }
 
 		ColonistLander* s = new ColonistLander(tile);
-		s->deployCallback().connect(this, &MapViewState::onDeployColonistLander);
+		s->deploySignal().connect(this, &MapViewState::onDeployColonistLander);
 		Utility<StructureManager>::get().addStructure(s, tile);
 
 		--mLandersColonist;
@@ -1181,7 +1181,7 @@ void MapViewState::placeStructure()
 		if (!validLanderSite(*tile)) { return; }
 
 		CargoLander* _lander = new CargoLander(tile);
-		_lander->deployCallback().connect(this, &MapViewState::onDeployCargoLander);
+		_lander->deploySignal().connect(this, &MapViewState::onDeployCargoLander);
 		Utility<StructureManager>::get().addStructure(_lander, tile);
 
 		--mLandersCargo;
@@ -1243,7 +1243,7 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 		}
 
 		SeedLander* s = new SeedLander(point);
-		s->deployCallback().connect(this, &MapViewState::onDeploySeedLander);
+		s->deploySignal().connect(this, &MapViewState::onDeploySeedLander);
 		Utility<StructureManager>::get().addStructure(s, &mTileMap->getTile(point)); // Can only ever be placed on depth level 0
 
 		clearMode();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -71,9 +71,9 @@ public:
 	};
 
 public:
-	using QuitCallback = NAS2D::Signal<>;
-	using ReportsUiCallback = NAS2D::Signal<>;
-	using MapChangedCallback = NAS2D::Signal<>;
+	using QuitSignal = NAS2D::Signal<>;
+	using ReportsUiSignal = NAS2D::Signal<>;
+	using MapChangedSignal = NAS2D::Signal<>;
 
 public:
 	MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame);
@@ -82,9 +82,9 @@ public:
 
 	void setPopulationLevel(PopulationLevel popLevel);
 
-	ReportsUiCallback::Source& showReporstUi() { return mReportsUiCallback; }
-	QuitCallback::Source& quit() { return mQuitCallback; }
-	MapChangedCallback::Source& mapChanged() { return mMapChangedCallback; }
+	ReportsUiSignal::Source& showReporstUi() { return mReportsUiSignal; }
+	QuitSignal::Source& quit() { return mQuitSignal; }
+	MapChangedSignal::Source& mapChanged() { return mMapChangedSignal; }
 
 	void focusOnStructure(Structure* s);
 
@@ -305,9 +305,9 @@ private:
 	NAS2D::Rectangle<int> mBottomUiRect;
 
 	// SIGNALS
-	QuitCallback mQuitCallback;
-	ReportsUiCallback mReportsUiCallback;
-	MapChangedCallback mMapChangedCallback;
+	QuitSignal mQuitSignal;
+	ReportsUiSignal mReportsUiSignal;
+	MapChangedSignal mMapChangedSignal;
 
 	// ROUTING
 	micropather::MicroPather* mPathSolver = nullptr;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -235,7 +235,7 @@ void MapViewState::load(const std::string& filePath)
 			SeedLander* s = dynamic_cast<SeedLander*>(list[0]);
 			if (!s) { throw std::runtime_error("MapViewState::load(): Structure in list is not a SeedLander."); }
 
-			s->deployCallback().connect(this, &MapViewState::onDeploySeedLander);
+			s->deploySignal().connect(this, &MapViewState::onDeploySeedLander);
 
 			mStructures.clear();
 			mConnections.clear();
@@ -251,7 +251,7 @@ void MapViewState::load(const std::string& filePath)
 
 	checkCommRangeOverlay();
 
-	mMapChangedCallback();
+	mMapChangedSignal();
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -609,7 +609,7 @@ void MapViewState::onReturnToGame()
 void MapViewState::onGameOver()
 {
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(static_cast<float>(constants::FADE_SPEED));
-	mQuitCallback();
+	mQuitSignal();
 }
 
 

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -50,7 +50,7 @@ void Planet::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
 	if (inArea != mMouseInArea)
 	{
 		mMouseInArea = inArea;
-		mMouseInArea ? mMouseEnterCallback() : mMouseExitCallback();
+		mMouseInArea ? mMouseEnterSignal() : mMouseExitSignal();
 		mTimer.reset();
 	}
 }

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -51,7 +51,7 @@ public:
 	};
 
 public:
-	using MouseCallback = NAS2D::Signal<>;
+	using MouseSignal = NAS2D::Signal<>;
 
 public:
 	Planet(const Attributes& attributes);
@@ -65,8 +65,8 @@ public:
 
 	bool mouseHovering() const { return mMouseInArea; }
 
-	MouseCallback::Source& mouseEnter() { return mMouseEnterCallback; }
-	MouseCallback::Source& mouseExit() { return mMouseExitCallback; }
+	MouseSignal::Source& mouseEnter() { return mMouseEnterSignal; }
+	MouseSignal::Source& mouseExit() { return mMouseExitSignal; }
 
 	void update();
 
@@ -87,8 +87,8 @@ private:
 	const NAS2D::Image mImage;
 	NAS2D::Point<int> mPosition;
 
-	MouseCallback mMouseEnterCallback;
-	MouseCallback mMouseExitCallback;
+	MouseSignal mMouseEnterSignal;
+	MouseSignal mMouseExitSignal;
 
 	bool mMouseInArea = false;
 

--- a/OPHD/Things/Robots/Robot.cpp
+++ b/OPHD/Things/Robots/Robot.cpp
@@ -36,7 +36,7 @@ void Robot::updateTask()
 
 	if (mTurnsToCompleteTask == 0)
 	{
-		mTaskCompleteCallback(this);
+		mTaskCompleteSignal(this);
 	}
 
 	mFuelCellAge++;

--- a/OPHD/Things/Robots/Robot.h
+++ b/OPHD/Things/Robots/Robot.h
@@ -15,7 +15,7 @@ public:
 		None
 	};
 
-	using TaskCallback = NAS2D::Signal<Robot*>;
+	using TaskSignal = NAS2D::Signal<Robot*>;
 
 public:
 	Robot(const std::string&, const std::string&, Type);
@@ -37,7 +37,7 @@ public:
 
 	Type type() const { return mType; }
 
-	TaskCallback::Source& taskComplete() { return mTaskCompleteCallback; }
+	TaskSignal::Source& taskComplete() { return mTaskCompleteSignal; }
 
 	void id(int newId) { mId = newId; }
 	int id() const { return mId; }
@@ -56,5 +56,5 @@ private:
 
 	Type mType{ Type::None };
 
-	TaskCallback mTaskCompleteCallback;
+	TaskSignal mTaskCompleteSignal;
 };

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -9,7 +9,7 @@ class CargoLander : public Structure
 {
 public:
 
-	using Callback = NAS2D::Signal<>;
+	using Signal = NAS2D::Signal<>;
 
 	CargoLander(Tile* t) : Structure(constants::CARGO_LANDER,
 		"structures/lander_0.sprite",
@@ -26,7 +26,7 @@ public:
 		enable();
 	}
 
-	Callback::Source& deployCallback() { return mDeploy; }
+	Signal::Source& deploySignal() { return mDeploy; }
 
 protected:
 	void think() override
@@ -44,6 +44,6 @@ private:
 	CargoLander& operator=(const CargoLander&) = delete;
 
 private:
-	Callback mDeploy;
+	Signal mDeploy;
 	Tile* mTile = nullptr;
 };

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -8,7 +8,7 @@
 class ColonistLander : public Structure
 {
 public:
-	using Callback = NAS2D::Signal<>;
+	using Signal = NAS2D::Signal<>;
 
 public:
 
@@ -27,7 +27,7 @@ public:
 		enable();
 	}
 
-	Callback::Source& deployCallback() { return mDeploy; }
+	Signal::Source& deploySignal() { return mDeploy; }
 
 protected:
 	void think() override
@@ -40,7 +40,7 @@ protected:
 	}
 
 private:
-	Callback mDeploy;
+	Signal mDeploy;
 
 	Tile* mTile;
 };

--- a/OPHD/Things/Structures/Factory.h
+++ b/OPHD/Things/Structures/Factory.h
@@ -25,8 +25,8 @@ class ProductionCost;
 class Factory : public Structure
 {
 public:
-	// Callback providing what was complete and a reference to the Factory.
-	using ProductionCallback = NAS2D::Signal<Factory&>;
+	// Signal providing what was complete and a reference to the Factory.
+	using ProductionSignal = NAS2D::Signal<Factory&>;
 
 	using ProductionTypeList = std::vector<ProductType>;
 
@@ -54,7 +54,7 @@ public:
 
 	virtual void initFactory() = 0;
 
-	ProductionCallback::Source& productionComplete() { return mProductionComplete; }
+	ProductionSignal::Source& productionComplete() { return mProductionComplete; }
 
 protected:
 	void clearProduction();
@@ -73,7 +73,7 @@ private:
 
 	ProductionTypeList mAvailableProducts; /**< List of products that the Factory can produce. */
 
-	ProductionCallback mProductionComplete; /**< Callback used when production is complete. */
+	ProductionSignal mProductionComplete; /**< Signal used when production is complete. */
 
 	const StorableResources* mResources = nullptr; /**< Pointer to the player's resource pool. UGLY. */
 };

--- a/OPHD/Things/Structures/MineFacility.h
+++ b/OPHD/Things/Structures/MineFacility.h
@@ -10,7 +10,7 @@
 class MineFacility: public Structure
 {
 public:
-	using ExtensionCompleteCallback = NAS2D::Signal<MineFacility*>;
+	using ExtensionCompleteSignal = NAS2D::Signal<MineFacility*>;
 public:
 	MineFacility(Mine* mine);
 
@@ -34,7 +34,7 @@ public:
 	 */
 	Mine* mine() { return mMine; }
 
-	ExtensionCompleteCallback::Source& extensionComplete() { return mExtensionComplete; }
+	ExtensionCompleteSignal::Source& extensionComplete() { return mExtensionComplete; }
 
 protected:
 	void think() override;
@@ -55,5 +55,5 @@ private:
 
 	Mine* mMine = nullptr; /**< Mine that this facility manages. */
 
-	ExtensionCompleteCallback mExtensionComplete; /**< Called whenever an extension is completed. */
+	ExtensionCompleteSignal mExtensionComplete; /**< Called whenever an extension is completed. */
 };

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -8,7 +8,7 @@
 class SeedLander: public Structure
 {
 public:
-	using Callback = NAS2D::Signal<NAS2D::Point<int>>;
+	using Signal = NAS2D::Signal<NAS2D::Point<int>>;
 
 public:
 	SeedLander() = delete;
@@ -33,7 +33,7 @@ public:
 		mPosition = position;
 	}
 
-	Callback::Source& deployCallback() { return mDeploy; }
+	Signal::Source& deploySignal() { return mDeploy; }
 
 protected:
 	void think() override
@@ -48,6 +48,6 @@ protected:
 	}
 
 private:
-	Callback mDeploy;
+	Signal mDeploy;
 	NAS2D::Point<int> mPosition;
 };

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -13,7 +13,7 @@
 class Thing
 {
 public:
-	using DieCallback = NAS2D::Signal<Thing*>;
+	using DieSignal = NAS2D::Signal<Thing*>;
 
 public:
 	Thing(const std::string& name, const std::string& spritePath, const std::string& initialAction) :
@@ -43,10 +43,10 @@ public:
 	 */
 	NAS2D::Sprite& sprite() { return mSprite; }
 
-	virtual void die() { mIsDead = true; mDieCallback(this); }
+	virtual void die() { mIsDead = true; mDieSignal(this); }
 	bool dead() const { return mIsDead; }
 
-	DieCallback::Source& onDie() { return mDieCallback; }
+	DieSignal::Source& onDie() { return mDieSignal; }
 
 private:
 	// No default copy constructor, or copy operator
@@ -60,5 +60,5 @@ private:
 
 	bool mIsDead = false;/**< Thing is dead and should be cleaned up. */
 
-	DieCallback mDieCallback;
+	DieSignal mDieSignal;
 };

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -117,7 +117,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 			else
 			{
 				mState = (mState == State::Pressed ? State::Normal : State::Pressed);
-				mCallback();
+				mSignal();
 			}
 		}
 	}
@@ -136,7 +136,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 			if (mRect.contains(Point<int>{x, y}))
 			{
-				mCallback();
+				mSignal();
 			}
 		}
 	}

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -20,7 +20,7 @@ public:
 		BUTTON_TOGGLE
 	};
 
-	using ClickCallback = NAS2D::Signal<>;
+	using ClickSignal = NAS2D::Signal<>;
 
 	Button(std::string newText = "");
 	~Button() override;
@@ -35,7 +35,7 @@ public:
 	void image(const std::string& path);
 	bool hasImage() const;
 
-	ClickCallback::Source& click() { return mCallback; }
+	ClickSignal::Source& click() { return mSignal; }
 
 	void update() override;
 
@@ -64,7 +64,7 @@ private:
 
 	const NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 
-	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
+	ClickSignal mSignal; /**< Object to notify when the Button is activated. */
 
 	bool mMouseHover = false; /**< Mouse is within the bounds of the Button. */
 };

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -60,9 +60,9 @@ bool CheckBox::checked() const
 }
 
 
-CheckBox::ClickCallback::Source& CheckBox::click()
+CheckBox::ClickSignal::Source& CheckBox::click()
 {
-	return mCallback;
+	return mSignal;
 }
 
 
@@ -73,7 +73,7 @@ void CheckBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	if (button == EventHandler::MouseButton::Left && mRect.contains(Point{x, y}))
 	{
 		mChecked = !mChecked;
-		mCallback();
+		mSignal();
 	}
 }
 

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -12,7 +12,7 @@
 class CheckBox : public TextControl
 {
 public:
-	using ClickCallback = NAS2D::Signal<>;
+	using ClickSignal = NAS2D::Signal<>;
 
 	CheckBox(std::string newText = "");
 	~CheckBox() override;
@@ -20,7 +20,7 @@ public:
 	void checked(bool toggle);
 	bool checked() const;
 
-	ClickCallback::Source& click();
+	ClickSignal::Source& click();
 
 	void update() override;
 
@@ -34,7 +34,7 @@ private:
 	const NAS2D::Font& mFont;
 	const NAS2D::Image& mSkin;
 
-	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
+	ClickSignal mSignal; /**< Object to notify when the Button is activated. */
 
 	bool mChecked = false;
 };

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -14,7 +14,7 @@
 class ComboBox : public Control
 {
 public:
-	using SelectionChangeCallback = NAS2D::Signal<>;
+	using SelectionChangeSignal = NAS2D::Signal<>;
 
 	ComboBox();
 	~ComboBox() override;
@@ -26,7 +26,7 @@ public:
 
 	void clearSelected();
 
-	SelectionChangeCallback::Source& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeSignal::Source& selectionChanged() { return mSelectionChanged; }
 
 	const std::string& selectionText() const;
 	int selectionTag() const;
@@ -54,7 +54,7 @@ private:
 
 	NAS2D::Rectangle<int> mBaseArea;
 
-	SelectionChangeCallback mSelectionChanged;
+	SelectionChangeSignal mSelectionChanged;
 
 	std::size_t mMaxDisplayItems = constants::MINIMUM_DISPLAY_ITEMS;
 };

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -36,9 +36,9 @@ int Control::positionY()
 
 
 /**
- * Callback fired whenever the Control's position changes.
+ * Signal fired whenever the Control's position changes.
  */
-Control::OnMoveCallback::Source& Control::moved()
+Control::OnMoveSignal::Source& Control::moved()
 {
 	return mOnMoveSignal;
 }
@@ -83,7 +83,7 @@ void Control::height(int h)
 }
 
 
-Control::ResizeCallback::Source& Control::resized()
+Control::ResizeSignal::Source& Control::resized()
 {
 	return mOnResizeSignal;
 }

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -16,8 +16,8 @@
 class Control
 {
 public:
-	using ResizeCallback = NAS2D::Signal<Control*>;
-	using OnMoveCallback = NAS2D::Signal<NAS2D::Vector<int>>;
+	using ResizeSignal = NAS2D::Signal<Control*>;
+	using OnMoveSignal = NAS2D::Signal<NAS2D::Vector<int>>;
 
 	Control() = default;
 	virtual ~Control() = default;
@@ -28,7 +28,7 @@ public:
 	int positionX();
 	int positionY();
 
-	OnMoveCallback::Source& moved();
+	OnMoveSignal::Source& moved();
 
 	void highlight(bool highlight);
 	bool highlight() const;
@@ -54,7 +54,7 @@ public:
 	void width(int w);
 	void height(int h);
 
-	ResizeCallback::Source& resized();
+	ResizeSignal::Source& resized();
 
 	virtual void update() {}
 
@@ -74,8 +74,8 @@ protected:
 
 	virtual void onFocusChange() {}
 
-	OnMoveCallback mOnMoveSignal; /**< Callback fired whenever the position of the Control changes. */
-	ResizeCallback mOnResizeSignal;
+	OnMoveSignal mOnMoveSignal; /**< Signal fired whenever the position of the Control changes. */
+	ResizeSignal mOnResizeSignal;
 
 	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -57,7 +57,7 @@ template <typename ListBoxItem = ListBoxItemText>
 class ListBox : public Control
 {
 public:
-	using SelectionChangeCallback = NAS2D::Signal<>;
+	using SelectionChangeSignal = NAS2D::Signal<>;
 
 	ListBox() :
 		mContext{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)}
@@ -186,7 +186,7 @@ public:
 		mSlider.update();
 	}
 
-	SelectionChangeCallback::Source& selectionChanged() {
+	SelectionChangeSignal::Source& selectionChanged() {
 		return mSelectionChanged;
 	}
 
@@ -273,6 +273,6 @@ private:
 
 	NAS2D::Rectangle<int> mScrollArea;
 
-	SelectionChangeCallback mSelectionChanged; /**< Callback for selection changed callback. */
+	SelectionChangeSignal mSelectionChanged; /**< Signal for selection changed callback. */
 	Slider mSlider;
 };

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -25,9 +25,9 @@ class ListBoxBase : public Control
 {
 public:
 	/**
-	 * Callback signal fired whenever the list selection changes.
+	 * Signal signal fired whenever the list selection changes.
 	 */
-	using SelectionChangeCallback = NAS2D::Signal<>;
+	using SelectionChangeSignal = NAS2D::Signal<>;
 
 	/**
 	 * Derived SpecialListBox types can inherit from this struct
@@ -59,7 +59,7 @@ public:
 
 	std::size_t currentHighlight() const;
 
-	SelectionChangeCallback::Source& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeSignal::Source& selectionChanged() { return mSelectionChanged; }
 
 	void update() override = 0;
 
@@ -106,6 +106,6 @@ private:
 	NAS2D::Color mHighlightBg = NAS2D::Color::DarkGreen; /**< Highlight Background color. */
 	NAS2D::Color mHighlightText = NAS2D::Color::White; /**< Text Color for an item that is currently highlighted. */
 
-	SelectionChangeCallback mSelectionChanged; /**< Callback for selection changed callback. */
+	SelectionChangeSignal mSelectionChanged; /**< Signal for selection changed callback. */
 	Slider mSlider; /**< Slider control. */
 };

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -60,7 +60,7 @@ const std::string& RadioButton::text() const
 	return mLabel.text();
 }
 
-RadioButton::ClickCallback::Source& RadioButton::click()
+RadioButton::ClickSignal::Source& RadioButton::click()
 {
 	for (auto* sibling : mParentContainer->controls())
 	{
@@ -70,7 +70,7 @@ RadioButton::ClickCallback::Source& RadioButton::click()
 		}
 	}
 	checked(true);
-	return mCallback;
+	return mSignal;
 }
 
 
@@ -81,7 +81,7 @@ void RadioButton::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	if (button == EventHandler::MouseButton::Left && mRect.contains(Point{x, y}))
 	{
 		click();
-		mCallback();
+		mSignal();
 	}
 }
 

--- a/OPHD/UI/Core/RadioButton.h
+++ b/OPHD/UI/Core/RadioButton.h
@@ -16,7 +16,7 @@ class UIContainer;
 class RadioButton : public TextControl
 {
 public:
-	using ClickCallback = NAS2D::Signal<>;
+	using ClickSignal = NAS2D::Signal<>;
 
 	RadioButton(std::string newText = "");
 	~RadioButton() override;
@@ -27,7 +27,7 @@ public:
 	void text(const std::string& text);
 	const std::string& text() const;
 
-	ClickCallback::Source& click();
+	ClickSignal::Source& click();
 
 	void update() override;
 
@@ -43,7 +43,7 @@ private:
 	const NAS2D::Font& mFont;
 	const NAS2D::Image& mSkin;
 	Label mLabel;
-	ClickCallback mCallback; /**< Object to notify when the Button is activated. */
+	ClickSignal mSignal; /**< Object to notify when the Button is activated. */
 	UIContainer* mParentContainer{nullptr};
 	bool mChecked{false};
 

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -157,7 +157,7 @@ float Slider::positionInternal()
 void Slider::positionInternal(float newPosition)
 {
 	mPosition = std::clamp(newPosition, 0.0f, mLength);
-	mCallback(mPosition);
+	mSignal(mPosition);
 }
 
 
@@ -360,7 +360,7 @@ void Slider::thumbPosition(float value)
 
 	mPosition = std::clamp(value, 0.0f, mLength);
 
-	mCallback(thumbPosition());
+	mSignal(thumbPosition());
 }
 
 
@@ -396,7 +396,7 @@ void Slider::thumbPositionNormalized(float value) {
 	value = std::clamp(value, 0.0f, 1.0f);
 	if (mBackward) { value = 1.0f - value; }
 	mPosition = mLength * value;
-	mCallback(thumbPosition());
+	mSignal(thumbPosition());
 }
 
 float Slider::thumbPositionNormalized() {

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -37,7 +37,7 @@ public:
 		NAS2D::RectangleSkin skinSlider;
 	};
 
-	using ValueChangeCallback = NAS2D::Signal<float>; /*!< type for Callback on value changed. */
+	using ValueChangeSignal = NAS2D::Signal<float>; /*!< type for Signal on value changed. */
 
 	Slider(SliderType sliderType = SliderType::Vertical);
 	Slider(Skins skins, SliderType sliderType = SliderType::Vertical);
@@ -61,7 +61,7 @@ public:
 
 	void update() override; /*!< Called to display the slider. */
 
-	ValueChangeCallback::Source& change() { return mCallback; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
+	ValueChangeSignal::Source& change() { return mSignal; } /*!< Give the callback to enable another control or a window to dis/connect to this event call. */
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y); /*!< Event raised on mouse button down. */
@@ -81,7 +81,7 @@ private:
 
 	NAS2D::Timer mTimer;
 
-	ValueChangeCallback mCallback; /*!< Callback executed when the value is changed. */
+	ValueChangeSignal mSignal; /*!< Signal executed when the value is changed. */
 
 	SliderType mSliderType{SliderType::Vertical}; /*!< Type of the Slider. */
 

--- a/OPHD/UI/Core/TextControl.h
+++ b/OPHD/UI/Core/TextControl.h
@@ -16,16 +16,16 @@ namespace NAS2D
 class TextControl : public Control
 {
 public:
-	using TextChangeCallback = NAS2D::Signal<TextControl*>;
+	using TextChangeSignal = NAS2D::Signal<TextControl*>;
 
 	void text(const std::string& text);
 	const std::string& text() const { return mText; }
-	TextChangeCallback::Source& textChanged() { return mTextChanged; }
+	TextChangeSignal::Source& textChanged() { return mTextChanged; }
 
 	virtual void onTextChange() { mTextChanged(this); }
 
 protected:
-	TextChangeCallback mTextChanged;
+	TextChangeSignal mTextChanged;
 
 	std::string mText; /**< Internal text string. */
 };

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -20,11 +20,11 @@ public:
 	void show() override;
 	void update() override;
 
-	using TitleChangeCallback = NAS2D::Signal<Window*>;
+	using TitleChangeSignal = NAS2D::Signal<Window*>;
 
 	void title(const std::string& title);
 	const std::string& title() const { return mTitle; }
-	TitleChangeCallback::Source& titleChanged() { return mTitleChanged; }
+	TitleChangeSignal::Source& titleChanged() { return mTitleChanged; }
 
 	virtual void onTitleChanged() { mTitleChanged(this); }
 
@@ -45,7 +45,7 @@ private:
 	const NAS2D::Image& mTitleBarRight;
 	NAS2D::RectangleSkin mBody;
 
-	TitleChangeCallback mTitleChanged;
+	TitleChangeSignal mTitleChanged;
 
 	std::string mTitle;
 };

--- a/OPHD/UI/DiggerDirection.cpp
+++ b/OPHD/UI/DiggerDirection.cpp
@@ -100,29 +100,29 @@ void DiggerDirection::selectDown()
 
 void DiggerDirection::onDiggerDown()
 {
-	mCallback(Direction::Down, mTile);
+	mSignal(Direction::Down, mTile);
 }
 
 
 void DiggerDirection::onDiggerNorth()
 {
-	mCallback(Direction::North, mTile);
+	mSignal(Direction::North, mTile);
 }
 
 
 void DiggerDirection::onDiggerSouth()
 {
-	mCallback(Direction::South, mTile);
+	mSignal(Direction::South, mTile);
 }
 
 
 void DiggerDirection::onDiggerEast()
 {
-	mCallback(Direction::East, mTile);
+	mSignal(Direction::East, mTile);
 }
 
 
 void DiggerDirection::onDiggerWest()
 {
-	mCallback(Direction::West, mTile);
+	mSignal(Direction::West, mTile);
 }

--- a/OPHD/UI/DiggerDirection.h
+++ b/OPHD/UI/DiggerDirection.h
@@ -11,13 +11,13 @@ class Tile;
 class DiggerDirection: public Window
 {
 public:
-	using Callback = NAS2D::Signal<Direction, Tile*>;
+	using Signal = NAS2D::Signal<Direction, Tile*>;
 
 	DiggerDirection();
 
 	void update() override;
 
-	Callback::Source& directionSelected() { return mCallback; }
+	Signal::Source& directionSelected() { return mSignal; }
 
 	void setParameters(Tile* tile);
 
@@ -44,7 +44,7 @@ private:
 	Button btnWest;
 	Button btnCancel;
 
-	Callback mCallback;
+	Signal mSignal;
 
 	Tile* mTile = nullptr;
 };

--- a/OPHD/UI/FactoryListBox.h
+++ b/OPHD/UI/FactoryListBox.h
@@ -18,7 +18,7 @@ class Factory;
 class FactoryListBox : public ListBoxBase
 {
 public:
-	using SelectionChangedCallback = NAS2D::Signal<Factory*>;
+	using SelectionChangedSignal = NAS2D::Signal<Factory*>;
 
 	struct FactoryListBoxItem : public ListBoxItem
 	{

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -164,7 +164,7 @@ void FileIo::onClose()
 
 void FileIo::onFileIo()
 {
-	mCallback(txtFileName.text(), mMode);
+	mSignal(txtFileName.text(), mMode);
 	txtFileName.text("");
 	txtFileName.resetCursorPosition();
 	btnFileOp.enabled(false);

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -18,7 +18,7 @@ public:
 		FILE_SAVE
 	};
 
-	using FileOperationCallback = NAS2D::Signal<const std::string&, FileOperation>;
+	using FileOperationSignal = NAS2D::Signal<const std::string&, FileOperation>;
 
 	FileIo();
 	~FileIo() override;
@@ -26,7 +26,7 @@ public:
 	void setMode(FileOperation fileOp);
 	void scanDirectory(const std::string& directory);
 
-	FileOperationCallback::Source& fileOperation() { return mCallback; }
+	FileOperationSignal::Source& fileOperation() { return mSignal; }
 
 	void update() override;
 
@@ -42,7 +42,7 @@ private:
 	void onFileSelect();
 	void onFileNameChange(TextControl* control);
 
-	FileOperationCallback mCallback;
+	FileOperationSignal mSignal;
 
 	FileOperation mMode;
 

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -60,20 +60,20 @@ void GameOptionsDialog::update()
 
 void GameOptionsDialog::onSave()
 {
-	mCallbackSave();
+	mSignalSave();
 }
 
 void GameOptionsDialog::onLoad()
 {
-	mCallbackLoad();
+	mSignalLoad();
 }
 
 void GameOptionsDialog::onReturn()
 {
-	mCallbackReturn();
+	mSignalReturn();
 }
 
 void GameOptionsDialog::onClose()
 {
-	mCallbackClose();
+	mSignalClose();
 }

--- a/OPHD/UI/GameOptionsDialog.h
+++ b/OPHD/UI/GameOptionsDialog.h
@@ -7,17 +7,17 @@
 class GameOptionsDialog : public Window
 {
 public:
-	using ClickCallback = NAS2D::Signal<>;
+	using ClickSignal = NAS2D::Signal<>;
 
 	GameOptionsDialog();
 	~GameOptionsDialog() override;
 
 	void update() override;
 
-	ClickCallback::Source& SaveGame() { return mCallbackSave; }
-	ClickCallback::Source& LoadGame() { return mCallbackLoad; }
-	ClickCallback::Source& returnToGame() { return mCallbackReturn; }
-	ClickCallback::Source& returnToMainMenu() { return mCallbackClose; }
+	ClickSignal::Source& SaveGame() { return mSignalSave; }
+	ClickSignal::Source& LoadGame() { return mSignalLoad; }
+	ClickSignal::Source& returnToGame() { return mSignalReturn; }
+	ClickSignal::Source& returnToMainMenu() { return mSignalClose; }
 
 private:
 	void onLoad();
@@ -32,8 +32,8 @@ private:
 	Button btnReturn;
 	Button btnClose;
 
-	ClickCallback mCallbackSave;
-	ClickCallback mCallbackLoad;
-	ClickCallback mCallbackReturn;
-	ClickCallback mCallbackClose;
+	ClickSignal mSignalSave;
+	ClickSignal mSignalLoad;
+	ClickSignal mSignalReturn;
+	ClickSignal mSignalClose;
 };

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -27,7 +27,7 @@ GameOverDialog::GameOverDialog() :
 
 void GameOverDialog::onClose()
 {
-	mCallback();
+	mSignal();
 }
 
 

--- a/OPHD/UI/GameOverDialog.h
+++ b/OPHD/UI/GameOverDialog.h
@@ -7,12 +7,12 @@
 class GameOverDialog : public Window
 {
 public:
-	using ClickCallback = NAS2D::Signal<>;
+	using ClickSignal = NAS2D::Signal<>;
 
 public:
 	GameOverDialog();
 
-	ClickCallback::Source& returnToMainMenu() { return mCallback; }
+	ClickSignal::Source& returnToMainMenu() { return mSignal; }
 
 	void update() override;
 
@@ -23,5 +23,5 @@ private:
 
 	Button btnClose;
 
-	ClickCallback mCallback;
+	ClickSignal mSignal;
 };

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -352,11 +352,11 @@ void IconGrid::raiseChangedEvent()
 {
 	if (mSelectedIndex != constants::NO_SELECTION)
 	{
-		mCallback(&mIconItemList[mSelectedIndex]);
+		mSignal(&mIconItemList[mSelectedIndex]);
 	}
 	else
 	{
-		mCallback(nullptr);
+		mSignal(nullptr);
 	}
 }
 

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -47,7 +47,7 @@ public:
 		NAS2D::Point<int> pos;
 	};
 
-	using Callback = NAS2D::Signal<const IconGridItem*>;
+	using Signal = NAS2D::Signal<const IconGridItem*>;
 
 public:
 	IconGrid(const std::string& filePath, int iconSize, int margin);
@@ -79,7 +79,7 @@ public:
 	void incrementSelection();
 	void decrementSelection();
 
-	Callback::Source& selectionChanged() { return mCallback; }
+	Signal::Source& selectionChanged() { return mSignal; }
 
 	void hide() override;
 
@@ -121,5 +121,5 @@ private:
 
 	IconItemList mIconItemList; /**< List of items. */
 
-	Callback mCallback; /**< Callback whenever a selection is made. */
+	Signal mSignal; /**< Signal whenever a selection is made. */
 };

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -380,7 +380,7 @@ void FactoryReport::onClearProduction()
 
 void FactoryReport::onTakeMeThere()
 {
-	takeMeThereCallback()(selectedFactory);
+	takeMeThereSignal()(selectedFactory);
 }
 
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -247,7 +247,7 @@ void MineReport::onDigNewLevel()
 
 void MineReport::onTakeMeThere()
 {
-	takeMeThereCallback()(mSelectedFacility);
+	takeMeThereSignal()(mSelectedFacility);
 }
 
 

--- a/OPHD/UI/Reports/ReportInterface.h
+++ b/OPHD/UI/Reports/ReportInterface.h
@@ -15,7 +15,7 @@ class ReportInterface : public UIContainer
 {
 public:
 	/**
-	 * Callback signal used to handle clicks of a "Take Me There" button to center
+	 * Signal signal used to handle clicks of a "Take Me There" button to center
 	 * the map view on a given structure.
 	 */
 	using TakeMeThere = NAS2D::Signal<Structure*>;
@@ -48,8 +48,8 @@ public:
 	 */
 	virtual void selectStructure(Structure*) = 0;
 
-	TakeMeThere& takeMeThereCallback() { return mTakeMeThereCallback; }
+	TakeMeThere& takeMeThereSignal() { return mTakeMeThereSignal; }
 
 private:
-	TakeMeThere mTakeMeThereCallback;
+	TakeMeThere mTakeMeThereSignal;
 };

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -225,7 +225,7 @@ void WarehouseReport::onDoubleClick(EventHandler::MouseButton button, int x, int
 
 	if (selectedWarehouse && lstStructures.rect().contains(NAS2D::Point{x, y}))
 	{
-		takeMeThereCallback()(selectedWarehouse);
+		takeMeThereSignal()(selectedWarehouse);
 	}
 }
 
@@ -319,7 +319,7 @@ void WarehouseReport::onDisabled()
 
 void WarehouseReport::onTakeMeThere()
 {
-	takeMeThereCallback()(selectedWarehouse);
+	takeMeThereSignal()(selectedWarehouse);
 }
 
 

--- a/OPHD/UI/RobotInspector.h
+++ b/OPHD/UI/RobotInspector.h
@@ -19,7 +19,7 @@ public:
 	void focusOnRobot(Robot*);
 	const Robot* focusedRobot() const { return mRobot; }
 
-	NAS2D::Signal<Robot*>& actionButtonClicked() { return mCallback; }
+	NAS2D::Signal<Robot*>& actionButtonClicked() { return mSignal; }
 
 	void update() override;
 
@@ -37,7 +37,7 @@ private:
 
 	NAS2D::Rectangle<int> mContentArea;
 
-	NAS2D::Signal<Robot*> mCallback;
+	NAS2D::Signal<Robot*> mSignal;
 
 	Robot* mRobot{ nullptr };
 };

--- a/OPHD/UI/StructureListBox.h
+++ b/OPHD/UI/StructureListBox.h
@@ -16,7 +16,7 @@ class Structure;
 class StructureListBox : public ListBoxBase
 {
 public:
-	using SelectionChangedCallback = NAS2D::Signal<Structure*>;
+	using SelectionChangedSignal = NAS2D::Signal<Structure*>;
 
 	struct StructureListBoxItem : public ListBoxItem
 	{


### PR DESCRIPTION
Reference: #854

Rename all uses of "Callback" to instead use "Signal".

Everywhere that "Callback" was used, the `Signal` type was intended. This is potentially confusing, since a `Signal` object manages a collection of callbacks for the event handlers. The `Signal` object itself is not the "Callback".

This impacts type aliases, method names, and private field names.
