### PR TITLE
Button constructor Delegate handler

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -16,11 +16,11 @@ using namespace NAS2D;
 
 MainMenuState::MainMenuState() :
 	mBgImage("sys/mainmenu.png"),
-	btnNewGame{constants::MAIN_MENU_NEW_GAME},
-	btnContinueGame{constants::MAIN_MENU_CONTINUE},
-	btnOptions{constants::MAIN_MENU_OPTIONS},
-	btnHelp{constants::MAIN_MENU_HELP},
-	btnQuit{constants::MAIN_MENU_QUIT},
+	btnNewGame{constants::MAIN_MENU_NEW_GAME, {this, &MainMenuState::onNewGame}},
+	btnContinueGame{constants::MAIN_MENU_CONTINUE, {this, &MainMenuState::onContinueGame}},
+	btnOptions{constants::MAIN_MENU_OPTIONS, {this, &MainMenuState::onOptions}},
+	btnHelp{constants::MAIN_MENU_HELP, {this, &MainMenuState::onHelp}},
+	btnQuit{constants::MAIN_MENU_QUIT, {this, &MainMenuState::onQuit}},
 	lblVersion{constants::VERSION},
 	mReturnState(this)
 {}
@@ -48,24 +48,19 @@ void MainMenuState::initialize()
 
 	btnNewGame.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnNewGame.size({200, 30});
-	btnNewGame.click().connect(this, &MainMenuState::onNewGame);
 
 	btnContinueGame.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnContinueGame.size({200, 30});
-	btnContinueGame.click().connect(this, &MainMenuState::onContinueGame);
 
 	btnOptions.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnOptions.size({200, 30});
 	btnOptions.enabled(false);
-	btnOptions.click().connect(this, &MainMenuState::onOptions);
 
 	btnHelp.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnHelp.size({200, 30});
-	btnHelp.click().connect(this, &MainMenuState::onHelp);
 
 	btnQuit.fontSize(constants::FONT_PRIMARY_MEDIUM);
 	btnQuit.size({200, 30});
-	btnQuit.click().connect(this, &MainMenuState::onQuit);
 
 	mFileIoDialog.setMode(FileIo::FileOperation::Load);
 	mFileIoDialog.fileOperation().connect(this, &MainMenuState::onFileIoAction);

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -15,14 +15,14 @@ using namespace NAS2D;
 
 
 MainMenuState::MainMenuState() :
-	mBgImage("sys/mainmenu.png"),
+	mBgImage{"sys/mainmenu.png"},
 	btnNewGame{constants::MAIN_MENU_NEW_GAME, {this, &MainMenuState::onNewGame}},
 	btnContinueGame{constants::MAIN_MENU_CONTINUE, {this, &MainMenuState::onContinueGame}},
 	btnOptions{constants::MAIN_MENU_OPTIONS, {this, &MainMenuState::onOptions}},
 	btnHelp{constants::MAIN_MENU_HELP, {this, &MainMenuState::onHelp}},
 	btnQuit{constants::MAIN_MENU_QUIT, {this, &MainMenuState::onQuit}},
 	lblVersion{constants::VERSION},
-	mReturnState(this)
+	mReturnState{this}
 {}
 
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -28,7 +28,7 @@ PlanetSelectState::PlanetSelectState() :
 	mBgMusic{"music/menu.ogg"},
 	mSelect{"sfx/click.ogg"},
 	mHover{"sfx/menu4.ogg"},
-	mQuit{"Main Menu"},
+	mQuit{"Main Menu", {this, &PlanetSelectState::onQuit}},
 	mReturnState{this},
 	PlanetAttributes(parsePlanetAttributes())
 {}
@@ -75,7 +75,6 @@ void PlanetSelectState::initialize()
 
 	mQuit.size({100, 20});
 	mQuit.position({renderer.size().x - 105, 30});
-	mQuit.click().connect(this, &PlanetSelectState::onQuit);
 
 	mPlanetDescription.text("");
 	mPlanetDescription.font(constants::FONT_PRIMARY, constants::FONT_PRIMARY_MEDIUM);

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -58,6 +58,12 @@ Button::Button(std::string newText) :
 }
 
 
