### PR TITLE
Fix screen offset bug

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -193,7 +193,7 @@ void MainMenuState::onKeyDown(NAS2D::EventHandler::KeyCode /*key*/, NAS2D::Event
 /**
  * Window resize event handler.
  */
-void MainMenuState::onWindowResized(int /*width*/, int /*height*/)
+void MainMenuState::onWindowResized(NAS2D::Vector<int> /*newSize*/)
 {
 	positionButtons();
 }

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -24,7 +24,7 @@ protected:
 
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
-	void onWindowResized(int width, int height);
+	void onWindowResized(NAS2D::Vector<int> newSize);
 	void onFadeComplete();
 
 	void positionButtons();

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -283,12 +283,12 @@ void MainReportsUiState::exit()
 /**
  * Window resized event handler.
  */
-void MainReportsUiState::onWindowResized(int w, int h)
+void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 {
-	setPanelRects(w);
+	setPanelRects(newSize.x);
 	for (Panel& panel : Panels)
 	{
-		if (panel.UiPanel) { panel.UiPanel->size(NAS2D::Vector{w, h - 48}); }
+		if (panel.UiPanel) { panel.UiPanel->size(NAS2D::Vector{newSize.x, newSize.y - 48}); }
 	}
 }
 

--- a/OPHD/States/MainReportsUiState.h
+++ b/OPHD/States/MainReportsUiState.h
@@ -41,7 +41,7 @@ private:
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
-	void onWindowResized(int w, int h);
+	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void deselectAllPanels();
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -335,10 +335,10 @@ void MapViewState::onActivate(bool /*newActiveValue*/)
 }
 
 
-void MapViewState::onWindowResized(int w, int h)
+void MapViewState::onWindowResized(NAS2D::Vector<int> newSize)
 {
-	setupUiPositions({w, h});
-	mTileMap->initMapDrawParams({w, h});
+	setupUiPositions(newSize);
+	mTileMap->initMapDrawParams(newSize);
 }
 
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -104,7 +104,7 @@ private:
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseMove(int x, int y, int rX, int rY);
 	void onMouseWheel(int x, int y);
-	void onWindowResized(int w, int h);
+	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	// ROBOT EVENT HANDLERS
 	void onDozerTaskComplete(Robot* robot);

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -179,16 +179,16 @@ void PlanetSelectState::onMousePlanetExit()
 }
 
 
-void PlanetSelectState::onWindowResized(int w, int h)
+void PlanetSelectState::onWindowResized(NAS2D::Vector<int> newSize)
 {
-	const auto middlePosition = NAS2D::Point{0, 0} + (NAS2D::Vector{w, h} - NAS2D::Vector{128, 128}) / 2;
-	const auto offset = NAS2D::Vector{w / 4, 0};
+	const auto middlePosition = NAS2D::Point{0, 0} + (newSize - NAS2D::Vector{128, 128}) / 2;
+	const auto offset = NAS2D::Vector{newSize.x / 4, 0};
 	mPlanets[0]->position(middlePosition - offset);
 	mPlanets[1]->position(middlePosition);
 	mPlanets[2]->position(middlePosition + offset);
 
-	mQuit.position(NAS2D::Point{w - 105, 30});
-	mPlanetDescription.position(NAS2D::Point{(w / 2) - 275, h - 225});
+	mQuit.position(NAS2D::Point{newSize.x - 105, 30});
+	mPlanetDescription.position(NAS2D::Point{(newSize.x / 2) - 275, newSize.y - 225});
 }
 
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -31,7 +31,7 @@ private:
 	void onMousePlanetEnter();
 	void onMousePlanetExit();
 
-	void onWindowResized(int, int);
+	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void onQuit();
 

--- a/OPHD/WindowEventWrapper.h
+++ b/OPHD/WindowEventWrapper.h
@@ -42,13 +42,13 @@ private:
 		NAS2D::Utility<NAS2D::Configuration>::get()["options"].set("maximized", false);
 	}
 
-	void onWindowResized(int w, int h)
+	void onWindowResized(NAS2D::Vector<int> newSize)
 	{
 		if (windowMaximized()) { return; }
 
 		auto& configuration = NAS2D::Utility<NAS2D::Configuration>::get();
 		auto& graphics = configuration["graphics"];
-		graphics.set("screenwidth", w);
-		graphics.set("screenheight", h);
+		graphics.set("screenwidth", newSize.x);
+		graphics.set("screenheight", newSize.y);
 	}
 };


### PR DESCRIPTION
Closes #873

Upstream references:
- https://github.com/lairworks/nas2d-core/pull/854
- https://github.com/lairworks/nas2d-core/pull/855

Fix screen offset bug by updating NAS2D to bring in fix to `RendererOpenGL::minimumSize`, which was previously setting the viewport size to the minimum size, rather than the actual size.

Also contains an update to the resize event handler signature that now takes a packed `Vector` parameter.
