### PR TITLE
Refactor RobotPool::addRobot

### DIFF
--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -48,8 +48,7 @@ void RobotPool::erase(Robot* robot)
 /**
  * Adds a robot of specified type to the pool.
  *
- * \return Returns a pointer to the recently.
- * \return Returns a nullptr if the robot type was invalid or unsupported.
+ * \return Returns a pointer to the robot, or nullptr if type was invalid.
  */
 Robot* RobotPool::addRobot(Robot::Type type, int id /*= 0*/)
 {

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -48,9 +48,24 @@ void RobotPool::erase(Robot* robot)
 /**
  * Adds a robot of specified type to the pool.
  *
+ * Generates a new unique ID for the robot.
+ *
  * \return Returns a pointer to the robot, or nullptr if type was invalid.
  */
-Robot* RobotPool::addRobot(Robot::Type type, int id /*= 0*/)
+Robot* RobotPool::addRobot(Robot::Type type)
+{
+	// Generate a new unique ID
+	const auto id = ++ROBOT_ID_COUNTER;
+	return addRobot(type, id);
+}
+
+
+/**
+ * Adds a robot of specified type to the pool.
+ *
+ * \return Returns a pointer to the robot, or nullptr if type was invalid.
+ */
+Robot* RobotPool::addRobot(Robot::Type type, int id)
 {
 	int _id = 0;
 	if (id == 0) { _id = ++ROBOT_ID_COUNTER; }

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -67,27 +67,23 @@ Robot* RobotPool::addRobot(Robot::Type type)
  */
 Robot* RobotPool::addRobot(Robot::Type type, int id)
 {
-	int _id = 0;
-	if (id == 0) { _id = ++ROBOT_ID_COUNTER; }
-	else { _id = id; }
-
 	switch (type)
 	{
 	case Robot::Type::Dozer:
 		mDozers.push_back(new Robodozer());
-		mDozers.back()->id(_id);
+		mDozers.back()->id(id);
 		mRobots.push_back(mDozers.back());
 		return mDozers.back();
 
 	case Robot::Type::Digger:
 		mDiggers.push_back(new Robodigger());
-		mDiggers.back()->id(_id);
+		mDiggers.back()->id(id);
 		mRobots.push_back(mDiggers.back());
 		return mDiggers.back();
 
 	case Robot::Type::Miner:
 		mMiners.push_back(new Robominer());
-		mMiners.back()->id(_id);
+		mMiners.back()->id(id);
 		mRobots.push_back(mMiners.back());
 		return mMiners.back();
 

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -19,7 +19,8 @@ public:
 	RobotPool();
 	~RobotPool();
 
-	Robot* addRobot(Robot::Type type, int id = 0);
+	Robot* addRobot(Robot::Type type);
+	Robot* addRobot(Robot::Type type, int id);
 
 	Robodigger* getDigger();
 	Robodozer* getDozer();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -263,11 +263,10 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 	mRobots.clear();
 
 	ROBOT_ID_COUNTER = 0;
-	int id = 0, type = 0, age = 0, production_time = 0, x = 0, y = 0, depth = 0, direction = 0;
 	XmlAttribute* attribute = nullptr;
 	for (XmlNode* robotNode = element->firstChild(); robotNode; robotNode = robotNode->nextSibling())
 	{
-		id = type = age = production_time = x = y = depth = direction = 0;
+		int id = 0, type = 0, age = 0, production_time = 0, x = 0, y = 0, depth = 0, direction = 0;
 		attribute = robotNode->toElement()->firstAttribute();
 		while (attribute)
 		{

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -332,14 +332,12 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 
 void MapViewState::readStructures(Xml::XmlElement* element)
 {
-	int x = 0, y = 0, depth = 0, age = 0, state = 0, direction = 0, forced_idle = 0, disabled_reason = 0, idle_reason = 0, pop0 = 0, pop1 = 0, type = 0;
-	int production_completed = 0, production_type = 0;
-	int crime_rate = 0;
-	XmlAttribute* attribute = nullptr;
 	for (XmlNode* structureNode = element->firstChild(); structureNode != nullptr; structureNode = structureNode->nextSibling())
 	{
-		x = y = depth = age = state = direction = production_completed = production_type = disabled_reason = idle_reason = pop0 = pop1 = type = crime_rate = 0;
-		attribute = structureNode->toElement()->firstAttribute();
+		int x = 0, y = 0, depth = 0, age = 0, state = 0, direction = 0, forced_idle = 0, disabled_reason = 0, idle_reason = 0, pop0 = 0, pop1 = 0, type = 0;
+		int production_completed = 0, production_type = 0;
+		int crime_rate = 0;
+		auto* attribute = structureNode->toElement()->firstAttribute();
 		while (attribute)
 		{
 			if (attribute->name() == "x") { attribute->queryIntValue(x); }

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -263,11 +263,10 @@ void MapViewState::readRobots(Xml::XmlElement* element)
 	mRobots.clear();
 
 	ROBOT_ID_COUNTER = 0;
-	XmlAttribute* attribute = nullptr;
 	for (XmlNode* robotNode = element->firstChild(); robotNode; robotNode = robotNode->nextSibling())
 	{
 		int id = 0, type = 0, age = 0, production_time = 0, x = 0, y = 0, depth = 0, direction = 0;
-		attribute = robotNode->toElement()->firstAttribute();
+		auto* attribute = robotNode->toElement()->firstAttribute();
 		while (attribute)
 		{
 			if (attribute->name() == "id") { attribute->queryIntValue(id); }


### PR DESCRIPTION
Bit of a followup to #964, where variables with leading underscores are renamed. This handles a change to `RobotPool::addRobot`, where there was previously a `_id` variable. This splits the function into two overloads, and eliminates the default parameter that previously collapsed the two cases. I figure it may be better to use two overloads, with one delegating to the other, as the use and meaning of the extra parameter appears to be statically decided at the point of call.

The only place using the extra parameter is the saved game file loading code. That has also been refactored slightly, and may contain a small bug fix in relation to the `forced_idle` field.
