### PR TITLE
Comm range refactor

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -87,7 +87,7 @@ static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int c
 }
 
 
-static void fillCommList(TileList& tileList, TileMap& tileMap, Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
+void MapViewState::fillCommList(TileList& tileList, TileMap& tileMap, Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
 {
 	for (int y = 0; y < area.height; ++y)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -87,25 +87,6 @@ static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int c
 }
 
 
-void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
-{
-	for (int y = 0; y < area.height; ++y)
-	{
-		for (int x = 0; x < area.width; ++x)
-		{
-			auto& tile = (*mTileMap).getTile({ x + area.x, y + area.y });
-			if (isPointInRange(centerTile.position(), tile.position(), commRange))
-			{
-				if (std::find(mCommRangeOverlay.begin(), mCommRangeOverlay.end(), &tile) == mCommRangeOverlay.end())
-				{
-					mCommRangeOverlay.push_back(&tile);
-				}
-			}
-		}
-	}
-}
-
-
 static void pushAgingRobotMessage(const Robot* robot, const Point<int> position, NotificationArea& notificationArea)
 {
 	const auto robotLocationText = "(" + std::to_string(position.x) + ", " + std::to_string(position.y) + ")";
@@ -1424,6 +1405,25 @@ void MapViewState::checkCommRangeOverlay()
 		auto& centerTile = structureManager.tileFromStructure(tower);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, constants::COMM_TOWER_BASE_RANGE);
 		fillCommList(centerTile, commAreaRect, constants::COMM_TOWER_BASE_RANGE);
+	}
+}
+
+
+void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
+{
+	for (int y = 0; y < area.height; ++y)
+	{
+		for (int x = 0; x < area.width; ++x)
+		{
+			auto& tile = (*mTileMap).getTile({ x + area.x, y + area.y });
+			if (isPointInRange(centerTile.position(), tile.position(), commRange))
+			{
+				if (std::find(mCommRangeOverlay.begin(), mCommRangeOverlay.end(), &tile) == mCommRangeOverlay.end())
+				{
+					mCommRangeOverlay.push_back(&tile);
+				}
+			}
+		}
 	}
 }
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -89,19 +89,16 @@ static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int c
 
 void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
 {
-	TileList& tileList = mCommRangeOverlay;
-	TileMap& tileMap = *mTileMap;
-
 	for (int y = 0; y < area.height; ++y)
 	{
 		for (int x = 0; x < area.width; ++x)
 		{
-			auto& tile = tileMap.getTile({ x + area.x, y + area.y });
+			auto& tile = (*mTileMap).getTile({ x + area.x, y + area.y });
 			if (isPointInRange(centerTile.position(), tile.position(), commRange))
 			{
-				if (std::find(tileList.begin(), tileList.end(), &tile) == tileList.end())
+				if (std::find(mCommRangeOverlay.begin(), mCommRangeOverlay.end(), &tile) == mCommRangeOverlay.end())
 				{
-					tileList.push_back(&tile);
+					mCommRangeOverlay.push_back(&tile);
 				}
 			}
 		}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -87,8 +87,11 @@ static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int c
 }
 
 
-void MapViewState::fillCommList(TileList& tileList, TileMap& tileMap, Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
+void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
 {
+	TileList& tileList = mCommRangeOverlay;
+	TileMap& tileMap = *mTileMap;
+
 	for (int y = 0; y < area.height; ++y)
 	{
 		for (int x = 0; x < area.width; ++x)
@@ -1415,7 +1418,7 @@ void MapViewState::checkCommRangeOverlay()
 		if (!cc->operational()) { continue; }
 		auto& centerTile = structureManager.tileFromStructure(cc);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, constants::ROBOT_COM_RANGE);
-		fillCommList(mCommRangeOverlay, *mTileMap, centerTile, commAreaRect, constants::ROBOT_COM_RANGE);
+		fillCommList(centerTile, commAreaRect, constants::ROBOT_COM_RANGE);
 	}
 
 	for (auto tower : commTowers)
@@ -1423,7 +1426,7 @@ void MapViewState::checkCommRangeOverlay()
 		if (!tower->operational()) { continue; }
 		auto& centerTile = structureManager.tileFromStructure(tower);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, constants::COMM_TOWER_BASE_RANGE);
-		fillCommList(mCommRangeOverlay, *mTileMap, centerTile, commAreaRect, constants::COMM_TOWER_BASE_RANGE);
+		fillCommList(centerTile, commAreaRect, constants::COMM_TOWER_BASE_RANGE);
 	}
 }
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -231,7 +231,7 @@ private:
 
 	void onFileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
-	void MapViewState::fillCommList(TileList& tileList, TileMap& tileMap, Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
+	void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
 
 private:
 	MainReportsUiState& mMainReportsState;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -231,6 +231,7 @@ private:
 
 	void onFileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
+	void MapViewState::fillCommList(TileList& tileList, TileMap& tileMap, Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
 
 private:
 	MainReportsUiState& mMainReportsState;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -231,7 +231,7 @@ private:
 
 	void onFileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
 
-	void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
+	void fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
 
 private:
 	MainReportsUiState& mMainReportsState;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -151,6 +151,7 @@ private:
 	void setMinimapView();
 
 	void checkCommRangeOverlay();
+	void fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
 	void checkConnectedness();
 	void changeViewDepth(int);
 
@@ -230,8 +231,6 @@ private:
 	void onDiggerSelectionDialog(Direction direction, Tile* tile);
 
 	void onFileIoAction(const std::string& filePath, FileIo::FileOperation fileOp);
-
-	void fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
 
 private:
 	MainReportsUiState& mMainReportsState;


### PR DESCRIPTION
I've been really inactive for a long time. Glad to see all the work on the project though by others. Some minor exploratory work today since I had some time.

Any issue if I create an `IStructureWithAreaAffect` interface? I want to move pulling the communication range from an external constant to a get function defined by this structure interface. This interface could also be used in the future to pull the police station ranges or any other structure that affects an area. To be less generic it could be namesd 'ICommunicationStructure'. 

I think this will also make changing the affect range of various structures via research easier if we go that route. 

It may also allow collapsing the 2 for statements within `checkCommRangeOverlay`.

```C++
for (auto cc : command)
{
	if (!cc->operational()) { continue; }
	auto& centerTile = structureManager.tileFromStructure(cc);
	auto commAreaRect = buildAreaRectFromTile(centerTile, constants::ROBOT_COM_RANGE);
	fillCommList(centerTile, commAreaRect, constants::ROBOT_COM_RANGE);
}

for (auto tower : commTowers)
{
	if (!tower->operational()) { continue; }
	auto& centerTile = structureManager.tileFromStructure(tower);
	auto commAreaRect = buildAreaRectFromTile(centerTile, constants::COMM_TOWER_BASE_RANGE);
	fillCommList(centerTile, commAreaRect, constants::COMM_TOWER_BASE_RANGE);
}
```