### PR TITLE
Surface police range overlay

### DIFF
--- a/OPHD/Constants/Strings.h
+++ b/OPHD/Constants/Strings.h
@@ -210,6 +210,7 @@ namespace constants
 	const std::string ToolTipBtnConnectedness = "Toggles display of the Tile Connection Overlay";
 	const std::string ToolTipBtnCommRange = "Toggles display of the Communications Range Overlay";
 	const std::string ToolTipBtnRoutes = "Toggles display of the Trucking Routes Overlay";
+	const std::string ToolTipBtnPolice = "Toggles display of the Police Station Coverage";
 	const std::string ToolTipRefinedResources = "Breakdown of storage levels for Smelted Resources";
 	const std::string ToolTipResourceStorage = "Smelted Resources Storage. Current Level / Capacity";
 	const std::string ToolTipFoodStorage = "Food Storage. Current Level / Capacity";

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -12,7 +12,8 @@ std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
 	{ Tile::Overlay::None, NAS2D::Color::Normal },
 	{ Tile::Overlay::Communications, { 125, 200, 255 } },
 	{ Tile::Overlay::Connectedness, NAS2D::Color::Green },
-	{ Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange }
+	{ Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange },
+	{ Tile::Overlay::Police, NAS2D::Color::Red }
 };
 
 std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
@@ -20,7 +21,8 @@ std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
 	{ Tile::Overlay::None, NAS2D::Color{ 125, 200, 255 } },
 	{ Tile::Overlay::Communications, { 100, 180, 230 } },
 	{ Tile::Overlay::Connectedness, NAS2D::Color{ 71, 224, 146 } },
-	{ Tile::Overlay::TruckingRoutes, NAS2D::Color{ 125, 200, 255 } }
+	{ Tile::Overlay::TruckingRoutes, NAS2D::Color{ 125, 200, 255 } },
+	{ Tile::Overlay::Police, NAS2D::Color{ 100, 180, 230} }
 };
 
 

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -20,6 +20,7 @@ public:
 		Communications,
 		Connectedness,
 		TruckingRoutes,
+		Police,
 
 		None
 	};

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1411,6 +1411,23 @@ void MapViewState::checkCommRangeOverlay()
 }
 
 
+void MapViewState::checkSurfacePoliceOverlay()
+{
+	mSurfacePoliceOverlay.clear();
+
+	auto& structureManager = NAS2D::Utility<StructureManager>::get();
+
+	const auto& policeStations = structureManager.structureList(Structure::StructureClass::SurfacePolice);
+
+	for (auto policeStation : policeStations)
+	{
+		if (!policeStation->operational()) { continue; }
+		auto& centerTile = structureManager.tileFromStructure(policeStation);
+		auto commAreaRect = buildAreaRectFromTile(centerTile, 10);
+		fillRangedAreaList(mSurfacePoliceOverlay, centerTile, commAreaRect, dynamic_cast<SurfacePolice*>(policeStation)->getRange());
+	}
+}
+
 
 void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, const NAS2D::Rectangle<int>& area, int range)
 {

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1397,7 +1397,7 @@ void MapViewState::checkCommRangeOverlay()
 		auto range = dynamic_cast<CommandCenter*>(cc)->getRange();
 		auto& centerTile = structureManager.tileFromStructure(cc);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, range);
-		fillCommList(centerTile, commAreaRect, range);
+		fillRangedAreaList(mCommRangeOverlay, centerTile, commAreaRect, range);
 	}
 
 	for (auto tower : commTowers)
@@ -1406,23 +1406,24 @@ void MapViewState::checkCommRangeOverlay()
 		auto range = dynamic_cast<CommTower*>(tower)->getRange();
 		auto& centerTile = structureManager.tileFromStructure(tower);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, range);
-		fillCommList(centerTile, commAreaRect, range);
+		fillRangedAreaList(mCommRangeOverlay, centerTile, commAreaRect, range);
 	}
 }
 
 