+Button::Button(std::string newText, ClickSignal::DelegateType clickHandler) : Button(newText)
+{
+	mSignal.connect(clickHandler);
+}
+
+
 Button::~Button()
 {
 	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Button::onMouseDown);

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -23,6 +23,7 @@ public:
 	using ClickSignal = NAS2D::Signal<>;
 
 	Button(std::string newText = "");
+	Button(std::string newText, ClickSignal::DelegateType clickHandler);
 	~Button() override;
 
 	void type(Type type);

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -24,19 +24,15 @@ FactoryProduction::FactoryProduction() :
 
 	add(btnOkay, {233, 138});
 	btnOkay.size({40, 20});
-	btnOkay.click().connect(this, &FactoryProduction::onOkay);
 
 	add(btnCancel, {276, 138});
 	btnCancel.size({40, 20});
-	btnCancel.click().connect(this, &FactoryProduction::onCancel);
 
 	add(btnClearSelection, {5, 138});
 	btnClearSelection.size({mProductGrid.size().x, 20});
-	btnClearSelection.click().connect(this, &FactoryProduction::onClearSelection);
 
 	add(btnApply, {mProductGrid.size().x + 12, btnClearSelection.positionY()});
 	btnApply.size({40, 20});
-	btnApply.click().connect(this, &FactoryProduction::onApply);
 
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 	chkIdle.size({50, 20});

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -46,10 +46,10 @@ private:
 
 	IconGrid mProductGrid{"ui/factory.png", 32, constants::MARGIN_TIGHT};
 
-	Button btnOkay{"Okay"};
-	Button btnCancel{"Cancel"};
-	Button btnClearSelection{"Clear Selection"};
-	Button btnApply{"Apply"};
+	Button btnOkay{"Okay", {this, &FactoryProduction::onOkay}};
+	Button btnCancel{"Cancel", {this, &FactoryProduction::onCancel}};
+	Button btnClearSelection{"Clear Selection", {this, &FactoryProduction::onClearSelection}};
+	Button btnApply{"Apply", {this, &FactoryProduction::onApply}};
 
 	CheckBox chkIdle{"Idle"};
 };

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -17,9 +17,9 @@ using namespace NAS2D;
 
 FileIo::FileIo() :
 	Window{"File I/O"},
-	btnClose{"Cancel"},
-	btnFileOp{"FileOp"},
-	btnFileDelete{"Delete"}
+	btnClose{"Cancel", {this, &FileIo::onClose}},
+	btnFileOp{"FileOp", {this, &FileIo::onFileIo}},
+	btnFileDelete{"Delete", {this, &FileIo::onFileDelete}}
 {
 	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &FileIo::onDoubleClick);
 	Utility<EventHandler>::get().keyDown().connect(this, &FileIo::onKeyDown);
@@ -28,17 +28,14 @@ FileIo::FileIo() :
 
 	add(btnFileOp, {445, 325});
 	btnFileOp.size({50, 20});
-	btnFileOp.click().connect(this, &FileIo::onFileIo);
 	btnFileOp.enabled(false);
 
 	add(btnFileDelete, {5, 325});
 	btnFileDelete.size({50, 20});
-	btnFileDelete.click().connect(this, &FileIo::onFileDelete);
 	btnFileDelete.enabled(false);
 
 	add(btnClose, {390, 325});
 	btnClose.size({50, 20});
-	btnClose.click().connect(this, &FileIo::onClose);
 
 	add(txtFileName, {5, 302});
 	txtFileName.size({490, 18});

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -5,29 +5,25 @@
 
 GameOptionsDialog::GameOptionsDialog() :
 	Window{constants::WINDOW_SYSTEM_TITLE},
-	btnSave{"Save current game"},
-	btnLoad{"Load a saved game"},
-	btnReturn{"Return to current game"},
-	btnClose{"Return to Main Menu"}
+	btnSave{"Save current game", {this, &GameOptionsDialog::onSave}},
+	btnLoad{"Load a saved game", {this, &GameOptionsDialog::onLoad}},
+	btnReturn{"Return to current game", {this, &GameOptionsDialog::onReturn}},
+	btnClose{"Return to Main Menu", {this, &GameOptionsDialog::onClose}}
 {
 	position({0, 0});
 	size({210, 160});
 
 	add(btnSave, {5, 25});
 	btnSave.size({200, 25});
-	btnSave.click().connect(this, &GameOptionsDialog::onSave);
 
 	add(btnLoad, {5, 53});
 	btnLoad.size({200, 25});
-	btnLoad.click().connect(this, &GameOptionsDialog::onLoad);
 
 	add(btnReturn, {5, 91});
 	btnReturn.size({200, 25});
-	btnReturn.click().connect(this, &GameOptionsDialog::onReturn);
 
 	add(btnClose, {5, 129});
 	btnClose.size({200, 25});
-	btnClose.click().connect(this, &GameOptionsDialog::onClose);
 
 	anchored(true);
 }

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -12,14 +12,13 @@ using namespace NAS2D;
 
 GameOverDialog::GameOverDialog() :
 	mHeader{imageCache.load("ui/interface/game_over.png")},
