### PR TITLE
Rename leading underscores

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -319,9 +319,9 @@ const std::string& disabledReason(DisabledReason disabledReason)
 }
 
 
-const std::string& idleReason(IdleReason _i)
+const std::string& idleReason(IdleReason idleReason)
 {
-	return IDLE_REASON_TABLE.at(_i);
+	return IDLE_REASON_TABLE.at(idleReason);
 }
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -313,9 +313,9 @@ ProductType productTypeFromDescription(const std::string& description)
 }
 
 
-const std::string& disabledReason(DisabledReason _d)
+const std::string& disabledReason(DisabledReason disabledReason)
 {
-	return DISABLED_REASON_TABLE.at(_d);
+	return DISABLED_REASON_TABLE.at(disabledReason);
 }
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -401,9 +401,9 @@ bool doYesNoMessage(const std::string& title, const std::string msg)
 		nullptr
 	};
 
-	int _bid = 0;
-	SDL_ShowMessageBox(&messageboxdata, &_bid);
-	yes = (_bid == 1);
+	int buttonId = 0;
+	SDL_ShowMessageBox(&messageboxdata, &buttonId);
+	yes = (buttonId == 1);
 #endif
 
 	return yes;

--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -133,10 +133,10 @@ void Tile::removeThing()
 }
 
 
-void Tile::pushMine(Mine* _mine)
+void Tile::pushMine(Mine* mine)
 {
 	delete mMine;
-	mMine = _mine;
+	mMine = mine;
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -380,7 +380,7 @@ TileMap::MouseMapRegion TileMap::getMouseMapRegion(int x, int y)
 }
 
 
