### PR TITLE
Allow setting difficulty to increase or decrease the rate at which crimes occur

### DIFF
--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -41,8 +41,9 @@ void CrimeRateUpdate::update(const std::vector<TileList>& policeOverlays)
 		structure->increaseCrimeRate(crimeRateChange);
 
 		// Crime Rate of 0% means no crime
-		// Crime Rate of 100% means crime occurs 10% of the time
-		if (structure->crimeRate() + randomNumberGenerator() > 1000)
+		// Crime Rate of 100% means crime occurs 10% of the time on medium difficulty
+		// chanceCrimeOccurs multiplier increases or decreases chance based on difficulty
+		if (structure->crimeRate() * chanceCrimeOccurs[mDifficulty] + randomNumberGenerator() > 1000)
 		{
 			mStructuresCommittingCrimes.push_back(structure);
 		}

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include "../Map/Tile.h"
+#include "../Common.h"
 #include <vector>
+#include <map>
 
 class PopulationPanel;
 class Structure;
+
 
 class CrimeRateUpdate
 {
@@ -14,9 +17,20 @@ public:
 	void update(const std::vector<TileList>& policeOverlays);
 
 	int moraleChange() const { return mMoraleChange; }
+	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
 	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
 private:
+	// Lower number indicates criminal activity occurs more often
+	std::map<Difficulty, float> chanceCrimeOccurs
+	{ 
+		{Difficulty::Beginner, 0.5},
+		{Difficulty::Easy, 0.75},
+		{Difficulty::Medium, 1},
+		{Difficulty::Hard, 2}
+	};
+
+	Difficulty mDifficulty{ Difficulty::Medium };
 	PopulationPanel& mPopulationPanel;
 	int mMoraleChange{ 0 };
 	std::vector<Structure*> mStructuresCommittingCrimes;


### PR DESCRIPTION
Related to issue #911.

Just realized the crime issue was literally the number 911...

So on Normal chance of crime occurring scales linear from 0 to 10% chance each turn. On Hard, the scale is doubled, so max of 20% chance of crime. On Easy and Beginner, it is reduces to 7.5% and 5% respectively. I'm not beholden to any specific number, just tried to pick somewhat sensible starting places.