### PR TITLE
Refactor StructureManager loops

### DIFF
--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -284,9 +284,9 @@ const StructureList& StructureManager::structureList(Structure::StructureClass s
  */
 void StructureManager::disconnectAll()
 {
-	for (auto st_it = mStructureTileTable.begin(); st_it != mStructureTileTable.end(); ++st_it)
+	for (auto pair : mStructureTileTable)
 	{
-		st_it->second->connected(false);
+		pair.second->connected(false);
 	}
 }
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -246,11 +246,6 @@ void StructureManager::removeStructure(Structure* structure)
 {
 	StructureList& structures = mStructureLists[structure->structureClass()];
 
-	if (structures.empty())
-	{
-		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
-	}
-
 	const auto it = std::find(structures.begin(), structures.end(), structure);
 	if (it != structures.end())
 	{
@@ -263,7 +258,8 @@ void StructureManager::removeStructure(Structure* structure)
 		tileTableIt->second->deleteThing();
 		mStructureTileTable.erase(tileTableIt);
 	}
-	else
+
+	if ((it == structures.end()) || (tileTableIt == mStructureTileTable.end()))
 	{
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -352,9 +352,9 @@ int StructureManager::destroyed()
 
 void StructureManager::dropAllStructures()
 {
-	for (auto map_it = mStructureTileTable.begin(); map_it != mStructureTileTable.end(); ++map_it)
+	for (auto pair : mStructureTileTable)
 	{
-		map_it->second->deleteThing();
+		pair.second->deleteThing();
 	}
 
 	mStructureTileTable.clear();

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -297,9 +297,9 @@ void StructureManager::disconnectAll()
 int StructureManager::count() const
 {
 	int count = 0;
-	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
+	for (auto pair : mStructureLists)
 	{
-		count += static_cast<int>(it->second.size());
+		count += static_cast<int>(pair.second.size());
 	}
 
 	return count;

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -251,16 +251,13 @@ void StructureManager::removeStructure(Structure* structure)
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
 
-	for (std::size_t i = 0; i < structures.size(); ++i)
+	const auto it = std::find(structures.begin(), structures.end(), structure);
+	if (it != structures.end())
 	{
-		if (structures[i] == structure)
-		{
-			structures.erase(structures.begin() + static_cast<std::ptrdiff_t>(i));
-			break;
-		}
+		structures.erase(it);
 	}
 
-	auto tileTableIt = mStructureTileTable.find(structure);
+	const auto tileTableIt = mStructureTileTable.find(structure);
 	if (tileTableIt == mStructureTileTable.end())
 	{
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -105,9 +105,9 @@ void StructureManager::updateEnergyConsumed()
 {
 	mTotalEnergyUsed = 0;
 
-	for (auto structureList : mStructureLists)
+	for (auto classListPair : mStructureLists)
 	{
-		for (auto structure : structureList.second)
+		for (auto structure : classListPair.second)
 		{
 			if (structure->operational() || structure->isIdle())
 			{

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -258,14 +258,14 @@ void StructureManager::removeStructure(Structure* structure)
 	}
 
 	const auto tileTableIt = mStructureTileTable.find(structure);
-	if (tileTableIt == mStructureTileTable.end())
-	{
-		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
-	}
-	else
+	if (tileTableIt != mStructureTileTable.end())
 	{
 		tileTableIt->second->deleteThing();
 		mStructureTileTable.erase(tileTableIt);
+	}
+	else
+	{
+		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
 }
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -341,9 +341,9 @@ int StructureManager::disabled()
 int StructureManager::destroyed()
 {
 	int count = 0;
-	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
+	for (auto pair : mStructureLists)
 	{
-		count += getCountInState(it->first, StructureState::Destroyed);
+		count += getCountInState(pair.first, StructureState::Destroyed);
 	}
 
 	return count;

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -326,9 +326,9 @@ int StructureManager::getCountInState(Structure::StructureClass structureClass, 
 int StructureManager::disabled()
 {
 	int count = 0;
-	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
+	for (auto pair : mStructureLists)
 	{
-		count += getCountInState(it->first, StructureState::Disabled);
+		count += getCountInState(pair.first, StructureState::Disabled);
 	}
 
 	return count;


### PR DESCRIPTION
Refactor `StructureManager` loops. Use range-for loops and `std::find` instead of manually coded loops.
