### PR TITLE
Agridome pilfering

### DIFF
--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -8,7 +8,7 @@
 CrimeExecution::CrimeExecution(NotificationArea& notificationArea) : mNotificationArea(notificationArea) {}
 
 
-void CrimeExecution::executeCrimes(std::vector<Structure*> structuresCommittingCrime)
+void CrimeExecution::executeCrimes(const std::vector<Structure*>& structuresCommittingCrime)
 {
 	for (auto& structure : structuresCommittingCrime)
 	{
@@ -26,13 +26,6 @@ void CrimeExecution::executeCrimes(std::vector<Structure*> structuresCommittingC
 			break;
 		}
 	}
-}
-
-
-void CrimeExecution::executeCrimes(std::vector<Structure*>&& structuresCommittingCrime)
-{
-	// Delegate to lvalue function overload
-	executeCrimes(structuresCommittingCrime);
 }
 
 

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -22,6 +22,8 @@ void CrimeExecution::executeCrimes(std::vector<Structure*> structuresCommittingC
 		case StructureID::SID_AGRIDOME:
 			executeStealingFood(static_cast<FoodProduction&>(*structure));
 			break;
+		default:
+			break;
 		}
 	}
 }

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -44,7 +44,6 @@ void CrimeExecution::executeStealingFood(FoodProduction& structure)
 		
 		structure.foodLevel(-foodStolen);
 
