### PR TITLE
Add ListBox::onMove overload to update scroll area

### DIFF
--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -236,6 +236,10 @@ protected:
 	}
 
 private:
+	void onMove(NAS2D::Vector<int> /*displacement*/) override {
+		updateScrollLayout();
+	}
+
 	void onResize() override {
 		updateScrollLayout();
 	}


### PR DESCRIPTION
Closes #856

Previously the scroll area was becoming detached from the `ListBox` border when the `Control` was moved. This forces an update of the scroll area, so it matches the position of the `ListBox`.