### PR TITLE
Refactor WarehouseReport list filling

### DIFF
--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -131,7 +131,7 @@ void WarehouseReport::_fillListFromStructureList(const std::vector<Warehouse*>& 
 		StructureListBox::StructureListBoxItem* item = lstStructures.last();
 
 		// \fixme	Abuse of interface to achieve custom results.
-		ProductPool& products = static_cast<Warehouse*>(warehouse)->products();
+		ProductPool& products = warehouse->products();
 
 		if (warehouse->state() != StructureState::Operational) { item->structureState = warehouse->stateDescription(); }
 		else if (products.empty()) { item->structureState = constants::WAREHOUSE_EMPTY; }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -17,11 +17,11 @@ using namespace NAS2D;
 namespace
 {
 	template <typename Predicate>
-	std::vector<Structure*> selectWarehouses(const Predicate& predicate)
+	std::vector<Warehouse*> selectWarehouses(const Predicate& predicate)
 	{
 		const auto& warehouses = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
 
-		std::vector<Structure*> output;
+		std::vector<Warehouse*> output;
 		for (auto structure : warehouses)
 		{
 			auto* warehouse = static_cast<Warehouse*>(structure);
@@ -123,7 +123,7 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 }
 
 
-void WarehouseReport::_fillListFromStructureList(const std::vector<Structure*>& list)
+void WarehouseReport::_fillListFromStructureList(const std::vector<Warehouse*>& list)
 {
 	for (auto structure : list)
 	{

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -123,17 +123,17 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 }
 
 
-void WarehouseReport::_fillListFromStructureList(const std::vector<Warehouse*>& list)
+void WarehouseReport::_fillListFromStructureList(const std::vector<Warehouse*>& warehouses)
 {
-	for (auto structure : list)
+	for (auto warehouse : warehouses)
 	{
-		lstStructures.addItem(structure);
+		lstStructures.addItem(warehouse);
 		StructureListBox::StructureListBoxItem* item = lstStructures.last();
 
 		// \fixme	Abuse of interface to achieve custom results.
-		ProductPool& products = static_cast<Warehouse*>(structure)->products();
+		ProductPool& products = static_cast<Warehouse*>(warehouse)->products();
 
-		if (structure->state() != StructureState::Operational) { item->structureState = structure->stateDescription(); }
+		if (warehouse->state() != StructureState::Operational) { item->structureState = warehouse->stateDescription(); }
 		else if (products.empty()) { item->structureState = constants::WAREHOUSE_EMPTY; }
 		else if (products.atCapacity()) { item->structureState = constants::WAREHOUSE_FULL; }
 		else if (!products.empty() && !products.atCapacity()) { item->structureState = constants::WAREHOUSE_SPACE_AVAILABLE; }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -158,17 +158,11 @@ void WarehouseReport::fillListSpaceAvailable()
 {
 	lstStructures.clear();
 
-	StructureList list;
-	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
-	{
-		Warehouse* wh = static_cast<Warehouse*>(structure);
-		if (!wh->products().atCapacity() && !wh->products().empty() && (wh->operational() || wh->isIdle()))
-		{
-			list.push_back(structure);
-		}
-	}
+	const auto predicate = [](Warehouse* wh) {
+		return !wh->products().atCapacity() && !wh->products().empty() && (wh->operational() || wh->isIdle());
+	};
 
-	_fillListFromStructureList(list);
+	_fillListFromStructureList(selectWarehouses(predicate));
 
 	lstStructures.setSelection(0);
 	computeTotalWarehouseCapacity();
@@ -180,17 +174,11 @@ void WarehouseReport::fillListFull()
 {
 	lstStructures.clear();
 
-	StructureList list;
-	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
-	{
-		Warehouse* wh = static_cast<Warehouse*>(structure);
-		if (wh->products().atCapacity() && (wh->operational() || wh->isIdle()))
-		{
-			list.push_back(structure);
-		}
-	}
+	const auto predicate = [](Warehouse* wh) {
+		return wh->products().atCapacity() && (wh->operational() || wh->isIdle());
+	};
 
-	_fillListFromStructureList(list);
+	_fillListFromStructureList(selectWarehouses(predicate));
 
 	lstStructures.setSelection(0);
 	computeTotalWarehouseCapacity();
@@ -201,17 +189,11 @@ void WarehouseReport::fillListEmpty()
 {
 	lstStructures.clear();
 
-	StructureList list;
-	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
-	{
-		Warehouse* wh = static_cast<Warehouse*>(structure);
-		if (wh->products().empty() && (wh->operational() || wh->isIdle()))
-		{
-			list.push_back(structure);
-		}
-	}
+	const auto predicate = [](Warehouse* wh) {
+		return wh->products().empty() && (wh->operational() || wh->isIdle());
+	};
 
-	_fillListFromStructureList(list);
+	_fillListFromStructureList(selectWarehouses(predicate));
 
 	lstStructures.setSelection(0);
 	computeTotalWarehouseCapacity();
@@ -222,16 +204,11 @@ void WarehouseReport::fillListDisabled()
 {
 	lstStructures.clear();
 
-	StructureList list;
-	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
-	{
-		if (structure->disabled() || structure->destroyed())
-		{
-			list.push_back(structure);
-		}
-	}
+	const auto predicate = [](Warehouse* structure) {
+		return structure->disabled() || structure->destroyed();
+	};
 
-	_fillListFromStructureList(list);
+	_fillListFromStructureList(selectWarehouses(predicate));
 
 	lstStructures.setSelection(0);
 	computeTotalWarehouseCapacity();

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -21,13 +21,15 @@ namespace
 	{
 		const auto& warehouses = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
 
-		const auto typeConvertedPredicate = [&predicate](Structure* structure) {
-			auto* warehouse = static_cast<Warehouse*>(structure);
-			return predicate(warehouse);
-		};
-
 		std::vector<Structure*> output;
-		std::copy_if(warehouses.begin(), warehouses.end(), output.end(), typeConvertedPredicate);
+		for (auto structure : warehouses)
+		{
+			auto* warehouse = static_cast<Warehouse*>(structure);
+			if (predicate(warehouse))
+			{
+				output.push_back(warehouse);
+			}
+		}
 
 		return output;
 	}

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -14,6 +14,26 @@
 using namespace NAS2D;
 
 
+namespace
+{
+	template <typename Predicate>
+	std::vector<Structure*> selectWarehouses(const Predicate& predicate)
+	{
+		const auto& warehouses = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+
+		const auto typeConvertedPredicate = [&predicate](Structure* structure) {
+			auto* warehouse = static_cast<Warehouse*>(structure);
+			return predicate(warehouse);
+		};
+
+		std::vector<Structure*> output;
+		std::copy_if(warehouses.begin(), warehouses.end(), output.end(), typeConvertedPredicate);
+
+		return output;
+	}
+}
+
+
 WarehouseReport::WarehouseReport() :
 	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM)},
 	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -147,7 +147,7 @@ void WarehouseReport::fillLists()
 {
 	lstStructures.clear();
 
-	_fillListFromStructureList(Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse));
+	_fillListFromStructureList(selectWarehouses([](Warehouse*) { return true; }));
 
 	lstStructures.setSelection(0);
 	computeTotalWarehouseCapacity();

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -36,7 +36,7 @@ public:
 private:
 	void computeTotalWarehouseCapacity();
 
-	void _fillListFromStructureList(const std::vector<Structure*>&);
+	void _fillListFromStructureList(const std::vector<Warehouse*>&);
 
 	void onResize() override;
 


### PR DESCRIPTION
Background cleanup to support #714.

This enables the `_fillListFromStructureList` to take a more specific `std::vector<Warehouse*>`, as opposed to `std::vector<Structure*>`.

If we later convert to a method that gets specific structure lists, this will be needed. In particular, C++ views `std::vector<A>` and `std::vector<B>` to be unrelated types, even if `A` and `B` are related. That means you can't simply cast between collections of a base and derived type.