-	btnClose{"Return to Main Menu"}
+	btnClose{"Return to Main Menu", {this, &GameOverDialog::onClose}}
 {
 	position({0, 0});
 	size({522, 340});
 
 	add(btnClose, {5, 310});
 	btnClose.size({512, 25});
-	btnClose.click().connect(this, &GameOverDialog::onClose);
 
 	anchored(true);
 }

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -18,7 +18,6 @@ MajorEventAnnouncement::MajorEventAnnouncement() :
 
 	add(btnClose, {5, 310});
 	btnClose.size({512, 25});
-	btnClose.click().connect(this, &MajorEventAnnouncement::onClose);
 
 	anchored(true);
 }

--- a/OPHD/UI/MajorEventAnnouncement.h
+++ b/OPHD/UI/MajorEventAnnouncement.h
@@ -25,5 +25,5 @@ private:
 
 	const NAS2D::Image& mHeader;
 	std::string mMessage;
-	Button btnClose{"Okay"};
+	Button btnClose{"Okay", {this, &MajorEventAnnouncement::onClose}};
 };

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -38,11 +38,11 @@ MineOperationsWindow::MineOperationsWindow() :
 	chkCommonMinerals{"Common Minerals"},
 	chkRareMetals{"Rare Metals"},
 	chkRareMinerals{"Rare Minerals"},
