### PR TITLE
Basic crime

### DIFF
--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -1,0 +1,88 @@
+#include "CrimeRateUpdate.h"
+#include "../UI/PopulationPanel.h"
+#include "../Things/Structures/Structure.h"
+#include "../StructureManager.h"
+#include <NAS2D/Utility.h>
+
+namespace CrimeRate
+{
+	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
+	int calculateMoraleChange(int meanCrimeRate);
+	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
+
+
+	int update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
+	{
+		const auto& structuresWithCrime = NAS2D::Utility<StructureManager>::get().structuresWithCrime();
+
+		// Colony will not have a crime rate until at least one structure that supports crime is built
+		if (structuresWithCrime.empty()) {
+			setPopulationPanel(0, 0, populationPanel);
+			return 0;
+		}
+
+		double accumulatedCrime = 0;
+
+		for (auto structure : structuresWithCrime)
+		{
+			int crimeRateChange = isProtectedByPolice(policeOverlays, structure) ? -1 : 1;
+			structure->IncreaseCrimeRate(crimeRateChange);
+
+			accumulatedCrime += structure->crimeRate();
+		}
+
+		int meanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
+		int moraleChange = calculateMoraleChange(meanCrimeRate);
+
+		setPopulationPanel(moraleChange, meanCrimeRate, populationPanel);
+
+		return moraleChange;
+	}
+
+
+	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure)
+	{
+		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
+
+		for (const auto& tile : policeOverlays[structureTile.depth()])
+		{
+			if (tile->position() == structureTile.position())
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	int calculateMoraleChange(int meanCrimeRate)
+	{
+		if (meanCrimeRate > 50)
+		{
+			// Reduce morale by 1 for every 10% above 50%
+			return -1 * (meanCrimeRate / 10 - 4);
+		}
+		else if (meanCrimeRate < 10)
+		{
+			return 1;
+		}
+
+		return 0;
+	}
+
+
+	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel)
+	{
+		populationPanel.crimeRate(meanCrimeRate);
+
+		if (moraleChange > 0)
+		{
+			populationPanel.addMoraleReason("Low Crime Rate", moraleChange);
+		}
+		else if (moraleChange < 0)
+		{
+			populationPanel.addMoraleReason("High Crime Rate", moraleChange);
+		}
+	}
+}

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../Map/Tile.h"
+#include <vector>
+
+class PopulationPanel;
+
+namespace CrimeRate
+{
+	// Returns change in current morale caused by colony's mean crime rate
+	int update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel);
+}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1402,7 +1402,7 @@ void MapViewState::checkCommRangeOverlay()
 
 	const auto& commTowers = structureManager.getStructures<CommTower>();
 	const auto& command = structureManager.getStructures<CommandCenter>();
-	
+
 	for (auto cc : command)
 	{
 		if (!cc->operational()) { continue; }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -709,6 +709,11 @@ void MapViewState::onMouseWheel(int /*x*/, int y)
  */
 void MapViewState::changeViewDepth(int depth)
 {
+	if (mBtnTogglePoliceOverlay.toggled())
+	{
+		changePoliceOverlayDepth(mTileMap->currentDepth(), depth);
+	}
+
 	mTileMap->currentDepth(depth);
 
 	if (mInsertMode != InsertMode::Robot) { clearMode(); }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -69,21 +69,21 @@ const std::map<Robot::Type, RobotMeta> RobotMetaTable
 };
 
 
-static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int commRange)
+static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int radius)
 {
-	const NAS2D::Point commAreaStartPoint
+	const NAS2D::Point areaStartPoint
 	{
-		std::clamp(centerTile.position().x - commRange, 0, 299),
-		std::clamp(centerTile.position().y - commRange, 0, 149)
+		std::clamp(centerTile.position().x - radius, 0, 299),
+		std::clamp(centerTile.position().y - radius, 0, 149)
 	};
 
-	const NAS2D::Point commAreaEndPoint
+	const NAS2D::Point areaEndPoint
 	{
-		std::clamp(centerTile.position().x + commRange, 0, 299),
-		std::clamp(centerTile.position().y + commRange, 0, 149)
+		std::clamp(centerTile.position().x + radius, 0, 299),
+		std::clamp(centerTile.position().y + radius, 0, 149)
 	};
 
-	return NAS2D::Rectangle<int>::Create(commAreaStartPoint, commAreaEndPoint);
+	return NAS2D::Rectangle<int>::Create(areaStartPoint, areaEndPoint);
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1406,19 +1406,15 @@ void MapViewState::checkCommRangeOverlay()
 	for (auto cc : command)
 	{
 		if (!cc->operational()) { continue; }
-		auto range = cc->getRange();
 		auto& centerTile = structureManager.tileFromStructure(cc);
-		auto commAreaRect = buildAreaRectFromTile(centerTile, range);
-		fillRangedAreaList(mCommRangeOverlay, centerTile, commAreaRect, range);
+		fillRangedAreaList(mCommRangeOverlay, centerTile, cc->getRange());
 	}
 
 	for (auto tower : commTowers)
 	{
 		if (!tower->operational()) { continue; }
-		auto range = tower->getRange();
 		auto& centerTile = structureManager.tileFromStructure(tower);
-		auto commAreaRect = buildAreaRectFromTile(centerTile, range);
-		fillRangedAreaList(mCommRangeOverlay, centerTile, commAreaRect, range);
+		fillRangedAreaList(mCommRangeOverlay, centerTile, tower->getRange());
 	}
 }
 
