### PR TITLE
Main menu Button array

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -281,11 +281,11 @@ NAS2D::State* MainMenuState::update()
 		renderer.drawBoxFilled(menuRect, NAS2D::Color{0, 0, 0, 150});
 		renderer.drawBox(menuRect, NAS2D::Color{0, 185, 0, 255});
 
-		btnNewGame.update();
-		btnContinueGame.update();
-		btnOptions.update();
-		btnHelp.update();
-		btnQuit.update();
+		auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
+		for (auto button : buttons)
+		{
+			button->update();
+		}
 	}
 
 	if (mFileIoDialog.visible())

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -16,11 +16,13 @@ using namespace NAS2D;
 
 MainMenuState::MainMenuState() :
 	mBgImage{"sys/mainmenu.png"},
-	btnNewGame{constants::MAIN_MENU_NEW_GAME, {this, &MainMenuState::onNewGame}},
-	btnContinueGame{constants::MAIN_MENU_CONTINUE, {this, &MainMenuState::onContinueGame}},
-	btnOptions{constants::MAIN_MENU_OPTIONS, {this, &MainMenuState::onOptions}},
-	btnHelp{constants::MAIN_MENU_HELP, {this, &MainMenuState::onHelp}},
-	btnQuit{constants::MAIN_MENU_QUIT, {this, &MainMenuState::onQuit}},
+	buttons{{
+		{constants::MAIN_MENU_NEW_GAME, {this, &MainMenuState::onNewGame}},
+		{constants::MAIN_MENU_CONTINUE, {this, &MainMenuState::onContinueGame}},
+		{constants::MAIN_MENU_OPTIONS, {this, &MainMenuState::onOptions}},
+		{constants::MAIN_MENU_HELP, {this, &MainMenuState::onHelp}},
+		{constants::MAIN_MENU_QUIT, {this, &MainMenuState::onQuit}}
+	}},
 	lblVersion{constants::VERSION},
 	mReturnState{this}
 {}
@@ -46,11 +48,10 @@ void MainMenuState::initialize()
 	e.windowResized().connect(this, &MainMenuState::onWindowResized);
 	e.keyDown().connect(this, &MainMenuState::onKeyDown);
 
-	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
-	for (auto button : buttons)
+	for (auto& button : buttons)
 	{
-		button->fontSize(constants::FONT_PRIMARY_MEDIUM);
-		button->size({200, 30});
+		button.fontSize(constants::FONT_PRIMARY_MEDIUM);
+		button.size({200, 30});
 	}
 
 	mFileIoDialog.setMode(FileIo::FileOperation::Load);
@@ -86,10 +87,9 @@ void MainMenuState::positionButtons()
 
 	auto buttonPosition = center - NAS2D::Vector{100, (35 * 4) / 2};
 
-	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
-	for (auto button : buttons)
+	for (auto& button : buttons)
 	{
-		button->position(buttonPosition);
+		button.position(buttonPosition);
 		buttonPosition.y += 35;
 	}
 
@@ -104,10 +104,9 @@ void MainMenuState::positionButtons()
  */
 void MainMenuState::disableButtons()
 {
-	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
-	for (auto button : buttons)
+	for (auto& button : buttons)
 	{
-		button->enabled(false);
+		button.enabled(false);
 	}
 }
 
@@ -117,12 +116,12 @@ void MainMenuState::disableButtons()
  */
 void MainMenuState::enableButtons()
 {
-	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
-	for (auto button : buttons)
+	for (auto& button : buttons)
 	{
-		button->enabled(true);
+		button.enabled(true);
 	}
-	btnOptions.enabled(false);
+	// "Options" (currently not implemented)
+	buttons[2].enabled(false);
 }
 
 