-	btnIdle{"Idle"},
-	btnExtendShaft{"Dig New Level"},
-	btnOkay{"Close"},
-	btnAssignTruck{"Add Truck"},
-	btnUnassignTruck{"Remove Truck"}
+	btnIdle{"Idle", {this, &MineOperationsWindow::onIdle}},
+	btnExtendShaft{"Dig New Level", {this, &MineOperationsWindow::onExtendShaft}},
+	btnOkay{"Close", {this, &MineOperationsWindow::onOkay}},
+	btnAssignTruck{"Add Truck", {this, &MineOperationsWindow::onAssignTruck}},
+	btnUnassignTruck{"Remove Truck", {this, &MineOperationsWindow::onUnassignTruck}}
 {
 	size({375, 270});
 
@@ -50,23 +50,18 @@ MineOperationsWindow::MineOperationsWindow() :
 	add(btnIdle, {10, 230});
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({60, 30});
-	btnIdle.click().connect(this, &MineOperationsWindow::onIdle);
 
 	add(btnExtendShaft, {72, 230});
 	btnExtendShaft.size({100, 30});
-	btnExtendShaft.click().connect(this, &MineOperationsWindow::onExtendShaft);
 
 	add(btnOkay, {mRect.width - 70, 230});
 	btnOkay.size({60, 30});
-	btnOkay.click().connect(this, &MineOperationsWindow::onOkay);
 
 	add(btnAssignTruck, {mRect.width - 85, 115});
 	btnAssignTruck.size({ 80, 20 });
-	btnAssignTruck.click().connect(this, &MineOperationsWindow::onAssignTruck);
 
 	add(btnUnassignTruck, {mRect.width - 170, 115});
 	btnUnassignTruck.size({ 80, 20 });
-	btnUnassignTruck.click().connect(this, &MineOperationsWindow::onUnassignTruck);
 
 	// ORE TOGGLE BUTTONS
 	add(chkCommonMetals, {148, 140});

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -17,11 +17,9 @@ NotificationWindow::NotificationWindow():
 
 	add(btnOkay, { 245, 195 });
 	btnOkay.size({ 50, 20 });
-	btnOkay.click().connect(this, &NotificationWindow::btnOkayClicked);
 
 	add(btnTakeMeThere, { 10, 195 });
 	btnTakeMeThere.size({ 125, 20 });
-	btnTakeMeThere.click().connect(this, &NotificationWindow::btnTakeMeThereClicked);
 	btnTakeMeThere.hide();
 
 	add(mMessageArea, { 5, 65 });

--- a/OPHD/UI/NotificationWindow.h
+++ b/OPHD/UI/NotificationWindow.h
@@ -29,8 +29,8 @@ private:
 	const NAS2D::Image& mIcons;
 
 	NotificationArea::Notification mNotification;
-	Button btnOkay{ "Okay" };
-	Button btnTakeMeThere{ "Take Me There" };
+	Button btnOkay{ "Okay", {this, &NotificationWindow::btnOkayClicked} };
+	Button btnTakeMeThere{ "Take Me There", {this, &NotificationWindow::btnTakeMeThereClicked} };
 	TextArea mMessageArea;
 	bool mTakeMeThereVisible{ false };
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -46,16 +46,16 @@ FactoryReport::FactoryReport() :
 	factorySeed{imageCache.load("ui/interface/factory_seed.png")},
 	factoryAboveGround{imageCache.load("ui/interface/factory_ag.png")},
 	factoryUnderGround{imageCache.load("ui/interface/factory_ug.png")},
-	btnShowAll{"All"},
-	btnShowSurface{"Surface"},
-	btnShowUnderground{"Underground"},
-	btnShowActive{"Active"},
-	btnShowIdle{"Idle"},
-	btnShowDisabled{"Disabled"},
-	btnIdle{"Idle"},
-	btnClearProduction{"Clear Production"},
-	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE},
-	btnApply{"Apply"}
+	btnShowAll{"All", {this, &FactoryReport::onShowAll}},
+	btnShowSurface{"Surface", {this, &FactoryReport::onShowSurface}},
+	btnShowUnderground{"Underground", {this, &FactoryReport::onShowUnderground}},
+	btnShowActive{"Active", {this, &FactoryReport::onShowActive}},
+	btnShowIdle{"Idle", {this, &FactoryReport::onShowIdle}},
+	btnShowDisabled{"Disabled", {this, &FactoryReport::onShowDisabled}},
+	btnIdle{"Idle", {this, &FactoryReport::onIdle}},
+	btnClearProduction{"Clear Production", {this, &FactoryReport::onClearProduction}},
+	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE, {this, &FactoryReport::onTakeMeThere}},
+	btnApply{"Apply", {this, &FactoryReport::onApply}}
 {
 	add(lstFactoryList, {10, 63});
 	lstFactoryList.selectionChanged().connect(this, &FactoryReport::onListSelectionChange);
@@ -64,50 +64,40 @@ FactoryReport::FactoryReport() :
 	btnShowAll.size({75, 20});
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
-	btnShowAll.click().connect(this, &FactoryReport::onShowAll);
 
 	add(btnShowSurface, {87, 10});
 	btnShowSurface.size({75, 20});
 	btnShowSurface.type(Button::Type::BUTTON_TOGGLE);
-	btnShowSurface.click().connect(this, &FactoryReport::onShowSurface);
 
 	add(btnShowUnderground, {164, 10});
 	btnShowUnderground.size({75, 20});
 	btnShowUnderground.type(Button::Type::BUTTON_TOGGLE);
-	btnShowUnderground.click().connect(this, &FactoryReport::onShowUnderground);
 
 	add(btnShowActive, {10, 33});
 	btnShowActive.size({75, 20});
 	btnShowActive.type(Button::Type::BUTTON_TOGGLE);
-	btnShowActive.click().connect(this, &FactoryReport::onShowActive);
 
 	add(btnShowIdle, {87, 33});
 	btnShowIdle.size({75, 20});
 	btnShowIdle.type(Button::Type::BUTTON_TOGGLE);
-	btnShowIdle.click().connect(this, &FactoryReport::onShowIdle);
 
 	add(btnShowDisabled, {164, 33});
 	btnShowDisabled.size({75, 20});
 	btnShowDisabled.type(Button::Type::BUTTON_TOGGLE);
-	btnShowDisabled.click().connect(this, &FactoryReport::onShowDisabled);
 
 	int position_x = Utility<Renderer>::get().size().x - 110;
 	add(btnIdle, {position_x, 35});
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({140, 30});
-	btnIdle.click().connect(this, &FactoryReport::onIdle);
 
 	add(btnClearProduction, {position_x, 75});
 	btnClearProduction.size({140, 30});
-	btnClearProduction.click().connect(this, &FactoryReport::onClearProduction);
 
 	add(btnTakeMeThere, {position_x, 115});
 	btnTakeMeThere.size({140, 30});
-	btnTakeMeThere.click().connect(this, &FactoryReport::onTakeMeThere);
 
 	add(btnApply, {0, 0});
 	btnApply.size({140, 30});
-	btnApply.click().connect(this, &FactoryReport::onApply);
 
 	add(cboFilterByProduct, {250, 33});
 	cboFilterByProduct.size({200, 20});

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -30,16 +30,16 @@ MineReport::MineReport() :
 	fontBigBold{ fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE) },
 	mineFacility{ imageCache.load("ui/interface/mine.png") },
 	uiIcons{ imageCache.load("ui/icons.png") },
