### PR TITLE
Temporarily remove the Options button from the main menu

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -19,7 +19,6 @@ MainMenuState::MainMenuState() :
 	buttons{{
 		{constants::MAIN_MENU_NEW_GAME, {this, &MainMenuState::onNewGame}},
 		{constants::MAIN_MENU_CONTINUE, {this, &MainMenuState::onContinueGame}},
-		{constants::MAIN_MENU_OPTIONS, {this, &MainMenuState::onOptions}},
 		{constants::MAIN_MENU_HELP, {this, &MainMenuState::onHelp}},
 		{constants::MAIN_MENU_QUIT, {this, &MainMenuState::onQuit}}
 	}},
@@ -120,8 +119,6 @@ void MainMenuState::enableButtons()
 	{
 		button.enabled(true);
 	}
-	// "Options" (currently not implemented)
-	buttons[2].enabled(false);
 }
 
 

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -46,7 +46,7 @@ private:
 
 	FileIo mFileIoDialog; /**< File IO window. */
 
-	std::array<Button, 5> buttons;
+	std::array<Button, 4> buttons;
 
 	Label lblVersion;
 	NAS2D::State* mReturnState = this;


### PR DESCRIPTION
The Options feature isn't currently implemented, so the button was set to always be disabled. Perhaps we should just remove the button for now, until the feature is implemented. At this point, it's very little code to change to add or remove a main menu button.

Relates to cleanup in #952, and feature from #951.
