### PR TITLE
Refactor RobotInspector constructor

### DIFF
--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -35,12 +35,11 @@ RobotInspector::RobotInspector() :
 	const NAS2D::Font& mainFontBold = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 
 	constexpr int padding = constants::MARGIN * 2;
-	const int buttonWidth = mainFont.width("Cancel Orders") + padding;
-	const int buttonHeight = mainFont.height() + padding;
-	const int buttonOffsetY = buttonHeight + constants::MARGIN_TIGHT;
+	const auto buttonSize = mainFont.size("Cancel Orders") + NAS2D::Vector{padding, padding};
+	const int buttonOffsetY = buttonSize.y + constants::MARGIN_TIGHT;
 
 	const int imageWidth = robotImage(Robot::Type::Digger).size().x + padding;
-	const int contentWidth = imageWidth + buttonWidth;
+	const int contentWidth = imageWidth + buttonSize.x;
 
 	mContentArea = {
 		imageWidth,
@@ -49,22 +48,22 @@ RobotInspector::RobotInspector() :
 		mainFont.height() + constants::MARGIN
 	};
 
-	if (mContentArea.width < buttonWidth) { mContentArea.width = buttonWidth; }
+	if (mContentArea.width < buttonSize.x) { mContentArea.width = buttonSize.x; }
 
 	auto buttonPosition = Vector{ imageWidth,  mContentArea.y + mContentArea.height + constants::MARGIN };
 
-	btnCancelOrders.size({ buttonWidth, buttonHeight });
+	btnCancelOrders.size(buttonSize);
 	add(btnCancelOrders, buttonPosition);
 	buttonPosition.y += buttonOffsetY;
 
-	btnSelfDestruct.size({ buttonWidth, buttonHeight });
+	btnSelfDestruct.size(buttonSize);
 	add(btnSelfDestruct, buttonPosition);
 
-	btnCancel.size({ mainFont.width(constants::ButtonCancel) + padding, buttonHeight });
+	btnCancel.size({ mainFont.width(constants::ButtonCancel) + padding, buttonSize.y });
 	buttonPosition = { contentWidth - btnCancel.size().x, buttonPosition.y + buttonOffsetY * 2 };
 	add(btnCancel, buttonPosition);
 
-	size({ contentWidth + constants::MARGIN, buttonPosition.y + buttonHeight + constants::MARGIN });
+	size({ contentWidth + constants::MARGIN, buttonPosition.y + buttonSize.y + constants::MARGIN });
 }
 
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -39,7 +39,7 @@ RobotInspector::RobotInspector() :
 	const int buttonHeight = mainFont.height() + padding;
 	const int buttonOffsetY = buttonHeight + constants::MARGIN_TIGHT;
 
-	const int imgSize = robotImage(Robot::Type::Digger).size().y + padding;
+	const int imgSize = robotImage(Robot::Type::Digger).size().x + padding;
 
 	mContentArea = {
 		imgSize,

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -31,12 +31,6 @@ RobotInspector::RobotInspector() :
 	btnSelfDestruct{ "Self Destruct", {this, &RobotInspector::onSelfDestruct} },
 	btnCancel{ constants::ButtonCancel, {this, &RobotInspector::onCancel} }
 {
-	init();
-}
-
-
-void RobotInspector::init()
-{
 	const NAS2D::Font& mainFont = fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 	const NAS2D::Font& mainFontBold = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FONT_PRIMARY_NORMAL);
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -51,8 +51,6 @@ RobotInspector::RobotInspector() :
 
 	if (mContentArea.width < buttonWidth) { mContentArea.width = buttonWidth; }
 
-	size({ contentWidth + constants::MARGIN, 0 });
-
 	auto buttonPosition = Vector{ imageWidth,  mContentArea.y + mContentArea.height + constants::MARGIN };
 
 	btnCancelOrders.size({ buttonWidth, buttonHeight });
@@ -66,7 +64,7 @@ RobotInspector::RobotInspector() :
 	buttonPosition = { contentWidth - btnCancel.size().x, buttonPosition.y + buttonOffsetY * 2 };
 	add(btnCancel, buttonPosition);
 
-	size({ size().x, buttonPosition.y + buttonHeight + constants::MARGIN });
+	size({ contentWidth + constants::MARGIN, buttonPosition.y + buttonHeight + constants::MARGIN });
 }
 
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -50,7 +50,7 @@ RobotInspector::RobotInspector() :
 
 	if (mContentArea.width < buttonWidth) { mContentArea.width = buttonWidth; }
 
