### PR TITLE
Add notification area

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,44 @@
 version: 2.1
 
 commands:
+  brew-install:
+    description: "Brew install MacOS dependencies (or restore from cache)"
+    steps:
+      - restore_cache:
+          name: Restoring brew dependencies
+          key: deps-OPHD-{{ arch }}-v1-{{ checksum "nas2d-core/BrewDeps.txt" }}
+      - run: make --directory nas2d-core/ install-dependencies
+      - save_cache:
+          name: Caching brew dependencies
+          key: deps-OPHD-{{ arch }}-v1-{{ checksum "nas2d-core/BrewDeps.txt" }}
+          paths:
+            - /usr/local/Cellar
   build:
     steps:
-      - checkout
-      - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
       - run: make package
       - store_artifacts:
           path: .build/package/
-  brew-install:
-    description: "Brew install MacOS dependencies (or restore from cache)"
-    parameters:
-      packages:
-        type: string
-    steps:
-      - restore_cache:
-          name: Restoring brew dependencies
-          key: deps-OPHD-v1-{{ arch }}
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install << parameters.packages >>
-      - save_cache:
-          name: Caching brew dependencies
-          key: deps-OPHD-v1-{{ arch }}
-          paths:
-            - /usr/local/Cellar
-      - run: brew link << parameters.packages >>
 
 jobs:
+  build-macos:
+    macos:
+      xcode: "12.4.0"
+    environment:
+      - HOMEBREW_NO_AUTO_UPDATE: 1
+      - WARN_EXTRA: "-Wno-double-promotion"
+    steps:
+      - checkout
+      - run: git submodule update --init nas2d-core/
+      - brew-install
+      - build
   build-linux:
     docker:
       - image: outpostuniverse/nas2d:1.4
     steps:
+      - checkout
+      - run: git submodule update --init nas2d-core/
       - build
   build-linux-gcc:
     docker:
@@ -39,6 +46,8 @@ jobs:
     environment:
       WARN_EXTRA: -Wsuggest-override
     steps:
+      - checkout
+      - run: git submodule update --init nas2d-core/
       - build
   build-linux-clang:
     docker:
@@ -46,6 +55,8 @@ jobs:
     environment:
       WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
+      - checkout
+      - run: git submodule update --init nas2d-core/
       - build
   build-linux-mingw:
     docker:
@@ -54,21 +65,12 @@ jobs:
       - checkout
       - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" intermediate
-  build-macos:
-    macos:
-      xcode: "12.3.0"
-    environment:
-      - WARN_EXTRA: "-Wno-double-promotion"
-    steps:
-      - brew-install:
-          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
-      - build
 
 workflows:
   build:
     jobs:
+      - build-macos
       - build-linux
       - build-linux-gcc
       - build-linux-clang
       - build-linux-mingw
-      - build-macos

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -215,7 +215,7 @@ private:
 	void onToggleCommRangeOverlay();
 	void onToggleRouteOverlay();
 
-	void onNotificationClicked(int);
+	void onNotificationClicked(const NotificationArea::Notification&);
 
 	void onSaveGame();
 	void onLoadGame();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -16,6 +16,7 @@
 
 #include "../UI/Gui.h"
 #include "../UI/NotificationArea.h"
+#include "../UI/NotificationWindow.h"
 #include "../UI/UI.h"
 
 #include <NAS2D/Signal/Signal.h>
@@ -291,6 +292,7 @@ private:
 	MajorEventAnnouncement mAnnouncement;
 	MineOperationsWindow mMineOperationsWindow;
 	NotificationArea mNotificationArea;
+	NotificationWindow mNotificationWindow;
 	PopulationPanel mPopulationPanel;
 	ResourceBreakdownPanel mResourceBreakdownPanel;
 	RobotInspector mRobotInspector;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -215,6 +215,8 @@ private:
 	void onToggleCommRangeOverlay();
 	void onToggleRouteOverlay();
 
+	void onNotificationClicked(int);
+
 	void onSaveGame();
 	void onLoadGame();
 	void onReturnToGame();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -15,6 +15,7 @@
 #include "../Things/Structures/Structure.h"
 
 #include "../UI/Gui.h"
+#include "../UI/NotificationArea.h"
 #include "../UI/UI.h"
 
 #include <NAS2D/Signal/Signal.h>
@@ -287,6 +288,7 @@ private:
 	GameOptionsDialog mGameOptionsDialog;
 	MajorEventAnnouncement mAnnouncement;
 	MineOperationsWindow mMineOperationsWindow;
+	NotificationArea mNotificationArea;
 	PopulationPanel mPopulationPanel;
 	ResourceBreakdownPanel mResourceBreakdownPanel;
 	RobotInspector mRobotInspector;

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -497,6 +497,9 @@ void MapViewState::nextTurn()
 	renderer.drawImage(*imageProcessingTurn, renderer.center() - imageProcessingTurn->size() / 2);
 	renderer.update();
 
+	mNotificationArea.clear();
+	mNotificationArea.push("Test notification message", NotificationArea::NotificationType::Information);
+
 	clearMode();
 
 	mPopulationPool.clear();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -498,7 +498,9 @@ void MapViewState::nextTurn()
 	renderer.update();
 
 	mNotificationArea.clear();
