### PR TITLE
Refactor Structure serialization to use Dictionary

### DIFF
--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -510,8 +510,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 	for (auto& [structure, tile] : mStructureTileTable)
 	{
-		auto* structureElement = serializeStructure(structure, tile);
-		structures->linkEndChild(structureElement);
+		structures->linkEndChild(serializeStructure(structure, tile));
 	}
 
 	element->linkEndChild(structures);

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -31,15 +31,15 @@ namespace
 	NAS2D::Xml::XmlElement* serializeStructure(Structure* structure, Tile* tile)
 	{
 		const auto position = tile->position();
-		NAS2D::Dictionary dict =
+		NAS2D::Dictionary dictionary =
 		{{
 			{"x", position.x},
 			{"y", position.y},
 			{"depth", tile->depth()},
 		}};
-		dict += structure->getDataDict();
+		dictionary += structure->getDataDict();
 
-		auto* structureElement = dictionaryToAttributes("structure", dict);
+		auto* structureElement = dictionaryToAttributes("structure", dictionary);
 
 		const auto& production = structure->production();
 		if (!production.isEmpty())

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -53,12 +53,6 @@ namespace
 			writeResources(structureElement, stored, "storage");
 		}
 
-		if (structure->isFactory())
-		{
-			structureElement->attribute("production_completed", static_cast<Factory*>(structure)->productionTurnsCompleted());
-			structureElement->attribute("production_type", static_cast<Factory*>(structure)->productType());
-		}
-
 		if (structure->isWarehouse())
 		{
 			auto* warehouse_products = new NAS2D::Xml::XmlElement("warehouse_products");

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -113,7 +113,7 @@ namespace
 		if (structure->isMineFacility())
 		{
 			MineFacility* facility = static_cast<MineFacility*>(structure);
-			
+
 			auto* trucks = new NAS2D::Xml::XmlElement("trucks");
 			trucks->attribute("assigned", facility->assignedTrucks());
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -43,6 +43,8 @@ namespace
 		structureElement->attribute("type", structure->structureId());
 		structureElement->attribute("direction", structure->connectorDirection());
 		structureElement->attribute("integrity", structure->integrity());
+		structureElement->attribute("pop0", structure->populationAvailable()[0]);
+		structureElement->attribute("pop1", structure->populationAvailable()[1]);
 
 		if (structure->hasCrime())
 		{
@@ -60,9 +62,6 @@ namespace
 		{
 			writeResources(structureElement, stored, "storage");
 		}
-
-		structureElement->attribute("pop0", structure->populationAvailable()[0]);
-		structureElement->attribute("pop1", structure->populationAvailable()[1]);
 
 		return structureElement;
 	}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -10,6 +10,8 @@
 
 #include "States/MapViewStateHelper.h" // <-- For removeRefinedResources()
 
+#include <NAS2D/ParserHelper.h>
+
 #include <algorithm>
 #include <sstream>
 
@@ -28,23 +30,16 @@ namespace
 
 	NAS2D::Xml::XmlElement* serializeStructure(Structure* structure, Tile* tile)
 	{
-		auto* structureElement = new NAS2D::Xml::XmlElement("structure");
-
 		const auto position = tile->position();
-		structureElement->attribute("x", position.x);
-		structureElement->attribute("y", position.y);
-		structureElement->attribute("depth", tile->depth());
+		NAS2D::Dictionary dict =
+		{{
+			{"x", position.x},
+			{"y", position.y},
+			{"depth", tile->depth()},
+		}};
+		dict += structure->getDataDict();
 
-		structureElement->attribute("age", structure->age());
-		structureElement->attribute("state", static_cast<int>(structure->state()));
-		structureElement->attribute("forced_idle", structure->forceIdle());
-		structureElement->attribute("disabled_reason", static_cast<int>(structure->disabledReason()));
-		structureElement->attribute("idle_reason", static_cast<int>(structure->idleReason()));
-		structureElement->attribute("type", structure->structureId());
-		structureElement->attribute("direction", structure->connectorDirection());
-		structureElement->attribute("integrity", structure->integrity());
-		structureElement->attribute("pop0", structure->populationAvailable()[0]);
-		structureElement->attribute("pop1", structure->populationAvailable()[1]);
+		auto* structureElement = dictionaryToAttributes("structure", dict);
 
 		if (structure->hasCrime())
 		{

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -41,11 +41,6 @@ namespace
 
 		auto* structureElement = dictionaryToAttributes("structure", dict);
 
-		if (structure->hasCrime())
-		{
-			structureElement->attribute("crime_rate", structure->crimeRate());
-		}
-
 		const auto& production = structure->production();
 		if (!production.isEmpty())
 		{

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -26,8 +26,10 @@ namespace
 	}
 
 
-	void serializeStructure(NAS2D::Xml::XmlElement* structureElement, Structure* structure, Tile* tile)
+	NAS2D::Xml::XmlElement* serializeStructure(Structure* structure, Tile* tile)
 	{
+		auto* structureElement = new NAS2D::Xml::XmlElement("structure");
+
 		const auto position = tile->position();
 		structureElement->attribute("x", position.x);
 		structureElement->attribute("y", position.y);
@@ -61,8 +63,9 @@ namespace
 
 		structureElement->attribute("pop0", structure->populationAvailable()[0]);
 		structureElement->attribute("pop1", structure->populationAvailable()[1]);
-	}
 
+		return structureElement;
+	}
 }
 
 
@@ -439,8 +442,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 
 	for (auto& [structure, tile] : mStructureTileTable)
 	{
-		auto* structureElement = new NAS2D::Xml::XmlElement("structure");
-		serializeStructure(structureElement, structure, tile);
+		auto* structureElement = serializeStructure(structure, tile);
 
 		if (structure->isFactory())
 		{

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -150,10 +150,10 @@ void Factory::updateProduction()
 
 NAS2D::Dictionary Factory::getDataDict() const
 {
-	auto dict = Structure::getDataDict();
-	dict.set("production_completed", mTurnsCompleted);
-	dict.set("production_type", mProduct);
-	return dict;
+	auto dictionary = Structure::getDataDict();
+	dictionary.set("production_completed", mTurnsCompleted);
+	dictionary.set("production_type", mProduct);
+	return dictionary;
 }
 
 

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -148,6 +148,15 @@ void Factory::updateProduction()
 }
 
 
+NAS2D::Dictionary Factory::getDataDict() const
+{
+	auto dict = Structure::getDataDict();
+	dict.set("production_completed", mTurnsCompleted);
+	dict.set("production_type", mProduct);
+	return dict;
+}
+
+
 bool Factory::enoughResourcesAvailable()
 {
 	if (mResources == nullptr) { throw std::runtime_error("Factory::enoughResourcesAvailable() called with a null Resource Pool set"); }

--- a/OPHD/Things/Structures/Factory.h
+++ b/OPHD/Things/Structures/Factory.h
@@ -56,6 +56,8 @@ public:
 
 	ProductionSignal::Source& productionComplete() { return mProductionComplete; }
 
+	NAS2D::Dictionary getDataDict() const override;
+
 protected:
 	void clearProduction();
 

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -380,5 +380,10 @@ NAS2D::Dictionary Structure::getDataDict() const
 		{"pop1", mPopulationAvailable[1]},
 	}};
 
+	if (mHasCrime)
+	{
+		dict.set("crime_rate", mCrimeRate);
+	}
+
 	return dict;
 }

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -366,7 +366,7 @@ void Structure::integrity(int integrity)
 
 NAS2D::Dictionary Structure::getDataDict() const
 {
-	NAS2D::Dictionary dict =
+	NAS2D::Dictionary dictionary =
 	{{
 		{"age", mAge},
 		{"state", static_cast<int>(mStructureState)},
@@ -382,8 +382,8 @@ NAS2D::Dictionary Structure::getDataDict() const
 
 	if (mHasCrime)
 	{
-		dict.set("crime_rate", mCrimeRate);
+		dictionary.set("crime_rate", mCrimeRate);
 	}
 
-	return dict;
+	return dictionary;
 }

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -362,3 +362,23 @@ void Structure::integrity(int integrity)
 {
 	mIntegrity = integrity;
 }
+
+
+NAS2D::Dictionary Structure::getDataDict() const
+{
+	NAS2D::Dictionary dict =
+	{{
+		{"age", mAge},
+		{"state", static_cast<int>(mStructureState)},
+		{"forced_idle", mForcedIdle},
+		{"disabled_reason", static_cast<int>(mDisabledReason)},
+		{"idle_reason", static_cast<int>(mIdleReason)},
+		{"type", mStructureId},
+		{"direction", mConnectorDirection},
+		{"integrity", mIntegrity},
+		{"pop0", mPopulationAvailable[0]},
+		{"pop1", mPopulationAvailable[1]},
+	}};
+
+	return dict;
+}

--- a/OPHD/Things/Structures/Structure.h
+++ b/OPHD/Things/Structures/Structure.h
@@ -6,6 +6,9 @@
 #include "../../StorableResources.h"
 #include "../../UI/StringTable.h"
 
+#include <NAS2D/Dictionary.h>
+
+
 /**
  * State of an individual Structure.
  */
@@ -153,6 +156,8 @@ public:
 	* Pass limited structure specific details for drawing. Use a custom UI window if needed.
 	*/
 	virtual StringTable createInspectorViewTable() { return StringTable(0, 0); }
+
+	virtual NAS2D::Dictionary getDataDict() const;
 
 protected:
 	friend class StructureCatalogue;


### PR DESCRIPTION
Refactor some of the `Structure` serialization code to use `NAS2D::Dictionary`.

I think this gives enough of a structure that people can start to convert serialization code to use `NAS2D::Dictionary`, and minimize direct reliance on XML code.

Reference: #830

----

I'm sure there's more to do with `Structure` serialization. In particular, the various sub-classes can override the `getDataDict()` method to add in their structure specific fields. That would allow much of the custom processing in the higher level `serializeStructure` function to be eliminated. The `Factory` class has been handled as an example.

Not addressed are the use of sub-elements to store additional structure data. For example, the `<food level="0" />` sub-element was not changed at all. The `Dictionary` object doesn't really provide a multi-level structure to the data, so that concept doesn't map well to `Dictionary`. If there is a fixed maximum nesting, such as at most 2 levels, we could instead use a `std::map` of `Dictionary` or similar. Though I suspect some of the current nesting can be removed, making the point perhaps a bit irrelevant.

In terms of reducing the nesting level, some sub-element values can be moved to regular attributes, such as `food="0"`. Currently there is some inconsistency in the code as to what format to use. Some sub-classes attach additional attributes to the `XmlElement`, others add child `XmlElement` objects for the data. I suggest we try to improve consistency by using attributes on the main `structure` tag whenever possible.

Example (existing format):
```xml
<structure x="60" y="98" depth="0" ... pop0="0" pop1="0">
    <food level="0" />
</structure>
```

Suggested:
```xml
<structure x="60" y="98" depth="0" ... pop0="0" pop1="0" food="0" />
```
