### PR TITLE
Remove hasFocus mouse checks

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -110,7 +110,7 @@ bool Button::hasImage() const
 
 void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left)
 	{
@@ -132,7 +132,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left)
 	{

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -52,7 +52,6 @@ Button::Button(std::string newText) :
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Button::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Button::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &Button::onMouseMove);
-	hasFocus(true);
 
 	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FONT_PRIMARY_NORMAL);
 }

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -68,7 +68,7 @@ CheckBox::ClickSignal::Source& CheckBox::click()
 
 void CheckBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left && mRect.contains(Point{x, y}))
 	{

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -79,7 +79,7 @@ void ComboBox::onMove(NAS2D::Vector<int> displacement)
  */
 void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (button != EventHandler::MouseButton::Left) { return; }
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -165,7 +165,7 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
  */
 void ListBoxBase::onMouseWheel(int /*x*/, int y)
 {
-	if (!visible()) { return; }
+	if (!enabled() || !visible()) { return; }
 	if (!mHasFocus) { return; }
 
 	float change = static_cast<float>(mItemHeight);

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -106,7 +106,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	const auto point = NAS2D::Point{x, y};
 
-	if (!visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible() || !hasFocus()) { return; }
 
 	if (isEmpty() || button == EventHandler::MouseButton::Middle) { return; }
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -106,7 +106,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	const auto point = NAS2D::Point{x, y};
 
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (isEmpty() || button == EventHandler::MouseButton::Middle) { return; }
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -84,7 +84,7 @@ void RadioButtonGroup::RadioButton::onTextChange()
 
 void RadioButtonGroup::RadioButton::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left && mRect.contains(Point{x, y}))
 	{

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -71,6 +71,5 @@ void RadioButtonGroup::update()
 	for (auto &control : mRadioButtons)
 	{
 		control.update();
-		control.hasFocus(true);
 	}
 }

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -177,7 +177,7 @@ void Slider::buttonCheck(bool& buttonFlag, Rectangle<int>& rect, float value)
 
 void Slider::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left)
 	{
@@ -201,7 +201,7 @@ void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 	mButton2Held = false;
 	mThumbPressed = false;
 
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (mSlider.contains(NAS2D::Point{x, y}))
 	{
@@ -235,7 +235,7 @@ void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 void Slider::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	mMousePosition = {x, y};
 

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -130,7 +130,6 @@ Slider::Slider(Slider::Skins skins, SliderType sliderType) :
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Slider::onMouseDown);
 	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Slider::onMouseUp);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &Slider::onMouseMove);
-	hasFocus(true);
 }
 
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -55,7 +55,6 @@ TextField::TextField() :
 	Utility<EventHandler>::get().keyDown().connect(this, &TextField::onKeyDown);
 	Utility<EventHandler>::get().textInput().connect(this, &TextField::onTextInput);
 
-	hasFocus(true);
 	Utility<EventHandler>::get().textInputMode(true);
 
 	height(mFont.height() + fieldPadding * 2);

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -224,7 +224,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	hasFocus(mRect.contains(Point{x, y})); // This is a very useful check, should probably include this in all controls.
 
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	int relativePosition = x - mRect.x;
 

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -44,7 +44,7 @@ Window::~Window()
 
 void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	UIContainer::onMouseDown(button, x, y);
 
@@ -61,7 +61,7 @@ void Window::onMouseUp(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*
 
 void Window::onMouseMove(int /*x*/, int /*y*/, int dX, int dY)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	if (mMouseDrag && !mAnchored)
 	{

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -44,7 +44,7 @@ Window::~Window()
 
 void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible() || !hasFocus()) { return; }
 
 	UIContainer::onMouseDown(button, x, y);
 
@@ -61,7 +61,7 @@ void Window::onMouseUp(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*
 
 void Window::onMouseMove(int /*x*/, int /*y*/, int dX, int dY)
 {
-	if (!visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible() || !hasFocus()) { return; }
 
 	if (mMouseDrag && !mAnchored)
 	{

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -78,7 +78,6 @@ void Window::anchored(bool isAnchored)
 void Window::show()
 {
 	Control::show();
-	hasFocus(true);
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -43,7 +43,6 @@ IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &IconGrid::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMove);
-	hasFocus(true);
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -68,7 +68,7 @@ void IconGrid::updateGrid()
  */
 void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible() || !hasFocus()) { return; }
 
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != EventHandler::MouseButton::Left) { return; }
@@ -111,7 +111,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
  */
 void IconGrid::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
-	if (!visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible() || !hasFocus()) { return; }
 
 	auto startPoint = mRect.startPoint();
 	auto mousePoint = NAS2D::Point{x, y};

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -68,7 +68,7 @@ void IconGrid::updateGrid()
  */
 void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != EventHandler::MouseButton::Left) { return; }
@@ -111,7 +111,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
  */
 void IconGrid::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
-	if (!enabled() || !visible() || !hasFocus()) { return; }
+	if (!enabled() || !visible()) { return; }
 
 	auto startPoint = mRect.startPoint();
 	auto mousePoint = NAS2D::Point{x, y};


### PR DESCRIPTION
Closes #884

Remove `hasFocus()` checks from mouse event handler code. The `hasFocus()` value is intended for keyboard focus, not mouse focus.

Also removed some hacks where certain controls would force `hasFocus(true)` in their constructors, so they would function correctly. With the erroneous checks removed, it's no longer necessary to force them to behave as if they had focus.

Focus should generally be controlled by the container, rather than by the control itself.
