### PR TITLE
Fix mine report crash bug

### DIFF
--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -325,15 +325,11 @@ void MineReport::updateManagementButtonsVisiblity()
 	btnDigNewLevel.visible(isVisible);
 	btnTakeMeThere.visible(isVisible);
 
-	btnAddTruck.visible(isVisible);
-	btnRemoveTruck.visible(isVisible);
+	bool isTruckButtonVisible = isVisible &&
+		!(mSelectedFacility->destroyed() || mSelectedFacility->underConstruction());
 
-	if (isVisible &&
-		(mSelectedFacility->destroyed() || mSelectedFacility->underConstruction()))
-	{
-		btnAddTruck.visible(false);
-		btnRemoveTruck.visible(false);
-	}
+	btnAddTruck.visible(isTruckButtonVisible);
+	btnRemoveTruck.visible(isTruckButtonVisible);
 
 	chkCommonMetals.visible(isVisible);
 	chkCommonMinerals.visible(isVisible);

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -319,24 +319,26 @@ void MineReport::onCheckBoxRareMineralsChange()
 
 void MineReport::updateManagementButtonsVisiblity()
 {
-	btnIdle.visible(mSelectedFacility);
-	btnDigNewLevel.visible(mSelectedFacility);
-	btnTakeMeThere.visible(mSelectedFacility);
+	bool isVisible = visible() && mSelectedFacility;
 
-	btnAddTruck.visible(mSelectedFacility);
-	btnRemoveTruck.visible(mSelectedFacility);
+	btnIdle.visible(isVisible);
+	btnDigNewLevel.visible(isVisible);
+	btnTakeMeThere.visible(isVisible);
 
-	if (mSelectedFacility &&
+	btnAddTruck.visible(isVisible);
+	btnRemoveTruck.visible(isVisible);
+
+	if (isVisible &&
 		(mSelectedFacility->destroyed() || mSelectedFacility->underConstruction()))
 	{
 		btnAddTruck.visible(false);
 		btnRemoveTruck.visible(false);
 	}
 
-	chkCommonMetals.visible(mSelectedFacility);
-	chkCommonMinerals.visible(mSelectedFacility);
-	chkRareMetals.visible(mSelectedFacility);
-	chkRareMinerals.visible(mSelectedFacility);
+	chkCommonMetals.visible(isVisible);
+	chkCommonMinerals.visible(isVisible);
+	chkRareMetals.visible(isVisible);
+	chkRareMinerals.visible(isVisible);
 }
 
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -182,6 +182,12 @@ void MineReport::onResize()
 }
 
 
+void MineReport::onVisibilityChange(bool /*visible*/)
+{
+	updateManagementButtonsVisiblity();
+}
+
+
 void MineReport::filterButtonClicked()
 {
 	btnShowAll.toggle(false);

--- a/OPHD/UI/Reports/MineReport.h
+++ b/OPHD/UI/Reports/MineReport.h
@@ -60,6 +60,7 @@ private:
 	void updateManagementButtonsVisiblity();
 
 	void onResize() override;
+	void onVisibilityChange(bool visible) override;
 
 	void drawMineFacilityPane(const NAS2D::Point<int>&);
 	void drawOreProductionPane(const NAS2D::Point<int>&);


### PR DESCRIPTION
Closes #863

Fix crash bug in `MineReport` display. Previously buttons could be visible and active without a selected mine facility, which would lead to crashes when the buttons were clicked.