-
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
 		
 		mNotificationArea.push("Food Stolen", NAS2D::stringFrom(foodStolen) + " units of food was pilfered.",

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -1,0 +1,52 @@
+#include "CrimeExecution.h"
+#include "../StructureManager.h"
+#include <NAS2D/StringUtils.h>
+#include <NAS2D/Utility.h>
+#include <algorithm>
+
+
+CrimeExecution::CrimeExecution(NotificationArea& notificationArea) : mNotificationArea(notificationArea) {}
+
+
+void CrimeExecution::executeCrimes(std::vector<Structure*> structuresCommittingCrime)
+{
+	for (auto& structure : structuresCommittingCrime)
+	{
+		if (structure == nullptr) 
+		{
+			continue;
+		}
+
+		switch (structure->structureId())
+		{
+		case StructureID::SID_AGRIDOME:
+			executeStealingFood(static_cast<FoodProduction&>(*structure));
+			break;
+		}
+	}
+}
+
+
+void CrimeExecution::executeCrimes(std::vector<Structure*>&& structuresCommittingCrime)
+{
+	// Delegate to lvalue function overload
+	executeCrimes(structuresCommittingCrime);
+}
+
+
+void CrimeExecution::executeStealingFood(FoodProduction& structure)
+{
+	if (structure.foodLevel() > 0)
+	{
+		int foodStolen = std::clamp(100, 0, structure.foodLevel());
+		
+		structure.foodLevel(-foodStolen);
+
+
+		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
+		
+		mNotificationArea.push("Food Stolen", NAS2D::stringFrom(foodStolen) + " units of food was pilfered.",
+			structureTile.position(),
+			NotificationArea::NotificationType::Warning);
+	}
+}

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -10,8 +10,7 @@ class CrimeExecution
 public:
 	CrimeExecution(NotificationArea& notificationArea);
 
-	void executeCrimes(std::vector<Structure*> structuresCommittingCrime);
-	void executeCrimes(std::vector<Structure*>&& structuresCommittingCrime);
+	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
 
 	void executeStealingFood(FoodProduction& structure);
 

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../UI/NotificationArea.h"
+#include "../Things/Structures/Structures.h"
+#include <vector>
+
+
+class CrimeExecution 
+{
+public:
+	CrimeExecution(NotificationArea& notificationArea);
+
+	void executeCrimes(std::vector<Structure*> structuresCommittingCrime);
+	void executeCrimes(std::vector<Structure*>&& structuresCommittingCrime);
+
+	void executeStealingFood(FoodProduction& structure);
+
+private:
+	NotificationArea& mNotificationArea;
+};

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -7,7 +7,8 @@
 #include <functional>
 
 
-namespace {
+namespace
+{
 	std::random_device randomDevice;
 	std::mt19937 generator(randomDevice());
 	std::uniform_int_distribution<int> distribution(0, 1000);
@@ -26,7 +27,8 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 	const auto& structuresWithCrime = NAS2D::Utility<StructureManager>::get().structuresWithCrime();
 
 	// Colony will not have a crime rate until at least one structure that supports crime is built
-	if (structuresWithCrime.empty()) {
+	if (structuresWithCrime.empty())
+	{
 		setPopulationPanel(0, 0);
 		return;
 	}

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -5,7 +5,10 @@
 #include <NAS2D/Utility.h>
 
 
-void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
+CrimeRateUpdate::CrimeRateUpdate(PopulationPanel& populationPanel) : mPopulationPanel(populationPanel) { }
+
+
+void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 {
 	mMoraleChange = 0;
 
@@ -13,7 +16,7 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, Popula
 
 	// Colony will not have a crime rate until at least one structure that supports crime is built
 	if (structuresWithCrime.empty()) {
-		setPopulationPanel(0, 0, populationPanel);
+		setPopulationPanel(0, 0);
 		return;
 	}
 
@@ -30,7 +33,7 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, Popula
 	int meanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
 	mMoraleChange = calculateMoraleChange(meanCrimeRate);
 
-	setPopulationPanel(mMoraleChange, meanCrimeRate, populationPanel);
+	setPopulationPanel(mMoraleChange, meanCrimeRate);
 }
 
 
@@ -66,16 +69,16 @@ int CrimeRateUpdate::calculateMoraleChange(int meanCrimeRate)
 }
 
 
-void CrimeRateUpdate::setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel)
+void CrimeRateUpdate::setPopulationPanel(int moraleChange, int meanCrimeRate)
 {
-	populationPanel.crimeRate(meanCrimeRate);
+	mPopulationPanel.crimeRate(meanCrimeRate);
 
 	if (moraleChange > 0)
 	{
-		populationPanel.addMoraleReason("Low Crime Rate", moraleChange);
+		mPopulationPanel.addMoraleReason("Low Crime Rate", moraleChange);
 	}
 	else if (moraleChange < 0)
 	{
-		populationPanel.addMoraleReason("High Crime Rate", moraleChange);
+		mPopulationPanel.addMoraleReason("High Crime Rate", moraleChange);
 	}
 }

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -31,7 +31,7 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 		return;
 	}
 
-	double accumulatedCrime = 0;
+	double accumulatedCrime{ 0 };
 
 	for (auto structure : structuresWithCrime)
 	{

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -4,14 +4,12 @@
 #include "../StructureManager.h"
 #include <NAS2D/Utility.h>
 
-namespace CrimeRate
-{
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
 	int calculateMoraleChange(int meanCrimeRate);
 	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
 
 
-	int update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
+	int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
 	{
 		const auto& structuresWithCrime = NAS2D::Utility<StructureManager>::get().structuresWithCrime();
 
@@ -85,4 +83,3 @@ namespace CrimeRate
 			populationPanel.addMoraleReason("High Crime Rate", moraleChange);
 		}
 	}
-}

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -11,7 +11,7 @@ namespace {
 	std::random_device randomDevice;
 	std::mt19937 generator(randomDevice());
 	std::uniform_int_distribution<int> distribution(0, 1000);
-	auto random = std::bind(distribution, std::ref(generator));
+	auto randomNumberGenerator = std::bind(distribution, std::ref(generator));
 }
 
 
@@ -40,7 +40,7 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 
 		// Crime Rate of 0% means no crime
 		// Crime Rate of 100% means crime occurs 10% of the time
-		if (structure->crimeRate() + random() > 1000)
+		if (structure->crimeRate() + randomNumberGenerator() > 1000)
 		{
 			mStructuresCommittingCrimes.push_back(structure);
 		}

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -5,14 +5,16 @@
 #include <NAS2D/Utility.h>
 
 
-int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
+void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
 {
+	mMoraleChange = 0;
+
 	const auto& structuresWithCrime = NAS2D::Utility<StructureManager>::get().structuresWithCrime();
 
 	// Colony will not have a crime rate until at least one structure that supports crime is built
 	if (structuresWithCrime.empty()) {
 		setPopulationPanel(0, 0, populationPanel);
-		return 0;
+		return;
 	}
 
 	double accumulatedCrime = 0;
@@ -26,11 +28,9 @@ int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, Populat
 	}
 
 	int meanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
-	int moraleChange = calculateMoraleChange(meanCrimeRate);
+	mMoraleChange = calculateMoraleChange(meanCrimeRate);
 
-	setPopulationPanel(moraleChange, meanCrimeRate, populationPanel);
-
-	return moraleChange;
+	setPopulationPanel(mMoraleChange, meanCrimeRate, populationPanel);
 }
 
 

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -4,82 +4,82 @@
 #include "../StructureManager.h"
 #include <NAS2D/Utility.h>
 
