### PR TITLE
Return by const& from UIContainer::controls()

### DIFF
--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -115,6 +115,6 @@ void UIContainer::update()
 }
 
 
-std::vector<Control*> UIContainer::controls() const {
+const std::vector<Control*>& UIContainer::controls() const {
 	return mControls;
 }

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -26,7 +26,7 @@ public:
 
 	void update() override;
 
-	std::vector<Control*> controls() const;
+	const std::vector<Control*>& controls() const;
 
 protected:
 	void onVisibilityChange(bool visible) override;


### PR DESCRIPTION
Prevent unnecessary copying of the std::vector.

I suppose another option might be to remove the method, since it's not actually used anywhere. Actually, that's maybe not a bad idea, since some compound controls like `ReportInterface` inherit from `UIContainer`, so this method would give access to contained `Control` objects, which should maybe be more of a private detail.