-	mNotificationArea.push("Test notification message", NotificationArea::NotificationType::Information);
+	mNotificationArea.push("Test notification message: Information", NotificationArea::NotificationType::Information);
+	mNotificationArea.push("Test notification message: Critical/Error", NotificationArea::NotificationType::Critical);
+	mNotificationArea.push("Test notification message: Warning", NotificationArea::NotificationType::Warning);
 
 	clearMode();
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -499,9 +499,6 @@ void MapViewState::nextTurn()
 
 	mNotificationWindow.hide();
 	mNotificationArea.clear();
-	mNotificationArea.push("Test notification message: Information", NotificationArea::NotificationType::Information);
-	mNotificationArea.push("Test notification message: Critical/Error", NotificationArea::NotificationType::Critical);
-	mNotificationArea.push("Test notification message: Warning", NotificationArea::NotificationType::Warning);
 
 	clearMode();
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -497,6 +497,7 @@ void MapViewState::nextTurn()
 	renderer.drawImage(*imageProcessingTurn, renderer.center() - imageProcessingTurn->size() / 2);
 	renderer.update();
 
+	mNotificationWindow.hide();
 	mNotificationArea.clear();
 	mNotificationArea.push("Test notification message: Information", NotificationArea::NotificationType::Information);
 	mNotificationArea.push("Test notification message: Critical/Error", NotificationArea::NotificationType::Critical);

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -92,6 +92,7 @@ void MapViewState::initUi()
 	mWindowStack.addWindow(&mWarehouseInspector);
 	mWindowStack.addWindow(&mMineOperationsWindow);
 	mWindowStack.addWindow(&mRobotInspector);
+	mWindowStack.addWindow(&mNotificationWindow);
 
 	mNotificationArea.notificationClicked().connect(this, &MapViewState::onNotificationClicked);
 
@@ -234,6 +235,8 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	mWarehouseInspector.position(centerPosition(mWarehouseInspector) - NAS2D::Vector{0, 100});
 	mMineOperationsWindow.position(centerPosition(mMineOperationsWindow) - NAS2D::Vector{0, 100});
