### PR TITLE
Use std::back_inserter in call to copy_if

### DIFF
--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -22,7 +22,7 @@ namespace
 		const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
 
 		std::vector<Warehouse*> output;
-		std::copy_if(warehouses.begin(), warehouses.end(), output.end(), predicate);
+		std::copy_if(warehouses.begin(), warehouses.end(), std::back_inserter(output), predicate);
 
 		return output;
 	}


### PR DESCRIPTION
Fixes an exception being thrown with the message "can't dereference value-initialized vector iterator". This was due to attempting to copy elements from one container into another that wasn't properly sized.