-void MapViewState::fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange)
+
+void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, const NAS2D::Rectangle<int>& area, int range)
 {
 	for (int y = 0; y < area.height; ++y)
 	{
 		for (int x = 0; x < area.width; ++x)
 		{
 			auto& tile = (*mTileMap).getTile({ x + area.x, y + area.y });
-			if (isPointInRange(centerTile.position(), tile.position(), commRange))
+			if (isPointInRange(centerTile.position(), tile.position(), range))
 			{
-				if (std::find(mCommRangeOverlay.begin(), mCommRangeOverlay.end(), &tile) == mCommRangeOverlay.end())
+				if (std::find(tileList.begin(), tileList.end(), &tile) == tileList.end())
 				{
-					mCommRangeOverlay.push_back(&tile);
+					tileList.push_back(&tile);
 				}
 			}
 		}

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -151,7 +151,7 @@ private:
 	void setMinimapView();
 
 	void checkCommRangeOverlay();
-	void fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
+	void checkSurfacePoliceOverlay();
 	void fillRangedAreaList(TileList& tileList, Tile& centerTile, const NAS2D::Rectangle<int>& area, int range);
 	void checkConnectedness();
 	void changeViewDepth(int);
@@ -332,6 +332,7 @@ private:
 
 	TileList mConnectednessOverlay;
 	TileList mCommRangeOverlay;
+	TileList mSurfacePoliceOverlay;
 	TileList mTruckRouteOverlay;
 
 	NAS2D::Point<int> mTubeStart;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -217,6 +217,7 @@ private:
 	void onToggleConnectedness();
 	void onToggleCommRangeOverlay();
 	void onToggleRouteOverlay();
+	void onTogglePoliceOverlay();
 
 	void onNotificationClicked(const NotificationArea::Notification&);
 
@@ -269,6 +270,7 @@ private:
 	Button mBtnToggleConnectedness;
 	Button mBtnToggleCommRangeOverlay;
 	Button mBtnToggleRouteOverlay;
+	Button mBtnTogglePoliceOverlay;
 
 	// Bare Control's use for ToolTips
 	Control mTooltipSystemButton;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -152,6 +152,7 @@ private:
 
 	void checkCommRangeOverlay();
 	void fillCommList(Tile& centerTile, const NAS2D::Rectangle<int>& area, int commRange);
+	void fillRangedAreaList(TileList& tileList, Tile& centerTile, const NAS2D::Rectangle<int>& area, int range);
 	void checkConnectedness();
 	void changeViewDepth(int);
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -250,6 +250,7 @@ void MapViewState::load(const std::string& filePath)
 	CURRENT_LEVEL_STRING = LEVEL_STRING_TABLE[mTileMap->currentDepth()];
 
 	checkCommRangeOverlay();
+	checkSurfacePoliceOverlay();
 
 	mMapChangedSignal();
 }

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -544,6 +544,7 @@ void MapViewState::nextTurn()
 
 	// Overlay Updates
 	checkCommRangeOverlay();
+	checkSurfacePoliceOverlay();
 	onToggleConnectedness();
 	onToggleCommRangeOverlay();
 	onToggleRouteOverlay();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -548,6 +548,7 @@ void MapViewState::nextTurn()
 	onToggleConnectedness();
 	onToggleCommRangeOverlay();
 	onToggleRouteOverlay();
+	onTogglePoliceOverlay();
 
 	auto& factories = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory);
 	for (auto factory : factories)

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -125,6 +125,11 @@ void MapViewState::initUi()
 	mBtnToggleRouteOverlay.type(Button::Type::BUTTON_TOGGLE);
 	mBtnToggleRouteOverlay.click().connect(this, &MapViewState::onToggleRouteOverlay);
 
+	mBtnTogglePoliceOverlay.image("ui/icons/PoliceIcon.png");
+	mBtnTogglePoliceOverlay.size(constants::MAIN_BUTTON_SIZE);
+	mBtnTogglePoliceOverlay.type(Button::Type::BUTTON_TOGGLE);
+	mBtnTogglePoliceOverlay.click().connect(this, &MapViewState::onTogglePoliceOverlay);
+
 	// Menus
 	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
 	mRobots.size({52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2});
@@ -168,6 +173,7 @@ void MapViewState::initUi()
 	mToolTip.add(mBtnToggleConnectedness, constants::ToolTipBtnConnectedness);
 	mToolTip.add(mBtnToggleCommRangeOverlay, constants::ToolTipBtnCommRange);
 	mToolTip.add(mBtnToggleRouteOverlay, constants::ToolTipBtnRoutes);
+	mToolTip.add(mBtnTogglePoliceOverlay, constants::ToolTipBtnPolice);
 	mToolTip.add(mTooltipResourceBreakdown, constants::ToolTipRefinedResources);
 	mToolTip.add(mTooltipResourceStorage, constants::ToolTipResourceStorage);
 	mToolTip.add(mTooltipFoodStorage, constants::ToolTipFoodStorage);
@@ -213,9 +219,10 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mBtnToggleConnectedness.position({ mBtnTurns.positionX(), mMiniMapBoundingBox.y + constants::MAIN_BUTTON_SIZE });
 	mBtnToggleCommRangeOverlay.position({ mBtnTurns.positionX(), mMiniMapBoundingBox.y + (constants::MAIN_BUTTON_SIZE * 2) });
 	mBtnToggleRouteOverlay.position({ mBtnTurns.positionX(), mMiniMapBoundingBox.y + (constants::MAIN_BUTTON_SIZE * 3) });