+
+	mNotificationWindow.position(centerPosition(mMineOperationsWindow) - NAS2D::Vector{ 0, 100 });
 
 	/**
 	 * \note	We are not setting the tile inspector window's position here because it's something that can be
@@ -473,7 +476,9 @@ void MapViewState::onToggleRouteOverlay()
 
 void MapViewState::onNotificationClicked(const NotificationArea::Notification& notification)
 {
-	
+	mNotificationWindow.notification(notification);
+	mNotificationWindow.show();
+	mWindowStack.bringToFront(&mNotificationWindow);
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -198,7 +198,7 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	// Notification Area
 	auto& renderer = Utility<Renderer>::get();
-	mNotificationArea.size({ 48, mMoveUpIconRect.y - 22 - constants::MARGIN });
+	mNotificationArea.height(mMoveUpIconRect.y - 22 - constants::MARGIN);
 	mNotificationArea.position({ renderer.size().x - mNotificationArea.size().x, 22 });
 
 	// Mini Map

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -198,7 +198,7 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	// Notification Area
 	auto& renderer = Utility<Renderer>::get();
-	mNotificationArea.size({ 48, mMoveUpIconRect.y - 22 - constants::MARGIN_TIGHT });
+	mNotificationArea.size({ 48, mMoveUpIconRect.y - 22 - constants::MARGIN });
 	mNotificationArea.position({ renderer.size().x - mNotificationArea.size().x, 22 });
 
 	// Mini Map

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -93,6 +93,8 @@ void MapViewState::initUi()
 	mWindowStack.addWindow(&mMineOperationsWindow);
 	mWindowStack.addWindow(&mRobotInspector);
 
+	mNotificationArea.notificationClicked().connect(this, &MapViewState::onNotificationClicked);
+
 	const auto size = renderer.size().to<int>();
 	mBottomUiRect = {0, size.y - constants::BOTTOM_UI_HEIGHT, size.x, constants::BOTTOM_UI_HEIGHT};
 
@@ -466,6 +468,11 @@ void MapViewState::onToggleRouteOverlay()
 	}
 
 	setOverlay(mBtnToggleRouteOverlay, mTruckRouteOverlay, Tile::Overlay::TruckingRoutes);
+}
+
+
+void MapViewState::onNotificationClicked(int index)
+{
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -198,7 +198,7 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	// Notification Area
 	auto& renderer = Utility<Renderer>::get();
-	mNotificationArea.height(mMoveUpIconRect.y - 22 - constants::MARGIN);
+	mNotificationArea.size({ 48, mMoveUpIconRect.y - 22 - constants::MARGIN_TIGHT });
 	mNotificationArea.position({ renderer.size().x - mNotificationArea.size().x, 22 });
 
 	// Mini Map

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -22,6 +22,7 @@
 
 
 using namespace constants;
+using namespace NAS2D;
 
 
 static void setOverlay(Button& button, TileList& tileList, Tile::Overlay overlay)
@@ -139,7 +140,6 @@ void MapViewState::initUi()
 	// Initial Structures
 	mStructures.addItem(constants::SEED_LANDER, 0, StructureID::SID_SEED_LANDER);
 
-
 	// tooltip control sizes
 	constexpr auto hudHeight = constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2;
 	mTooltipResourceBreakdown.size({ 265, hudHeight });
@@ -195,6 +195,11 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mMoveUpIconRect = {mMoveDownIconRect.x, mMoveDownIconRect.y - navIconSpacing, 32, 32};
 	mMoveNorthIconRect = {mMoveUpIconRect.x - navIconSpacing, mMoveUpIconRect.y + 8, 32, 16};
 	mMoveWestIconRect = {mMoveUpIconRect.x - 2 * navIconSpacing, mMoveUpIconRect.y + 8, 32, 16};
+
+	// Notification Area
+	auto& renderer = Utility<Renderer>::get();
+	mNotificationArea.size({ 48, mMoveUpIconRect.y - 22 - constants::MARGIN_TIGHT });
+	mNotificationArea.position({ renderer.size().x - mNotificationArea.size().x, 22 });
 
 	// Mini Map
 	mMiniMapBoundingBox = {size.x - 300 - constants::MARGIN, mBottomUiRect.y + constants::MARGIN, 300, 150};

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -473,6 +473,7 @@ void MapViewState::onToggleRouteOverlay()
 
 void MapViewState::onNotificationClicked(int index)
 {
+	const auto& notification = mNotificationArea.notificationFromIndex(index);
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -471,9 +471,9 @@ void MapViewState::onToggleRouteOverlay()
 }
 
 
-void MapViewState::onNotificationClicked(int index)
+void MapViewState::onNotificationClicked(const NotificationArea::Notification& notification)
 {
-	const auto& notification = mNotificationArea.notificationFromIndex(index);
+	
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -393,6 +393,8 @@ void MapViewState::drawUI()
 	drawNavInfo();
 	drawRobotInfo();
 
+	mNotificationArea.update();
+
 	// Buttons
 	mBtnTurns.update();
 	mBtnToggleHeightmap.update();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -273,7 +273,6 @@ void MapViewState::unhideUi()
 
 	mGameOverDialog.enabled(true);
 	mGameOptionsDialog.enabled(true);
-
 }
 
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -33,6 +33,8 @@ NotificationArea::NotificationArea() :
 	auto& eventhandler = Utility<EventHandler>::get();
 
 	eventhandler.mouseButtonDown().connect(this, &NotificationArea::onMouseDown);
+
+	width(Width);
 }
 
 
@@ -67,7 +69,7 @@ void NotificationArea::update()
 	constexpr Rectangle<float> bgRect{128, 64, 32, 32};
 	constexpr int offset = constants::MARGIN_TIGHT + 32;
 
-	const int posX = positionX() + (size().x / 2) - 16;
+	const int posX = positionX() + (Width / 2) - 16;
 
 	int count = 1;
 	for (auto& notification : mNotificationList)
@@ -75,6 +77,8 @@ void NotificationArea::update()
 		auto position = Point<int>{ posX, positionY() + size().y - (offset * count) };
 		renderer.drawSubImage(mIcons, position, bgRect, NotificationIconColor.at(notification.type));
 		renderer.drawSubImage(mIcons, position, NotificationIconRect.at(notification.type), Color::Normal);
+
+		renderer.drawBox(Rectangle<int>{ position.x, position.y, 32, 32 });
 
 		count++;
 	}

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -70,9 +70,9 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 	{
 		if (rect.contains(clickPoint))
 		{
-			// fire off some event with notification here
 			mNotificationList.erase(mNotificationList.begin() + count);
 			mNotificationRectList.erase(mNotificationRectList.begin() + count);
+			mNotificationClicked(static_cast<int>(count));
 			updateRectListPositions();
 			return;
 		}

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -26,6 +26,17 @@ static const std::map<NotificationArea::NotificationType, NAS2D::Color> Notifica
 };
 
 
+const Rectangle<float>& IconRectFromNotificationType(const NotificationArea::NotificationType type)
+{
+	return NotificationIconRect.at(type);
+}
+
+const Color ColorFromNotification(const NotificationArea::NotificationType type)
+{
+	return NotificationIconColor.at(type);
+}
+
+
 static constexpr int Offset = constants::MARGIN_TIGHT + 32;
 
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -32,7 +32,6 @@ NotificationArea::NotificationArea() :
 	auto& eventhandler = Utility<EventHandler>::get();
 
 	eventhandler.mouseButtonDown().connect(this, &NotificationArea::onMouseDown);
-	eventhandler.mouseMotion().connect(this, &NotificationArea::onMouseMove);
 }
 
 
@@ -41,7 +40,6 @@ NotificationArea::~NotificationArea()
 	auto& eventhandler = Utility<EventHandler>::get();
 
 	eventhandler.mouseButtonDown().disconnect(this, &NotificationArea::onMouseDown);
-	eventhandler.mouseMotion().disconnect(this, &NotificationArea::onMouseMove);
 }
 
 
@@ -51,13 +49,7 @@ void NotificationArea::push(const std::string& message, NotificationType type)
 }
 
 
-void NotificationArea::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
-{
-
-}
-
-
-void NotificationArea::onMouseMove(int x, int y, int deltaX, int deltaY)
+void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 
 }

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -118,7 +118,6 @@ void NotificationArea::update()
 	renderer.drawBox(rect());
 
 	constexpr Rectangle<float> bgRect{128, 64, 32, 32};
-	const int posX = positionX() + (Width / 2) - 16;
 
 	size_t count = 0;
 	for (auto& notification : mNotificationList)

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -84,14 +84,12 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 
 void NotificationArea::positionChanged(int dX, int dY)
 {
-	Control::positionChanged(dX, dY);
 	updateRectListPositions();
 }
 
 
 void NotificationArea::onSizeChanged()
 {
-	Control::onSizeChanged();
 	updateRectListPositions();
 }
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -70,9 +70,9 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 	{
 		if (rect.contains(clickPoint))
 		{
+			mNotificationClicked(mNotificationList.at(count));
 			mNotificationList.erase(mNotificationList.begin() + count);
 			mNotificationRectList.erase(mNotificationRectList.begin() + count);
-			mNotificationClicked(static_cast<int>(count));
 			updateRectListPositions();
 			return;
 		}

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -82,14 +82,14 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 }
 
 
-void NotificationArea::positionChanged(int dX, int dY)
+void NotificationArea::positionChanged(int, int)
 {
 	Control::positionChanged(dX, dY);
 	updateRectListPositions();
 }
 
 
-void NotificationArea::onSizeChanged()
+void NotificationArea::onResize()
 {
 	Control::onSizeChanged();
 	updateRectListPositions();

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -63,7 +63,22 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 {
 	if (button != EventHandler::MouseButton::Left) { return; }
 
-	NAS2D::Point clickPoint{ x, y };
+	const NAS2D::Point clickPoint{ x, y };
+
+	size_t count = 0;
+	for (auto& rect : mNotificationRectList)
+	{
+		if (rect.contains(clickPoint))
+		{
+			// fire off some event with notification here
+			mNotificationList.erase(mNotificationList.begin() + count);
+			mNotificationRectList.erase(mNotificationRectList.begin() + count);
+			updateRectListPositions();
+			return;
+		}
+
+		count++;
+	}
 }
 
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -26,6 +26,15 @@ static const std::map<NotificationArea::NotificationType, NAS2D::Color> Notifica
 };
 
 
+static const std::map<NotificationArea::NotificationType, std::string> NotificationText
+{
+	{ NotificationArea::NotificationType::Critical, "Critical" },
+	{ NotificationArea::NotificationType::Information, "Information" },
+	{ NotificationArea::NotificationType::Warning, "Warning" }
+};
+
+
+
 const Rectangle<float>& IconRectFromNotificationType(const NotificationArea::NotificationType type)
 {
 	return NotificationIconRect.at(type);
@@ -35,6 +44,12 @@ const Color ColorFromNotification(const NotificationArea::NotificationType type)
 {
 	return NotificationIconColor.at(type);
 }
+
+const std::string& StringFromNotificationType(const NotificationArea::NotificationType type)
+{
+	return NotificationText.at(type);
+}
+
 
 
 static constexpr int Offset = constants::MARGIN_TIGHT + 32;

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -1,0 +1,49 @@
+#include "NotificationArea.h"
+
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
+using namespace NAS2D;
+
+
+NotificationArea::NotificationArea()
+{
+	auto& eventhandler = Utility<EventHandler>::get();
+
+	eventhandler.mouseButtonDown().connect(this, &NotificationArea::onMouseDown);
+	eventhandler.mouseMotion().connect(this, &NotificationArea::onMouseMove);
+}
+
+
+NotificationArea::~NotificationArea()
+{
+	auto& eventhandler = Utility<EventHandler>::get();
+
+	eventhandler.mouseButtonDown().disconnect(this, &NotificationArea::onMouseDown);
+	eventhandler.mouseMotion().disconnect(this, &NotificationArea::onMouseMove);
+}
+
+
+void NotificationArea::push(Notification notification)
+{
+
+}
+
+
+void NotificationArea::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
+{
+
+}
+
+
+void NotificationArea::onMouseMove(int x, int y, int deltaX, int deltaY)
+{
+
+}
+
+void NotificationArea::update()
+{
+	auto& renderer = Utility<Renderer>::get();
+
+	renderer.drawBox(rect());
+}

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -1,6 +1,7 @@
 #include "NotificationArea.h"
 
 #include "../Cache.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -45,13 +46,15 @@ NotificationArea::~NotificationArea()
 
 void NotificationArea::push(const std::string& message, NotificationType type)
 {
-	mNotificationList.emplace_back(Notification{ message, type, Point<int>{0, 0} });
+	mNotificationList.emplace_back(Notification{ message, type });
 }
 
 
 void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	if (button != EventHandler::MouseButton::Left) { return; }
 
+	NAS2D::Point clickPoint{ x, y };
 }
 
 
@@ -62,10 +65,17 @@ void NotificationArea::update()
 	renderer.drawBox(rect());
 
 	constexpr Rectangle<float> bgRect{128, 64, 32, 32};
+	constexpr int offset = constants::MARGIN_TIGHT + 32;
 
+	const int posX = positionX() + (size().x / 2) - 16;
+
+	int count = 1;
 	for (auto& notification : mNotificationList)
 	{
-		renderer.drawSubImage(mIcons, { 0, 0 }, bgRect, NotificationIconColor.at(notification.type));
-		renderer.drawSubImage(mIcons, { 0, 0 }, NotificationIconRect.at(notification.type), Color::Normal);
+		auto position = Point<int>{ posX, positionY() + size().y - (offset * count) };
+		renderer.drawSubImage(mIcons, position, bgRect, NotificationIconColor.at(notification.type));
+		renderer.drawSubImage(mIcons, position, NotificationIconRect.at(notification.type), Color::Normal);
+
+		count++;
 	}
 }

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -34,22 +34,22 @@ static const std::map<NotificationArea::NotificationType, std::string> Notificat
 };
 
 
-
 const Rectangle<float>& IconRectFromNotificationType(const NotificationArea::NotificationType type)
 {
 	return NotificationIconRect.at(type);
 }
+
 
 const Color ColorFromNotification(const NotificationArea::NotificationType type)
 {
 	return NotificationIconColor.at(type);
 }
 
+
 const std::string& StringFromNotificationType(const NotificationArea::NotificationType type)
 {
 	return NotificationText.at(type);
 }
-
 
 
 static constexpr int Offset = constants::MARGIN_TIGHT + 32;

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -141,16 +141,12 @@ void NotificationArea::update()
 {
 	auto& renderer = Utility<Renderer>::get();
 
-	renderer.drawBox(rect());
-
-	constexpr Rectangle<float> bgRect{128, 64, 32, 32};
-
 	size_t count = 0;
 	for (auto& notification : mNotificationList)
 	{
 		auto& rect = mNotificationRectList.at(count);
 
-		renderer.drawSubImage(mIcons, rect.startPoint(), bgRect, NotificationIconColor.at(notification.type));
+		renderer.drawSubImage(mIcons, rect.startPoint(), { 128, 64, 32, 32 }, NotificationIconColor.at(notification.type));
 		renderer.drawSubImage(mIcons, rect.startPoint(), NotificationIconRect.at(notification.type), Color::Normal);
 		
 		count++;

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -70,9 +70,9 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 	{
 		if (rect.contains(clickPoint))
 		{
-			// fire off some event with notification here
 			mNotificationList.erase(mNotificationList.begin() + count);
 			mNotificationRectList.erase(mNotificationRectList.begin() + count);
+			mNotificationClicked(static_cast<int>(count));
 			updateRectListPositions();
 			return;
 		}
@@ -82,16 +82,16 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 }
 
 
-void NotificationArea::positionChanged(int, int)
+void NotificationArea::onMove(NAS2D::Vector<int> displacement)
 {
-	Control::positionChanged(dX, dY);
+	Control::onMove(displacement);
 	updateRectListPositions();
 }
 
 
 void NotificationArea::onResize()
 {
-	Control::onSizeChanged();
+	Control::onResize();
 	updateRectListPositions();
 }
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -1,12 +1,33 @@
 #include "NotificationArea.h"
 
+#include "../Cache.h"
+
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
+
 
 using namespace NAS2D;
 
 
-NotificationArea::NotificationArea()
+static const std::map<NotificationArea::NotificationType, Rectangle<float>> NotificationIconRect
+{
+	{ NotificationArea::NotificationType::Critical, { 64, 64, 32, 32 } },
+	{ NotificationArea::NotificationType::Information, { 32, 64, 32, 32 } },
+	{ NotificationArea::NotificationType::Warning, { 96, 64, 32, 32 } }
+};
+
+
+static const std::map<NotificationArea::NotificationType, NAS2D::Color> NotificationIconColor
+{
+	{ NotificationArea::NotificationType::Critical, Color::Red },
+	{ NotificationArea::NotificationType::Information, Color::Green },
+	{ NotificationArea::NotificationType::Warning, Color::Yellow }
+};
+
+
+
+NotificationArea::NotificationArea() :
+	mIcons{ imageCache.load("ui/icons.png") }
 {
 	auto& eventhandler = Utility<EventHandler>::get();
 
@@ -24,9 +45,9 @@ NotificationArea::~NotificationArea()
 }
 
 
-void NotificationArea::push(Notification notification)
+void NotificationArea::push(const std::string& message, NotificationType type)
 {
-
+	mNotificationList.emplace_back(Notification{ message, type, Point<int>{0, 0} });
 }
 
 
@@ -41,9 +62,18 @@ void NotificationArea::onMouseMove(int x, int y, int deltaX, int deltaY)
 
 }
 
+
 void NotificationArea::update()
 {
 	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawBox(rect());
+
+	constexpr Rectangle<float> bgRect{128, 64, 32, 32};
+
+	for (auto& notification : mNotificationList)
+	{
+		renderer.drawSubImage(mIcons, { 0, 0 }, bgRect, NotificationIconColor.at(notification.type));
+		renderer.drawSubImage(mIcons, { 0, 0 }, NotificationIconRect.at(notification.type), Color::Normal);
+	}
 }

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -66,3 +66,6 @@ private:
 
 	NotificationCallback mNotificationClicked;
 };
+
+const NAS2D::Rectangle<float>& IconRectFromNotificationType(const NotificationArea::NotificationType);
+const NAS2D::Color ColorFromNotification(const NotificationArea::NotificationType);

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -49,7 +49,7 @@ public:
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
 
-	void positionChanged(int, int);
+	void onMove(NAS2D::Vector<int> displacement) override;
 	void onResize() override;
 
 private:

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 #include <NAS2D/EventHandler.h>
-#include <NAS2D/Resource/Image.h>
-#include <NAS2D/Signal/Signal.h>
+#include <NAS2D/Resources/Image.h>
 
 
 class NotificationArea : public Control
@@ -24,11 +23,8 @@ public:
 	{
 		std::string message{ "" };
 		NotificationType type{ NotificationType::Information };
+		NAS2D::Point<int> position{ 0, 0 };
 	};
-
-	const int Width = 48;
-	
-	using NotificationCallback = NAS2D::Signal<int>;
 
 public:
 	NotificationArea();
@@ -36,28 +32,15 @@ public:
 
 	void push(const std::string& message, NotificationType type);
 
-	void clear()
-	{
-		mNotificationList.clear();
-		mNotificationRectList.clear();
-	}
+	void clear() { mNotificationList.clear(); }
 
 	void update() override;
 
-	NotificationCallback& notificationClicked() { return mNotificationClicked; }
-
 protected:
-	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
-
-	void positionChanged(int dX, int dY);
-	void onSizeChanged();
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, int, int);
+	void onMouseMove(int, int, int, int);
 
 private:
-	void updateRectListPositions();
-
 	const NAS2D::Image& mIcons;
 	std::vector<Notification> mNotificationList;
-	std::vector<NAS2D::Rectangle<int>> mNotificationRectList;
-
-	NotificationCallback mNotificationClicked;
 };

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -42,9 +42,9 @@ public:
 		mNotificationRectList.clear();
 	}
 
-	void update() override;
-
 	NotificationCallback& notificationClicked() { return mNotificationClicked; }
+
+	void update() override;
 
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -28,7 +28,7 @@ public:
 
 	const int Width = 48;
 	
-	using NotificationCallback = NAS2D::Signal<int>;
+	using NotificationCallback = NAS2D::Signal<const Notification&>;
 
 public:
 	NotificationArea();

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -39,7 +39,6 @@ public:
 
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int, int);
-	void onMouseMove(int, int, int, int);
 
 private:
 	const NAS2D::Image& mIcons;

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Core/Control.h"
+
+#include <vector>
+#include <NAS2D/EventHandler.h>
+
+class NotificationArea : public Control
+{
+public:
+	enum class NotificationType
+	{
+		Critical,
+		Information,
+		Warning
+	};
+
+
+	struct Notification
+	{
+		std::string message;
+		NotificationType type;
+		NAS2D::Point<int> position{ 0, 0 };
+	};
+
+public:
+	NotificationArea();
+	~NotificationArea() override;
+
+	void push(Notification);
+
+	void clear() { mNotificationList.clear(); }
+
+	void update() override;
+
+protected:
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, int, int);
+	void onMouseMove(int, int, int, int);
+
+private:
+	std::vector<Notification> mNotificationList;
+};

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -23,8 +23,6 @@ public:
 	{
 		std::string message{ "" };
 		NotificationType type{ NotificationType::Information };
-		NAS2D::Point<int> position{ 0, 0 };
-		NAS2D::Vector<int> size{ 32, 32 };
 	};
 
 public:

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -24,6 +24,7 @@ public:
 		std::string message{ "" };
 		NotificationType type{ NotificationType::Information };
 		NAS2D::Point<int> position{ 0, 0 };
+		NAS2D::Vector<int> size{ 32, 32 };
 	};
 
 public:

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -69,3 +69,4 @@ private:
 
 const NAS2D::Rectangle<float>& IconRectFromNotificationType(const NotificationArea::NotificationType);
 const NAS2D::Color ColorFromNotification(const NotificationArea::NotificationType);
+const std::string& StringFromNotificationType(const NotificationArea::NotificationType);

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -5,7 +5,8 @@
 
 #include <vector>
 #include <NAS2D/EventHandler.h>
-#include <NAS2D/Resources/Image.h>
+#include <NAS2D/Resource/Image.h>
+#include <NAS2D/Signal/Signal.h>
 
 
 class NotificationArea : public Control
@@ -26,6 +27,8 @@ public:
 	};
 
 	const int Width = 48;
+	
+	using NotificationCallback = NAS2D::Signal<int>;
 
 public:
 	NotificationArea();
@@ -41,11 +44,13 @@ public:
 
 	void update() override;
 
+	NotificationCallback& notificationClicked() { return mNotificationClicked; }
+
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
 
-	void positionChanged(int dX, int dY) override;
-	void onSizeChanged() override;
+	void positionChanged(int, int);
+	void onResize() override;
 
 private:
 	void updateRectListPositions();
@@ -53,4 +58,6 @@ private:
 	const NAS2D::Image& mIcons;
 	std::vector<Notification> mNotificationList;
 	std::vector<NAS2D::Rectangle<int>> mNotificationRectList;
+
+	NotificationCallback mNotificationClicked;
 };

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -5,7 +5,8 @@
 
 #include <vector>
 #include <NAS2D/EventHandler.h>
-#include <NAS2D/Resources/Image.h>
+#include <NAS2D/Resource/Image.h>
+#include <NAS2D/Signal/Signal.h>
 
 
 class NotificationArea : public Control
@@ -26,8 +27,8 @@ public:
 	};
 
 	const int Width = 48;
-
-	using NotificationCallback = NAS2D::Signals::Signal<int>;
+	
+	using NotificationCallback = NAS2D::Signal<int>;
 
 public:
 	NotificationArea();
@@ -48,8 +49,8 @@ public:
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
 
-	void positionChanged(int dX, int dY) override;
-	void onSizeChanged() override;
+	void positionChanged(int dX, int dY);
+	void onSizeChanged();
 
 private:
 	void updateRectListPositions();

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -27,6 +27,8 @@ public:
 
 	const int Width = 48;
 
+	using NotificationCallback = NAS2D::Signals::Signal<int>;
+
 public:
 	NotificationArea();
 	~NotificationArea() override;
@@ -41,6 +43,8 @@ public:
 
 	void update() override;
 
+	NotificationCallback& notificationClicked() { return mNotificationClicked; }
+
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
 
@@ -53,4 +57,6 @@ private:
 	const NAS2D::Image& mIcons;
 	std::vector<Notification> mNotificationList;
 	std::vector<NAS2D::Rectangle<int>> mNotificationRectList;
+
+	NotificationCallback mNotificationClicked;
 };

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -25,6 +25,8 @@ public:
 		NotificationType type{ NotificationType::Information };
 	};
 
+	const int Width = 48;
+
 public:
 	NotificationArea();
 	~NotificationArea() override;

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -2,8 +2,11 @@
 
 #include "Core/Control.h"
 
+
 #include <vector>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Resources/Image.h>
+
 
 class NotificationArea : public Control
 {
@@ -18,8 +21,8 @@ public:
 
 	struct Notification
 	{
-		std::string message;
-		NotificationType type;
+		std::string message{ "" };
+		NotificationType type{ NotificationType::Information };
 		NAS2D::Point<int> position{ 0, 0 };
 	};
 
@@ -27,7 +30,7 @@ public:
 	NotificationArea();
 	~NotificationArea() override;
 
-	void push(Notification);
+	void push(const std::string& message, NotificationType type);
 
 	void clear() { mNotificationList.clear(); }
 
@@ -38,5 +41,6 @@ protected:
 	void onMouseMove(int, int, int, int);
 
 private:
+	const NAS2D::Image& mIcons;
 	std::vector<Notification> mNotificationList;
 };

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -44,6 +44,11 @@ public:
 
 	NotificationCallback& notificationClicked() { return mNotificationClicked; }
 
+	const Notification& notificationFromIndex(int index)
+	{
+		return mNotificationList.at(static_cast<size_t>(index));
+	}
+
 	void update() override;
 
 protected:

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -33,14 +33,24 @@ public:
 
 	void push(const std::string& message, NotificationType type);
 
-	void clear() { mNotificationList.clear(); }
+	void clear()
+	{
+		mNotificationList.clear();
+		mNotificationRectList.clear();
+	}
 
 	void update() override;
 
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int, int);
 
+	void positionChanged(int dX, int dY) override;
+	void onSizeChanged() override;
+
 private:
+	void updateRectListPositions();
+
 	const NAS2D::Image& mIcons;
 	std::vector<Notification> mNotificationList;
+	std::vector<NAS2D::Rectangle<int>> mNotificationRectList;
 };

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -42,7 +42,7 @@ public:
 	void update() override;
 
 protected:
-	void onMouseDown(NAS2D::EventHandler::MouseButton button, int, int);
+	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
 
 	void positionChanged(int dX, int dY) override;
 	void onSizeChanged() override;

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -1,0 +1,37 @@
+#include "NotificationWindow.h"
+
+#include "../Cache.h"
+
+
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
+
+using namespace NAS2D;
+
+
+NotificationWindow::NotificationWindow():
+	mIcons{ imageCache.load("ui/icons.png") }
+{
+	size({ 350, 220 });
+
+	add(btnOkay, { 295, 195 });
+	btnOkay.size({ 50, 20 });
+	btnOkay.click().connect(this, &NotificationWindow::btnOkayClicked);
+}
+
+
+void NotificationWindow::btnOkayClicked()
+{
+	hide();
+}
+
+
+void NotificationWindow::update()
+{
+	if (!visible()) { return; }
+
+	Window::update();
+
+	auto& renderer = Utility<Renderer>::get();
+}

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -1,6 +1,7 @@
 #include "NotificationWindow.h"
 
 #include "../Cache.h"
+#include "../Constants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -17,6 +18,10 @@ NotificationWindow::NotificationWindow():
 	add(btnOkay, { 245, 195 });
 	btnOkay.size({ 50, 20 });
 	btnOkay.click().connect(this, &NotificationWindow::btnOkayClicked);
+
+	add(mMessageArea, { 5, 65 });
+	mMessageArea.size({ size().x - 10, 125 });
+	mMessageArea.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }
 
 
@@ -24,6 +29,7 @@ void NotificationWindow::notification(const NotificationArea::Notification& noti
 {
 	mNotification = notification;
 	title(StringFromNotificationType(mNotification.type));
+	mMessageArea.text(mNotification.message);
 }
 
 

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -12,11 +12,18 @@ using namespace NAS2D;
 NotificationWindow::NotificationWindow():
 	mIcons{ imageCache.load("ui/icons.png") }
 {
-	size({ 350, 220 });
+	size({ 300, 220 });
 
-	add(btnOkay, { 295, 195 });
+	add(btnOkay, { 245, 195 });
 	btnOkay.size({ 50, 20 });
 	btnOkay.click().connect(this, &NotificationWindow::btnOkayClicked);
+}
+
+
+void NotificationWindow::notification(const NotificationArea::Notification& notification)
+{
+	mNotification = notification;
+	title(StringFromNotificationType(mNotification.type));
 }
 
 

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -2,7 +2,6 @@
 
 #include "../Cache.h"
 
-
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
@@ -34,4 +33,9 @@ void NotificationWindow::update()
 	Window::update();
 
 	auto& renderer = Utility<Renderer>::get();
+
+	Point<float> iconLocation = position() + Vector{ 10, 30 };
+
+	renderer.drawSubImage(mIcons, iconLocation, { 128, 64, 32, 32 }, ColorFromNotification(mNotification.type));
+	renderer.drawSubImage(mIcons, iconLocation, IconRectFromNotificationType(mNotification.type), Color::Normal);
 }

--- a/OPHD/UI/NotificationWindow.h
+++ b/OPHD/UI/NotificationWindow.h
@@ -11,10 +11,7 @@ public:
 	NotificationWindow();
 	~NotificationWindow() = default;
 
-	void notification(const NotificationArea::Notification& notification)
-	{
-		mNotification = notification;
-	}
+	void notification(const NotificationArea::Notification&);
 
 	void update() override;
 

--- a/OPHD/UI/NotificationWindow.h
+++ b/OPHD/UI/NotificationWindow.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "Core/Window.h"
 #include "Core/Button.h"
+#include "Core/TextArea.h"
+#include "Core/Window.h"
 
 #include "NotificationArea.h"
 
@@ -22,4 +23,5 @@ private:
 
 	NotificationArea::Notification mNotification;
 	Button btnOkay{ "Okay" };
+	TextArea mMessageArea;
 };

--- a/OPHD/UI/NotificationWindow.h
+++ b/OPHD/UI/NotificationWindow.h
@@ -10,7 +10,6 @@ class NotificationWindow : public Window
 {
 public:
 	NotificationWindow();
-	~NotificationWindow() = default;
 
 	void notification(const NotificationArea::Notification&);
 

--- a/OPHD/UI/NotificationWindow.h
+++ b/OPHD/UI/NotificationWindow.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Core/Window.h"
+#include "Core/Button.h"
+
+#include "NotificationArea.h"
+
+class NotificationWindow : public Window
+{
+public:
+	NotificationWindow();
+	~NotificationWindow() = default;
+
+	void notification(const NotificationArea::Notification& notification);
+
+	void update() override;
+
+private:
+	void btnOkayClicked();
+
+
+	const NAS2D::Image& mIcons;
+
+	Button btnOkay{ "Okay" };
+};

--- a/OPHD/UI/NotificationWindow.h
+++ b/OPHD/UI/NotificationWindow.h
@@ -11,15 +11,18 @@ public:
 	NotificationWindow();
 	~NotificationWindow() = default;
 
-	void notification(const NotificationArea::Notification& notification);
+	void notification(const NotificationArea::Notification& notification)
+	{
+		mNotification = notification;
+	}
 
 	void update() override;
 
 private:
 	void btnOkayClicked();
 
-
 	const NAS2D::Image& mIcons;
 
+	NotificationArea::Notification mNotification;
 	Button btnOkay{ "Okay" };
 };

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -309,6 +309,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="UI\IconGrid.cpp" />
     <ClCompile Include="UI\MajorEventAnnouncement.cpp" />
     <ClCompile Include="UI\MineOperationsWindow.cpp" />
+    <ClCompile Include="UI\NotificationArea.cpp" />
     <ClCompile Include="UI\PopulationPanel.cpp" />
     <ClCompile Include="UI\ProductListBox.cpp" />
     <ClCompile Include="UI\Reports\FactoryReport.cpp" />
@@ -431,6 +432,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="UI\IconGrid.h" />
     <ClInclude Include="UI\MajorEventAnnouncement.h" />
     <ClInclude Include="UI\MineOperationsWindow.h" />
+    <ClInclude Include="UI\NotificationArea.h" />
     <ClInclude Include="UI\PopulationPanel.h" />
     <ClInclude Include="UI\ProductListBox.h" />
     <ClInclude Include="UI\Reports\FactoryReport.h" />

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -310,6 +310,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="UI\MajorEventAnnouncement.cpp" />
     <ClCompile Include="UI\MineOperationsWindow.cpp" />
     <ClCompile Include="UI\NotificationArea.cpp" />
+    <ClCompile Include="UI\NotificationWindow.cpp" />
     <ClCompile Include="UI\PopulationPanel.cpp" />
     <ClCompile Include="UI\ProductListBox.cpp" />
     <ClCompile Include="UI\Reports\FactoryReport.cpp" />
@@ -433,6 +434,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="UI\MajorEventAnnouncement.h" />
     <ClInclude Include="UI\MineOperationsWindow.h" />
     <ClInclude Include="UI\NotificationArea.h" />
+    <ClInclude Include="UI\NotificationWindow.h" />
     <ClInclude Include="UI\PopulationPanel.h" />
     <ClInclude Include="UI\ProductListBox.h" />
     <ClInclude Include="UI\Reports\FactoryReport.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -300,6 +300,9 @@
     <ClCompile Include="XmlSerializer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UI\NotificationArea.cpp">
+      <Filter>Source Files\UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -670,6 +673,9 @@
     </ClInclude>
     <ClInclude Include="XmlSerializer.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\NotificationArea.h">
+      <Filter>Header Files\UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -303,6 +303,9 @@
     <ClCompile Include="UI\NotificationArea.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
+    <ClCompile Include="UI\NotificationWindow.cpp">
+      <Filter>Source Files\UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -675,6 +678,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="UI\NotificationArea.h">
+      <Filter>Header Files\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\NotificationWindow.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Adds a NotificationArea with clickable icons that then open a window with a more detailed message.

NOTE: Mac build via circle-ci appears to be broken not due to code. All other checks pass so I would merge this if it looks good regardless and find a fix for the mac build after the fact.