### PR TITLE
Fixes for RadioButtonGroup

### DIFF
--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -1,6 +1,8 @@
 #include "RadioButtonGroup.h"
 
+
 using namespace NAS2D;
+
 
 RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup* parentContainer, std::string newText, NAS2D::Delegate<void()> delegate) :
 	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL)},
@@ -14,10 +16,12 @@ RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup* parentContainer, st
 	onTextChange();
 }
 
+
 RadioButtonGroup::RadioButton::~RadioButton()
 {
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &RadioButtonGroup::RadioButton::onMouseDown);
 }
+
 
 /**
  * Sets checked state.
@@ -36,16 +40,19 @@ bool RadioButtonGroup::RadioButton::checked() const
 	return mChecked;
 }
 
+
 void RadioButtonGroup::RadioButton::text(const std::string& text)
 {
 	mLabel.text(text);
 	onTextChange();
 }
 
+
 const std::string& RadioButtonGroup::RadioButton::text() const
 {
 	return mLabel.text();
 }
+
 
 void RadioButtonGroup::RadioButton::update()
 {
@@ -58,6 +65,7 @@ void RadioButtonGroup::RadioButton::update()
 	renderer.drawText(mFont, text(), position() + NAS2D::Vector{20, 0}, NAS2D::Color::White);
 }
 
+
 /**
  * Enforces minimum and maximum sizes.
  */
@@ -66,11 +74,13 @@ void RadioButtonGroup::RadioButton::onResize()
 	mRect.size({std::max(mRect.width, 13), 13});
 }
 
+
 void RadioButtonGroup::RadioButton::onTextChange()
 {
 	const auto textWidth = mFont.width(text());
 	width((textWidth > 0) ? 20 + textWidth : 13);
 }
+
 
 void RadioButtonGroup::RadioButton::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -19,7 +19,7 @@ RadioButtonGroup::RadioButtonGroup(std::vector<ButtonInfo> buttonInfos)
 	for(auto &buttonInfo : buttonInfos)
 	{
 		NAS2D::Vector<int> offset = {0, 13};
-		offset.y = mRadioButtons.size() * offset.y;
+		offset.y = static_cast<int>(mRadioButtons.size()) * offset.y;
 
 		auto &button = mRadioButtons.emplace_back(this, buttonInfo.name, buttonInfo.delegate);
 		button.visible(visible());

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -27,6 +27,7 @@ RadioButtonGroup::RadioButtonGroup(std::vector<ButtonInfo> buttonInfos)
 	}
 }
 
+
 void RadioButtonGroup::onMove(NAS2D::Vector<int> displacement)
 {
 	Control::onMove(displacement);
@@ -37,6 +38,7 @@ void RadioButtonGroup::onMove(NAS2D::Vector<int> displacement)
 	}
 }
 
+
 void RadioButtonGroup::clear()
 {
 	if (mIndex != constants::NO_SELECTION)
@@ -46,6 +48,7 @@ void RadioButtonGroup::clear()
 	mIndex = constants::NO_SELECTION;
 }
 
+
 void RadioButtonGroup::select(std::size_t index)
 {
 	clear();
@@ -53,11 +56,13 @@ void RadioButtonGroup::select(std::size_t index)
 	mRadioButtons[index].checked(true);
 }
 
+
 void RadioButtonGroup::select(RadioButtonGroup::RadioButton& button)
 {
 	auto index = std::distance(mRadioButtons.data(), &button);
 	select(index);
 }
+
 
 void RadioButtonGroup::update()
 {

--- a/OPHD/UI/Core/RadioButtonGroup.h
+++ b/OPHD/UI/Core/RadioButtonGroup.h
@@ -25,6 +25,11 @@ private:
         RadioButton(RadioButtonGroup* parentContainer, std::string newText, NAS2D::Delegate<void()> delegate);
         ~RadioButton() override;
 
+        // TODO: Best to delete these, but they need to exist for now
+        // The default methods do not properly handle global event connect/disconnect
+        RadioButton(const RadioButton&) = default;
+        RadioButton(RadioButton&&) = default;
+
         void checked(bool toggle);
         bool checked() const;
 

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -292,6 +292,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="UI\Core\ListBox.cpp" />
     <ClCompile Include="UI\Core\ListBoxBase.cpp" />
     <ClCompile Include="UI\Core\RadioButton.cpp" />
+    <ClCompile Include="UI\Core\RadioButtonGroup.cpp" />
     <ClCompile Include="UI\Core\Slider.cpp" />
     <ClCompile Include="UI\Core\TextArea.cpp" />
     <ClCompile Include="UI\Core\TextControl.cpp" />
@@ -415,7 +416,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="UI\Core\Label.h" />
     <ClInclude Include="UI\Core\ListBox.h" />
     <ClInclude Include="UI\Core\ListBoxBase.h" />
-    <ClInclude Include="UI\Core\RadioButton.h" />
+    <ClInclude Include="UI\Core\RadioButtonGroup.h" />
     <ClInclude Include="UI\Core\Slider.h" />
     <ClInclude Include="UI\Core\TextArea.h" />
     <ClInclude Include="UI\Core\TextControl.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClCompile Include="UI\Core\RadioButton.cpp">
       <Filter>Source Files\UI\Core</Filter>
     </ClCompile>
+    <ClCompile Include="UI\Core\RadioButtonGroup.cpp">
+      <Filter>Source Files\UI\Core</Filter>
+    </ClCompile>
     <ClCompile Include="UI\TextRender.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
@@ -623,7 +626,7 @@
     <ClInclude Include="UI\Core\Label.h">
       <Filter>Header Files\UI\Core</Filter>
     </ClInclude>
-    <ClInclude Include="UI\Core\RadioButton.h">
+    <ClInclude Include="UI\Core\RadioButtonGroup.h">
       <Filter>Header Files\UI\Core</Filter>
     </ClInclude>
     <ClInclude Include="Things\Structures\SurfacePolice.h">


### PR DESCRIPTION
The Windows project file update was accidentally missed from #879. The CI builds didn't run since the PR was from a repository fork rather than the main repository. It was caught by CI after the PR was merged into the main repository.

Additionally, with the increased warning level for the Clang compiler, it was noted that `RadioButton` should have explicitly declared copy and move constructors. Technically the default implementation is incorrect, since it won't properly handle the global event source, however, this won't matter in practice since the code is written so as to never copy or move `RadioButton` objects. In particular, the `std::vector::reserve` call prevents the vector from being resized, which would require copy or move. At any rate, the methods are needed to form a `std::vector` of the objects.

Added a `static_cast` to eliminate an MSVC conversion warning.

Added double blank lines between method implementations to match project convention.