+	mBtnTogglePoliceOverlay.position({ mBtnTurns.positionX() - constants::MAIN_BUTTON_SIZE, mMiniMapBoundingBox.y});
 
 	// UI Panels
-	mRobots.position({mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
+	mRobots.position({mBtnTogglePoliceOverlay.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
 	mConnections.position({mRobots.positionX() - constants::MARGIN_TIGHT - 52, mBottomUiRect.y + MARGIN});
 	mStructures.position(NAS2D::Point{constants::MARGIN, mBottomUiRect.y + MARGIN});
 
@@ -256,6 +263,7 @@ void MapViewState::hideUi()
 	mBtnToggleConnectedness.hide();
 	mBtnToggleCommRangeOverlay.hide();
 	mBtnToggleRouteOverlay.hide();
+	mBtnTogglePoliceOverlay.hide();
 
 	mStructures.hide();
 	mRobots.hide();
@@ -275,6 +283,7 @@ void MapViewState::unhideUi()
 	mBtnToggleHeightmap.show();
 	mBtnToggleConnectedness.show();
 	mBtnToggleCommRangeOverlay.show();
+	mBtnTogglePoliceOverlay.visible(true);
 	mBtnToggleRouteOverlay.show();
 
 	mStructures.show();
@@ -411,6 +420,7 @@ void MapViewState::drawUI()
 	mBtnToggleConnectedness.update();
 	mBtnToggleCommRangeOverlay.update();
 	mBtnToggleRouteOverlay.update();
+	mBtnTogglePoliceOverlay.update();
 
 	// Menus
 	mRobots.update();
@@ -435,9 +445,11 @@ void MapViewState::onToggleConnectedness()
 	{
 		mBtnToggleCommRangeOverlay.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
+		mBtnTogglePoliceOverlay.toggle(false);
 
 		onToggleCommRangeOverlay();
 		onToggleRouteOverlay();
+		onTogglePoliceOverlay();
 	}
 
 	setOverlay(mBtnToggleConnectedness, mConnectednessOverlay, Tile::Overlay::Connectedness);
@@ -450,14 +462,31 @@ void MapViewState::onToggleCommRangeOverlay()
 	{
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
+		mBtnTogglePoliceOverlay.toggle(false);
 
 		onToggleConnectedness();
 		onToggleRouteOverlay();
+		onTogglePoliceOverlay();
 	}
 
 	setOverlay(mBtnToggleCommRangeOverlay, mCommRangeOverlay, Tile::Overlay::Communications);
 }
 
+void MapViewState::onTogglePoliceOverlay()
+{
+	if (mBtnTogglePoliceOverlay.toggled())
+	{
+		mBtnToggleCommRangeOverlay.toggle(false);
+		mBtnToggleConnectedness.toggle(false);
+		mBtnToggleRouteOverlay.toggle(false);
+
+		onToggleCommRangeOverlay();
+		onToggleConnectedness();
+		onToggleRouteOverlay();
+	}
+
+	setOverlay(mBtnTogglePoliceOverlay, mSurfacePoliceOverlay, Tile::Overlay::Police);
+}
 
 void MapViewState::onToggleRouteOverlay()
 {
@@ -465,9 +494,11 @@ void MapViewState::onToggleRouteOverlay()
 	{
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleCommRangeOverlay.toggle(false);
+		mBtnTogglePoliceOverlay.toggle(false);
 
 		onToggleCommRangeOverlay();
 		onToggleConnectedness();
+		onTogglePoliceOverlay();
 	}
 
 	setOverlay(mBtnToggleRouteOverlay, mTruckRouteOverlay, Tile::Overlay::TruckingRoutes);

--- a/OPHD/Things/Structures/SurfacePolice.h
+++ b/OPHD/Things/Structures/SurfacePolice.h
@@ -18,6 +18,11 @@ public:
 		requiresCHAP(true);
 	}
 
+	int getRange() const
+	{
+		return 5;
+	}
+
 protected:
 	void defineResourceInput() override
 	{


### PR DESCRIPTION
If this looks good, the next step is to either get the underground views showing or make the surface police actually do something useful.

It wasn't too difficult to modify the comm range code to also handle police coverage, so nice job on the original design there. It also wasn't difficult to modify the UI code positioning, so appreciate the time put in developing it.

I'm not beholden to using red or this shade of red if someone has a better color.

See new icon on display below.

<img width="766" alt="Police Overlay" src="https://user-images.githubusercontent.com/15183337/119578352-5a1e3e00-bd8a-11eb-8dc8-e1467e7e11fb.png">
.
