### PR TITLE
Misc Structure list building

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -309,9 +309,12 @@ int MapViewState::refinedResourcesInStorage()
 
 void MapViewState::countPlayerResources()
 {
-	auto storage = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
 	auto& command = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
-	storage.insert(storage.begin(), command.begin(), command.end());
+
+	std::vector<Structure*> storage;
+	storage.insert(storage.end(), command.begin(), command.end());
+	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
 
 	StorableResources resources;
 	for (auto structure : storage)

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -238,16 +238,16 @@ void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robot
  */
 void updateRobotControl(RobotPool& robotPool)
 {
-	const auto& CommandCenter = Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
-	const auto& RobotCommand = Utility<StructureManager>::get().structureList(Structure::StructureClass::RobotCommand);
+	const auto& commandCenters = Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
+	const auto& robotCommands = Utility<StructureManager>::get().structureList(Structure::StructureClass::RobotCommand);
 
 	// 3 for the first command center
 	uint32_t _maxRobots = 0;
-	if (CommandCenter.size() > 0) { _maxRobots += 3; }
+	if (commandCenters.size() > 0) { _maxRobots += 3; }
 	// the 10 per robot command facility
-	for (std::size_t s = 0; s < RobotCommand.size(); ++s)
+	for (std::size_t s = 0; s < robotCommands.size(); ++s)
 	{
-		if (RobotCommand[s]->operational()) { _maxRobots += 10; }
+		if (robotCommands[s]->operational()) { _maxRobots += 10; }
 	}
 
 	robotPool.InitRobotCtrl(_maxRobots);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -452,15 +452,18 @@ void resourceShortageMessage(const StorableResources& resources, StructureID sid
  */
 void addRefinedResources(StorableResources& resourcesToAdd)
 {
-	StructureList storage = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
-
 	/**
 	 * The Command Center acts as backup storage especially during the beginning of the
 	 * game before storage tanks are built. This ensure that the CC is in the storage
 	 * structure list and that it's always the first structure in the list.
 	 */
+
 	auto& command = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
-	storage.insert(storage.begin(), command.begin(), command.end());
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
+
+	std::vector<Structure*> storage;
+	storage.insert(storage.end(), command.begin(), command.end());
+	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
 
 	for (auto structure : storage)
 	{
@@ -485,10 +488,13 @@ void addRefinedResources(StorableResources& resourcesToAdd)
  */
 void removeRefinedResources(StorableResources& resourcesToRemove)
 {
-	StructureList storage = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
-
 	// Command Center is backup storage, we want to pull from it last
+
 	auto& command = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
+
+	std::vector<Structure*> storage;
+	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
 	storage.insert(storage.end(), command.begin(), command.end());
 
 	for (auto structure : storage)

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -18,7 +18,7 @@ namespace {
 	/**
 	 * Fills population requirements fields in a Structure.
 	 */
-	static void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
+	void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
 	{
 		available[0] = std::min(required[0], populationPool.populationAvailable(Population::PersonRole::ROLE_WORKER));
 		available[1] = std::min(required[1], populationPool.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));


### PR DESCRIPTION
Background cleanup to support #714.

Refactor building of `Structure*` collections, to prepare them to work with more specific collection types. In particular `std::vector<CommandCenter*>` and `std::vector<StorageTanks*>` can not store their elements in each other's collection, but can have their elements stored in a `std::vector<Structure*>`.
