### PR TITLE
Fix potential undefined behavior in casting

### DIFF
--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -282,7 +282,7 @@ void MapViewState::transportOreFromMines()
 		if (routeIt != routeTable.end())
 		{
 			const auto& route = routeIt->second;
-			const auto smelter = static_cast<Smelter*>(static_cast<Tile*>(route.path.back())->structure());
+			const auto smelter = static_cast<OreRefining*>(static_cast<Tile*>(route.path.back())->structure());
 			const auto mineFacility = static_cast<MineFacility*>(static_cast<Tile*>(route.path.front())->structure());
 
 			if (!smelter->operational()) { break; }


### PR DESCRIPTION
Fixes a case of `static_cast`'ing from a base class to a `Smelter` which could actually be a `SEED Smelter`. This probably didn't have immediate effects because all of the functions used are implemented in `OreRefining` but there are all sorts of nefarious things that could happen here. Might even be responsible for some of the mysterious heap corruption issues the debugger has been complaining about.

Anyway, point being this is clearly incorrect and is how obscure and annoying bugs are introduced. This will hopefully prevent explosions going forward.