-	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
-	int calculateMoraleChange(int meanCrimeRate);
-	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
+bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
+int calculateMoraleChange(int meanCrimeRate);
+void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
 
 
-	int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
-	{
-		const auto& structuresWithCrime = NAS2D::Utility<StructureManager>::get().structuresWithCrime();
+int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
+{
+	const auto& structuresWithCrime = NAS2D::Utility<StructureManager>::get().structuresWithCrime();
 
-		// Colony will not have a crime rate until at least one structure that supports crime is built
-		if (structuresWithCrime.empty()) {
-			setPopulationPanel(0, 0, populationPanel);
-			return 0;
-		}
-
-		double accumulatedCrime = 0;
-
-		for (auto structure : structuresWithCrime)
-		{
-			int crimeRateChange = isProtectedByPolice(policeOverlays, structure) ? -1 : 1;
-			structure->increaseCrimeRate(crimeRateChange);
-
-			accumulatedCrime += structure->crimeRate();
-		}
-
-		int meanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
-		int moraleChange = calculateMoraleChange(meanCrimeRate);
-
-		setPopulationPanel(moraleChange, meanCrimeRate, populationPanel);
-
-		return moraleChange;
-	}
-
-
-	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure)
-	{
-		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
-
-		for (const auto& tile : policeOverlays[structureTile.depth()])
-		{
-			if (tile->position() == structureTile.position())
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-
-	int calculateMoraleChange(int meanCrimeRate)
-	{
-		if (meanCrimeRate > 50)
-		{
-			// Reduce morale by 1 for every 10% above 50%
-			return -1 * (meanCrimeRate / 10 - 4);
-		}
-		else if (meanCrimeRate < 10)
-		{
-			return 1;
-		}
-
+	// Colony will not have a crime rate until at least one structure that supports crime is built
+	if (structuresWithCrime.empty()) {
+		setPopulationPanel(0, 0, populationPanel);
 		return 0;
 	}
 
+	double accumulatedCrime = 0;
 
-	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel)
+	for (auto structure : structuresWithCrime)
 	{
-		populationPanel.crimeRate(meanCrimeRate);
+		int crimeRateChange = isProtectedByPolice(policeOverlays, structure) ? -1 : 1;
+		structure->increaseCrimeRate(crimeRateChange);
 
-		if (moraleChange > 0)
+		accumulatedCrime += structure->crimeRate();
+	}
+
+	int meanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
+	int moraleChange = calculateMoraleChange(meanCrimeRate);
+
+	setPopulationPanel(moraleChange, meanCrimeRate, populationPanel);
+
+	return moraleChange;
+}
+
+
+bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure)
+{
+	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
+
+	for (const auto& tile : policeOverlays[structureTile.depth()])
+	{
+		if (tile->position() == structureTile.position())
 		{
-			populationPanel.addMoraleReason("Low Crime Rate", moraleChange);
-		}
-		else if (moraleChange < 0)
-		{
-			populationPanel.addMoraleReason("High Crime Rate", moraleChange);
+			return true;
 		}
 	}
+
+	return false;
+}
+
+
+int calculateMoraleChange(int meanCrimeRate)
+{
+	if (meanCrimeRate > 50)
+	{
+		// Reduce morale by 1 for every 10% above 50%
+		return -1 * (meanCrimeRate / 10 - 4);
+	}
+	else if (meanCrimeRate < 10)
+	{
+		return 1;
+	}
+
+	return 0;
+}
+
+
+void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel)
+{
+	populationPanel.crimeRate(meanCrimeRate);
+
+	if (moraleChange > 0)
+	{
+		populationPanel.addMoraleReason("Low Crime Rate", moraleChange);
+	}
+	else if (moraleChange < 0)
+	{
+		populationPanel.addMoraleReason("High Crime Rate", moraleChange);
+	}
+}

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -4,10 +4,6 @@
 #include "../StructureManager.h"
 #include <NAS2D/Utility.h>
 
-bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
-int calculateMoraleChange(int meanCrimeRate);
-void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
-
 
 int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel)
 {
@@ -38,7 +34,7 @@ int CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays, Populat
 }
 
 
-bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure)
+bool CrimeRateUpdate::isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure)
 {
 	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
 
@@ -54,7 +50,7 @@ bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure*
 }
 
 
-int calculateMoraleChange(int meanCrimeRate)
+int CrimeRateUpdate::calculateMoraleChange(int meanCrimeRate)
 {
 	if (meanCrimeRate > 50)
 	{
@@ -70,7 +66,7 @@ int calculateMoraleChange(int meanCrimeRate)
 }
 
 
-void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel)
+void CrimeRateUpdate::setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel)
 {
 	populationPanel.crimeRate(meanCrimeRate);
 

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -29,7 +29,7 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 	// Colony will not have a crime rate until at least one structure that supports crime is built
 	if (structuresWithCrime.empty())
 	{
-		setPopulationPanel(0, 0);
+		updateCrimeOnPopulationPanel(0, 0);
 		return;
 	}
 
@@ -53,7 +53,7 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 	int meanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
 	mMoraleChange = calculateMoraleChange(meanCrimeRate);
 
-	setPopulationPanel(mMoraleChange, meanCrimeRate);
+	updateCrimeOnPopulationPanel(mMoraleChange, meanCrimeRate);
 }
 
 
@@ -89,7 +89,7 @@ int CrimeRateUpdate::calculateMoraleChange(int meanCrimeRate)
 }
 
 
-void CrimeRateUpdate::setPopulationPanel(int moraleChange, int meanCrimeRate)
+void CrimeRateUpdate::updateCrimeOnPopulationPanel(int moraleChange, int meanCrimeRate)
 {
 	mPopulationPanel.crimeRate(meanCrimeRate);
 

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -9,14 +9,17 @@ class Structure;
 class CrimeRateUpdate
 {
 public:
-	void update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel);
+	CrimeRateUpdate(PopulationPanel& populationPanel);
+
+	void update(const std::vector<TileList>& policeOverlays);
 
 	int getMoraleChange() const { return mMoraleChange; }
 
 private:
+	PopulationPanel& mPopulationPanel;
 	int mMoraleChange = 0;
 
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
 	int calculateMoraleChange(int meanCrimeRate);
-	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
+	void setPopulationPanel(int moraleChange, int meanCrimeRate);
 };

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -4,10 +4,16 @@
 #include <vector>
 
 class PopulationPanel;
+class Structure;
 
 class CrimeRateUpdate
 {
 public:
 	// Returns change in current morale caused by colony's mean crime rate
 	int update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel);
+
+private:
+	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
+	int calculateMoraleChange(int meanCrimeRate);
+	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);
 };

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -9,10 +9,13 @@ class Structure;
 class CrimeRateUpdate
 {
 public:
-	// Returns change in current morale caused by colony's mean crime rate
-	int update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel);
+	void update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel);
+
+	int getMoraleChange() const { return mMoraleChange; }
 
 private:
+	int mMoraleChange = 0;
+
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
 	int calculateMoraleChange(int meanCrimeRate);
 	void setPopulationPanel(int moraleChange, int meanCrimeRate, PopulationPanel& populationPanel);

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -14,10 +14,12 @@ public:
 	void update(const std::vector<TileList>& policeOverlays);
 
 	int getMoraleChange() const { return mMoraleChange; }
+	std::vector<Structure*> getStructuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
 private:
 	PopulationPanel& mPopulationPanel;
 	int mMoraleChange = 0;
+	std::vector<Structure*> mStructuresCommittingCrimes;
 
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
 	int calculateMoraleChange(int meanCrimeRate);

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -18,7 +18,7 @@ public:
 
 private:
 	PopulationPanel& mPopulationPanel;
-	int mMoraleChange = 0;
+	int mMoraleChange{ 0 };
 	std::vector<Structure*> mStructuresCommittingCrimes;
 
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -5,8 +5,9 @@
 
 class PopulationPanel;
 
