### PR TITLE
Fix serialize bug for StorableResources

### DIFF
--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -48,13 +48,13 @@ namespace
 		}
 
 		const auto& production = structure->production();
-		if (production > StorableResources{ 0 })
+		if (!production.isEmpty())
 		{
 			writeResources(structureElement, production, "production");
 		}
 
 		const auto& stored = structure->storage();
-		if (stored > StorableResources{ 0 })
+		if (!stored.isEmpty())
 		{
 			writeResources(structureElement, stored, "storage");
 		}

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -137,7 +137,7 @@ public:
 	bool isWarehouse() const { return structureClass() == StructureClass::Warehouse; }
 	bool isRobotCommand() const { return structureClass() == StructureClass::RobotCommand; }
 	bool isMineFacility() const { return structureClass() == StructureClass::Mine; }
-	bool energyProducer() const { return structureClass() == StructureClass::EnergyProduction; }
+	bool isEnergyProducer() const { return structureClass() == StructureClass::EnergyProduction; }
 	bool isConnector() const { return structureClass() == StructureClass::Tube; }
 	bool isRoad() const { return structureClass() == StructureClass::Road; }
 


### PR DESCRIPTION
Previously, `Structure` serialization would only save certain `StorableResources` objects if all components were greater than 0, rather than if any component was greater than 0.

Noticed this while reviewing seriailization code in preparation for #830.