@@ -1435,19 +1431,25 @@ void MapViewState::checkSurfacePoliceOverlay()
 	{
 		if (!policeStation->operational()) { continue; }
 		auto& centerTile = structureManager.tileFromStructure(policeStation);
-		auto commAreaRect = buildAreaRectFromTile(centerTile, 10);
-		fillRangedAreaList(mSurfacePoliceOverlay, centerTile, commAreaRect, policeStation->getRange());
+		fillRangedAreaList(mPoliceOverlay, centerTile, policeStation->getRange());
 	}
 }
 
 
-void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, const NAS2D::Rectangle<int>& area, int range)
+void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, int range)
 {
+	fillRangedAreaList(tileList, centerTile, range, 0);
+}
+
+void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, int range, int depth)
+{
+	auto area = buildAreaRectFromTile(centerTile, range);
+
 	for (int y = 0; y < area.height; ++y)
 	{
 		for (int x = 0; x < area.width; ++x)
 		{
-			auto& tile = (*mTileMap).getTile({ x + area.x, y + area.y });
+			auto& tile = (*mTileMap).getTile({ x + area.x, y + area.y }, depth);
 			if (isPointInRange(centerTile.position(), tile.position(), range))
 			{
 				if (std::find(tileList.begin(), tileList.end(), &tile) == tileList.end())

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1421,7 +1421,11 @@ void MapViewState::checkCommRangeOverlay()
 
 void MapViewState::checkSurfacePoliceOverlay()
 {
-	mSurfacePoliceOverlay.clear();
+	mPoliceOverlays.clear();
+	for (std::size_t i = 0; i <= mTileMap->maxDepth(); ++i)
+	{
+		mPoliceOverlays.push_back(TileList());
+	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
@@ -1431,7 +1435,17 @@ void MapViewState::checkSurfacePoliceOverlay()
 	{
 		if (!policeStation->operational()) { continue; }
 		auto& centerTile = structureManager.tileFromStructure(policeStation);
-		fillRangedAreaList(mPoliceOverlay, centerTile, policeStation->getRange());
+		fillRangedAreaList(mPoliceOverlays[0], centerTile, policeStation->getRange());
+	}
+
+	const auto& undergroundPoliceStations = structureManager.getStructures<UndergroundPolice>();
+
+	for (auto undergroundPoliceStation : undergroundPoliceStations)
+	{
+		if (!undergroundPoliceStation->operational()) { continue; }
+		auto depth = structureManager.tileFromStructure(undergroundPoliceStation).depth();
+		auto& centerTile = structureManager.tileFromStructure(undergroundPoliceStation);
+		fillRangedAreaList(mPoliceOverlays[depth], centerTile, undergroundPoliceStation->getRange(), depth);
 	}
 }
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1427,7 +1427,7 @@ void MapViewState::checkCommRangeOverlay()
 void MapViewState::checkSurfacePoliceOverlay()
 {
 	mPoliceOverlays.clear();
-	for (std::size_t i = 0; i <= mTileMap->maxDepth(); ++i)
+	for (int i = 0; i <= mTileMap->maxDepth(); ++i)
 	{
 		mPoliceOverlays.push_back(TileList());
 	}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1374,7 +1374,7 @@ void MapViewState::checkConnectedness()
 
 	// Assumes that the 'thing' at mCCLocation is in fact a Structure.
 	auto& tile = mTileMap->getTile(ccLocation(), 0);
-	Structure *cc = tile.structure();
+	Structure* cc = tile.structure();
 
 	if (!cc)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1443,7 +1443,7 @@ void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, int 
 
 void MapViewState::fillRangedAreaList(TileList& tileList, Tile& centerTile, int range, int depth)
 {
-	auto area = buildAreaRectFromTile(centerTile, range);
+	auto area = buildAreaRectFromTile(centerTile, range + 1);
 
 	for (int y = 0; y < area.height; ++y)
 	{

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -220,6 +220,7 @@ private:
 	void setOverlay(TileList& tileList, Tile::Overlay overlay);
 	void clearOverlays();
 	void clearOverlay(TileList& tileList);
+	void changePoliceOverlayDepth(int oldDepth, int newDepth);
 	void onToggleConnectedness();
 	void onToggleCommRangeOverlay();
 	void onToggleRouteOverlay();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -339,7 +339,7 @@ private:
 
 	TileList mConnectednessOverlay;
 	TileList mCommRangeOverlay;
-	TileList mSurfacePoliceOverlay;
+	std::vector<TileList> mPoliceOverlays;
 	TileList mTruckRouteOverlay;
 
 	NAS2D::Point<int> mTubeStart;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -218,6 +218,8 @@ private:
 	// UI EVENT HANDLERS
 	void onTurns();
 	void setOverlay(TileList& tileList, Tile::Overlay overlay);
+	void clearOverlays();
+	void clearOverlay(TileList& tileList);
 	void onToggleConnectedness();
 	void onToggleCommRangeOverlay();
 	void onToggleRouteOverlay();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -217,6 +217,7 @@ private:
 
 	// UI EVENT HANDLERS
 	void onTurns();
+	void setOverlay(TileList& tileList, Tile::Overlay overlay);
 	void onToggleConnectedness();
 	void onToggleCommRangeOverlay();
 	void onToggleRouteOverlay();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -152,7 +152,8 @@ private:
 
 	void checkCommRangeOverlay();
 	void checkSurfacePoliceOverlay();
-	void fillRangedAreaList(TileList& tileList, Tile& centerTile, const NAS2D::Rectangle<int>& area, int range);
+	void fillRangedAreaList(TileList& tileList, Tile& centerTile, int range);
+	void fillRangedAreaList(TileList& tileList, Tile& centerTile, int range, int depth);
 	void checkConnectedness();
 	void changeViewDepth(int);
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -335,10 +335,11 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 {
 	int x = 0, y = 0, depth = 0, age = 0, state = 0, direction = 0, forced_idle = 0, disabled_reason = 0, idle_reason = 0, pop0 = 0, pop1 = 0, type = 0;
 	int production_completed = 0, production_type = 0;
+	int crime_rate = 0;
 	XmlAttribute* attribute = nullptr;
 	for (XmlNode* structureNode = element->firstChild(); structureNode != nullptr; structureNode = structureNode->nextSibling())
 	{
-		x = y = depth = age = state = direction = production_completed = production_type = disabled_reason = idle_reason = pop0 = pop1 = type = 0;
+		x = y = depth = age = state = direction = production_completed = production_type = disabled_reason = idle_reason = pop0 = pop1 = type = crime_rate = 0;
 		attribute = structureNode->toElement()->firstAttribute();
 		while (attribute)
 		{
@@ -352,6 +353,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			else if (attribute->name() == "forced_idle") { attribute->queryIntValue(forced_idle); }
 			else if (attribute->name() == "disabled_reason") { attribute->queryIntValue(disabled_reason); }
 			else if (attribute->name() == "idle_reason") { attribute->queryIntValue(idle_reason); }
+			else if (attribute->name() == "crime_rate") { attribute->queryIntValue(crime_rate); }
 
 			else if (attribute->name() == "production_completed") { attribute->queryIntValue(production_completed); }
 			else if (attribute->name() == "production_type") { attribute->queryIntValue(production_type); }
@@ -480,6 +482,11 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			{
 				readRccRobots(robotsElement->firstAttribute(), structure, mRobotPool);
 			}
+		}
+
+		if (structure.hasCrime())
+		{
+			structure.crimeRate(crime_rate);
 		}
 
 		structure.populationAvailable()[0] = pop0;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -113,6 +113,7 @@ void MapViewState::save(const std::string& filePath)
 	population->attribute("workers", mPopulation.size(Population::PersonRole::ROLE_WORKER));
 	population->attribute("scientists", mPopulation.size(Population::PersonRole::ROLE_SCIENTIST));
 	population->attribute("retired", mPopulation.size(Population::PersonRole::ROLE_RETIRED));
+	population->attribute("mean_crime", mPopulationPanel.crimeRate());
 	root->linkEndChild(population);
 
 	auto moraleChangeReasons = new XmlElement("morale_change");
@@ -535,6 +536,12 @@ void MapViewState::readPopulation(Xml::XmlElement* element)
 			{
 				attribute->queryIntValue(mPreviousMorale);
 				mPopulationPanel.old_morale(mPreviousMorale);
+			}
+			else if (attribute->name() == "mean_crime")
+			{
+				int meanCrimeRate = 0;
+				attribute->queryIntValue(meanCrimeRate);
+				mPopulationPanel.crimeRate(meanCrimeRate);
 			}
 			else if (attribute->name() == "colonist_landers") { attribute->queryIntValue(mLandersColonist); }
 			else if (attribute->name() == "cargo_landers") { attribute->queryIntValue(mLandersCargo); }

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -4,6 +4,7 @@
 
 #include "MapViewState.h"
 #include "MapViewStateHelper.h"
+#include "CrimeRateUpdate.h"
 
 #include "../Map/TileMap.h"
 #include "../Things/Structures/Structures.h"
@@ -580,6 +581,7 @@ void MapViewState::nextTurn()
 	updateResources();
 	updateStructuresAvailability();
 	updateRoads();
+	mCurrentMorale += CrimeRate::update(mPoliceOverlays, mPopulationPanel);
 
 	// Overlay Updates
 	checkCommRangeOverlay();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -429,13 +429,27 @@ void MapViewState::drawUI()
 }
 
 
-void MapViewState::setOverlay(Button& button, TileList& tileList, Tile::Overlay overlay)
+void MapViewState::setOverlay(TileList& tileList, Tile::Overlay overlay)
 {
-	auto overlayToUse = button.toggled() ? overlay : Tile::Overlay::None;
 	for (auto tile : tileList)
 	{
-		tile->overlay(overlayToUse);
+		tile->overlay(overlay);
 	}
+}
+
+
+void MapViewState::clearOverlays()
+{
+	clearOverlay(mConnectednessOverlay);
+	clearOverlay(mCommRangeOverlay);
+	clearOverlay(mPoliceOverlays[0]);
+	clearOverlay(mTruckRouteOverlay);
+}
+
+
+void MapViewState::clearOverlay(TileList& tileList)
+{
+	setOverlay(tileList, Tile::Overlay::None);
 }
 
 
@@ -444,67 +458,59 @@ void MapViewState::setOverlay(Button& button, TileList& tileList, Tile::Overlay 
  */
 void MapViewState::onToggleConnectedness()
 {
+	clearOverlays();
+
 	if (mBtnToggleConnectedness.toggled())
 	{
 		mBtnToggleCommRangeOverlay.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 		mBtnTogglePoliceOverlay.toggle(false);
 
-		onToggleCommRangeOverlay();
-		onToggleRouteOverlay();
-		onTogglePoliceOverlay();
+		setOverlay(mConnectednessOverlay, Tile::Overlay::Connectedness);
 	}
-
-	setOverlay(mBtnToggleConnectedness, mConnectednessOverlay, Tile::Overlay::Connectedness);
 }
 
 
 void MapViewState::onToggleCommRangeOverlay()
 {
+	clearOverlays();
+
 	if (mBtnToggleCommRangeOverlay.toggled())
 	{
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 		mBtnTogglePoliceOverlay.toggle(false);
 
-		onToggleConnectedness();
-		onToggleRouteOverlay();
-		onTogglePoliceOverlay();
+		setOverlay(mCommRangeOverlay, Tile::Overlay::Communications);
 	}
-
-	setOverlay(mBtnToggleCommRangeOverlay, mCommRangeOverlay, Tile::Overlay::Communications);
 }
 
 void MapViewState::onTogglePoliceOverlay()
 {
+	clearOverlays();
+
 	if (mBtnTogglePoliceOverlay.toggled())
 	{
 		mBtnToggleCommRangeOverlay.toggle(false);
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 
-		onToggleCommRangeOverlay();
-		onToggleConnectedness();
-		onToggleRouteOverlay();
+		setOverlay(mPoliceOverlays[0], Tile::Overlay::Police);
 	}
-
-	setOverlay(mBtnTogglePoliceOverlay, mPoliceOverlays[0], Tile::Overlay::Police);
 }
 
 void MapViewState::onToggleRouteOverlay()
 {
+	clearOverlays();
+
 	if (mBtnToggleRouteOverlay.toggled())
 	{
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleCommRangeOverlay.toggle(false);
 		mBtnTogglePoliceOverlay.toggle(false);
 
-		onToggleCommRangeOverlay();
-		onToggleConnectedness();
-		onTogglePoliceOverlay();
+		setOverlay(mTruckRouteOverlay, Tile::Overlay::TruckingRoutes);
 	}
-
-	setOverlay(mBtnToggleRouteOverlay, mTruckRouteOverlay, Tile::Overlay::TruckingRoutes);
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -25,16 +25,6 @@ using namespace constants;
 using namespace NAS2D;
 
 
-static void setOverlay(Button& button, TileList& tileList, Tile::Overlay overlay)
-{
-	auto overlayToUse = button.toggled() ? overlay : Tile::Overlay::None;
-	for (auto tile : tileList)
-	{
-		tile->overlay(overlayToUse);
-	}
-}
-
-
 /**
  * Sets up the user interface elements
  * 
@@ -436,6 +426,16 @@ void MapViewState::drawUI()
 	mWindowStack.update();
 
 	if (!modalUiElementDisplayed()) { mToolTip.update(); }
+}
+
+
+void MapViewState::setOverlay(Button& button, TileList& tileList, Tile::Overlay overlay)
+{
+	auto overlayToUse = button.toggled() ? overlay : Tile::Overlay::None;
+	for (auto tile : tileList)
+	{
+		tile->overlay(overlayToUse);
+	}
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -442,7 +442,7 @@ void MapViewState::clearOverlays()
 {
 	clearOverlay(mConnectednessOverlay);
 	clearOverlay(mCommRangeOverlay);
-	clearOverlay(mPoliceOverlays[0]);
+	clearOverlay(mPoliceOverlays[mTileMap->currentDepth()]);
 	clearOverlay(mTruckRouteOverlay);
 }
 
@@ -450,6 +450,13 @@ void MapViewState::clearOverlays()
 void MapViewState::clearOverlay(TileList& tileList)
 {
 	setOverlay(tileList, Tile::Overlay::None);
+}
+
+
+void MapViewState::changePoliceOverlayDepth(int oldDepth, int newDepth)
+{
+	clearOverlay(mPoliceOverlays[oldDepth]);
+	setOverlay(mPoliceOverlays[newDepth], Tile::Overlay::Police);
 }
 
 
@@ -495,7 +502,7 @@ void MapViewState::onTogglePoliceOverlay()
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 
-		setOverlay(mPoliceOverlays[0], Tile::Overlay::Police);
+		setOverlay(mPoliceOverlays[mTileMap->currentDepth()], Tile::Overlay::Police);
 	}
 }
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -488,7 +488,7 @@ void MapViewState::onTogglePoliceOverlay()
 		onToggleRouteOverlay();
 	}
 
-	setOverlay(mBtnTogglePoliceOverlay, mSurfacePoliceOverlay, Tile::Overlay::Police);
+	setOverlay(mBtnTogglePoliceOverlay, mPoliceOverlays[0], Tile::Overlay::Police);
 }
 
 void MapViewState::onToggleRouteOverlay()

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -396,6 +396,11 @@ void serializeStructure(NAS2D::Xml::XmlElement* _ti, Structure* structure, Tile*
 	_ti->attribute("type", structure->structureId());
 	_ti->attribute("direction", structure->connectorDirection());
 
+	if (structure->hasCrime())
+	{
+		_ti->attribute("crime_rate", structure->crimeRate());
+	}
+
 	const auto& production = structure->production();
 	if (production > StorableResources{ 0 })
 	{

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -41,6 +41,7 @@ void StructureManager::update(const StorableResources& resources, PopulationPool
 {
 	mAgingStructures.clear();
 	mNewlyBuiltStructures.clear();
+	mStructuresWithCrime.clear();
 
 	// Called separately so that 1) high priority structures can be updated first and
 	// 2) so that resource handling code (like energy) can be handled between update
@@ -152,6 +153,11 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 		if (structure->age() == structure->turnsToBuild())
 		{
 			mNewlyBuiltStructures.push_back(structure);
+		}
+
+		if (structure->hasCrime() && !structure->underConstruction())
+		{
+			mStructuresWithCrime.push_back(structure);
 		}
 
 		// State Check

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -106,6 +106,7 @@ public:
 
 	const StructureList& agingStructures() const { return mAgingStructures; }
 	const StructureList& newlyBuiltStructures() const { return mNewlyBuiltStructures; }
+	const StructureList& structuresWithCrime() const { return mStructuresWithCrime; }
 
 	int disabled();
 	int destroyed();
@@ -137,6 +138,7 @@ private:
 
 	StructureList mAgingStructures;
 	StructureList mNewlyBuiltStructures;
+	StructureList mStructuresWithCrime;
 
 	int mTotalEnergyOutput = 0; /**< Total energy output of all energy producers in the structure list. */
 	int mTotalEnergyUsed = 0;

--- a/OPHD/Things/Structures/Agridome.h
+++ b/OPHD/Things/Structures/Agridome.h
@@ -19,6 +19,7 @@ public:
 		turnsToBuild(3);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Commercial.h
+++ b/OPHD/Things/Structures/Commercial.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(3);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/FusionReactor.h
+++ b/OPHD/Things/Structures/FusionReactor.h
@@ -21,6 +21,7 @@ public:
 		maxAge(1000);
 		turnsToBuild(10);
 		requiresCHAP(false);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Laboratory.h
+++ b/OPHD/Things/Structures/Laboratory.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(false);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/MedicalCenter.h
+++ b/OPHD/Things/Structures/MedicalCenter.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Nursery.h
+++ b/OPHD/Things/Structures/Nursery.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Park.h
+++ b/OPHD/Things/Structures/Park.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(3);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/RecreationCenter.h
+++ b/OPHD/Things/Structures/RecreationCenter.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Recycling.h
+++ b/OPHD/Things/Structures/Recycling.h
@@ -23,6 +23,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 

--- a/OPHD/Things/Structures/RedLightDistrict.h
+++ b/OPHD/Things/Structures/RedLightDistrict.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Residence.h
+++ b/OPHD/Things/Structures/Residence.h
@@ -29,6 +29,7 @@ public:
 		turnsToBuild(2);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 

--- a/OPHD/Things/Structures/RobotCommand.h
+++ b/OPHD/Things/Structures/RobotCommand.h
@@ -25,6 +25,7 @@ public:
 		turnsToBuild(3);
 
 		requiresCHAP(false);
+		hasCrime(true);
 	}
 
 	bool isControlling(Robot* robot) const;

--- a/OPHD/Things/Structures/Smelter.h
+++ b/OPHD/Things/Structures/Smelter.h
@@ -18,6 +18,7 @@ public:
 		maxAge(600);
 		turnsToBuild(9);
 		requiresCHAP(false);
+		hasCrime(true);
 
 		storageCapacity(StorageCapacity);
 	}

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -20,6 +20,7 @@ public:
 		maxAge(1000);
 		turnsToBuild(4);
 		requiresCHAP(false);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -20,6 +20,7 @@ public:
 		maxAge(1000);
 		turnsToBuild(4);
 		requiresCHAP(false);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/StorageTanks.h
+++ b/OPHD/Things/Structures/StorageTanks.h
@@ -21,6 +21,7 @@ public:
 
 		requiresCHAP(false);
 		storageCapacity(StorageTanksCapacity);
+		hasCrime(true);
 	}
 
 	StringTable createInspectorViewTable() override

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -1,6 +1,7 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+#include <algorithm>
 
 
 /**
@@ -312,4 +313,14 @@ void Structure::die()
 	Thing::die();
 
 	throw std::runtime_error("Thing::die() was called on a Structure!");
+}
+
+void Structure::crimeRate(int crimeRate) 
+{ 
+	mCrimeRate = std::clamp(crimeRate, 0, 100); 
+}
+
+void Structure::IncreaseCrimeRate(int deltaCrimeRate) 
+{ 
+	mCrimeRate = std::clamp(mCrimeRate + deltaCrimeRate, 0, 100); 
 }

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -114,6 +114,10 @@ public:
 	bool ages() const { return maxAge() > 0; }
 	int energyRequirement() const { return mEnergyRequirement; }
 	int storageCapacity() const { return mStorageCapacity; }
+	bool hasCrime() const { return mHasCrime; }
+	int crimeRate() const { return mCrimeRate; }
+	void crimeRate(int crimeRate);
+	void IncreaseCrimeRate(int deltaCrimeRate);
 
 	// FLAGS
 	bool requiresCHAP() const { return mRequiresCHAP; }
@@ -167,6 +171,7 @@ protected:
 
 	void requiresCHAP(bool value) { mRequiresCHAP = value; }
 	void selfSustained(bool value) { mSelfSustained = value; }
+	void hasCrime(bool value) { mHasCrime = value; }
 
 	void setPopulationRequirements(const PopulationRequirements& pr) { mPopulationRequirements = pr; }
 	void energyRequired(int energy) { mEnergyRequirement = energy; }
@@ -193,6 +198,7 @@ private:
 	int mMaxAge = 0; /**< Maximum number of turns the Structure can remain in good repair. */
 	int mEnergyRequirement = 0;
 	int mStorageCapacity = 0;
+	int mCrimeRate = 0;
 
 	StructureID mStructureId{ StructureID::SID_NONE };
 
@@ -214,6 +220,7 @@ private:
 	bool mRepairable = true; /**< Indicates whether or not the Structure can be repaired. Useful for forcing some Structures to die at the end of their life. */
 	bool mRequiresCHAP = true; /**< Indicates that the Structure needs to have an active CHAP facility in order to operate. */
 	bool mSelfSustained = false; /**< Indicates that the Structure is self contained and can operate by itself. */
+	bool mHasCrime = false; /*< Indicates that the Structure acculumates a crime rate over time.*/
 	bool mForcedIdle = false; /**< Indicates that the Structure was manually set to Idle by the user and should remain that way until the user says otherwise. */
 };
 

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -220,7 +220,7 @@ private:
 	bool mRepairable = true; /**< Indicates whether or not the Structure can be repaired. Useful for forcing some Structures to die at the end of their life. */
 	bool mRequiresCHAP = true; /**< Indicates that the Structure needs to have an active CHAP facility in order to operate. */
 	bool mSelfSustained = false; /**< Indicates that the Structure is self contained and can operate by itself. */
-	bool mHasCrime = false; /*< Indicates that the Structure acculumates a crime rate over time.*/
+	bool mHasCrime = false; /**< Indicates that the Structure acculumates a crime rate over time. */
 	bool mForcedIdle = false; /**< Indicates that the Structure was manually set to Idle by the user and should remain that way until the user says otherwise. */
 };
 

--- a/OPHD/Things/Structures/SurfaceFactory.h
+++ b/OPHD/Things/Structures/SurfaceFactory.h
@@ -15,6 +15,7 @@ public:
 		maxAge(600);
 		turnsToBuild(7);
 		requiresCHAP(false);
+		hasCrime(true);
 
 		initFactory();
 	}

--- a/OPHD/Things/Structures/UndergroundFactory.h
+++ b/OPHD/Things/Structures/UndergroundFactory.h
@@ -16,6 +16,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(false);
+		hasCrime(true);
 
 		initFactory();
 	}

--- a/OPHD/Things/Structures/UndergroundPolice.h
+++ b/OPHD/Things/Structures/UndergroundPolice.h
@@ -19,6 +19,11 @@ public:
 		requiresCHAP(true);
 	}
 
+	int getRange() const
+	{
+		return 5;
+	}
+
 protected:
 	void defineResourceInput() override
 	{

--- a/OPHD/Things/Structures/University.h
+++ b/OPHD/Things/Structures/University.h
@@ -17,6 +17,7 @@ public:
 		turnsToBuild(4);
 
 		requiresCHAP(true);
+		hasCrime(true);
 	}
 
 protected:

--- a/OPHD/Things/Structures/Warehouse.h
+++ b/OPHD/Things/Structures/Warehouse.h
@@ -18,6 +18,7 @@ public:
 		turnsToBuild(2);
 
 		requiresCHAP(false);
+		hasCrime(true);
 	}
 
 	ProductPool& products() { return mProducts; }

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -142,6 +142,9 @@ void PopulationPanel::update()
 	const auto housingText = "Housing: " + std::to_string(mPopulation->size()) + " / " + std::to_string(mResidentialCapacity) + "  (" + std::to_string(capacityPercent) + "%)";
 	renderer.drawText(mFont, housingText, position, NAS2D::Color::White);
 
+	position.y += fontHeight;
+	renderer.drawText(mFont, "Mean Crime Rate: " + std::to_string(mCrimeRate) + "%", position, NAS2D::Color::White);
+
 	position.y += fontHeight + fontHeight / 2;
 
 	renderer.drawLine(position, position + NAS2D::Vector<int>{ rect().width - mPopulationPanelWidth - constants::MARGIN * 2, 0 }, Color::DarkGray);

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -23,7 +23,7 @@ public:
 	void residentialCapacity(int val) { mResidentialCapacity = val; }
 
 	void crimeRate(int val) { mCrimeRate = val; }
-	int crimeRate() { return mCrimeRate; } const
+	int crimeRate() const { return mCrimeRate; }
 
 	void addMoraleReason(const std::string& str, int val)
 	{

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -23,6 +23,7 @@ public:
 	void residentialCapacity(int val) { mResidentialCapacity = val; }
 
 	void crimeRate(int val) { mCrimeRate = val; }
+	int crimeRate() { return mCrimeRate; } const
 
 	void addMoraleReason(const std::string& str, int val)
 	{

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -22,6 +22,8 @@ public:
 
 	void residentialCapacity(int val) { mResidentialCapacity = val; }
 
+	void crimeRate(int val) { mCrimeRate = val; }
+
 	void addMoraleReason(const std::string& str, int val)
 	{
 		if (val == 0) { return; }
@@ -47,5 +49,6 @@ private:
 	int mMorale{ 0 };
 	int mPreviousMorale{ 0 };
 	int mResidentialCapacity{ 0 };
+	int mCrimeRate{ 0 };
 	int mPopulationPanelWidth{ 0 };
 };

--- a/OPHD/UI/PopulationPanel.h
+++ b/OPHD/UI/PopulationPanel.h
@@ -10,7 +10,7 @@
 class Population;
 
 
-class PopulationPanel: public Control
+class PopulationPanel : public Control
 {
 public:
 	PopulationPanel();

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -19,10 +19,10 @@ StructureInspector::StructureInspector() :
 	btnClose{"Close"},
 	mIcons{imageCache.load("ui/icons.png")}
 {
-	size({ 350, 220 });
+	size({ 350, 240 });
 
 	btnClose.size({ 50, 20 });
-	add(btnClose, { rect().width - btnClose.rect().width - 5, rect().height - btnClose.rect().height - 5 });
+	add(btnClose, { rect().width - btnClose.rect().width - 5, rect().height - btnClose.rect().height - 5, });
 	btnClose.click().connect(this, &StructureInspector::onClose);
 }
 
@@ -50,7 +50,7 @@ void StructureInspector::onClose()
 
 StringTable StructureInspector::buildStringTable() const
 {
-	StringTable stringTable(4, 4);
+	StringTable stringTable(4, 5);
 	stringTable.position(mRect.startPoint() + NAS2D::Vector{ 5, 25 });
 	stringTable.setVerticalPadding(5);
 	stringTable.setColumnFont(2, stringTable.GetDefaultTitleFont());
@@ -95,6 +95,12 @@ StringTable StructureInspector::buildStringTable() const
 		stringTable[{0, 3}].text = "Scientists:";
 		stringTable[{1, 3}].text = std::to_string(populationAvailable[1]) + " / " + std::to_string(populationRequirements[scientistIndex]);
 		stringTable[{1, 3}].textColor = populationAvailable[scientistIndex] >= populationRequirements[scientistIndex] ? Color::White : Color::Red;
+	}
+
+	if (mStructure->hasCrime())
+	{
+		stringTable[{0, 4}].text = "Crime Rate:";
+		stringTable[{1, 4}].text = std::to_string(mStructure->crimeRate()) + "%";
 	}
 
 	stringTable.computeRelativeCellPositions();

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -21,8 +21,8 @@ StructureInspector::StructureInspector() :
 {
 	size({ 350, 220 });
 
-	add(btnClose, { 295, 195 });
 	btnClose.size({ 50, 20 });
+	add(btnClose, { rect().width - btnClose.rect().width - 5, rect().height - btnClose.rect().height - 5 });
 	btnClose.click().connect(this, &StructureInspector::onClose);
 }
 

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -264,6 +264,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="Population\Population.cpp" />
     <ClCompile Include="ProductPool.cpp" />
     <ClCompile Include="RobotPool.cpp" />
+    <ClCompile Include="States\CrimeRateUpdate.cpp" />
     <ClCompile Include="States\GameState.cpp" />
     <ClCompile Include="States\MapViewState.cpp" />
     <ClCompile Include="States\MainMenuState.cpp" />
@@ -341,6 +342,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="Map\TileMap.h" />
     <ClInclude Include="MicroPather\micropather.h" />
     <ClInclude Include="Mine.h" />
+    <ClInclude Include="States\CrimeRateUpdate.h" />
     <ClInclude Include="StorableResources.h" />
     <ClInclude Include="PopulationPool.h" />
     <ClInclude Include="Population\Morale.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -309,6 +309,9 @@
     <ClCompile Include="UI\NotificationWindow.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
+    <ClCompile Include="States\CrimeRateUpdate.cpp">
+      <Filter>Source Files\States</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -685,6 +688,9 @@
     </ClInclude>
     <ClInclude Include="UI\NotificationWindow.h">
       <Filter>Header Files\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="States\CrimeRateUpdate.h">
+      <Filter>Header Files\States</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
**Implements the following:**
* Expands police overlay to show underground coverage
* Adds Crime rate to structures
  * Structures may be marked to support crime similar to how they are marked to require the CHAP
* Saves/Loads crime rate to saved games (doesn't break backwards compatibility)
* Shows structure crime rate in structure inspector window
* Increases or decreases crime rate of each structure each turn based on police station coverage
* Calculates the mean crime rate of the colony
* Displays the mean crime rate on the population panel
* Decreases or Increases morale based on crime rate
* Saves/loads mean crime rate (doesn't break backwards compatibility)

Relates to Issue #911. More work is required before this issue could be considered closed.

Was hoping to get this done before version 0.8.3 was released, but was too slow. :)