-namespace CrimeRate
+class CrimeRateUpdate
 {
+public:
 	// Returns change in current morale caused by colony's mean crime rate
 	int update(const std::vector<TileList>& policeOverlays, PopulationPanel& populationPanel);
-}
+};

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -13,8 +13,8 @@ public:
 
 	void update(const std::vector<TileList>& policeOverlays);
 
-	int getMoraleChange() const { return mMoraleChange; }
-	std::vector<Structure*> getStructuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
+	int moraleChange() const { return mMoraleChange; }
+	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
 private:
 	PopulationPanel& mPopulationPanel;
@@ -23,5 +23,5 @@ private:
 
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
 	int calculateMoraleChange(int meanCrimeRate);
-	void setPopulationPanel(int moraleChange, int meanCrimeRate);
+	void updateCrimeOnPopulationPanel(int moraleChange, int meanCrimeRate);
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -110,6 +110,7 @@ static void pushAgingRobotMessage(const Robot* robot, const Point<int> position,
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
 	mMainReportsState(mainReportsState),
+	mCrimeRateUpdate(mPopulationPanel),
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
 {
@@ -121,6 +122,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes) :
 	mMainReportsState(mainReportsState),
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
+	mCrimeRateUpdate(mPopulationPanel),
 	mPlanetAttributes(planetAttributes),
 	mMapDisplay{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION)},
 	mHeightMap{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION)}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -111,6 +111,7 @@ static void pushAgingRobotMessage(const Robot* robot, const Point<int> position,
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
 	mMainReportsState(mainReportsState),
 	mCrimeRateUpdate(mPopulationPanel),
+	mCrimeExecution(mNotificationArea),
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
 {
@@ -123,6 +124,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mMainReportsState(mainReportsState),
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
 	mCrimeRateUpdate(mPopulationPanel),
+	mCrimeExecution(mNotificationArea),
 	mPlanetAttributes(planetAttributes),
 	mMapDisplay{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION)},
 	mHeightMap{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION)}

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -3,6 +3,7 @@
 #include "MapViewStateHelper.h"
 #include "Wrapper.h"
 #include "CrimeRateUpdate.h"
+#include "CrimeExecution.h"
 
 #include "Planet.h"
 #include "Route.h"
@@ -248,6 +249,7 @@ private:
 	MainReportsUiState& mMainReportsState;
 	TileMap* mTileMap = nullptr;
 	CrimeRateUpdate mCrimeRateUpdate;
+	CrimeExecution mCrimeExecution;
 
 	Planet::Attributes mPlanetAttributes;
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -2,6 +2,7 @@
 
 #include "MapViewStateHelper.h"
 #include "Wrapper.h"
+#include "CrimeRateUpdate.h"
 
 #include "Planet.h"
 #include "Route.h"
@@ -246,6 +247,7 @@ private:
 private:
 	MainReportsUiState& mMainReportsState;
 	TileMap* mTileMap = nullptr;
+	CrimeRateUpdate mCrimeRateUpdate;
 
 	Planet::Attributes mPlanetAttributes;
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -247,7 +247,7 @@ private:
 
 private:
 	MainReportsUiState& mMainReportsState;
-	TileMap* mTileMap = nullptr;
+	TileMap* mTileMap{ nullptr };
 	CrimeRateUpdate mCrimeRateUpdate;
 	CrimeExecution mCrimeExecution;
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -568,6 +568,10 @@ void MapViewState::nextTurn()
 	mPreviousMorale = mCurrentMorale;
 
 	transferFoodToCommandCenter();
+
+	mCrimeRateUpdate.update(mPoliceOverlays, mPopulationPanel);
+	mCurrentMorale += mCrimeRateUpdate.getMoraleChange();
+
 	updateResidentialCapacity();
 
 	countFood();
@@ -580,9 +584,6 @@ void MapViewState::nextTurn()
 	updateResources();
 	updateStructuresAvailability();
 	updateRoads();
-
-	mCrimeRateUpdate.update(mPoliceOverlays, mPopulationPanel);
-	mCurrentMorale += mCrimeRateUpdate.getMoraleChange();
 
 	// Overlay Updates
 	checkCommRangeOverlay();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -580,7 +580,9 @@ void MapViewState::nextTurn()
 	updateResources();
 	updateStructuresAvailability();
 	updateRoads();