@@ -275,14 +274,13 @@ NAS2D::State* MainMenuState::update()
 	if (!mFileIoDialog.visible())
 	{
 		const auto padding = NAS2D::Vector{5, 5};
-		const auto menuRect = NAS2D::Rectangle<int>::Create(btnNewGame.rect().startPoint() - padding, btnQuit.rect().endPoint() + padding);
+		const auto menuRect = NAS2D::Rectangle<int>::Create(buttons.front().rect().startPoint() - padding, buttons.back().rect().endPoint() + padding);
 		renderer.drawBoxFilled(menuRect, NAS2D::Color{0, 0, 0, 150});
 		renderer.drawBox(menuRect, NAS2D::Color{0, 185, 0, 255});
 
-		auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
-		for (auto button : buttons)
+		for (auto& button : buttons)
 		{
-			button->update();
+			button.update();
 		}
 	}
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -106,11 +106,11 @@ void MainMenuState::positionButtons()
  */
 void MainMenuState::disableButtons()
 {
-	btnNewGame.enabled(false);
-	btnContinueGame.enabled(false);
-	btnOptions.enabled(false);
-	btnHelp.enabled(false);
-	btnQuit.enabled(false);
+	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
+	for (auto button : buttons)
+	{
+		button->enabled(false);
+	}
 }
 
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -88,15 +88,12 @@ void MainMenuState::positionButtons()
 
 	auto buttonPosition = center - NAS2D::Vector{100, (35 * 4) / 2};
 
-	btnNewGame.position(buttonPosition);
-	buttonPosition.y += 35;
-	btnContinueGame.position(buttonPosition);
-	buttonPosition.y += 35;
-	btnOptions.position(buttonPosition);
-	buttonPosition.y += 35;
-	btnHelp.position(buttonPosition);
-	buttonPosition.y += 35;
-	btnQuit.position(buttonPosition);
+	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
+	for (auto button : buttons)
+	{
+		button->position(buttonPosition);
+		buttonPosition.y += 35;
+	}
 
 	mFileIoDialog.position(center - mFileIoDialog.size() / 2);
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -46,21 +46,14 @@ void MainMenuState::initialize()
 	e.windowResized().connect(this, &MainMenuState::onWindowResized);
 	e.keyDown().connect(this, &MainMenuState::onKeyDown);
 
-	btnNewGame.fontSize(constants::FONT_PRIMARY_MEDIUM);
-	btnNewGame.size({200, 30});
+	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
+	for (auto button : buttons)
+	{
+		button->fontSize(constants::FONT_PRIMARY_MEDIUM);
+		button->size({200, 30});
+	}
 
-	btnContinueGame.fontSize(constants::FONT_PRIMARY_MEDIUM);
-	btnContinueGame.size({200, 30});
-
-	btnOptions.fontSize(constants::FONT_PRIMARY_MEDIUM);
-	btnOptions.size({200, 30});
 	btnOptions.enabled(false);
-
-	btnHelp.fontSize(constants::FONT_PRIMARY_MEDIUM);
-	btnHelp.size({200, 30});
-
-	btnQuit.fontSize(constants::FONT_PRIMARY_MEDIUM);
-	btnQuit.size({200, 30});
 
 	mFileIoDialog.setMode(FileIo::FileOperation::Load);
 	mFileIoDialog.fileOperation().connect(this, &MainMenuState::onFileIoAction);

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -119,11 +119,12 @@ void MainMenuState::disableButtons()
  */
 void MainMenuState::enableButtons()
 {
-	btnNewGame.enabled(true);
-	btnContinueGame.enabled(true);
+	auto buttons = std::array{&btnNewGame, &btnContinueGame, &btnOptions, &btnHelp, &btnQuit};
+	for (auto button : buttons)
+	{
+		button->enabled(true);
+	}
 	btnOptions.enabled(false);
-	btnHelp.enabled(true);
-	btnQuit.enabled(true);
 }
 
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -53,8 +53,6 @@ void MainMenuState::initialize()
 		button->size({200, 30});
 	}
 
-	btnOptions.enabled(false);
-
 	mFileIoDialog.setMode(FileIo::FileOperation::Load);
 	mFileIoDialog.fileOperation().connect(this, &MainMenuState::onFileIoAction);
 	mFileIoDialog.anchored(false);

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -8,6 +8,8 @@
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Resource/Image.h>
 
+#include <array>
+
 
 /**
  * Implements the main menu screen.
@@ -44,11 +46,7 @@ private:
 
 	FileIo mFileIoDialog; /**< File IO window. */
 
-	Button btnNewGame;
-	Button btnContinueGame;
-	Button btnOptions;
-	Button btnHelp;
-	Button btnQuit;
+	std::array<Button, 5> buttons;
 
 	Label lblVersion;
 	NAS2D::State* mReturnState = this;


### PR DESCRIPTION
The main menu `Button` code is quite repetitive. Using array processing simplifies things, and ensures uniform handling.

Mind you, the always disabled "Options" button is slightly non-uniform. Maybe we could get rid of it for now?

Anyway, noticed some of the potential for cleanup after working on #951, which had a way of separating the unique portions from the repetitive portions.