-	btnShowAll{ "All" },
-	btnShowActive{ "Active" },
-	btnShowIdle{ "Idle" },
-	btnShowTappedOut{ "Tapped Out" },
-	btnShowDisabled{ "Disabled" },
-	btnIdle{ constants::BUTTON_IDLE },
-	btnDigNewLevel{ "Dig New Level" },
-	btnTakeMeThere{ constants::BUTTON_TAKE_ME_THERE },
-	btnAddTruck { constants::BUTTON_ADD_TRUCK },
-	btnRemoveTruck{ constants::BUTTON_REMOVE_TRUCK },
+	btnShowAll{ "All", {this, &MineReport::onShowAll} },
+	btnShowActive{ "Active", {this, &MineReport::onShowActive} },
+	btnShowIdle{ "Idle", {this, &MineReport::onShowIdle} },
+	btnShowTappedOut{ "Tapped Out", {this, &MineReport::onShowTappedOut} },
+	btnShowDisabled{ "Disabled", {this, &MineReport::onShowDisabled} },
+	btnIdle{ constants::BUTTON_IDLE, {this, &MineReport::onIdle} },
+	btnDigNewLevel{ "Dig New Level", {this, &MineReport::onDigNewLevel} },
+	btnTakeMeThere{ constants::BUTTON_TAKE_ME_THERE, {this, &MineReport::onTakeMeThere} },
+	btnAddTruck { constants::BUTTON_ADD_TRUCK, {this, &MineReport::onAddTruck} },
+	btnRemoveTruck{ constants::BUTTON_REMOVE_TRUCK, {this, &MineReport::onRemoveTruck} },
 	chkCommonMetals{ "Mine Common Metals" },
 	chkCommonMinerals{ "Mine Common Minerals" },
 	chkRareMetals{ "Mine Rare Metals" },
@@ -50,27 +50,22 @@ MineReport::MineReport() :
 	btnShowAll.size({ 75, 20 });
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
-	btnShowAll.click().connect(this, &MineReport::onShowAll);
 
 	add(btnShowActive, {87, 10});
 	btnShowActive.size({ 75, 20 });
 	btnShowActive.type(Button::Type::BUTTON_TOGGLE);
-	btnShowActive.click().connect(this, &MineReport::onShowActive);
 
 	add(btnShowIdle, {164, 10});
 	btnShowIdle.size({ 75, 20 });
 	btnShowIdle.type(Button::Type::BUTTON_TOGGLE);
-	btnShowIdle.click().connect(this, &MineReport::onShowIdle);
 
 	add(btnShowTappedOut, {241, 10});
 	btnShowTappedOut.size({ 75, 20 });
 	btnShowTappedOut.type(Button::Type::BUTTON_TOGGLE);
-	btnShowTappedOut.click().connect(this, &MineReport::onShowTappedOut);
 
 	add(btnShowDisabled, {318, 10});
 	btnShowDisabled.size({ 75, 20 });
 	btnShowDisabled.type(Button::Type::BUTTON_TOGGLE);
-	btnShowDisabled.click().connect(this, &MineReport::onShowDisabled);
 
 	add(lstMineFacilities, {10, 40});
 	lstMineFacilities.selectionChanged().connect(this, &MineReport::onMineFacilitySelectionChange);
@@ -79,15 +74,12 @@ MineReport::MineReport() :
 	add(btnIdle, {0, 40});
 	btnIdle.type(Button::Type::BUTTON_TOGGLE);
 	btnIdle.size({ 140, 30 });