-	mCurrentMorale += CrimeRate::update(mPoliceOverlays, mPopulationPanel);
+
+	mCrimeRateUpdate.update(mPoliceOverlays, mPopulationPanel);
+	mCurrentMorale += mCrimeRateUpdate.getMoraleChange();
 
 	// Overlay Updates
 	checkCommRangeOverlay();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -569,7 +569,7 @@ void MapViewState::nextTurn()
 
 	transferFoodToCommandCenter();
 
-	mCrimeRateUpdate.update(mPoliceOverlays, mPopulationPanel);
+	mCrimeRateUpdate.update(mPoliceOverlays);
 	mCurrentMorale += mCrimeRateUpdate.getMoraleChange();
 
 	updateResidentialCapacity();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -571,6 +571,9 @@ void MapViewState::nextTurn()
 
 	mCrimeRateUpdate.update(mPoliceOverlays);
 	mCurrentMorale += mCrimeRateUpdate.getMoraleChange();
+	auto structuresCommittingCrimes = mCrimeRateUpdate.getStructuresCommittingCrimes();
+	mCrimeExecution.executeCrimes(structuresCommittingCrimes);
+	
 
 	updateResidentialCapacity();
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -570,8 +570,8 @@ void MapViewState::nextTurn()
 	transferFoodToCommandCenter();
 
 	mCrimeRateUpdate.update(mPoliceOverlays);
-	mCurrentMorale += mCrimeRateUpdate.getMoraleChange();
-	auto structuresCommittingCrimes = mCrimeRateUpdate.getStructuresCommittingCrimes();
+	mCurrentMorale += mCrimeRateUpdate.moraleChange();
+	auto structuresCommittingCrimes = mCrimeRateUpdate.structuresCommittingCrimes();
 	mCrimeExecution.executeCrimes(structuresCommittingCrimes);
 	
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -4,7 +4,6 @@
 
 #include "MapViewState.h"
 #include "MapViewStateHelper.h"
-#include "CrimeRateUpdate.h"
 
 #include "../Map/TileMap.h"
 #include "../Things/Structures/Structures.h"

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -264,6 +264,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="Population\Population.cpp" />
     <ClCompile Include="ProductPool.cpp" />
     <ClCompile Include="RobotPool.cpp" />
+    <ClCompile Include="States\CrimeExecution.cpp" />
     <ClCompile Include="States\CrimeRateUpdate.cpp" />
     <ClCompile Include="States\GameState.cpp" />
     <ClCompile Include="States\MapViewState.cpp" />
@@ -342,6 +343,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="Map\TileMap.h" />
     <ClInclude Include="MicroPather\micropather.h" />
     <ClInclude Include="Mine.h" />
+    <ClInclude Include="States\CrimeExecution.h" />
     <ClInclude Include="States\CrimeRateUpdate.h" />
     <ClInclude Include="StorableResources.h" />
     <ClInclude Include="PopulationPool.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -312,6 +312,9 @@
     <ClCompile Include="States\CrimeRateUpdate.cpp">
       <Filter>Source Files\States</Filter>
     </ClCompile>
+    <ClCompile Include="States\CrimeExecution.cpp">
+      <Filter>Source Files\States</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -690,6 +693,9 @@
       <Filter>Header Files\UI</Filter>
     </ClInclude>
     <ClInclude Include="States\CrimeRateUpdate.h">
+      <Filter>Header Files\States</Filter>
+    </ClInclude>
+    <ClInclude Include="States\CrimeExecution.h">
       <Filter>Header Files\States</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Working on #911 

Checking to make sure approach is sound before filling in more structures to have crime.

Added the module `CrimeExecution` to actually implement crime. This would allow triggering criminal activity in a more scripted manner if ever desired in the future and hopefully breaks the code into more manageable pieces.

I made `CrimeRateUpdate` into a class to move `moraleChange` to a separate get function based on feedback in other PRs.

If this looks good, will probably try to follow up with allowing smelters and storage tanks to be stolen from. I figured the food in the Command Center should probably be off limits from pilfering.

Right now, up to 100 food is stolen each time crime occurs. That should be updated to be a bit more of a random amount if the overall structure of the code looks good. Also, I didn't really know how to label food, so I just said units. Maybe tons of food?

![FoodPilfered](https://user-images.githubusercontent.com/15183337/121976345-a210ff00-cd51-11eb-9fbd-aacc0209bad7.png)