### PR TITLE
Opt to not throw if some tags are missing from savegame

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -395,22 +395,18 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			mineFacility.extensionComplete().connect(this, &MapViewState::onMineFacilityExtend);
 
 			auto trucks = structureNode->firstChildElement("trucks");
-			if (trucks == nullptr)
+			if (trucks)
 			{
-				throw std::runtime_error("MapViewState::readStructures(): MineFacility structure saved without a trucks node.");
+				auto trucksAssigned = trucks->attribute("assigned");
+				mineFacility.assignedTrucks(std::stoi(trucksAssigned));
 			}
-
-			auto trucksAssigned = trucks->attribute("assigned");
-			mineFacility.assignedTrucks(std::stoi(trucksAssigned));
 
 			auto extension = structureNode->firstChildElement("extension");
-			if (extension == nullptr)
+			if (extension)
 			{
-				throw std::runtime_error("MapViewState::readStructures(): MineFacility structure saved without an extension node.");
+				auto turnsRemaining = extension->attribute("turns_remaining");
+				mineFacility.digTimeRemaining(std::stoi(turnsRemaining));
 			}
-
-			auto turnsRemaining = extension->attribute("turns_remaining");
-			mineFacility.digTimeRemaining(std::stoi(turnsRemaining));
 		}
 
 		if (structureId == StructureID::SID_AIR_SHAFT && depth != 0)


### PR DESCRIPTION
Addresses an exception throwing during savegame load where the loader doesn't actually need to throw and can just accept missing data as it's not critical. Discussed here: https://github.com/OutpostUniverse/OPHD/pull/935#discussion_r645927190