### PR TITLE
Add StructureManager::getStructures<StructureType>() template method

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -468,7 +468,7 @@ int getTruckAvailability()
 {
 	int trucksAvailable = 0;
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
+	auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouseList)
 	{
 		trucksAvailable += warehouse->products().count(ProductType::PRODUCT_TRUCK);
@@ -484,7 +484,7 @@ int pullTruckFromInventory()
 
 	if (trucksAvailable == 0) { return 0; }
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
+	auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouseList)
 	{
 		if (warehouse->products().pull(ProductType::PRODUCT_TRUCK, 1) > 0)
@@ -501,7 +501,7 @@ int pushTruckIntoInventory()
 {
 	const int storageNeededForTruck = storageRequiredPerUnit(ProductType::PRODUCT_TRUCK);
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
+	auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouseList)
 	{
 		if (warehouse->products().availableStorage() >= storageNeededForTruck)

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -468,7 +468,7 @@ int getTruckAvailability()
 {
 	int trucksAvailable = 0;
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
 	for (auto structure : warehouseList)
 	{
 		Warehouse* warehouse = static_cast<Warehouse*>(structure);
@@ -485,7 +485,7 @@ int pullTruckFromInventory()
 
 	if (trucksAvailable == 0) { return 0; }
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
 	for (auto structure : warehouseList)
 	{
 		Warehouse* warehouse = static_cast<Warehouse*>(structure);
@@ -503,7 +503,7 @@ int pushTruckIntoInventory()
 {
 	const int storageNeededForTruck = storageRequiredPerUnit(ProductType::PRODUCT_TRUCK);
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
 	for (auto structure : warehouseList)
 	{
 		Warehouse* warehouse = static_cast<Warehouse*>(structure);

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -469,9 +469,8 @@ int getTruckAvailability()
 	int trucksAvailable = 0;
 
 	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
-	for (auto structure : warehouseList)
+	for (auto warehouse : warehouseList)
 	{
-		Warehouse* warehouse = static_cast<Warehouse*>(structure);
 		trucksAvailable += warehouse->products().count(ProductType::PRODUCT_TRUCK);
 	}
 
@@ -486,9 +485,8 @@ int pullTruckFromInventory()
 	if (trucksAvailable == 0) { return 0; }
 
 	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
-	for (auto structure : warehouseList)
+	for (auto warehouse : warehouseList)
 	{
-		Warehouse* warehouse = static_cast<Warehouse*>(structure);
 		if (warehouse->products().pull(ProductType::PRODUCT_TRUCK, 1) > 0)
 		{
 			return 1;
@@ -504,9 +502,8 @@ int pushTruckIntoInventory()
 	const int storageNeededForTruck = storageRequiredPerUnit(ProductType::PRODUCT_TRUCK);
 
 	auto& warehouseList = NAS2D::Utility<StructureManager>::get().structures<Warehouse>();
-	for (auto structure : warehouseList)
+	for (auto warehouse : warehouseList)
 	{
-		Warehouse* warehouse = static_cast<Warehouse*>(structure);
 		if (warehouse->products().availableStorage() >= storageNeededForTruck)
 		{
 			warehouse->products().store(ProductType::PRODUCT_TRUCK, 1);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -309,8 +309,8 @@ int MapViewState::refinedResourcesInStorage()
 
 void MapViewState::countPlayerResources()
 {
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structures<StorageTanks>();
-	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
+	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), command.begin(), command.end());
@@ -1296,7 +1296,7 @@ void MapViewState::updateRobots()
 				tile->removeThing();
 			}
 
-			for (auto rcc : Utility<StructureManager>::get().structures<RobotCommand>())
+			for (auto rcc : Utility<StructureManager>::get().getStructures<RobotCommand>())
 			{
 				rcc->removeRobot(robot);
 			}
@@ -1391,8 +1391,8 @@ void MapViewState::checkCommRangeOverlay()
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	const auto& commTowers = structureManager.structures<CommTower>();
-	const auto& command = structureManager.structures<CommandCenter>();
+	const auto& commTowers = structureManager.getStructures<CommTower>();
+	const auto& command = structureManager.getStructures<CommandCenter>();
 	
 	for (auto cc : command)
 	{
@@ -1420,7 +1420,7 @@ void MapViewState::checkSurfacePoliceOverlay()
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	const auto& policeStations = structureManager.structures<SurfacePolice>();
+	const auto& policeStations = structureManager.getStructures<SurfacePolice>();
 
 	for (auto policeStation : policeStations)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -309,8 +309,8 @@ int MapViewState::refinedResourcesInStorage()
 
 void MapViewState::countPlayerResources()
 {
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
-	auto& command = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structures<StorageTanks>();
+	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), command.begin(), command.end());
@@ -1296,7 +1296,7 @@ void MapViewState::updateRobots()
 				tile->removeThing();
 			}
 
-			for (auto rcc : Utility<StructureManager>::get().structureList(Structure::StructureClass::RobotCommand))
+			for (auto rcc : Utility<StructureManager>::get().structures<RobotCommand>())
 			{
 				static_cast<RobotCommand*>(rcc)->removeRobot(robot);
 			}
@@ -1391,8 +1391,8 @@ void MapViewState::checkCommRangeOverlay()
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	const auto& commTowers = structureManager.structureList(Structure::StructureClass::Communication);
-	const auto& command = structureManager.structureList(Structure::StructureClass::Command);
+	const auto& commTowers = structureManager.structures<CommTower>();
+	const auto& command = structureManager.structures<CommandCenter>();
 	
 	for (auto cc : command)
 	{
@@ -1420,7 +1420,7 @@ void MapViewState::checkSurfacePoliceOverlay()
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	const auto& policeStations = structureManager.structureList(Structure::StructureClass::SurfacePolice);
+	const auto& policeStations = structureManager.structures<SurfacePolice>();
 
 	for (auto policeStation : policeStations)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1298,7 +1298,7 @@ void MapViewState::updateRobots()
 
 			for (auto rcc : Utility<StructureManager>::get().structures<RobotCommand>())
 			{
-				static_cast<RobotCommand*>(rcc)->removeRobot(robot);
+				rcc->removeRobot(robot);
 			}
 
 			if (mRobotInspector.focusedRobot() == robot) { mRobotInspector.hide(); }
@@ -1397,7 +1397,7 @@ void MapViewState::checkCommRangeOverlay()
 	for (auto cc : command)
 	{
 		if (!cc->operational()) { continue; }
-		auto range = dynamic_cast<CommandCenter*>(cc)->getRange();
+		auto range = cc->getRange();
 		auto& centerTile = structureManager.tileFromStructure(cc);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, range);
 		fillRangedAreaList(mCommRangeOverlay, centerTile, commAreaRect, range);
@@ -1406,7 +1406,7 @@ void MapViewState::checkCommRangeOverlay()
 	for (auto tower : commTowers)
 	{
 		if (!tower->operational()) { continue; }
-		auto range = dynamic_cast<CommTower*>(tower)->getRange();
+		auto range = tower->getRange();
 		auto& centerTile = structureManager.tileFromStructure(tower);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, range);
 		fillRangedAreaList(mCommRangeOverlay, centerTile, commAreaRect, range);
@@ -1427,7 +1427,7 @@ void MapViewState::checkSurfacePoliceOverlay()
 		if (!policeStation->operational()) { continue; }
 		auto& centerTile = structureManager.tileFromStructure(policeStation);
 		auto commAreaRect = buildAreaRectFromTile(centerTile, 10);
-		fillRangedAreaList(mSurfacePoliceOverlay, centerTile, commAreaRect, dynamic_cast<SurfacePolice*>(policeStation)->getRange());
+		fillRangedAreaList(mSurfacePoliceOverlay, centerTile, commAreaRect, policeStation->getRange());
 	}
 }
 

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -72,7 +72,7 @@ void MapViewState::drawMiniMap()
 	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	for (auto commTower : structureManager.structureList(Structure::StructureClass::Communication))
+	for (auto commTower : structureManager.structures<CommTower>())
 	{
 		if (commTower->operational())
 		{

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -72,7 +72,7 @@ void MapViewState::drawMiniMap()
 	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	for (auto commTower : structureManager.structures<CommTower>())
+	for (auto commTower : structureManager.getStructures<CommTower>())
 	{
 		if (commTower->operational())
 		{

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -349,8 +349,8 @@ Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
  * 
  * \note	Assumes a check for only one robot at any given time.
  * 
- * \return	Returns a pointer to a Warehouse structure or \c nullptr if
- *			there are no warehouses available with the required space.
+ * \return	Returns a pointer to a RobotCommand structure or \c nullptr if
+ *			there are no robot commands available with the required space.
  */
 RobotCommand* getAvailableRobotCommand()
 {

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -292,7 +292,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	{
 		if (!cc->operational()) { continue; }
 
-		if (isPointInRange(position, structureManager.tileFromStructure(cc).position(), dynamic_cast<CommandCenter*>(cc)->getRange()))
+		if (isPointInRange(position, structureManager.tileFromStructure(cc).position(), cc->getRange()))
 		{
 			return true;
 		}
@@ -303,7 +303,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	{
 		if (!tower->operational()) { continue; }
 
-		if (isPointInRange(position, structureManager.tileFromStructure(tower).position(), dynamic_cast<CommTower*>(tower)->getRange()))
+		if (isPointInRange(position, structureManager.tileFromStructure(tower).position(), tower->getRange()))
 		{
 			return true;
 		}
@@ -331,12 +331,11 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
 {
-	for (auto structure : Utility<StructureManager>::get().structures<Warehouse>())
+	for (auto warehouse : Utility<StructureManager>::get().structures<Warehouse>())
 	{
-		Warehouse* _wh = static_cast<Warehouse*>(structure);
-		if (_wh->products().canStore(type, static_cast<int>(count)))
+		if (warehouse->products().canStore(type, static_cast<int>(count)))
 		{
-			return _wh;
+			return warehouse;
 		}
 	}
 
@@ -355,12 +354,11 @@ Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
  */
 RobotCommand* getAvailableRobotCommand()
 {
-	for (auto structure : Utility<StructureManager>::get().structures<RobotCommand>())
+	for (auto robotCommand : Utility<StructureManager>::get().structures<RobotCommand>())
 	{
-		RobotCommand* _rc = static_cast<RobotCommand*>(structure);
-		if (_rc->operational() && _rc->commandCapacityAvailable())
+		if (robotCommand->operational() && robotCommand->commandCapacityAvailable())
 		{
-			return _rc;
+			return robotCommand;
 		}
 	}
 
@@ -379,12 +377,11 @@ RobotCommand* getAvailableRobotCommand()
 bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
 	ProductPool sourcePool = sourceWarehouse->products();
-	const auto& structures = Utility<StructureManager>::get().structures<Warehouse>();
-	for (auto structure : structures)
+	const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+	for (auto warehouse : warehouses)
 	{
-		if (structure->operational())
+		if (warehouse->operational())
 		{
-			Warehouse* warehouse = static_cast<Warehouse*>(structure);
 			if (warehouse != sourceWarehouse)
 			{
 				ProductPool destinationPool = warehouse->products();
@@ -411,12 +408,11 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
  */
 void moveProducts(Warehouse* sourceWarehouse)
 {
-	const auto& structures = Utility<StructureManager>::get().structures<Warehouse>();
-	for (auto structure : structures)
+	const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+	for (auto warehouse : warehouses)
 	{
-		if (structure->operational())
+		if (warehouse->operational())
 		{
-			Warehouse* warehouse = static_cast<Warehouse*>(structure);
 			if (warehouse != sourceWarehouse)
 			{
 				sourceWarehouse->products().transferAllTo(warehouse->products());

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -238,8 +238,8 @@ void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robot
  */
 void updateRobotControl(RobotPool& robotPool)
 {
-	const auto& commandCenters = Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
-	const auto& robotCommands = Utility<StructureManager>::get().structureList(Structure::StructureClass::RobotCommand);
+	const auto& commandCenters = Utility<StructureManager>::get().structures<CommandCenter>();
+	const auto& robotCommands = Utility<StructureManager>::get().structures<RobotCommand>();
 
 	// 3 for the first command center
 	uint32_t _maxRobots = 0;
@@ -287,7 +287,7 @@ bool inCommRange(NAS2D::Point<int> position)
 {
 	auto& structureManager = Utility<StructureManager>::get();
 
-	const auto& command = structureManager.structureList(Structure::StructureClass::Command);
+	const auto& command = structureManager.structures<CommandCenter>();
 	for (auto cc : command)
 	{
 		if (!cc->operational()) { continue; }
@@ -298,7 +298,7 @@ bool inCommRange(NAS2D::Point<int> position)
 		}
 	}
 
-	const auto& commTowers = structureManager.structureList(Structure::StructureClass::Communication);
+	const auto& commTowers = structureManager.structures<CommTower>();
 	for (auto tower : commTowers)
 	{
 		if (!tower->operational()) { continue; }
@@ -331,7 +331,7 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
 {
-	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse))
+	for (auto structure : Utility<StructureManager>::get().structures<Warehouse>())
 	{
 		Warehouse* _wh = static_cast<Warehouse*>(structure);
 		if (_wh->products().canStore(type, static_cast<int>(count)))
@@ -355,7 +355,7 @@ Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
  */
 RobotCommand* getAvailableRobotCommand()
 {
-	for (auto structure : Utility<StructureManager>::get().structureList(Structure::StructureClass::RobotCommand))
+	for (auto structure : Utility<StructureManager>::get().structures<RobotCommand>())
 	{
 		RobotCommand* _rc = static_cast<RobotCommand*>(structure);
 		if (_rc->operational() && _rc->commandCapacityAvailable())
@@ -379,7 +379,7 @@ RobotCommand* getAvailableRobotCommand()
 bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
 	ProductPool sourcePool = sourceWarehouse->products();
-	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+	const auto& structures = Utility<StructureManager>::get().structures<Warehouse>();
 	for (auto structure : structures)
 	{
 		if (structure->operational())
@@ -411,7 +411,7 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
  */
 void moveProducts(Warehouse* sourceWarehouse)
 {
-	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+	const auto& structures = Utility<StructureManager>::get().structures<Warehouse>();
 	for (auto structure : structures)
 	{
 		if (structure->operational())
@@ -458,8 +458,8 @@ void addRefinedResources(StorableResources& resourcesToAdd)
 	 * structure list and that it's always the first structure in the list.
 	 */
 
-	auto& command = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
+	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structures<StorageTanks>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), command.begin(), command.end());
@@ -490,8 +490,8 @@ void removeRefinedResources(StorableResources& resourcesToRemove)
 {
 	// Command Center is backup storage, we want to pull from it last
 
-	auto& command = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Command);
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Storage);
+	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structures<StorageTanks>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -238,8 +238,8 @@ void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robot
  */
 void updateRobotControl(RobotPool& robotPool)
 {
-	const auto& commandCenters = Utility<StructureManager>::get().structures<CommandCenter>();
-	const auto& robotCommands = Utility<StructureManager>::get().structures<RobotCommand>();
+	const auto& commandCenters = Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& robotCommands = Utility<StructureManager>::get().getStructures<RobotCommand>();
 
 	// 3 for the first command center
 	uint32_t _maxRobots = 0;
@@ -287,7 +287,7 @@ bool inCommRange(NAS2D::Point<int> position)
 {
 	auto& structureManager = Utility<StructureManager>::get();
 
-	const auto& command = structureManager.structures<CommandCenter>();
+	const auto& command = structureManager.getStructures<CommandCenter>();
 	for (auto cc : command)
 	{
 		if (!cc->operational()) { continue; }
@@ -298,7 +298,7 @@ bool inCommRange(NAS2D::Point<int> position)
 		}
 	}
 
-	const auto& commTowers = structureManager.structures<CommTower>();
+	const auto& commTowers = structureManager.getStructures<CommTower>();
 	for (auto tower : commTowers)
 	{
 		if (!tower->operational()) { continue; }
@@ -331,7 +331,7 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
 {
-	for (auto warehouse : Utility<StructureManager>::get().structures<Warehouse>())
+	for (auto warehouse : Utility<StructureManager>::get().getStructures<Warehouse>())
 	{
 		if (warehouse->products().canStore(type, static_cast<int>(count)))
 		{
@@ -354,7 +354,7 @@ Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
  */
 RobotCommand* getAvailableRobotCommand()
 {
-	for (auto robotCommand : Utility<StructureManager>::get().structures<RobotCommand>())
+	for (auto robotCommand : Utility<StructureManager>::get().getStructures<RobotCommand>())
 	{
 		if (robotCommand->operational() && robotCommand->commandCapacityAvailable())
 		{
@@ -377,7 +377,7 @@ RobotCommand* getAvailableRobotCommand()
 bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
 	ProductPool sourcePool = sourceWarehouse->products();
-	const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouses)
 	{
 		if (warehouse->operational())
@@ -408,7 +408,7 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
  */
 void moveProducts(Warehouse* sourceWarehouse)
 {
-	const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouses)
 	{
 		if (warehouse->operational())
@@ -454,8 +454,8 @@ void addRefinedResources(StorableResources& resourcesToAdd)
 	 * structure list and that it's always the first structure in the list.
 	 */
 
-	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structures<StorageTanks>();
+	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), command.begin(), command.end());
@@ -486,8 +486,8 @@ void removeRefinedResources(StorableResources& resourcesToRemove)
 {
 	// Command Center is backup storage, we want to pull from it last
 
-	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().structures<StorageTanks>();
+	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -229,7 +229,7 @@ void MapViewState::load(const std::string& filePath)
 			 * There should only ever be one structure if the turn count is 0, the
 			 * SEED Lander which at this point should not have been deployed.
 			 */
-			const auto& list = Utility<StructureManager>::get().structureList(Structure::StructureClass::Lander);
+			const auto& list = Utility<StructureManager>::get().structures<SeedLander>();
 			if (list.size() != 1) { throw std::runtime_error("MapViewState::load(): Turn counter at 0 but more than one structure in list."); }
 
 			SeedLander* s = dynamic_cast<SeedLander*>(list[0]);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -229,7 +229,7 @@ void MapViewState::load(const std::string& filePath)
 			 * There should only ever be one structure if the turn count is 0, the
 			 * SEED Lander which at this point should not have been deployed.
 			 */
-			const auto& list = Utility<StructureManager>::get().structures<SeedLander>();
+			const auto& list = Utility<StructureManager>::get().getStructures<SeedLander>();
 			if (list.size() != 1) { throw std::runtime_error("MapViewState::load(): Turn counter at 0 but more than one structure in list."); }
 
 			SeedLander* seedLander = list[0];

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -232,10 +232,10 @@ void MapViewState::load(const std::string& filePath)
 			const auto& list = Utility<StructureManager>::get().structures<SeedLander>();
 			if (list.size() != 1) { throw std::runtime_error("MapViewState::load(): Turn counter at 0 but more than one structure in list."); }
 
-			SeedLander* s = dynamic_cast<SeedLander*>(list[0]);
-			if (!s) { throw std::runtime_error("MapViewState::load(): Structure in list is not a SeedLander."); }
+			SeedLander* seedLander = list[0];
+			if (!seedLander) { throw std::runtime_error("MapViewState::load(): Structure in list is not a SeedLander."); }
 
-			s->deploySignal().connect(this, &MapViewState::onDeploySeedLander);
+			seedLander->deploySignal().connect(this, &MapViewState::onDeploySeedLander);
 
 			mStructures.clear();
 			mConnections.clear();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -89,8 +89,8 @@ void MapViewState::updatePopulation()
 	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, StructureState::Operational);
 	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::Operational);
 
-	auto foodProducers = structureManager.structures<FoodProduction>();
-	auto& commandCenters = structureManager.structures<CommandCenter>();
+	auto foodProducers = structureManager.getStructures<FoodProduction>();
+	auto& commandCenters = structureManager.getStructures<CommandCenter>();
 	foodProducers.insert(foodProducers.end(), commandCenters.begin(), commandCenters.end());
 
 	int remainder = mPopulation.update(mCurrentMorale, mFood, residences, universities, nurseries, hospitals);
@@ -106,8 +106,8 @@ void MapViewState::updateCommercial()
 {
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	const auto& _warehouses = structureManager.structures<Warehouse>();
-	const auto& _commercial = structureManager.structures<Commercial>();
+	const auto& _warehouses = structureManager.getStructures<Warehouse>();
+	const auto& _commercial = structureManager.getStructures<Commercial>();
 
 	// No need to do anything if there are no commercial structures.
 	if (_commercial.empty()) { return; }
@@ -179,7 +179,7 @@ void MapViewState::updateMorale()
 	const int residentialOverCapacityHit = mPopulation.size() > mResidentialCapacity ? 2 : 0;
 	const int foodProductionHit = foodProducingStructures > 0 ? 0 : 5;
 
-	auto& residences = NAS2D::Utility<StructureManager>::get().structures<Residence>();
+	auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
 	int bioWasteAccumulation = 0;
 	for (auto residence : residences)
 	{
@@ -234,12 +234,12 @@ void MapViewState::updateMorale()
 
 void MapViewState::findMineRoutes()
 {
-	auto& smelterList = NAS2D::Utility<StructureManager>::get().structures<Smelter>();
+	auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<Smelter>();
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();
 	mPathSolver->Reset();
 	mTruckRouteOverlay.clear();
 
-	for (auto mine : NAS2D::Utility<StructureManager>::get().structures<MineFacility>())
+	for (auto mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
 		mine->mine()->checkExhausted();
 
@@ -275,7 +275,7 @@ void MapViewState::findMineRoutes()
 void MapViewState::transportOreFromMines()
 {
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();
-	for (auto mine : NAS2D::Utility<StructureManager>::get().structures<MineFacility>())
+	for (auto mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
 		auto routeIt = routeTable.find(mine);
 		if (routeIt != routeTable.end())
@@ -320,7 +320,7 @@ void MapViewState::transportOreFromMines()
 
 void MapViewState::transportResourcesToStorage()
 {
-	auto& smelterList = NAS2D::Utility<StructureManager>::get().structures<Smelter>();
+	auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<Smelter>();
 	for (auto smelter : smelterList)
 	{
 		if (!smelter->operational() && !smelter->isIdle()) { continue; }
@@ -385,7 +385,7 @@ void MapViewState::checkColonyShip()
 void MapViewState::updateResidentialCapacity()
 {
 	mResidentialCapacity = 0;
-	const auto& residences = NAS2D::Utility<StructureManager>::get().structures<Residence>();
+	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
 	for (auto residence : residences)
 	{
 		if (residence->operational()) { mResidentialCapacity += residence->capacity(); }
@@ -399,8 +399,8 @@ void MapViewState::updateResidentialCapacity()
 
 void MapViewState::updateBiowasteRecycling()
 {
-	auto& residences = NAS2D::Utility<StructureManager>::get().structures<Residence>();
-	auto& recyclingFacilities = NAS2D::Utility<StructureManager>::get().structures<Recycling>();
+	auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
+	auto& recyclingFacilities = NAS2D::Utility<StructureManager>::get().getStructures<Recycling>();
 
 	if (residences.empty() || recyclingFacilities.empty()) { return; }
 
@@ -428,8 +428,8 @@ void MapViewState::countFood()
 {
 	mFood = 0;
 
-	auto foodProducers = NAS2D::Utility<StructureManager>::get().structures<FoodProduction>();
-	auto& command = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
+	auto foodProducers = NAS2D::Utility<StructureManager>::get().getStructures<FoodProduction>();
+	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
@@ -445,8 +445,8 @@ void MapViewState::countFood()
 
 void MapViewState::transferFoodToCommandCenter()
 {
-	auto& foodProducers = NAS2D::Utility<StructureManager>::get().structures<FoodProduction>();
-	auto& commandCenters = NAS2D::Utility<StructureManager>::get().structures<CommandCenter>();
+	auto& foodProducers = NAS2D::Utility<StructureManager>::get().getStructures<FoodProduction>();
+	auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	auto foodProducerIterator = foodProducers.begin();
 	for (auto commandCenter : commandCenters)
@@ -478,7 +478,7 @@ void MapViewState::transferFoodToCommandCenter()
  */
 void MapViewState::updateRoads()
 {
-	auto roads = NAS2D::Utility<StructureManager>::get().structures<Road>();
+	auto roads = NAS2D::Utility<StructureManager>::get().getStructures<Road>();
 
 	for (auto road : roads)
 	{
@@ -545,7 +545,7 @@ void MapViewState::nextTurn()
 	onToggleRouteOverlay();
 	onTogglePoliceOverlay();
 
-	auto& factories = NAS2D::Utility<StructureManager>::get().structures<Factory>();
+	auto& factories = NAS2D::Utility<StructureManager>::get().getStructures<Factory>();
 	for (auto factory : factories)
 	{
 		factory->updateProduction();

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -76,7 +76,7 @@ public:
 	void removeStructure(Structure* structure);
 
 	template <typename StructureType>
-	const std::vector<StructureType*> structures()
+	const std::vector<StructureType*> getStructures()
 	{
 		// Get list of structures with same function
 		const auto& sameClassStructures = structureList(structureTypeToClass<StructureType>());

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -15,6 +15,8 @@ class PopulationPool;
 struct StorableResources;
 
 
+template <typename T> constexpr bool dependent_false = false;
+
 template <typename StructureType>
 constexpr Structure::StructureClass structureTypeToClass() {
 	if constexpr (std::is_same_v<StructureType, Agridome>) { return Structure::StructureClass::FoodProduction; }
@@ -58,6 +60,7 @@ constexpr Structure::StructureClass structureTypeToClass() {
 	else if constexpr (std::is_same_v<StructureType, UndergroundPolice>) { return Structure::StructureClass::UndergroundPolice; }
 	else if constexpr (std::is_same_v<StructureType, University>) { return Structure::StructureClass::University; }
 	else if constexpr (std::is_same_v<StructureType, Warehouse>) { return Structure::StructureClass::Warehouse; }
+	else { static_assert(dependent_false<StructureType>, "Unknown type"); }
 }
 
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Things/Structures/Structure.h"
+#include "Things/Structures/Structures.h"
 
 
 namespace NAS2D {
@@ -12,6 +13,52 @@ namespace NAS2D {
 class Tile;
 class PopulationPool;
 struct StorableResources;
+
+
+template <typename StructureType>
+constexpr Structure::StructureClass structureTypeToClass() {
+	if constexpr (std::is_same_v<StructureType, Agridome>) { return Structure::StructureClass::FoodProduction; }
+	else if constexpr (std::is_same_v<StructureType, AirShaft>) { return Structure::StructureClass::Tube; }
+	else if constexpr (std::is_same_v<StructureType, CargoLander>) { return Structure::StructureClass::Lander; }
+	else if constexpr (std::is_same_v<StructureType, CHAP>) { return Structure::StructureClass::LifeSupport; }
+	else if constexpr (std::is_same_v<StructureType, ColonistLander>) { return Structure::StructureClass::Lander; }
+	else if constexpr (std::is_same_v<StructureType, CommandCenter>) { return Structure::StructureClass::Command; }
+	else if constexpr (std::is_same_v<StructureType, Commercial>) { return Structure::StructureClass::Commercial; }
+	else if constexpr (std::is_same_v<StructureType, CommTower>) { return Structure::StructureClass::Communication; }
+	else if constexpr (std::is_same_v<StructureType, Factory>) { return Structure::StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, FoodProduction>) { return Structure::StructureClass::FoodProduction; }
+	else if constexpr (std::is_same_v<StructureType, FusionReactor>) { return Structure::StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, HotLaboratory>) { return Structure::StructureClass::Laboratory; }
+	else if constexpr (std::is_same_v<StructureType, Laboratory>) { return Structure::StructureClass::Laboratory; }
+	else if constexpr (std::is_same_v<StructureType, MedicalCenter>) { return Structure::StructureClass::MedicalCenter; }
+	else if constexpr (std::is_same_v<StructureType, MineFacility>) { return Structure::StructureClass::Mine; }
+	else if constexpr (std::is_same_v<StructureType, MineShaft>) { return Structure::StructureClass::Undefined; }
+	else if constexpr (std::is_same_v<StructureType, Nursery>) { return Structure::StructureClass::Nursery; }
+	else if constexpr (std::is_same_v<StructureType, OreRefining>) { return Structure::StructureClass::Smelter; }
+	else if constexpr (std::is_same_v<StructureType, Park>) { return Structure::StructureClass::Park; }
+	else if constexpr (std::is_same_v<StructureType, PowerStructure>) { return Structure::StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, RecreationCenter>) { return Structure::StructureClass::RecreationCenter; }
+	else if constexpr (std::is_same_v<StructureType, Recycling>) { return Structure::StructureClass::Recycling; }
+	else if constexpr (std::is_same_v<StructureType, RedLightDistrict>) { return Structure::StructureClass::Residence; }
+	else if constexpr (std::is_same_v<StructureType, Residence>) { return Structure::StructureClass::Residence; }
+	else if constexpr (std::is_same_v<StructureType, Road>) { return Structure::StructureClass::Road; }
+	else if constexpr (std::is_same_v<StructureType, RobotCommand>) { return Structure::StructureClass::RobotCommand; }
+	else if constexpr (std::is_same_v<StructureType, SeedFactory>) { return Structure::StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, SeedLander>) { return Structure::StructureClass::Lander; }
+	else if constexpr (std::is_same_v<StructureType, SeedPower>) { return Structure::StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, SeedSmelter>) { return Structure::StructureClass::Smelter; }
+	else if constexpr (std::is_same_v<StructureType, Smelter>) { return Structure::StructureClass::Smelter; }
+	else if constexpr (std::is_same_v<StructureType, SolarPanelArray>) { return Structure::StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, SolarPlant>) { return Structure::StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, StorageTanks>) { return Structure::StructureClass::Storage; }
+	else if constexpr (std::is_same_v<StructureType, SurfaceFactory>) { return Structure::StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, SurfacePolice>) { return Structure::StructureClass::SurfacePolice; }
+	else if constexpr (std::is_same_v<StructureType, Tube>) { return Structure::StructureClass::Tube; }
+	else if constexpr (std::is_same_v<StructureType, UndergroundFactory>) { return Structure::StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, UndergroundPolice>) { return Structure::StructureClass::UndergroundPolice; }
+	else if constexpr (std::is_same_v<StructureType, University>) { return Structure::StructureClass::University; }
+	else if constexpr (std::is_same_v<StructureType, Warehouse>) { return Structure::StructureClass::Warehouse; }
+}
 
 
 /**

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -75,6 +75,25 @@ public:
 	void addStructure(Structure* structure, Tile* tile);
 	void removeStructure(Structure* structure);
 
+	template <typename StructureType>
+	const std::vector<StructureType*> structures()
+	{
+		// Get list of structures with same function
+		const auto& sameClassStructures = structureList(structureTypeToClass<StructureType>());
+
+		std::vector<StructureType*> output;
+		// Filter for instances of the exact type parameter
+		for (auto structure : sameClassStructures)
+		{
+			StructureType* derivedStructure = dynamic_cast<StructureType*>(structure);
+			if (derivedStructure)
+			{
+				output.push_back(derivedStructure);
+			}
+		}
+		return output;
+	}
+
 	const StructureList& structureList(Structure::StructureClass structureClass);
 	Tile& tileFromStructure(Structure* structure);
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -169,7 +169,7 @@ void FactoryReport::fillLists()
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		lstFactoryList.addItem(factory);
 	}
@@ -184,7 +184,7 @@ void FactoryReport::fillFactoryList(ProductType type)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (factory->productType() == type)
 		{
@@ -203,7 +203,7 @@ void FactoryReport::fillFactoryList(bool surface)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (surface && (factory->name() == constants::SURFACE_FACTORY || factory->name() == constants::SEED_FACTORY))
 		{
@@ -226,7 +226,7 @@ void FactoryReport::fillFactoryList(StructureState state)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (factory->state() == state)
 		{

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -169,7 +169,7 @@ void FactoryReport::fillLists()
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
+	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
 	{
 		lstFactoryList.addItem(static_cast<Factory*>(factory));
 	}
@@ -184,7 +184,7 @@ void FactoryReport::fillFactoryList(ProductType type)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
+	for (auto f : Utility<StructureManager>::get().structures<Factory>())
 	{
 		Factory* factory = static_cast<Factory*>(f);
 		if (factory->productType() == type)
@@ -204,7 +204,7 @@ void FactoryReport::fillFactoryList(bool surface)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
+	for (auto f : Utility<StructureManager>::get().structures<Factory>())
 	{
 		Factory* factory = static_cast<Factory*>(f);
 		if (surface && (factory->name() == constants::SURFACE_FACTORY || factory->name() == constants::SEED_FACTORY))
@@ -228,7 +228,7 @@ void FactoryReport::fillFactoryList(StructureState state)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto f : Utility<StructureManager>::get().structureList(Structure::StructureClass::Factory))
+	for (auto f : Utility<StructureManager>::get().structures<Factory>())
 	{
 		if (f->state() == state)
 		{

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -171,7 +171,7 @@ void FactoryReport::fillLists()
 	lstFactoryList.clear();
 	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
 	{
-		lstFactoryList.addItem(static_cast<Factory*>(factory));
+		lstFactoryList.addItem(factory);
 	}
 	checkFactoryActionControls();
 }
@@ -184,9 +184,8 @@ void FactoryReport::fillFactoryList(ProductType type)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto f : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
 	{
-		Factory* factory = static_cast<Factory*>(f);
 		if (factory->productType() == type)
 		{
 			lstFactoryList.addItem(factory);
@@ -204,9 +203,8 @@ void FactoryReport::fillFactoryList(bool surface)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto f : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
 	{
-		Factory* factory = static_cast<Factory*>(f);
 		if (surface && (factory->name() == constants::SURFACE_FACTORY || factory->name() == constants::SEED_FACTORY))
 		{
 			lstFactoryList.addItem(factory);
@@ -228,11 +226,11 @@ void FactoryReport::fillFactoryList(StructureState state)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto f : Utility<StructureManager>::get().structures<Factory>())
+	for (auto factory : Utility<StructureManager>::get().structures<Factory>())
 	{
-		if (f->state() == state)
+		if (factory->state() == state)
 		{
-			lstFactoryList.addItem(static_cast<Factory*>(f));
+			lstFactoryList.addItem(factory);
 		}
 	}
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -138,7 +138,7 @@ void MineReport::fillLists()
 {
 	lstMineFacilities.clear();
 	std::size_t id = 1;
-	for (auto facility : NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::Mine))
+	for (auto facility : NAS2D::Utility<StructureManager>::get().structures<MineFacility>())
 	{
 		lstMineFacilities.addItem(facility);
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -138,7 +138,7 @@ void MineReport::fillLists()
 {
 	lstMineFacilities.clear();
 	std::size_t id = 1;
-	for (auto facility : NAS2D::Utility<StructureManager>::get().structures<MineFacility>())
+	for (auto facility : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
 		lstMineFacilities.addItem(facility);
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -19,7 +19,7 @@ namespace
 	template <typename Predicate>
 	std::vector<Warehouse*> selectWarehouses(const Predicate& predicate)
 	{
-		const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+		const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
 
 		std::vector<Warehouse*> output;
 		std::copy_if(warehouses.begin(), warehouses.end(), output.end(), predicate);
@@ -97,7 +97,7 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 	int capacityTotal = 0;
 	int capacityAvailable = 0;
 
-	const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouses)
 	{
 		if (warehouse->operational())

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -19,7 +19,7 @@ namespace
 	template <typename Predicate>
 	std::vector<Warehouse*> selectWarehouses(const Predicate& predicate)
 	{
-		const auto& warehouses = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+		const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
 
 		std::vector<Warehouse*> output;
 		for (auto structure : warehouses)
@@ -104,7 +104,7 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 	int capacityTotal = 0;
 	int capacityAvailable = 0;
 
-	const auto& structures = Utility<StructureManager>::get().structureList(Structure::StructureClass::Warehouse);
+	const auto& structures = Utility<StructureManager>::get().structures<Warehouse>();
 	for (auto warehouseStructure : structures)
 	{
 		if (warehouseStructure->operational())

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -22,9 +22,8 @@ namespace
 		const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
 
 		std::vector<Warehouse*> output;
-		for (auto structure : warehouses)
+		for (auto warehouse : warehouses)
 		{
-			auto* warehouse = static_cast<Warehouse*>(structure);
 			if (predicate(warehouse))
 			{
 				output.push_back(warehouse);
@@ -104,12 +103,12 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 	int capacityTotal = 0;
 	int capacityAvailable = 0;
 
-	const auto& structures = Utility<StructureManager>::get().structures<Warehouse>();
-	for (auto warehouseStructure : structures)
+	const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
+	for (auto warehouse : warehouses)
 	{
-		if (warehouseStructure->operational())
+		if (warehouse->operational())
 		{
-			const auto& warehouseProducts = static_cast<Warehouse*>(warehouseStructure)->products();
+			const auto& warehouseProducts = warehouse->products();
 			capacityAvailable += warehouseProducts.availableStorage();
 			capacityTotal += warehouseProducts.capacity();
 		}
@@ -117,7 +116,7 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 
 	int capacityUsed = capacityTotal - capacityAvailable;
 
-	warehouseCount = structures.size();
+	warehouseCount = warehouses.size();
 	warehouseCapacityTotal = capacityTotal;
 	warehouseCapacityPercent = static_cast<float>(capacityUsed) / static_cast<float>(capacityTotal);
 }

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -22,13 +22,7 @@ namespace
 		const auto& warehouses = Utility<StructureManager>::get().structures<Warehouse>();
 
 		std::vector<Warehouse*> output;
-		for (auto warehouse : warehouses)
-		{
-			if (predicate(warehouse))
-			{
-				output.push_back(warehouse);
-			}
-		}
+		std::copy_if(warehouses.begin(), warehouses.end(), output.end(), predicate);
 
 		return output;
 	}


### PR DESCRIPTION
Closes #714

Add a `constexpr` template method `structureTypeToClass` to convert a structure type (C++ class) to a `StructureClass` enum value.

Implement `StructureManager::getStructures<StructureType>()` template method to get a list of derived structure types.

Remove a lot of no longer needed casts from `Structure*` to derived types.