-static void serializeTile(XmlElement* _ti, int x, int y, int depth, TerrainType index)
+static void serializeTile(XmlElement* tilesElement, int x, int y, int depth, TerrainType index)
 {
 	auto* tileElement = new XmlElement("tile");
 	tileElement->attribute("x", x);
@@ -388,7 +388,7 @@ static void serializeTile(XmlElement* _ti, int x, int y, int depth, TerrainType 
 	tileElement->attribute("depth", depth);
 	tileElement->attribute("index", static_cast<int>(index));
 
-	_ti->linkEndChild(tileElement);
+	tilesElement->linkEndChild(tileElement);
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -382,13 +382,13 @@ TileMap::MouseMapRegion TileMap::getMouseMapRegion(int x, int y)
 
 static void serializeTile(XmlElement* _ti, int x, int y, int depth, TerrainType index)
 {
-	auto* t = new XmlElement("tile");
-	t->attribute("x", x);
-	t->attribute("y", y);
-	t->attribute("depth", depth);
-	t->attribute("index", static_cast<int>(index));
+	auto* tileElement = new XmlElement("tile");
+	tileElement->attribute("x", x);
+	tileElement->attribute("y", y);
+	tileElement->attribute("depth", depth);
+	tileElement->attribute("index", static_cast<int>(index));
 
-	_ti->linkEndChild(t);
+	_ti->linkEndChild(tileElement);
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -261,14 +261,14 @@ void TileMap::mapViewLocation(NAS2D::Point<int> point)
 /**
  * Convenience function to focus the TileMap's view on a specified tile.
  * 
- * \param	_t	Pointer to a Tile. Safe to pass nullptr.
+ * \param	tile	Pointer to a Tile. Safe to pass nullptr.
  */
-void TileMap::centerMapOnTile(Tile* _t)
+void TileMap::centerMapOnTile(Tile* tile)
 {
-	if (!_t) { return; }
+	if (!tile) { return; }
 
-	mapViewLocation(_t->position() - NAS2D::Vector{mEdgeLength, mEdgeLength} / 2);
-	currentDepth(_t->depth());
+	mapViewLocation(tile->position() - NAS2D::Vector{mEdgeLength, mEdgeLength} / 2);
+	currentDepth(tile->depth());
 }
 
 

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -31,12 +31,12 @@ static const std::map<MineProductionRate, std::array<int, 4>> YieldTable =
  */
 static int getOreCount(const Mine::MineVeins& veins, Mine::OreType ore, int depth)
 {
-	int _value = 0;
+	int value = 0;
 	for (std::size_t i = 0; i < static_cast<std::size_t>(depth); ++i)
 	{
-		_value += veins[i][ore];
+		value += veins[i][ore];
 	}
-	return _value;
+	return value;
 }
 
 

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -336,18 +336,18 @@ void Mine::deserialize(NAS2D::Xml::XmlElement* element)
 	mVeins.resize(static_cast<std::size_t>(depth));
 	for (XmlNode* vein = element->firstChild(); vein != nullptr; vein = vein->nextSibling())
 	{
-		auto _mv = MineVein{0, 0, 0, 0};
+		auto mineVein = MineVein{0, 0, 0, 0};
 		attribute = vein->toElement()->firstAttribute();
 		int id = 0;
 		while (attribute)
 		{
-			if (attribute->name() == "common_metals") { attribute->queryIntValue(_mv[OreType::ORE_COMMON_METALS]); }
-			else if (attribute->name() == "common_minerals") { attribute->queryIntValue(_mv[OreType::ORE_COMMON_MINERALS]); }
-			else if (attribute->name() == "rare_metals") { attribute->queryIntValue(_mv[OreType::ORE_RARE_METALS]); }
-			else if (attribute->name() == "rare_minerals") { attribute->queryIntValue(_mv[OreType::ORE_RARE_MINERALS]); }
+			if (attribute->name() == "common_metals") { attribute->queryIntValue(mineVein[OreType::ORE_COMMON_METALS]); }
+			else if (attribute->name() == "common_minerals") { attribute->queryIntValue(mineVein[OreType::ORE_COMMON_MINERALS]); }
+			else if (attribute->name() == "rare_metals") { attribute->queryIntValue(mineVein[OreType::ORE_RARE_METALS]); }
+			else if (attribute->name() == "rare_minerals") { attribute->queryIntValue(mineVein[OreType::ORE_RARE_MINERALS]); }
 			else if (attribute->name() == "id") { attribute->queryIntValue(id); }
 			attribute = attribute->next();
 		}
-		mVeins[static_cast<std::size_t>(id)] = _mv;
+		mVeins[static_cast<std::size_t>(id)] = mineVein;
 	}
 }

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -47,7 +47,7 @@ private:
 	void kill_students(int morale, int hospitals);
 	void kill_adults(Population::PersonRole role, int morale, int hospitals);
 
-	int consume_food(int _food);
+	int consume_food(int food);
 
 
 	using PopulationTable = std::array<int, 5>;

--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -156,16 +156,16 @@ namespace {
 	{
 		if (role == Population::PersonRole::ROLE_CHILD || role == Population::PersonRole::ROLE_STUDENT || role == Population::PersonRole::ROLE_RETIRED)
 		{
-			std::string _popRole;
+			std::string roleTypeName;
 			switch (role)
 			{
-			case Population::PersonRole::ROLE_CHILD: _popRole = "Population::PersonRole::ROLE_CHILD"; break;
-			case Population::PersonRole::ROLE_STUDENT: _popRole = "Population::PersonRole::ROLE_STUDENT"; break;
-			case Population::PersonRole::ROLE_RETIRED: _popRole = "Population::PersonRole::ROLE_RETIRED"; break;
+			case Population::PersonRole::ROLE_CHILD: roleTypeName = "Population::PersonRole::ROLE_CHILD"; break;
+			case Population::PersonRole::ROLE_STUDENT: roleTypeName = "Population::PersonRole::ROLE_STUDENT"; break;
+			case Population::PersonRole::ROLE_RETIRED: roleTypeName = "Population::PersonRole::ROLE_RETIRED"; break;
 			default: break;
 			}
 
-			throw std::runtime_error("PopulationPool::BasicCheck(): Invalid population role specified (" + _popRole + ").");
+			throw std::runtime_error("PopulationPool::BasicCheck(): Invalid population role specified (" + roleTypeName + ").");
 		}
 	}
 }

--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -5,7 +5,7 @@
 
 
 namespace {
-	void BasicCheck(Population::PersonRole _role);
+	void BasicCheck(Population::PersonRole role);
 }
 
 
@@ -152,12 +152,12 @@ namespace {
 	 *
 	 * \throws	std::runtime_exception if Child/Student/Retired is asked for.
 	 */
-	void BasicCheck(Population::PersonRole _role)
+	void BasicCheck(Population::PersonRole role)
 	{
-		if (_role == Population::PersonRole::ROLE_CHILD || _role == Population::PersonRole::ROLE_STUDENT || _role == Population::PersonRole::ROLE_RETIRED)
+		if (role == Population::PersonRole::ROLE_CHILD || role == Population::PersonRole::ROLE_STUDENT || role == Population::PersonRole::ROLE_RETIRED)
 		{
 			std::string _popRole;
-			switch (_role)
+			switch (role)
 			{
 			case Population::PersonRole::ROLE_CHILD: _popRole = "Population::PersonRole::ROLE_CHILD"; break;
 			case Population::PersonRole::ROLE_STUDENT: _popRole = "Population::PersonRole::ROLE_STUDENT"; break;

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -50,11 +50,11 @@ class Panel
 public:
 	void Selected(bool isSelected)
 	{
-		_selected = isSelected;
+		mIsSelected = isSelected;
 		if (UiPanel) { UiPanel->enabled(isSelected); }
 	}
 
-	bool Selected() { return _selected; }
+	bool Selected() { return mIsSelected; }
 
 public:
 	std::string Name;
@@ -69,7 +69,7 @@ public:
 	ReportInterface* UiPanel = nullptr;
 
 private:
-	bool _selected = false;
+	bool mIsSelected = false;
 };
 
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -48,10 +48,10 @@ enum NavigationPanel
 class Panel
 {
 public:
-	void Selected(bool _b)
+	void Selected(bool isSelected)
 	{
-		_selected = _b;
-		if (UiPanel) { UiPanel->enabled(_b); }
+		_selected = isSelected;
+		if (UiPanel) { UiPanel->enabled(isSelected); }
 	}
 
 	bool Selected() { return _selected; }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1190,9 +1190,9 @@ void MapViewState::placeStructure()
 	{
 		if (!validLanderSite(*tile)) { return; }
 
-		CargoLander* _lander = new CargoLander(tile);
-		_lander->deploySignal().connect(this, &MapViewState::onDeployCargoLander);
-		Utility<StructureManager>::get().addStructure(_lander, tile);
+		CargoLander* cargoLander = new CargoLander(tile);
+		cargoLander->deploySignal().connect(this, &MapViewState::onDeployCargoLander);
+		Utility<StructureManager>::get().addStructure(cargoLander, tile);
 
 		--mLandersCargo;
 		if (mLandersCargo == 0)

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -82,8 +82,8 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
 	case ProductType::PRODUCT_CLOTHING:
 	case ProductType::PRODUCT_MEDICINE:
 		{
-			Warehouse* _wh = getAvailableWarehouse(factory.productWaiting(), 1);
-			if (_wh) { _wh->products().store(factory.productWaiting(), 1); factory.pullProduct(); }
+			Warehouse* warehouse = getAvailableWarehouse(factory.productWaiting(), 1);
+			if (warehouse) { warehouse->products().store(factory.productWaiting(), 1); factory.pullProduct(); }
 			else { factory.idle(IdleReason::FactoryInsufficientWarehouseSpace); }
 			break;
 		}

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -16,9 +16,9 @@
 
 void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 {
-	RobotCommand* _rc = getAvailableRobotCommand();
+	RobotCommand* robotCommand = getAvailableRobotCommand();
 
-	if ((_rc != nullptr) || mRobotPool.commandCapacityAvailable())
+	if ((robotCommand != nullptr) || mRobotPool.commandCapacityAvailable())
 	{
 		Robot* robot = nullptr;
 
@@ -49,7 +49,7 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 			throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
 		}
 
-		if (_rc != nullptr) { _rc->addRobot(robot); }
+		if (robotCommand != nullptr) { robotCommand->addRobot(robot); }
 	}
 	else
 	{

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -558,21 +558,21 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 /** 
  * Document me!
  */
-void checkRobotDeployment(XmlElement* _ti, RobotTileTable& _rm, Robot* _r, Robot::Type _type)
+void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& _rm, Robot* _r, Robot::Type _type)
 {
-	_ti->attribute("id", _r->id());
-	_ti->attribute("type", static_cast<int>(_type));
-	_ti->attribute("age", _r->fuelCellAge());
-	_ti->attribute("production", _r->turnsToCompleteTask());
+	robotElement->attribute("id", _r->id());
+	robotElement->attribute("type", static_cast<int>(_type));
+	robotElement->attribute("age", _r->fuelCellAge());
+	robotElement->attribute("production", _r->turnsToCompleteTask());
 
 	const auto it = _rm.find(_r);
 	if (it != _rm.end())
 	{
 		const auto& tile = *it->second;
 		const auto position = tile.position();
-		_ti->attribute("x", position.x);
-		_ti->attribute("y", position.y);
-		_ti->attribute("depth", tile.depth());
+		robotElement->attribute("x", position.x);
+		robotElement->attribute("y", position.y);
+		robotElement->attribute("depth", tile.depth());
 	}
 }
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -558,15 +558,15 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 /** 
  * Document me!
  */
-void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& _rm, Robot* _r, Robot::Type _type)
+void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTable, Robot* _r, Robot::Type _type)
 {
 	robotElement->attribute("id", _r->id());
 	robotElement->attribute("type", static_cast<int>(_type));
 	robotElement->attribute("age", _r->fuelCellAge());
 	robotElement->attribute("production", _r->turnsToCompleteTask());
 
-	const auto it = _rm.find(_r);
-	if (it != _rm.end())
+	const auto it = robotTileTable.find(_r);
+	if (it != robotTileTable.end())
 	{
 		const auto& tile = *it->second;
 		const auto position = tile.position();

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -242,15 +242,15 @@ void updateRobotControl(RobotPool& robotPool)
 	const auto& robotCommands = Utility<StructureManager>::get().getStructures<RobotCommand>();
 
 	// 3 for the first command center
-	uint32_t _maxRobots = 0;
-	if (commandCenters.size() > 0) { _maxRobots += 3; }
+	uint32_t maxRobots = 0;
+	if (commandCenters.size() > 0) { maxRobots += 3; }
 	// the 10 per robot command facility
 	for (std::size_t s = 0; s < robotCommands.size(); ++s)
 	{
-		if (robotCommands[s]->operational()) { _maxRobots += 10; }
+		if (robotCommands[s]->operational()) { maxRobots += 10; }
 	}
 
-	robotPool.InitRobotCtrl(_maxRobots);
+	robotPool.InitRobotCtrl(maxRobots);
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -558,10 +558,10 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 /** 
  * Document me!
  */
-void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTable, Robot* robot, Robot::Type _type)
+void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
 {
 	robotElement->attribute("id", robot->id());
-	robotElement->attribute("type", static_cast<int>(_type));
+	robotElement->attribute("type", static_cast<int>(type));
 	robotElement->attribute("age", robot->fuelCellAge());
 	robotElement->attribute("production", robot->turnsToCompleteTask());
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -90,22 +90,22 @@ bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnector
  */
 bool checkStructurePlacement(Tile& tile, Direction dir)
 {
-	Structure* _structure = tile.structure();
-	if (tile.mine() || !tile.bulldozed() || !tile.excavated() || !tile.thingIsStructure() || !tile.connected() || !_structure->isConnector())
+	Structure* structure = tile.structure();
+	if (tile.mine() || !tile.bulldozed() || !tile.excavated() || !tile.thingIsStructure() || !tile.connected() || !structure->isConnector())
 	{
 		return false;
 	}
 
 	if (dir == Direction::East || dir == Direction::West)
 	{
-		if (_structure->connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION || _structure->connectorDirection() == ConnectorDir::CONNECTOR_RIGHT || _structure->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL)
+		if (structure->connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION || structure->connectorDirection() == ConnectorDir::CONNECTOR_RIGHT || structure->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL)
 		{
 			return true;
 		}
 	}
 	else // NORTH/SOUTH
 	{
-		if (_structure->connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION || _structure->connectorDirection() == ConnectorDir::CONNECTOR_LEFT || _structure->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL)
+		if (structure->connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION || structure->connectorDirection() == ConnectorDir::CONNECTOR_LEFT || structure->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL)
 		{
 			return true;
 		}

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -558,14 +558,14 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 /** 
  * Document me!
  */
-void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTable, Robot* _r, Robot::Type _type)
+void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTable, Robot* robot, Robot::Type _type)
 {
-	robotElement->attribute("id", _r->id());
+	robotElement->attribute("id", robot->id());
 	robotElement->attribute("type", static_cast<int>(_type));
-	robotElement->attribute("age", _r->fuelCellAge());
-	robotElement->attribute("production", _r->turnsToCompleteTask());
+	robotElement->attribute("age", robot->fuelCellAge());
+	robotElement->attribute("production", robot->turnsToCompleteTask());
 
-	const auto it = robotTileTable.find(_r);
+	const auto it = robotTileTable.find(robot);
 	if (it != robotTileTable.end())
 	{
 		const auto& tile = *it->second;

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -109,7 +109,7 @@ void MapViewState::updateCommercial()
 {
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	const auto& _warehouses = structureManager.getStructures<Warehouse>();
+	const auto& warehouses = structureManager.getStructures<Warehouse>();
 	const auto& _commercial = structureManager.getStructures<Commercial>();
 
 	// No need to do anything if there are no commercial structures.
@@ -118,7 +118,7 @@ void MapViewState::updateCommercial()
 	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
 	int commercialCount = luxuryCount;
 
-	for (auto warehouse : _warehouses)
+	for (auto warehouse : warehouses)
 	{
 		ProductPool& _pl = warehouse->products();
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -110,10 +110,10 @@ void MapViewState::updateCommercial()
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 
 	const auto& warehouses = structureManager.getStructures<Warehouse>();
-	const auto& _commercial = structureManager.getStructures<Commercial>();
+	const auto& commercial = structureManager.getStructures<Commercial>();
 
 	// No need to do anything if there are no commercial structures.
-	if (_commercial.empty()) { return; }
+	if (commercial.empty()) { return; }
 
 	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
 	int commercialCount = luxuryCount;
@@ -149,8 +149,8 @@ void MapViewState::updateCommercial()
 		}
 	}
 
-	auto _comm_r_it = _commercial.rbegin();
-	for (std::size_t i = 0; i < static_cast<std::size_t>(luxuryCount) && _comm_r_it != _commercial.rend(); ++i, ++_comm_r_it)
+	auto _comm_r_it = commercial.rbegin();
+	for (std::size_t i = 0; i < static_cast<std::size_t>(luxuryCount) && _comm_r_it != commercial.rend(); ++i, ++_comm_r_it)
 	{
 		if ((*_comm_r_it)->operational())
 		{

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -120,7 +120,7 @@ void MapViewState::updateCommercial()
 
 	for (auto warehouse : warehouses)
 	{
-		ProductPool& _pl = warehouse->products();
+		ProductPool& productPool = warehouse->products();
 
 		/**
 		 * inspect for luxury products.
@@ -129,17 +129,17 @@ void MapViewState::updateCommercial()
 		 *			is only one luxury item, clothing, but as this changes more
 		 *			items may be seen as luxury.
 		 */
-		int clothing = _pl.count(ProductType::PRODUCT_CLOTHING);
+		int clothing = productPool.count(ProductType::PRODUCT_CLOTHING);
 
 		if (clothing >= luxuryCount)
 		{
-			_pl.pull(ProductType::PRODUCT_CLOTHING, luxuryCount);
+			productPool.pull(ProductType::PRODUCT_CLOTHING, luxuryCount);
 			luxuryCount = 0;
 			break;
 		}
 		else if (clothing < luxuryCount)
 		{
-			_pl.pull(ProductType::PRODUCT_CLOTHING, clothing);
+			productPool.pull(ProductType::PRODUCT_CLOTHING, clothing);
 			luxuryCount -= clothing;
 		}
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -149,12 +149,12 @@ void MapViewState::updateCommercial()
 		}
 	}
 
-	auto _comm_r_it = commercial.rbegin();
-	for (std::size_t i = 0; i < static_cast<std::size_t>(luxuryCount) && _comm_r_it != commercial.rend(); ++i, ++_comm_r_it)
+	auto commercialReverseIterator = commercial.rbegin();
+	for (std::size_t i = 0; i < static_cast<std::size_t>(luxuryCount) && commercialReverseIterator != commercial.rend(); ++i, ++commercialReverseIterator)
 	{
-		if ((*_comm_r_it)->operational())
+		if ((*commercialReverseIterator)->operational())
 		{
-			(*_comm_r_it)->idle(IdleReason::InsufficientLuxuryProduct);
+			(*commercialReverseIterator)->idle(IdleReason::InsufficientLuxuryProduct);
 		}
 	}
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -533,29 +533,29 @@ void MapViewState::onNotificationClicked(const NotificationArea::Notification& n
 * Currently uses a text comparison function. Not inherently bad but
 * should really be turned into a key/value pair table for easier lookups.
 */
-void MapViewState::onStructuresSelectionChange(const IconGrid::IconGridItem* _item)
+void MapViewState::onStructuresSelectionChange(const IconGrid::IconGridItem* item)
 {
 	mConnections.clearSelection();
 	mRobots.clearSelection();
 
-	if (!_item) { return; }
+	if (!item) { return; }
 
 	// Check availability
-	if (!_item->available)
+	if (!item->available)
 	{
-		resourceShortageMessage(mResourcesCount, static_cast<StructureID>(_item->meta));
+		resourceShortageMessage(mResourcesCount, static_cast<StructureID>(item->meta));
 		mStructures.clearSelection();
 		return;
 	}
 
-	setStructureID(static_cast<StructureID>(_item->meta), InsertMode::Structure);
+	setStructureID(static_cast<StructureID>(item->meta), InsertMode::Structure);
 }
 
 
 /**
  * Handler for the Tubes Pallette dialog.
  */
-void MapViewState::onConnectionsSelectionChange(const IconGrid::IconGridItem* /*_item*/)
+void MapViewState::onConnectionsSelectionChange(const IconGrid::IconGridItem* /*item*/)
 {
 	mRobots.clearSelection();
 	mStructures.clearSelection();
@@ -567,18 +567,18 @@ void MapViewState::onConnectionsSelectionChange(const IconGrid::IconGridItem* /*
 /**
  * Handles clicks of the Robot Selection Menu.
  */
-void MapViewState::onRobotsSelectionChange(const IconGrid::IconGridItem* _item)
+void MapViewState::onRobotsSelectionChange(const IconGrid::IconGridItem* item)
 {
 	mConnections.clearSelection();
 	mStructures.clearSelection();
 
-	if (!_item)
+	if (!item)
 	{
 		clearMode();
 		return;
 	}
 
-	mCurrentRobot = static_cast<Robot::Type>(_item->meta);
+	mCurrentRobot = static_cast<Robot::Type>(item->meta);
 
 	mInsertMode = InsertMode::Robot;
 	NAS2D::Utility<NAS2D::Renderer>::get().setCursor(PointerType::POINTER_PLACE_TILE);

--- a/OPHD/States/Wrapper.h
+++ b/OPHD/States/Wrapper.h
@@ -23,15 +23,15 @@
 class Wrapper : public NAS2D::State
 {
 public:
-	Wrapper() : _active(false) {}
+	Wrapper() : mIsActive(false) {}
 
 	State* _update() { return update(); }
 
 	void _initialize() { initialize(); }
 
-	void deactivate() { _active = false; _deactivate(); }
-	void activate() { _active = true; _activate(); }
-	bool active() { return _active; }
+	void deactivate() { mIsActive = false; _deactivate(); }
+	void activate() { mIsActive = true; _activate(); }
+	bool active() { return mIsActive; }
 
 private:
 
@@ -52,7 +52,7 @@ private:
 
 
 private:
-	bool _active;
+	bool mIsActive;
 };
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -387,40 +387,40 @@ Tile& StructureManager::tileFromStructure(Structure* structure)
 }
 
 
-void serializeStructure(NAS2D::Xml::XmlElement* _ti, Structure* structure, Tile* _t)
+void serializeStructure(NAS2D::Xml::XmlElement* structureElement, Structure* structure, Tile* _t)
 {
 	const auto position = _t->position();
-	_ti->attribute("x", position.x);
-	_ti->attribute("y", position.y);
-	_ti->attribute("depth", _t->depth());
+	structureElement->attribute("x", position.x);
+	structureElement->attribute("y", position.y);
+	structureElement->attribute("depth", _t->depth());
 
-	_ti->attribute("age", structure->age());
-	_ti->attribute("state", static_cast<int>(structure->state()));
-	_ti->attribute("forced_idle", structure->forceIdle());
-	_ti->attribute("disabled_reason", static_cast<int>(structure->disabledReason()));
-	_ti->attribute("idle_reason", static_cast<int>(structure->idleReason()));
-	_ti->attribute("type", structure->structureId());
-	_ti->attribute("direction", structure->connectorDirection());
+	structureElement->attribute("age", structure->age());
+	structureElement->attribute("state", static_cast<int>(structure->state()));
+	structureElement->attribute("forced_idle", structure->forceIdle());
+	structureElement->attribute("disabled_reason", static_cast<int>(structure->disabledReason()));
+	structureElement->attribute("idle_reason", static_cast<int>(structure->idleReason()));
+	structureElement->attribute("type", structure->structureId());
+	structureElement->attribute("direction", structure->connectorDirection());
 
 	if (structure->hasCrime())
 	{
-		_ti->attribute("crime_rate", structure->crimeRate());
+		structureElement->attribute("crime_rate", structure->crimeRate());
 	}
 
 	const auto& production = structure->production();
 	if (production > StorableResources{ 0 })
 	{
-		writeResources(_ti, production, "production");
+		writeResources(structureElement, production, "production");
 	}
 
 	const auto& stored = structure->storage();
 	if (stored > StorableResources{ 0 })
 	{
-		writeResources(_ti, stored, "storage");
+		writeResources(structureElement, stored, "storage");
 	}
 
-	_ti->attribute("pop0", structure->populationAvailable()[0]);
-	_ti->attribute("pop1", structure->populationAvailable()[1]);
+	structureElement->attribute("pop0", structure->populationAvailable()[0]);
+	structureElement->attribute("pop1", structure->populationAvailable()[1]);
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -387,12 +387,12 @@ Tile& StructureManager::tileFromStructure(Structure* structure)
 }
 
 
-void serializeStructure(NAS2D::Xml::XmlElement* structureElement, Structure* structure, Tile* _t)
+void serializeStructure(NAS2D::Xml::XmlElement* structureElement, Structure* structure, Tile* tile)
 {
-	const auto position = _t->position();
+	const auto position = tile->position();
 	structureElement->attribute("x", position.x);
 	structureElement->attribute("y", position.y);
-	structureElement->attribute("depth", _t->depth());
+	structureElement->attribute("depth", tile->depth());
 
 	structureElement->attribute("age", structure->age());
 	structureElement->attribute("state", static_cast<int>(structure->state()));

--- a/OPHD/Things/Structures/AirShaft.h
+++ b/OPHD/Things/Structures/AirShaft.h
@@ -22,17 +22,17 @@ public:
 	void ug()
 	{
 		sprite().play(constants::STRUCTURE_STATE_OPERATIONAL_UG);
-		_ug = true;
+		mIsUnderground = true;
 	}
 
 	void forced_state_change(StructureState, DisabledReason, IdleReason) override
 	{
-		if (_ug)
+		if (mIsUnderground)
 		{
 			return;
 		}
 	}
 
 private:
-	bool _ug = false;
+	bool mIsUnderground = false;
 };

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -9,10 +9,10 @@ const int MineFacilityStorageCapacity = 500;
 /**
  * Computes how many units of ore should be pulled.
  */
-static int pull_count(MineFacility* _mf, size_t index)
+static int pull_count(MineFacility* mineFacility, size_t index)
 {
-	const int storageCapacity = (_mf->storageCapacity() / 4);
-	const int remainingCapacity = storageCapacity - _mf->production().resources[index];
+	const int storageCapacity = (mineFacility->storageCapacity() / 4);
+	const int remainingCapacity = storageCapacity - mineFacility->production().resources[index];
 
 	const int total = std::clamp(constants::BASE_MINE_PRODUCTION_RATE, 0, remainingCapacity);
 

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -9,7 +9,7 @@ const int MineFacilityStorageCapacity = 500;
 /**
  * Computes how many units of ore should be pulled.
  */
-static int pull_count(MineFacility* mineFacility, size_t index)
+static int pullCount(MineFacility* mineFacility, size_t index)
 {
 	const int storageCapacity = (mineFacility->storageCapacity() / 4);
 	const int remainingCapacity = storageCapacity - mineFacility->production().resources[index];
@@ -92,22 +92,22 @@ void MineFacility::think()
 
 		if (mMine->miningCommonMetals())
 		{
-			ore.resources[0] = mMine->pull(Mine::OreType::ORE_COMMON_METALS, pull_count(this, 0));
+			ore.resources[0] = mMine->pull(Mine::OreType::ORE_COMMON_METALS, pullCount(this, 0));
 		}
 
 		if (mMine->miningCommonMinerals())
 		{
-			ore.resources[1] = mMine->pull(Mine::OreType::ORE_COMMON_MINERALS, pull_count(this, 1));
+			ore.resources[1] = mMine->pull(Mine::OreType::ORE_COMMON_MINERALS, pullCount(this, 1));
 		}
 
 		if (mMine->miningRareMetals())
 		{
-			ore.resources[2] = mMine->pull(Mine::OreType::ORE_RARE_METALS, pull_count(this, 2));
+			ore.resources[2] = mMine->pull(Mine::OreType::ORE_RARE_METALS, pullCount(this, 2));
 		}
 
 		if (mMine->miningRareMinerals())
 		{
-			ore.resources[3] = mMine->pull(Mine::OreType::ORE_RARE_MINERALS, pull_count(this, 3));
+			ore.resources[3] = mMine->pull(Mine::OreType::ORE_RARE_MINERALS, pullCount(this, 3));
 		}
 
 		storage() += ore;

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -161,7 +161,7 @@ void Slider::positionInternal(float newPosition)
 }
 
 
-void Slider::_buttonCheck(bool& buttonFlag, Rectangle<int>& rect, float value)
+void Slider::buttonCheck(bool& buttonFlag, Rectangle<int>& rect, float value)
 {
 	if (rect.contains(mMousePosition))
 	{
@@ -187,8 +187,8 @@ void Slider::onMouseDown(EventHandler::MouseButton button, int x, int y)
 			return;
 		}
 
-		_buttonCheck(mButton1Held, mButton1, -1.0);
-		_buttonCheck(mButton2Held, mButton2, 1.0);
+		buttonCheck(mButton1Held, mButton1, -1.0);
+		buttonCheck(mButton2Held, mButton2, 1.0);
 	}
 }
 

--- a/OPHD/UI/Core/Slider.h
+++ b/OPHD/UI/Core/Slider.h
@@ -73,7 +73,7 @@ private:
 	void draw() override; /**< Draw the widget on screen. */
 	void logic(); /**< Compute some values before drawing the control. */
 
-	void _buttonCheck(bool& buttonFlag, NAS2D::Rectangle<int>& rect, float value);
+	void buttonCheck(bool& buttonFlag, NAS2D::Rectangle<int>& rect, float value);
 
 	const NAS2D::Font& mFont;
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -79,11 +79,11 @@ void TextField::resetCursorPosition()
 /**
  * When set, will only allow numbers to be entered into the TextField.
  * 
- * \param _b True or False.
+ * \param isNumbersOnly True or False.
  */
-void TextField::numbers_only(bool _b)
+void TextField::numbers_only(bool isNumbersOnly)
 {
-	mNumbersOnly = _b;
+	mNumbersOnly = isNumbersOnly;
 }
 
 

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -56,17 +56,17 @@ void FactoryProduction::hide()
 }
 
 
-void FactoryProduction::onProductSelectionChange(const IconGrid::IconGridItem* _item)
+void FactoryProduction::onProductSelectionChange(const IconGrid::IconGridItem* item)
 {
 	if (!mFactory) { return; }
 
-	if (!_item)
+	if (!item)
 	{
 		mProductCost.clear();
 		return;
 	}
 
-	mProduct = static_cast<ProductType>(_item->meta);
+	mProduct = static_cast<ProductType>(item->meta);
 	mProductCost = productCost(mProduct);
 }
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -181,11 +181,11 @@ void IconGrid::addItem(const std::string& name, int sheetIndex, int meta)
 
 	mIconItemList.push_back(IconGridItem());
 
-	IconGrid::IconGridItem& _item = mIconItemList.back();
+	IconGrid::IconGridItem& item = mIconItemList.back();
 
-	_item.name = name;
-	_item.pos = {x_pos, y_pos};
-	_item.meta = meta;
+	item.name = name;
+	item.pos = {x_pos, y_pos};
+	item.meta = meta;
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -402,8 +402,7 @@ void FactoryReport::onListSelectionChange()
 	lstProducts.clear();
 	if (selectedFactory->state() != StructureState::Destroyed)
 	{
-		const Factory::ProductionTypeList& _pl = selectedFactory->productList();
-		for (auto item : _pl)
+		for (auto item : selectedFactory->productList())
 		{
 			lstProducts.add(productDescription(item), static_cast<int>(item));
 		}

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -449,12 +449,12 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 	const auto labelWidth = fontMediumBold.width("Resources Required");
 
 	// MINERAL RESOURCES
-	const ProductionCost& _pc = productCost(selectedFactory->productType());
+	const ProductionCost& productionCost = productCost(selectedFactory->productType());
 	const std::array requiredResources{
-		std::pair{"Common Metals", _pc.commonMetals()},
-		std::pair{"Common Minerals", _pc.commonMinerals()},
-		std::pair{"Rare Metals", _pc.rareMetals()},
-		std::pair{"Rare Minerals", _pc.rareMinerals()},
+		std::pair{"Common Metals", productionCost.commonMetals()},
+		std::pair{"Common Minerals", productionCost.commonMinerals()},
+		std::pair{"Rare Metals", productionCost.rareMetals()},
+		std::pair{"Rare Minerals", productionCost.rareMinerals()},
 	};
 	auto position = startPoint + NAS2D::Vector{138, 80};
 	for (auto [title, value] : requiredResources) {

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -284,8 +284,8 @@ void FactoryReport::onVisibilityChange(bool visible)
 {
 	if (!selectedFactory) { return; }
 
-	StructureState _state = selectedFactory->state();
-	btnApply.visible(visible && (_state == StructureState::Operational || _state == StructureState::Idle));
+	StructureState state = selectedFactory->state();
+	btnApply.visible(visible && (state == StructureState::Operational || state == StructureState::Idle));
 	checkFactoryActionControls();
 }
 
@@ -411,8 +411,8 @@ void FactoryReport::onListSelectionChange()
 	lstProducts.selectIf([productType = selectedFactory->productType()](const auto& item){ return item.tag == productType; });
 	selectedProductType = selectedFactory->productType();
 
-	StructureState _state = selectedFactory->state();
-	btnApply.visible(_state == StructureState::Operational || _state == StructureState::Idle);
+	StructureState state = selectedFactory->state();
+	btnApply.visible(state == StructureState::Operational || state == StructureState::Idle);
 }
 
 

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 			Utility<Mixer>::init<MixerNull>();
 		}
 
-		WindowEventWrapper _wew;
+		WindowEventWrapper windowEventWrapper;
 
 		auto& renderer = Utility<Renderer>::init<RendererOpenGL>("OutpostHD");
 


### PR DESCRIPTION
Rename variables and methods that start with a leading underscore.

I've never quite understood what the leading underscore was supposed to signify. Some people use that to denote member variables, though OPHD uses "m" to signify that, plus many of these variables were locals rather than members. I've also wondered if it was used to signify private methods, though if that's the case it's been inconsistently applied. As there is no clear meaning to the underscore, I thought it best to remove it where possible.

Another reason for the change is that many of these variables with underscore prefixes were abbreviated to a point where they lost meaning without context. Better to write out the name in full in those cases, and avoid ambiguity.

Here I focused on the easy cases where changes had very local impacts, such as local variables, or private method names, and no significant code structure changes were needed. More involved cases can be dealt with individually in their own PR.