-	btnIdle.click().connect(this, &MineReport::onIdle);
 
 	add(btnDigNewLevel, {0, 75});
 	btnDigNewLevel.size({ 140, 30 });
-	btnDigNewLevel.click().connect(this, &MineReport::onDigNewLevel);
 
 	add(btnTakeMeThere, {0, 110});
 	btnTakeMeThere.size({ 140, 30 });
-	btnTakeMeThere.click().connect(this, &MineReport::onTakeMeThere);
 
 	// Ore Management Pane
 	add(chkCommonMetals, {0, 210});
@@ -105,11 +97,9 @@ MineReport::MineReport() :
 	// Truck Management Pane
 	add(btnAddTruck, {0, 215});
 	btnAddTruck.size({ 140, 30 });
-	btnAddTruck.click().connect(this, &MineReport::onAddTruck);
 
 	add(btnRemoveTruck, {0, 250});
 	btnRemoveTruck.size({ 140, 30 });
-	btnRemoveTruck.click().connect(this, &MineReport::onRemoveTruck);
 
 	fillLists();
 }

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -38,14 +38,13 @@ MineReport::MineReport() :
 	btnIdle{ constants::BUTTON_IDLE, {this, &MineReport::onIdle} },
 	btnDigNewLevel{ "Dig New Level", {this, &MineReport::onDigNewLevel} },
 	btnTakeMeThere{ constants::BUTTON_TAKE_ME_THERE, {this, &MineReport::onTakeMeThere} },
-	btnAddTruck { constants::BUTTON_ADD_TRUCK, {this, &MineReport::onAddTruck} },
+	btnAddTruck{ constants::BUTTON_ADD_TRUCK, {this, &MineReport::onAddTruck} },
 	btnRemoveTruck{ constants::BUTTON_REMOVE_TRUCK, {this, &MineReport::onRemoveTruck} },
 	chkCommonMetals{ "Mine Common Metals" },
 	chkCommonMinerals{ "Mine Common Minerals" },
 	chkRareMetals{ "Mine Rare Metals" },
 	chkRareMinerals{ "Mine Rare Minerals" }
 {
-
 	add(btnShowAll, {10, 10});
 	btnShowAll.size({ 75, 20 });
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -34,46 +34,40 @@ WarehouseReport::WarehouseReport() :
 	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_MEDIUM)},
 	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_HUGE)},
 	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
-	btnShowAll{"All"},
-	btnSpaceAvailable{"Space Available"},
-	btnFull{"Full"},
-	btnEmpty{"Empty"},
-	btnDisabled{"Disabled"},
-	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE}
+	btnShowAll{"All", {this, &WarehouseReport::onShowAll}},
+	btnSpaceAvailable{"Space Available", {this, &WarehouseReport::onSpaceAvailable}},
+	btnFull{"Full", {this, &WarehouseReport::onFull}},
+	btnEmpty{"Empty", {this, &WarehouseReport::onEmpty}},
+	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},
+	btnTakeMeThere{constants::BUTTON_TAKE_ME_THERE, {this, &WarehouseReport::onTakeMeThere}}
 {
 	add(btnShowAll, {10, 10});
 	btnShowAll.size({75, 20});
 	btnShowAll.type(Button::Type::BUTTON_TOGGLE);
 	btnShowAll.toggle(true);
-	btnShowAll.click().connect(this, &WarehouseReport::onShowAll);
 
 	add(btnSpaceAvailable, {90, 10});
 	btnSpaceAvailable.size({100, 20});
 	btnSpaceAvailable.type(Button::Type::BUTTON_TOGGLE);
 	btnSpaceAvailable.toggle(false);
-	btnSpaceAvailable.click().connect(this, &WarehouseReport::onSpaceAvailable);
 
 	add(btnFull, {195, 10});
 	btnFull.size({75, 20});
 	btnFull.type(Button::Type::BUTTON_TOGGLE);
 	btnFull.toggle(false);
-	btnFull.click().connect(this, &WarehouseReport::onFull);
 
 	add(btnEmpty, {275, 10});
 	btnEmpty.size({75, 20});
 	btnEmpty.type(Button::Type::BUTTON_TOGGLE);
 	btnEmpty.toggle(false);
-	btnEmpty.click().connect(this, &WarehouseReport::onEmpty);
 
 	add(btnDisabled, {355, 10});
 	btnDisabled.size({75, 20});
 	btnDisabled.type(Button::Type::BUTTON_TOGGLE);
 	btnDisabled.toggle(false);
-	btnDisabled.click().connect(this, &WarehouseReport::onDisabled);
 
 	add(btnTakeMeThere, {10, 10});
 	btnTakeMeThere.size({140, 30});
-	btnTakeMeThere.click().connect(this, &WarehouseReport::onTakeMeThere);
 
 	add(lstStructures, {10, mRect.y + 115});
 	lstStructures.selectionChanged().connect(this, &WarehouseReport::onStructureSelectionChange);

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -27,9 +27,9 @@ namespace
 
 
 RobotInspector::RobotInspector() :
-	btnCancelOrders{ "Cancel Orders" },
-	btnSelfDestruct{ "Self Destruct" },
-	btnCancel{ constants::ButtonCancel }
+	btnCancelOrders{ "Cancel Orders", {this, &RobotInspector::onCancelOrders} },
+	btnSelfDestruct{ "Self Destruct", {this, &RobotInspector::onSelfDestruct} },
+	btnCancel{ constants::ButtonCancel, {this, &RobotInspector::onCancel} }
 {
 	init();
 }
@@ -70,10 +70,6 @@ void RobotInspector::init()
 	add(btnCancel, buttonPosition);
 
 	size({ size().x, buttonPosition.y + buttonHeight + constants::MARGIN });
-
-	btnCancelOrders.click().connect(this, &RobotInspector::onCancelOrders);
-	btnSelfDestruct.click().connect(this, &RobotInspector::onSelfDestruct);
-	btnCancel.click().connect(this, &RobotInspector::onCancel);
 }
 
 

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -16,14 +16,13 @@ using namespace NAS2D;
 
 StructureInspector::StructureInspector() :
 	Window{constants::WINDOW_STRUCTURE_INSPECTOR},
