### PR TITLE
Get all OreProcessing derived structures, not just Smelter

### DIFF
--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -33,7 +33,7 @@ static inline void pullFoodFromStructure(FoodProduction* producer, int& remainde
 }
 
 
-static RouteList findRoutes(micropather::MicroPather* solver, TileMap* tilemap, Structure* mine, const std::vector<Smelter*>& smelters)
+static RouteList findRoutes(micropather::MicroPather* solver, TileMap* tilemap, Structure* mine, const std::vector<OreRefining*>& smelters)
 {
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
@@ -235,7 +235,7 @@ void MapViewState::updateMorale()
 
 void MapViewState::findMineRoutes()
 {
-	auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<Smelter>();
+	auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<OreRefining>();
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();
 	mPathSolver->Reset();
 	mTruckRouteOverlay.clear();


### PR DESCRIPTION
Fixes an issue in route processing where the StructureManager was asked to return all Smelter's, not OreProcessing structures. This would skip anything except the derived Smelter class so the SEED Smelter would be ignored. This should resolve the behavior reported by @Brett208 here: https://github.com/OutpostUniverse/OPHD/issues/911#issuecomment-853507343