-	size({ buttonWidth + robotImage(Robot::Type::Digger).size().x + padding + constants::MARGIN, 0 });
+	size({ buttonWidth + imageWidth + constants::MARGIN, 0 });
 
 	auto buttonPosition = Vector{ imageWidth,  mContentArea.y + mContentArea.height + constants::MARGIN };
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -41,10 +41,12 @@ RobotInspector::RobotInspector() :
 
 	const int imgSize = robotImage(Robot::Type::Digger).size().y + padding;
 
-	mContentArea = { imgSize,
+	mContentArea = {
+		imgSize,
 		sWindowTitleBarHeight + constants::MARGIN,
 		mainFontBold.width("Age") + mainFont.width("    9999"),
-		mainFont.height() + constants::MARGIN };
+		mainFont.height() + constants::MARGIN
+	};
 
 	if (mContentArea.width < buttonWidth) { mContentArea.width = buttonWidth; }
 

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -39,10 +39,10 @@ RobotInspector::RobotInspector() :
 	const int buttonHeight = mainFont.height() + padding;
 	const int buttonOffsetY = buttonHeight + constants::MARGIN_TIGHT;
 
-	const int imgSize = robotImage(Robot::Type::Digger).size().x + padding;
+	const int imageWidth = robotImage(Robot::Type::Digger).size().x + padding;
 
 	mContentArea = {
-		imgSize,
+		imageWidth,
 		sWindowTitleBarHeight + constants::MARGIN,
 		mainFontBold.width("Age") + mainFont.width("    9999"),
 		mainFont.height() + constants::MARGIN
@@ -52,7 +52,7 @@ RobotInspector::RobotInspector() :
 
 	size({ buttonWidth + robotImage(Robot::Type::Digger).size().x + padding + constants::MARGIN, 0 });
 
-	auto buttonPosition = Vector{ imgSize,  mContentArea.y + mContentArea.height + constants::MARGIN };
+	auto buttonPosition = Vector{ imageWidth,  mContentArea.y + mContentArea.height + constants::MARGIN };
 
 	btnCancelOrders.size({ buttonWidth, buttonHeight });
 	add(btnCancelOrders, buttonPosition);

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -63,7 +63,7 @@ RobotInspector::RobotInspector() :
 	add(btnSelfDestruct, buttonPosition);
 
 	btnCancel.size({ mainFont.width(constants::ButtonCancel) + padding, buttonHeight });
-	buttonPosition = { rect().width - btnCancel.size().x - constants::MARGIN, buttonPosition.y + buttonOffsetY * 2 };
+	buttonPosition = { contentWidth - btnCancel.size().x, buttonPosition.y + buttonOffsetY * 2 };
 	add(btnCancel, buttonPosition);
 
 	size({ size().x, buttonPosition.y + buttonHeight + constants::MARGIN });

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -40,6 +40,7 @@ RobotInspector::RobotInspector() :
 	const int buttonOffsetY = buttonHeight + constants::MARGIN_TIGHT;
 
 	const int imageWidth = robotImage(Robot::Type::Digger).size().x + padding;
+	const int contentWidth = imageWidth + buttonWidth;
 
 	mContentArea = {
 		imageWidth,
@@ -50,7 +51,7 @@ RobotInspector::RobotInspector() :
 
 	if (mContentArea.width < buttonWidth) { mContentArea.width = buttonWidth; }
 
-	size({ buttonWidth + imageWidth + constants::MARGIN, 0 });
+	size({ contentWidth + constants::MARGIN, 0 });
 
 	auto buttonPosition = Vector{ imageWidth,  mContentArea.y + mContentArea.height + constants::MARGIN };
 

--- a/OPHD/UI/RobotInspector.h
+++ b/OPHD/UI/RobotInspector.h
@@ -24,8 +24,6 @@ public:
 	void update() override;
 
 private:
-	void init();
-
 	void onCancelOrders();
 	void onSelfDestruct();
 	void onCancel();


### PR DESCRIPTION
A bit of refactoring for the `RobotInspector` window's constructor. I noticed the split use of `init()` when working on #951, and after looking at the method a bit, I thought I'd do some refactoring.
