### PR TITLE
Refactor resource serialization

### DIFF
--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -4,6 +4,8 @@
 
 #include "StorableResources.h"
 
+#include <NAS2D/ParserHelper.h>
+
 
 void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources)
 {
@@ -24,12 +26,13 @@ void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources
 
 NAS2D::Xml::XmlElement* writeResources(const StorableResources& resources, const std::string& tagName)
 {
-	NAS2D::Xml::XmlElement* resourcesElement = new NAS2D::Xml::XmlElement(tagName);
-
-	resourcesElement->attribute(constants::SaveGameResource0, resources.resources[0]);
-	resourcesElement->attribute(constants::SaveGameResource1, resources.resources[1]);
-	resourcesElement->attribute(constants::SaveGameResource2, resources.resources[2]);
-	resourcesElement->attribute(constants::SaveGameResource3, resources.resources[3]);
-
-	return resourcesElement;
+	return NAS2D::dictionaryToAttributes(
+		tagName,
+		{{
+			{constants::SaveGameResource0, resources.resources[0]},
+			{constants::SaveGameResource1, resources.resources[1]},
+			{constants::SaveGameResource2, resources.resources[2]},
+			{constants::SaveGameResource3, resources.resources[3]},
+		}}
+	);
 }

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -24,12 +24,12 @@ void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources
 
 NAS2D::Xml::XmlElement* writeResources(const StorableResources& resources, const std::string& tagName)
 {
-	NAS2D::Xml::XmlElement* resources_elem = new NAS2D::Xml::XmlElement(tagName);
+	NAS2D::Xml::XmlElement* resourcesElement = new NAS2D::Xml::XmlElement(tagName);
 
-	resources_elem->attribute(constants::SaveGameResource0, resources.resources[0]);
-	resources_elem->attribute(constants::SaveGameResource1, resources.resources[1]);
-	resources_elem->attribute(constants::SaveGameResource2, resources.resources[2]);
-	resources_elem->attribute(constants::SaveGameResource3, resources.resources[3]);
+	resourcesElement->attribute(constants::SaveGameResource0, resources.resources[0]);
+	resourcesElement->attribute(constants::SaveGameResource1, resources.resources[1]);
+	resourcesElement->attribute(constants::SaveGameResource2, resources.resources[2]);
+	resourcesElement->attribute(constants::SaveGameResource3, resources.resources[3]);
 
-	return resources_elem;
+	return resourcesElement;
 }

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -12,6 +12,10 @@ StorableResources readResources(NAS2D::Xml::XmlElement* element)
 	if (!element) { throw std::runtime_error("MapViewState::readResources(): Called with element==nullptr"); }
 
 	const auto dictionary = NAS2D::attributesToDictionary(*element);
+
+	const auto requiredFields = {constants::SaveGameResource0, constants::SaveGameResource1, constants::SaveGameResource2, constants::SaveGameResource3};
+	NAS2D::reportMissingOrUnexpected(dictionary.keys(), requiredFields, {});
+
 	StorableResources resources{{
 		dictionary.get<int>(constants::SaveGameResource0),
 		dictionary.get<int>(constants::SaveGameResource1),

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -7,10 +7,11 @@
 #include <NAS2D/ParserHelper.h>
 
 
-void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources)
+StorableResources readResources(NAS2D::Xml::XmlElement* element)
 {
 	if (!element) { throw std::runtime_error("MapViewState::readResources(): Called with element==nullptr"); }
 
+	StorableResources resources{};
 	NAS2D::Xml::XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
@@ -21,6 +22,7 @@ void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources
 
 		attribute = attribute->next();
 	}
+	return resources;
 }
 
 

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -16,14 +16,12 @@ StorableResources readResources(NAS2D::Xml::XmlElement* element)
 	const auto requiredFields = {constants::SaveGameResource0, constants::SaveGameResource1, constants::SaveGameResource2, constants::SaveGameResource3};
 	NAS2D::reportMissingOrUnexpected(dictionary.keys(), requiredFields, {});
 
-	StorableResources resources{{
+	return StorableResources{{
 		dictionary.get<int>(constants::SaveGameResource0),
 		dictionary.get<int>(constants::SaveGameResource1),
 		dictionary.get<int>(constants::SaveGameResource2),
 		dictionary.get<int>(constants::SaveGameResource3),
 	}};
-
-	return resources;
 }
 
 

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -22,7 +22,7 @@ void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources
 }
 
 
-void writeResources(NAS2D::Xml::XmlElement* element, const StorableResources& resources, const std::string& tagName)
+NAS2D::Xml::XmlElement* writeResources(const StorableResources& resources, const std::string& tagName)
 {
 	NAS2D::Xml::XmlElement* resources_elem = new NAS2D::Xml::XmlElement(tagName);
 
@@ -31,5 +31,5 @@ void writeResources(NAS2D::Xml::XmlElement* element, const StorableResources& re
 	resources_elem->attribute(constants::SaveGameResource2, resources.resources[2]);
 	resources_elem->attribute(constants::SaveGameResource3, resources.resources[3]);
 
-	element->linkEndChild(resources_elem);
+	return resources_elem;
 }

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -11,17 +11,14 @@ StorableResources readResources(NAS2D::Xml::XmlElement* element)
 {
 	if (!element) { throw std::runtime_error("MapViewState::readResources(): Called with element==nullptr"); }
 
-	StorableResources resources{};
-	NAS2D::Xml::XmlAttribute* attribute = element->firstAttribute();
-	while (attribute)
-	{
-		if (attribute->name() == constants::SaveGameResource0) { attribute->queryIntValue(resources.resources[0]); }
-		else if (attribute->name() == constants::SaveGameResource1) { attribute->queryIntValue(resources.resources[1]); }
-		else if (attribute->name() == constants::SaveGameResource2) { attribute->queryIntValue(resources.resources[2]); }
-		else if (attribute->name() == constants::SaveGameResource3) { attribute->queryIntValue(resources.resources[3]); }
+	const auto dictionary = NAS2D::attributesToDictionary(*element);
+	StorableResources resources{{
+		dictionary.get<int>(constants::SaveGameResource0),
+		dictionary.get<int>(constants::SaveGameResource1),
+		dictionary.get<int>(constants::SaveGameResource2),
+		dictionary.get<int>(constants::SaveGameResource3),
+	}};
 
-		attribute = attribute->next();
-	}
 	return resources;
 }
 

--- a/OPHD/IOHelper.cpp
+++ b/OPHD/IOHelper.cpp
@@ -13,7 +13,7 @@ StorableResources readResources(NAS2D::Xml::XmlElement* element)
 
 	const auto dictionary = NAS2D::attributesToDictionary(*element);
 
-	const auto requiredFields = {constants::SaveGameResource0, constants::SaveGameResource1, constants::SaveGameResource2, constants::SaveGameResource3};
+	const auto requiredFields = std::vector<std::string>{constants::SaveGameResource0, constants::SaveGameResource1, constants::SaveGameResource2, constants::SaveGameResource3};
 	NAS2D::reportMissingOrUnexpected(dictionary.keys(), requiredFields, {});
 
 	return StorableResources{{

--- a/OPHD/IOHelper.h
+++ b/OPHD/IOHelper.h
@@ -5,6 +5,7 @@
 
 struct StorableResources;
 
-void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources);
+
+StorableResources readResources(NAS2D::Xml::XmlElement* element);
 
 NAS2D::Xml::XmlElement* writeResources(const StorableResources&, const std::string&);

--- a/OPHD/IOHelper.h
+++ b/OPHD/IOHelper.h
@@ -7,4 +7,4 @@ struct StorableResources;
 
 void readResources(NAS2D::Xml::XmlElement* element, StorableResources& resources);
 
-void writeResources(NAS2D::Xml::XmlElement*, const StorableResources&, const std::string&);
+NAS2D::Xml::XmlElement* writeResources(const StorableResources&, const std::string&);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -98,7 +98,7 @@ void MapViewState::save(const std::string& filePath)
 	mTileMap->serialize(root);
 	Utility<StructureManager>::get().serialize(root);
 	writeRobots(root, mRobotPool, mRobotList);
-	writeResources(root, mResourceBreakdownPanel.previousResources(), "prev_resources");
+	root->linkEndChild(writeResources(mResourceBreakdownPanel.previousResources(), "prev_resources"));
 
 	XmlElement* turns = new XmlElement("turns");
 	turns->attribute("count", mTurnCount);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -214,7 +214,7 @@ void MapViewState::load(const std::string& filePath)
 	readRobots(root->firstChildElement("robots"));
 	readStructures(root->firstChildElement("structures"));
 
-	readResources(root->firstChildElement("prev_resources"), mResourceBreakdownPanel.previousResources());
+	mResourceBreakdownPanel.previousResources() = readResources(root->firstChildElement("prev_resources"));
 	readPopulation(root->firstChildElement("population"));
 	readTurns(root->firstChildElement("turns"));
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -44,13 +44,13 @@ namespace
 		const auto& production = structure->production();
 		if (!production.isEmpty())
 		{
-			writeResources(structureElement, production, "production");
+			structureElement->linkEndChild(writeResources(production, "production"));
 		}
 
 		const auto& stored = structure->storage();
 		if (!stored.isEmpty())
 		{
-			writeResources(structureElement, stored, "storage");
+			structureElement->linkEndChild(writeResources(stored, "storage"));
 		}
 
 		if (structure->isWarehouse())


### PR DESCRIPTION
Reference: #830

Refactor serialization of `StorableResources`.

----

Hmm, interesting, `g++-8` from the Ubuntu 18.04 build caught a mistake that the other compilers silently corrected for. That may be relevant to the discussion in https://github.com/lairworks/nas2d-core/issues/826.
