### PR TITLE
Rename EventHandler references

### DIFF
--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -27,7 +27,7 @@ GameState::~GameState()
 {
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();
 
-	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseMotion().disconnect(this, &GameState::onMouseMove);
 
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeComplete().disconnect(this, &GameState::onFadeComplete);
@@ -52,7 +52,7 @@ GameState::~GameState()
  */
 void GameState::initialize()
 {
-	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseMotion().connect(this, &GameState::onMouseMove);
 
 	mMainReportsState = std::make_unique<MainReportsUiState>();

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -27,8 +27,8 @@ GameState::~GameState()
 {
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();
 
-	NAS2D::EventHandler& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-	e.mouseMotion().disconnect(this, &GameState::onMouseMove);
+	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().disconnect(this, &GameState::onMouseMove);
 
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeComplete().disconnect(this, &GameState::onFadeComplete);
 
@@ -52,8 +52,8 @@ GameState::~GameState()
  */
 void GameState::initialize()
 {
-	NAS2D::EventHandler& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-	e.mouseMotion().connect(this, &GameState::onMouseMove);
+	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().connect(this, &GameState::onMouseMove);
 
 	mMainReportsState = std::make_unique<MainReportsUiState>();
 	mMainReportsState->_initialize();

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -29,9 +29,9 @@ MainMenuState::MainMenuState() :
 
 MainMenuState::~MainMenuState()
 {
-	EventHandler& e = Utility<EventHandler>::get();
-	e.windowResized().disconnect(this, &MainMenuState::onWindowResized);
-	e.keyDown().disconnect(this, &MainMenuState::onKeyDown);
+	EventHandler& eventHandler = Utility<EventHandler>::get();
+	eventHandler.windowResized().disconnect(this, &MainMenuState::onWindowResized);
+	eventHandler.keyDown().disconnect(this, &MainMenuState::onKeyDown);
 
 	Utility<Mixer>::get().stopAllAudio();
 	Utility<Renderer>::get().fadeComplete().disconnect(this, &MainMenuState::onFadeComplete);
@@ -43,9 +43,9 @@ MainMenuState::~MainMenuState()
  */
 void MainMenuState::initialize()
 {
-	EventHandler& e = Utility<EventHandler>::get();
-	e.windowResized().connect(this, &MainMenuState::onWindowResized);
-	e.keyDown().connect(this, &MainMenuState::onKeyDown);
+	EventHandler& eventHandler = Utility<EventHandler>::get();
+	eventHandler.windowResized().connect(this, &MainMenuState::onWindowResized);
+	eventHandler.keyDown().connect(this, &MainMenuState::onKeyDown);
 
 	for (auto& button : buttons)
 	{

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -29,7 +29,7 @@ MainMenuState::MainMenuState() :
 
 MainMenuState::~MainMenuState()
 {
-	EventHandler& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = Utility<EventHandler>::get();
 	eventHandler.windowResized().disconnect(this, &MainMenuState::onWindowResized);
 	eventHandler.keyDown().disconnect(this, &MainMenuState::onKeyDown);
 
@@ -43,7 +43,7 @@ MainMenuState::~MainMenuState()
  */
 void MainMenuState::initialize()
 {
-	EventHandler& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = Utility<EventHandler>::get();
 	eventHandler.windowResized().connect(this, &MainMenuState::onWindowResized);
 	eventHandler.keyDown().connect(this, &MainMenuState::onKeyDown);
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -124,17 +124,19 @@ static void drawPanel(Renderer& renderer, Panel& panel)
 
 MainReportsUiState::MainReportsUiState()
 {
-	Utility<EventHandler>::get().windowResized().connect(this, &MainReportsUiState::onWindowResized);
-	Utility<EventHandler>::get().keyDown().connect(this, &MainReportsUiState::onKeyDown);
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &MainReportsUiState::onMouseDown);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.windowResized().connect(this, &MainReportsUiState::onWindowResized);
+	eventHandler.keyDown().connect(this, &MainReportsUiState::onKeyDown);
+	eventHandler.mouseButtonDown().connect(this, &MainReportsUiState::onMouseDown);
 }
 
 
 MainReportsUiState::~MainReportsUiState()
 {
-	Utility<EventHandler>::get().windowResized().disconnect(this, &MainReportsUiState::onWindowResized);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &MainReportsUiState::onKeyDown);
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &MainReportsUiState::onMouseDown);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.windowResized().disconnect(this, &MainReportsUiState::onWindowResized);
+	eventHandler.keyDown().disconnect(this, &MainReportsUiState::onKeyDown);
+	eventHandler.mouseButtonDown().disconnect(this, &MainReportsUiState::onMouseDown);
 
 	for (Panel& panel : Panels)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -143,17 +143,17 @@ MapViewState::~MapViewState()
 
 	Utility<Renderer>::get().setCursor(PointerType::POINTER_NORMAL);
 
-	EventHandler& e = Utility<EventHandler>::get();
-	e.activate().disconnect(this, &MapViewState::onActivate);
-	e.keyDown().disconnect(this, &MapViewState::onKeyDown);
-	e.mouseButtonDown().disconnect(this, &MapViewState::onMouseDown);
-	e.mouseButtonUp().disconnect(this, &MapViewState::onMouseUp);
-	e.mouseDoubleClick().disconnect(this, &MapViewState::onMouseDoubleClick);
-	e.mouseMotion().disconnect(this, &MapViewState::onMouseMove);
-	e.mouseWheel().disconnect(this, &MapViewState::onMouseWheel);
-	e.windowResized().disconnect(this, &MapViewState::onWindowResized);
+	EventHandler& eventHandler = Utility<EventHandler>::get();
+	eventHandler.activate().disconnect(this, &MapViewState::onActivate);
+	eventHandler.keyDown().disconnect(this, &MapViewState::onKeyDown);
+	eventHandler.mouseButtonDown().disconnect(this, &MapViewState::onMouseDown);
+	eventHandler.mouseButtonUp().disconnect(this, &MapViewState::onMouseUp);
+	eventHandler.mouseDoubleClick().disconnect(this, &MapViewState::onMouseDoubleClick);
+	eventHandler.mouseMotion().disconnect(this, &MapViewState::onMouseMove);
+	eventHandler.mouseWheel().disconnect(this, &MapViewState::onMouseWheel);
+	eventHandler.windowResized().disconnect(this, &MapViewState::onWindowResized);
 
-	e.textInputMode(false);
+	eventHandler.textInputMode(false);
 
 	NAS2D::Utility<std::map<class MineFacility*, Route>>::get().clear();
 }
@@ -195,17 +195,17 @@ void MapViewState::initialize()
 
 	Utility<Renderer>::get().fadeIn(constants::FadeSpeed);
 
-	EventHandler& e = Utility<EventHandler>::get();
+	EventHandler& eventHandler = Utility<EventHandler>::get();
 
-	e.activate().connect(this, &MapViewState::onActivate);
-	e.keyDown().connect(this, &MapViewState::onKeyDown);
-	e.mouseButtonDown().connect(this, &MapViewState::onMouseDown);
-	e.mouseButtonUp().connect(this, &MapViewState::onMouseUp);
-	e.mouseDoubleClick().connect(this, &MapViewState::onMouseDoubleClick);
-	e.mouseMotion().connect(this, &MapViewState::onMouseMove);
-	e.mouseWheel().connect(this, &MapViewState::onMouseWheel);
+	eventHandler.activate().connect(this, &MapViewState::onActivate);
+	eventHandler.keyDown().connect(this, &MapViewState::onKeyDown);
+	eventHandler.mouseButtonDown().connect(this, &MapViewState::onMouseDown);
+	eventHandler.mouseButtonUp().connect(this, &MapViewState::onMouseUp);
+	eventHandler.mouseDoubleClick().connect(this, &MapViewState::onMouseDoubleClick);
+	eventHandler.mouseMotion().connect(this, &MapViewState::onMouseMove);
+	eventHandler.mouseWheel().connect(this, &MapViewState::onMouseWheel);
 
-	e.textInputMode(true);
+	eventHandler.textInputMode(true);
 
 	MAIN_FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
 
@@ -612,7 +612,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 		// Click was within the bounds of the TileMap.
 		else if (mTileMap->boundingBox().contains(MOUSE_COORDS))
 		{
-			EventHandler& e = Utility<EventHandler>::get();
+			EventHandler& eventHandler = Utility<EventHandler>::get();
 			if (mInsertMode == InsertMode::Structure)
 			{
 				placeStructure();
@@ -621,7 +621,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 			{
 				placeRobot();
 			}
-			else if ( (mInsertMode == InsertMode::Tube) && e.query_shift())
+			else if ( (mInsertMode == InsertMode::Tube) && eventHandler.query_shift())
 			{
 				placeTubeStart();
 			}
@@ -668,8 +668,8 @@ void MapViewState::onMouseUp(EventHandler::MouseButton button, int /*x*/, int /*
 	if (button == EventHandler::MouseButton::Left)
 	{
 		mLeftButtonDown = false;
-		EventHandler& e = Utility<EventHandler>::get();
-		if ((mInsertMode == InsertMode::Tube) && e.query_shift())
+		EventHandler& eventHandler = Utility<EventHandler>::get();
+		if ((mInsertMode == InsertMode::Tube) && eventHandler.query_shift())
 		{
 			placeTubeEnd();
 		}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -143,7 +143,7 @@ MapViewState::~MapViewState()
 
 	Utility<Renderer>::get().setCursor(PointerType::POINTER_NORMAL);
 
-	EventHandler& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = Utility<EventHandler>::get();
 	eventHandler.activate().disconnect(this, &MapViewState::onActivate);
 	eventHandler.keyDown().disconnect(this, &MapViewState::onKeyDown);
 	eventHandler.mouseButtonDown().disconnect(this, &MapViewState::onMouseDown);
@@ -195,7 +195,7 @@ void MapViewState::initialize()
 
 	Utility<Renderer>::get().fadeIn(constants::FadeSpeed);
 
-	EventHandler& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = Utility<EventHandler>::get();
 
 	eventHandler.activate().connect(this, &MapViewState::onActivate);
 	eventHandler.keyDown().connect(this, &MapViewState::onKeyDown);
@@ -612,7 +612,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int 
 		// Click was within the bounds of the TileMap.
 		else if (mTileMap->boundingBox().contains(MOUSE_COORDS))
 		{
-			EventHandler& eventHandler = Utility<EventHandler>::get();
+			auto& eventHandler = Utility<EventHandler>::get();
 			if (mInsertMode == InsertMode::Structure)
 			{
 				placeStructure();
@@ -668,7 +668,7 @@ void MapViewState::onMouseUp(EventHandler::MouseButton button, int /*x*/, int /*
 	if (button == EventHandler::MouseButton::Left)
 	{
 		mLeftButtonDown = false;
-		EventHandler& eventHandler = Utility<EventHandler>::get();
+		auto& eventHandler = Utility<EventHandler>::get();
 		if ((mInsertMode == InsertMode::Tube) && eventHandler.query_shift())
 		{
 			placeTubeEnd();

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -36,10 +36,10 @@ PlanetSelectState::PlanetSelectState() :
 
 PlanetSelectState::~PlanetSelectState()
 {
-	EventHandler& e = Utility<EventHandler>::get();
-	e.mouseButtonDown().disconnect(this, &PlanetSelectState::onMouseDown);
-	e.mouseMotion().disconnect(this, &PlanetSelectState::onMouseMove);
-	e.windowResized().disconnect(this, &PlanetSelectState::onWindowResized);
+	EventHandler& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect(this, &PlanetSelectState::onMouseDown);
+	eventHandler.mouseMotion().disconnect(this, &PlanetSelectState::onMouseMove);
+	eventHandler.windowResized().disconnect(this, &PlanetSelectState::onWindowResized);
 
 	for (auto planet : mPlanets) { delete planet; }
 
@@ -49,10 +49,10 @@ PlanetSelectState::~PlanetSelectState()
 
 void PlanetSelectState::initialize()
 {
-	EventHandler& e = Utility<EventHandler>::get();
-	e.mouseButtonDown().connect(this, &PlanetSelectState::onMouseDown);
-	e.mouseMotion().connect(this, &PlanetSelectState::onMouseMove);
-	e.windowResized().connect(this, &PlanetSelectState::onWindowResized);
+	EventHandler& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().connect(this, &PlanetSelectState::onMouseDown);
+	eventHandler.mouseMotion().connect(this, &PlanetSelectState::onMouseMove);
+	eventHandler.windowResized().connect(this, &PlanetSelectState::onWindowResized);
 
 	for (const auto& planetAttribute : PlanetAttributes)
 	{

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -36,7 +36,7 @@ PlanetSelectState::PlanetSelectState() :
 
 PlanetSelectState::~PlanetSelectState()
 {
-	EventHandler& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = Utility<EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect(this, &PlanetSelectState::onMouseDown);
 	eventHandler.mouseMotion().disconnect(this, &PlanetSelectState::onMouseMove);
 	eventHandler.windowResized().disconnect(this, &PlanetSelectState::onWindowResized);
@@ -49,7 +49,7 @@ PlanetSelectState::~PlanetSelectState()
 
 void PlanetSelectState::initialize()
 {
-	EventHandler& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = Utility<EventHandler>::get();
 	eventHandler.mouseButtonDown().connect(this, &PlanetSelectState::onMouseDown);
 	eventHandler.mouseMotion().connect(this, &PlanetSelectState::onMouseMove);
 	eventHandler.windowResized().connect(this, &PlanetSelectState::onWindowResized);

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -56,17 +56,17 @@ SplashState::SplashState() :
 
 SplashState::~SplashState()
 {
-	NAS2D::EventHandler& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-	e.keyDown().disconnect(this, &SplashState::onKeyDown);
-	e.mouseButtonDown().disconnect(this, &SplashState::onMouseDown);
+	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.keyDown().disconnect(this, &SplashState::onKeyDown);
+	eventHandler.mouseButtonDown().disconnect(this, &SplashState::onMouseDown);
 }
 
 
 void SplashState::initialize()
 {
-	NAS2D::EventHandler& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-	e.keyDown().connect(this, &SplashState::onKeyDown);
-	e.mouseButtonDown().connect(this, &SplashState::onMouseDown);
+	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.keyDown().connect(this, &SplashState::onKeyDown);
+	eventHandler.mouseButtonDown().connect(this, &SplashState::onMouseDown);
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.showSystemPointer(false);

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -56,7 +56,7 @@ SplashState::SplashState() :
 
 SplashState::~SplashState()
 {
-	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.keyDown().disconnect(this, &SplashState::onKeyDown);
 	eventHandler.mouseButtonDown().disconnect(this, &SplashState::onMouseDown);
 }
@@ -64,7 +64,7 @@ SplashState::~SplashState()
 
 void SplashState::initialize()
 {
-	NAS2D::EventHandler& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.keyDown().connect(this, &SplashState::onKeyDown);
 	eventHandler.mouseButtonDown().connect(this, &SplashState::onMouseDown);
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -49,9 +49,10 @@ Button::Button(std::string newText) :
 {
 	text(newText);
 
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Button::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Button::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Button::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().connect(this, &Button::onMouseDown);
+	eventHandler.mouseButtonUp().connect(this, &Button::onMouseUp);
+	eventHandler.mouseMotion().connect(this, &Button::onMouseMove);
 
 	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
 }
@@ -65,9 +66,10 @@ Button::Button(std::string newText, ClickSignal::DelegateType clickHandler) : Bu
 
 Button::~Button()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Button::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Button::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Button::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect(this, &Button::onMouseDown);
+	eventHandler.mouseButtonUp().disconnect(this, &Button::onMouseUp);
+	eventHandler.mouseMotion().disconnect(this, &Button::onMouseMove);
 }
 
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -14,8 +14,9 @@ using namespace NAS2D;
 
 ComboBox::ComboBox()
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ComboBox::onMouseDown);
-	Utility<EventHandler>::get().mouseWheel().connect(this, &ComboBox::onMouseWheel);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().connect(this, &ComboBox::onMouseDown);
+	eventHandler.mouseWheel().connect(this, &ComboBox::onMouseWheel);
 
 	btnDown.image("ui/icons/down.png");
 	btnDown.size({20, 20});
@@ -31,8 +32,9 @@ ComboBox::ComboBox()
 ComboBox::~ComboBox()
 {
 	lstItems.selectionChanged().disconnect(this, &ComboBox::onListSelectionChange);
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
-	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
+	eventHandler.mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -16,9 +16,10 @@ using namespace NAS2D;
 
 ListBoxBase::ListBoxBase()
 {
-	Utility<EventHandler>::get().mouseWheel().connect(this, &ListBoxBase::onMouseWheel);
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBoxBase::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBoxBase::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseWheel().connect(this, &ListBoxBase::onMouseWheel);
+	eventHandler.mouseButtonDown().connect(this, &ListBoxBase::onMouseDown);
+	eventHandler.mouseMotion().connect(this, &ListBoxBase::onMouseMove);
 
 	mSlider.displayPosition(false);
 	mSlider.length(0);
@@ -33,9 +34,10 @@ ListBoxBase::~ListBoxBase()
 {
 	mSlider.change().disconnect(this, &ListBoxBase::onSlideChange);
 
-	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ListBoxBase::onMouseWheel);
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ListBoxBase::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &ListBoxBase::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseWheel().disconnect(this, &ListBoxBase::onMouseWheel);
+	eventHandler.mouseButtonDown().disconnect(this, &ListBoxBase::onMouseDown);
+	eventHandler.mouseMotion().disconnect(this, &ListBoxBase::onMouseMove);
 
 	for (auto item : mItems) { delete item; }
 }

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -127,17 +127,19 @@ Slider::Slider(Slider::Skins skins, SliderType sliderType) :
 	mSliderType{sliderType},
 	mSkins{skins}
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Slider::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Slider::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Slider::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().connect(this, &Slider::onMouseDown);
+	eventHandler.mouseButtonUp().connect(this, &Slider::onMouseUp);
+	eventHandler.mouseMotion().connect(this, &Slider::onMouseMove);
 }
 
 
 Slider::~Slider()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Slider::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Slider::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Slider::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect(this, &Slider::onMouseDown);
+	eventHandler.mouseButtonUp().disconnect(this, &Slider::onMouseUp);
+	eventHandler.mouseMotion().disconnect(this, &Slider::onMouseMove);
 }
 
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -51,11 +51,12 @@ TextField::TextField() :
 		imageCache.load("ui/skin/textbox_bottom_right_highlight.png")
 	}
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &TextField::onMouseDown);
-	Utility<EventHandler>::get().keyDown().connect(this, &TextField::onKeyDown);
-	Utility<EventHandler>::get().textInput().connect(this, &TextField::onTextInput);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().connect(this, &TextField::onMouseDown);
+	eventHandler.keyDown().connect(this, &TextField::onKeyDown);
+	eventHandler.textInput().connect(this, &TextField::onTextInput);
 
-	Utility<EventHandler>::get().textInputMode(true);
+	eventHandler.textInputMode(true);
 
 	height(mFont.height() + fieldPadding * 2);
 }
@@ -63,9 +64,10 @@ TextField::TextField() :
 
 TextField::~TextField()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &TextField::onMouseDown);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &TextField::onKeyDown);
-	Utility<EventHandler>::get().textInput().disconnect(this, &TextField::onTextInput);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect(this, &TextField::onMouseDown);
+	eventHandler.keyDown().disconnect(this, &TextField::onKeyDown);
+	eventHandler.textInput().disconnect(this, &TextField::onTextInput);
 }
 
 

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -30,15 +30,17 @@ Window::Window(std::string newTitle) :
 {
 	title(newTitle);
 
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Window::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Window::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonUp().connect(this, &Window::onMouseUp);
+	eventHandler.mouseMotion().connect(this, &Window::onMouseMove);
 }
 
 
 Window::~Window()
 {
-	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Window::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Window::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonUp().disconnect(this, &Window::onMouseUp);
+	eventHandler.mouseMotion().disconnect(this, &Window::onMouseMove);
 }
 
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -21,8 +21,9 @@ FileIo::FileIo() :
 	btnFileOp{"FileOp", {this, &FileIo::onFileIo}},
 	btnFileDelete{"Delete", {this, &FileIo::onFileDelete}}
 {
-	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &FileIo::onDoubleClick);
-	Utility<EventHandler>::get().keyDown().connect(this, &FileIo::onKeyDown);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseDoubleClick().connect(this, &FileIo::onDoubleClick);
+	eventHandler.keyDown().connect(this, &FileIo::onKeyDown);
 
 	size({500, 350});
 
@@ -51,8 +52,9 @@ FileIo::FileIo() :
 
 FileIo::~FileIo()
 {
-	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &FileIo::onDoubleClick);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &FileIo::onKeyDown);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseDoubleClick().disconnect(this, &FileIo::onDoubleClick);
+	eventHandler.keyDown().disconnect(this, &FileIo::onKeyDown);
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -41,15 +41,17 @@ IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(margin));
 	}
 
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &IconGrid::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &IconGrid::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().connect(this, &IconGrid::onMouseDown);
+	eventHandler.mouseMotion().connect(this, &IconGrid::onMouseMove);
 }
 
 
 IconGrid::~IconGrid()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &IconGrid::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &IconGrid::onMouseMove);
+	auto& eventHandler = Utility<EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect(this, &IconGrid::onMouseDown);
+	eventHandler.mouseMotion().disconnect(this, &IconGrid::onMouseMove);
 }
 
 


### PR DESCRIPTION
Rename `EventHandler` references from `e` to `eventHandler`. This makes searching for `EventHandler` code easier. It also makes it easier to highlight variable references in Atom, which won't highlight single character variables.

Prep-work in preparation for working on #894.
