### PR TITLE
Add Constants.h include to structures

### DIFF
--- a/OPHD/Things/Structures/Agridome.h
+++ b/OPHD/Things/Structures/Agridome.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "FoodProduction.h"
+
+#include "../../Constants.h"
+
 #include <algorithm>
+
 
 const int AGRIDOME_CAPACITY = 1000;
 const int AGRIDOME_BASE_PRODUCUCTION = 10;

--- a/OPHD/Things/Structures/AirShaft.h
+++ b/OPHD/Things/Structures/AirShaft.h
@@ -2,6 +2,8 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
 
 class AirShaft: public Structure
 {

--- a/OPHD/Things/Structures/CHAP.h
+++ b/OPHD/Things/Structures/CHAP.h
@@ -2,6 +2,9 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
+
 class CHAP : public Structure
 {
 public:

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -5,6 +5,7 @@
 #include "../../Constants.h"
 #include "../../Map/Tile.h"
 
+
 class CargoLander : public Structure
 {
 public:

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -5,6 +5,7 @@
 #include "../../Constants.h"
 #include "../../Map/Tile.h"
 
+
 class ColonistLander : public Structure
 {
 public:

--- a/OPHD/Things/Structures/CommandCenter.h
+++ b/OPHD/Things/Structures/CommandCenter.h
@@ -2,6 +2,9 @@
 
 #include "FoodProduction.h"
 
+#include "../../Constants.h"
+
+
 /**
  * Implements the Command Center structure.
  */

--- a/OPHD/Things/Structures/Commercial.h
+++ b/OPHD/Things/Structures/Commercial.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class Commercial : public Structure
 {
 public:

--- a/OPHD/Things/Structures/FusionReactor.h
+++ b/OPHD/Things/Structures/FusionReactor.h
@@ -3,9 +3,12 @@
 #include "PowerStructure.h"
 
 #include "../../Constants.h"
+
 #include <string>
 
+
 const int FUSION_REACTOR_BASE_PRODUCUCTION = 1000;
+
 
 class FusionReactor : public PowerStructure
 {

--- a/OPHD/Things/Structures/HotLaboratory.h
+++ b/OPHD/Things/Structures/HotLaboratory.h
@@ -2,6 +2,9 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
+
 class HotLaboratory : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Laboratory.h
+++ b/OPHD/Things/Structures/Laboratory.h
@@ -2,6 +2,9 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
+
 class Laboratory : public Structure
 {
 public:

--- a/OPHD/Things/Structures/MedicalCenter.h
+++ b/OPHD/Things/Structures/MedicalCenter.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class MedicalCenter : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Nursery.h
+++ b/OPHD/Things/Structures/Nursery.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class Nursery : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Park.h
+++ b/OPHD/Things/Structures/Park.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class Park : public Structure
 {
 public:

--- a/OPHD/Things/Structures/PowerStructure.h
+++ b/OPHD/Things/Structures/PowerStructure.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "Structure.h"
+
 #include "../../Constants.h"
+
 #include <string>
+
 
 /**
  * Virtual class for structures whose primary purpose is power production

--- a/OPHD/Things/Structures/RecreationCenter.h
+++ b/OPHD/Things/Structures/RecreationCenter.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class RecreationCenter : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Recycling.h
+++ b/OPHD/Things/Structures/Recycling.h
@@ -3,7 +3,9 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+
 #include <NAS2D/StringUtils.h>
+
 
 class Recycling : public Structure
 {

--- a/OPHD/Things/Structures/RedLightDistrict.h
+++ b/OPHD/Things/Structures/RedLightDistrict.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class RedLightDistrict : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Residence.h
+++ b/OPHD/Things/Structures/Residence.h
@@ -2,6 +2,8 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
 #include <algorithm>
 
 

--- a/OPHD/Things/Structures/Road.h
+++ b/OPHD/Things/Structures/Road.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants/Strings.h"
 
+
 class Road : public Structure
 {
 public:

--- a/OPHD/Things/Structures/RobotCommand.h
+++ b/OPHD/Things/Structures/RobotCommand.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Structure.h"
+
 #include "../../Constants.h"
 
 #include <vector>

--- a/OPHD/Things/Structures/SeedFactory.h
+++ b/OPHD/Things/Structures/SeedFactory.h
@@ -2,6 +2,8 @@
 
 #include "Factory.h"
 
+#include "../../Constants.h"
+
 
 class SeedFactory: public Factory
 {

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -2,6 +2,8 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
 #include <NAS2D/Renderer/Point.h>
 
 

--- a/OPHD/Things/Structures/SeedPower.h
+++ b/OPHD/Things/Structures/SeedPower.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "PowerStructure.h"
+
 #include "../../Constants.h"
 
 #include <string>

--- a/OPHD/Things/Structures/SeedSmelter.h
+++ b/OPHD/Things/Structures/SeedSmelter.h
@@ -2,6 +2,8 @@
 
 #include "OreRefining.h"
 
+#include "../../Constants.h"
+
 
 class SeedSmelter : public OreRefining
 {

--- a/OPHD/Things/Structures/Smelter.h
+++ b/OPHD/Things/Structures/Smelter.h
@@ -2,6 +2,9 @@
 
 #include "OreRefining.h"
 
+#include "../../Constants.h"
+
+
 class Smelter : public OreRefining
 {
 	const int StorageCapacity = 800;

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -4,7 +4,9 @@
 
 #include "../../Constants.h"
 
+
 const int SOLAR_PANEL_BASE_PRODUCUCTION = 50;
+
 
 class SolarPanelArray : public PowerStructure
 {

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -4,7 +4,9 @@
 
 #include "../../Constants.h"
 
+
 const int SOLAR_PLANT_BASE_PRODUCUCTION = 2000;
+
 
 class SolarPlant : public PowerStructure
 {

--- a/OPHD/Things/Structures/StorageTanks.h
+++ b/OPHD/Things/Structures/StorageTanks.h
@@ -2,7 +2,11 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
+
+
 const int StorageTanksCapacity = 1000;
+
 
 class StorageTanks : public Structure
 {

--- a/OPHD/Things/Structures/SurfaceFactory.h
+++ b/OPHD/Things/Structures/SurfaceFactory.h
@@ -2,6 +2,8 @@
 
 #include "Factory.h"
 
+#include "../../Constants.h"
+
 
 class SurfaceFactory: public Factory
 {

--- a/OPHD/Things/Structures/SurfacePolice.h
+++ b/OPHD/Things/Structures/SurfacePolice.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class SurfacePolice : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -2,7 +2,9 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
 #include "../../Common.h"
+
 
 /**
  * Implements a Tube Structure.

--- a/OPHD/Things/Structures/UndergroundFactory.h
+++ b/OPHD/Things/Structures/UndergroundFactory.h
@@ -2,6 +2,8 @@
 
 #include "Factory.h"
 
+#include "../../Constants.h"
+
 
 class UndergroundFactory: public Factory
 {

--- a/OPHD/Things/Structures/UndergroundPolice.h
+++ b/OPHD/Things/Structures/UndergroundPolice.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class UndergroundPolice : public Structure
 {
 public:

--- a/OPHD/Things/Structures/University.h
+++ b/OPHD/Things/Structures/University.h
@@ -4,6 +4,7 @@
 
 #include "../../Constants.h"
 
+
 class University : public Structure
 {
 public:

--- a/OPHD/Things/Structures/Warehouse.h
+++ b/OPHD/Things/Structures/Warehouse.h
@@ -2,7 +2,9 @@
 
 #include "Structure.h"
 
+#include "../../Constants.h"
 #include "../../ProductPool.h"
+
 
 class Warehouse : public Structure
 {


### PR DESCRIPTION
Add missing `Constants.h` include to various `Structure` sub-classes.

Normalize formatting of include sections.
