### PR TITLE
Update CircleCI config for MacOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 commands:
   build:
     steps:
-      - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
       - run: make package
@@ -34,6 +33,7 @@ jobs:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
       - checkout
+      - run: git submodule update --init nas2d-core/
       - brew-install:
           packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
       - build
@@ -42,6 +42,7 @@ jobs:
       - image: outpostuniverse/nas2d:1.4
     steps:
       - checkout
+      - run: git submodule update --init nas2d-core/
       - build
   build-linux-gcc:
     docker:
@@ -50,6 +51,7 @@ jobs:
       WARN_EXTRA: -Wsuggest-override
     steps:
       - checkout
+      - run: git submodule update --init nas2d-core/
       - build
   build-linux-clang:
     docker:
@@ -58,6 +60,7 @@ jobs:
       WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
       - checkout
+      - run: git submodule update --init nas2d-core/
       - build
   build-linux-mingw:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "12.3.0"
+      xcode: "12.4.0"
     environment:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,15 @@ commands:
       - run: brew link << parameters.packages >>
 
 jobs:
+  build-macos:
+    macos:
+      xcode: "12.3.0"
+    environment:
+      - WARN_EXTRA: "-Wno-double-promotion"
+    steps:
+      - brew-install:
+          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
+      - build
   build-linux:
     docker:
       - image: outpostuniverse/nas2d:1.4
@@ -54,21 +63,12 @@ jobs:
       - checkout
       - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" intermediate
-  build-macos:
-    macos:
-      xcode: "12.3.0"
-    environment:
-      - WARN_EXTRA: "-Wno-double-promotion"
-    steps:
-      - brew-install:
-          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
-      - build
 
 workflows:
   build:
     jobs:
+      - build-macos
       - build-linux
       - build-linux-gcc
       - build-linux-clang
       - build-linux-mingw
-      - build-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,6 @@
 version: 2.1
 
 commands:
-  build:
-    steps:
-      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
-      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
-      - run: make package
-      - store_artifacts:
-          path: .build/package/
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
     parameters:
@@ -24,6 +17,13 @@ commands:
           paths:
             - /usr/local/Cellar
       - run: brew link << parameters.packages >>
+  build:
+    steps:
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
+      - run: make package
+      - store_artifacts:
+          path: .build/package/
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 commands:
   build:
     steps:
-      - checkout
       - run: git submodule update --init nas2d-core/
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
@@ -34,6 +33,7 @@ jobs:
     environment:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
+      - checkout
       - brew-install:
           packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
       - build
@@ -41,6 +41,7 @@ jobs:
     docker:
       - image: outpostuniverse/nas2d:1.4
     steps:
+      - checkout
       - build
   build-linux-gcc:
     docker:
@@ -48,6 +49,7 @@ jobs:
     environment:
       WARN_EXTRA: -Wsuggest-override
     steps:
+      - checkout
       - build
   build-linux-clang:
     docker:
@@ -55,6 +57,7 @@ jobs:
     environment:
       WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
+      - checkout
       - build
   build-linux-mingw:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,16 @@ version: 2.1
 commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
-    parameters:
-      packages:
-        type: string
     steps:
       - restore_cache:
           name: Restoring brew dependencies
-          key: deps-OPHD-v1-{{ arch }}
-      - run: brew install << parameters.packages >>
+          key: deps-OPHD-{{ arch }}-v1-{{ checksum "nas2d-core/BrewDeps.txt" }}
+      - run: make --directory nas2d-core/ install-dependencies
       - save_cache:
           name: Caching brew dependencies
-          key: deps-OPHD-v1-{{ arch }}
+          key: deps-OPHD-{{ arch }}-v1-{{ checksum "nas2d-core/BrewDeps.txt" }}
           paths:
             - /usr/local/Cellar
-      - run: brew link << parameters.packages >>
   build:
     steps:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
@@ -35,8 +31,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - brew-install:
-          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
+      - brew-install
       - build
   build-linux:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
       - restore_cache:
           name: Restoring brew dependencies
           key: deps-OPHD-v1-{{ arch }}
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install << parameters.packages >>
+      - run: brew install << parameters.packages >>
       - save_cache:
           name: Caching brew dependencies
           key: deps-OPHD-v1-{{ arch }}
@@ -30,6 +30,7 @@ jobs:
     macos:
       xcode: "12.4.0"
     environment:
+      - HOMEBREW_NO_AUTO_UPDATE: 1
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
       - checkout


### PR DESCRIPTION
Helps keep MacOS dependencies in sync between NAS2D and OPHD.

Addresses some recent issues for MacOS builds.