-	btnClose{"Close"},
+	btnClose{"Close", {this, &StructureInspector::onClose}},
 	mIcons{imageCache.load("ui/icons.png")}
 {
 	size({ 350, 240 });
 
 	btnClose.size({ 50, 20 });
 	add(btnClose, { rect().width - btnClose.rect().width - 5, rect().height - btnClose.rect().height - 5, });
-	btnClose.click().connect(this, &StructureInspector::onClose);
 }
 
 

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -22,11 +22,6 @@ TileInspector::TileInspector() :
 }
 
 
-TileInspector::~TileInspector()
-{
-}
-
-
 void TileInspector::update()
 {
 	if (!visible())

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -13,13 +13,12 @@ using namespace NAS2D;
 
 TileInspector::TileInspector() :
 	Window{constants::WINDOW_TILE_INSPECTOR},
-	btnClose{"Close"}
+	btnClose{"Close", {this, &TileInspector::onClose}}
 {
 	size({200, 88});
 
 	add(btnClose, {145, 63});
 	btnClose.size({50, 20});
-	btnClose.click().connect(this, &TileInspector::onClose);
 }
 
 

--- a/OPHD/UI/TileInspector.h
+++ b/OPHD/UI/TileInspector.h
@@ -10,7 +10,6 @@ class TileInspector: public Window
 {
 public:
 	TileInspector();
-	~TileInspector() override;
 
 	void tile(Tile* t) { mTile = t; }
 

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -11,13 +11,12 @@ using namespace NAS2D;
 
 WarehouseInspector::WarehouseInspector() :
 	Window{constants::WINDOW_WH_INSPECTOR},
-	btnClose{"Okay"}
+	btnClose{"Okay", {this, &WarehouseInspector::onClose}}
 {
 	size({250, 350});
 
 	add(btnClose, {105, 325});
 	btnClose.size({40, 20});
-	btnClose.click().connect(this, &WarehouseInspector::onClose);
 }
 
 


### PR DESCRIPTION
Add a `Button` constructor that takes an initial `Delegate` handler. This allows both the button text and the handler method to be specified together in a single constructor call. As the button text and handler method are strongly associated, it makes sense to specify them together.

Update various UI elements to make use of the new constructor.

The new constructor can be used in a constructor init list in a .cpp file, or as the default constructor values in a .h file. The header usage may be particularly convenient, though do note that any changes means a recompile of all including files. Examples of both usage can be found in the changes, based on where the original code specified the button text.
