### PR TITLE
Refactor population

### DIFF
--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -257,15 +257,15 @@ int Population::consume_food(int food)
 
 	for (int i = 0; i < population_to_kill; /**/ )
 	{
-		std::size_t role_idx = i % 5;
+		std::size_t roleIndex = i % 5;
 
 		std::size_t counter = 0;
 		for (;;)
 		{
-			role_idx = role_idx + counter;
-			if (role_idx > 4) { role_idx = 0; }
+			roleIndex = roleIndex + counter;
+			if (roleIndex > 4) { roleIndex = 0; }
 
-			if (mPopulation[role_idx] > 0)
+			if (mPopulation[roleIndex] > 0)
 			{
 				break;
 			}
@@ -274,7 +274,7 @@ int Population::consume_food(int food)
 			if (counter > 4) { counter = 0; }
 		}
 
-		--mPopulation[role_idx];
+		--mPopulation[roleIndex];
 		++i;
 	}
 

--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -72,7 +72,7 @@ int Population::adults() const
  * 
  * \todo	Account for nurseries when implemented.
  */
-void Population::spawn_children(int morale, int residences, int nurseries)
+void Population::spawnChildren(int morale, int residences, int nurseries)
 {
 	if (residences < 1 && nurseries < 1) { return; }
 
@@ -92,7 +92,7 @@ void Population::spawn_children(int morale, int residences, int nurseries)
 }
 
 
-void Population::spawn_students()
+void Population::spawnStudents()
 {
 	if (mPopulation[PopulationTable::Role::Child] > 0)
 	{
@@ -110,7 +110,7 @@ void Population::spawn_students()
 }
 
 
-void Population::spawn_adults(int universities)
+void Population::spawnAdults(int universities)
 {
 	//-- New Adults --//
 	if (mPopulation[PopulationTable::Role::Student] > 0)
@@ -138,7 +138,7 @@ void Population::spawn_adults(int universities)
 }
 
 
-void Population::spawn_retiree()
+void Population::spawnRetiree()
 {
 	int total_adults = mPopulation[PopulationTable::Role::Worker] + mPopulation[PopulationTable::Role::Scientist];
 	if (total_adults > 0)
@@ -161,7 +161,7 @@ void Population::spawn_retiree()
 }
 
 
-void Population::kill_children(int morale, int nurseries)
+void Population::killChildren(int morale, int nurseries)
 {
 	if (mPopulation[PopulationTable::Role::Child] > 0)
 	{
@@ -184,7 +184,7 @@ void Population::kill_children(int morale, int nurseries)
 }
 
 
-void Population::kill_students(int morale, int hospitals)
+void Population::killStudents(int morale, int hospitals)
 {
 	if (mPopulation[PopulationTable::Role::Child] > 0)
 	{
@@ -293,13 +293,13 @@ int Population::update(int morale, int food, int residences, int universities, i
 	mBirthCount = 0;
 	mDeathCount = 0;
 
-	spawn_children(morale, residences, nurseries);
-	spawn_students();
-	spawn_adults(universities);
-	spawn_retiree();
+	spawnChildren(morale, residences, nurseries);
+	spawnStudents();
+	spawnAdults(universities);
+	spawnRetiree();
 
-	kill_children(morale, nurseries);
-	kill_students(morale, hospitals);
+	killChildren(morale, nurseries);
+	killStudents(morale, hospitals);
 
 	// Workers will die more often than scientists.
 	if (randomNumber.generate(0, 100) <= 45) { kill_adults(PopulationTable::Role::Scientist, morale, hospitals); }

--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -56,7 +56,7 @@ void Population::clear()
  * \param	role		Segment of the population to populate.
  * \param	count		Base age in months of the population to populated.
  */
-void Population::addPopulation(PopulationTable::PersonRole role, int count)
+void Population::addPopulation(PopulationTable::Role role, int count)
 {
 	mPopulation[role] += count;
 }
@@ -64,7 +64,7 @@ void Population::addPopulation(PopulationTable::PersonRole role, int count)
 
 int Population::adults() const
 {
-	return mPopulation[PopulationTable::PersonRole::ROLE_STUDENT] + mPopulation[PopulationTable::PersonRole::ROLE_WORKER] + mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST] + mPopulation[PopulationTable::PersonRole::ROLE_RETIRED];
+	return mPopulation[PopulationTable::Role::Student] + mPopulation[PopulationTable::Role::Worker] + mPopulation[PopulationTable::Role::Scientist] + mPopulation[PopulationTable::Role::Retired];
 }
 
 /**
@@ -77,16 +77,16 @@ void Population::spawn_children(int morale, int residences, int nurseries)
 	if (residences < 1 && nurseries < 1) { return; }
 
 	// This should be adjusted to maybe two or three kids per couple to allow for higher growth rates.
-	if (mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST] + mPopulation[PopulationTable::PersonRole::ROLE_WORKER] > mPopulation[PopulationTable::PersonRole::ROLE_CHILD])
+	if (mPopulation[PopulationTable::Role::Scientist] + mPopulation[PopulationTable::Role::Worker] > mPopulation[PopulationTable::Role::Child])
 	{
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_CHILD] += mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST] / 4 + mPopulation[PopulationTable::PersonRole::ROLE_WORKER] / 2;
+		mPopulationGrowth[PopulationTable::Role::Child] += mPopulation[PopulationTable::Role::Scientist] / 4 + mPopulation[PopulationTable::Role::Worker] / 2;
 
 		int divisor = moraleModifierTable[moraleIndex(morale)].fertilityRate;
 
-		int newChildren = mPopulationGrowth[PopulationTable::PersonRole::ROLE_CHILD] / divisor;
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_CHILD] = mPopulationGrowth[PopulationTable::PersonRole::ROLE_CHILD] % divisor;
+		int newChildren = mPopulationGrowth[PopulationTable::Role::Child] / divisor;
+		mPopulationGrowth[PopulationTable::Role::Child] = mPopulationGrowth[PopulationTable::Role::Child] % divisor;
 
-		mPopulation[PopulationTable::PersonRole::ROLE_CHILD] += newChildren;
+		mPopulation[PopulationTable::Role::Child] += newChildren;
 		mBirthCount = newChildren;
 	}
 }
@@ -94,18 +94,18 @@ void Population::spawn_children(int morale, int residences, int nurseries)
 
 void Population::spawn_students()
 {
-	if (mPopulation[PopulationTable::PersonRole::ROLE_CHILD] > 0)
+	if (mPopulation[PopulationTable::Role::Child] > 0)
 	{
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_STUDENT] += mPopulation[PopulationTable::PersonRole::ROLE_CHILD];
+		mPopulationGrowth[PopulationTable::Role::Student] += mPopulation[PopulationTable::Role::Child];
 
 		int divisor = std::max(adults(), studentToAdultBase);
 		divisor = ((divisor / 40) * 3 + 16) * 4;
 
-		int newStudents = mPopulationGrowth[PopulationTable::PersonRole::ROLE_STUDENT] / divisor;
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_STUDENT] = mPopulationGrowth[PopulationTable::PersonRole::ROLE_STUDENT] % divisor;
+		int newStudents = mPopulationGrowth[PopulationTable::Role::Student] / divisor;
+		mPopulationGrowth[PopulationTable::Role::Student] = mPopulationGrowth[PopulationTable::Role::Student] % divisor;
 
-		mPopulation[PopulationTable::PersonRole::ROLE_STUDENT] += newStudents;
-		mPopulation[PopulationTable::PersonRole::ROLE_CHILD] -= newStudents;
+		mPopulation[PopulationTable::Role::Student] += newStudents;
+		mPopulation[PopulationTable::Role::Child] -= newStudents;
 	}
 }
 
@@ -113,72 +113,72 @@ void Population::spawn_students()
 void Population::spawn_adults(int universities)
 {
 	//-- New Adults --//
-	if (mPopulation[PopulationTable::PersonRole::ROLE_STUDENT] > 0)
+	if (mPopulation[PopulationTable::Role::Student] > 0)
 	{
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_WORKER] += mPopulation[PopulationTable::PersonRole::ROLE_STUDENT];
+		mPopulationGrowth[PopulationTable::Role::Worker] += mPopulation[PopulationTable::Role::Student];
 
 		int divisor = std::max(adults(), studentToAdultBase);
 		divisor = ((divisor / 40) * 3 + 45) * 4;
 
-		int newAdult = mPopulationGrowth[PopulationTable::PersonRole::ROLE_WORKER] / divisor;
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_WORKER] = mPopulationGrowth[PopulationTable::PersonRole::ROLE_WORKER] % divisor;
+		int newAdult = mPopulationGrowth[PopulationTable::Role::Worker] / divisor;
+		mPopulationGrowth[PopulationTable::Role::Worker] = mPopulationGrowth[PopulationTable::Role::Worker] % divisor;
 
 		// account for universities
 		if (universities > 0 && randomNumber.generate(0, 100) <= studentToScientistRate)
 		{
-			mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST] += newAdult;
+			mPopulation[PopulationTable::Role::Scientist] += newAdult;
 		}
 		else
 		{
-			mPopulation[PopulationTable::PersonRole::ROLE_WORKER] += newAdult;
+			mPopulation[PopulationTable::Role::Worker] += newAdult;
 		}
 
-		mPopulation[PopulationTable::PersonRole::ROLE_STUDENT] -= newAdult;
+		mPopulation[PopulationTable::Role::Student] -= newAdult;
 	}
 }
 
 
 void Population::spawn_retiree()
 {
-	int total_adults = mPopulation[PopulationTable::PersonRole::ROLE_WORKER] + mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST];
+	int total_adults = mPopulation[PopulationTable::Role::Worker] + mPopulation[PopulationTable::Role::Scientist];
 	if (total_adults > 0)
 	{
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_RETIRED] += total_adults / 10;
+		mPopulationGrowth[PopulationTable::Role::Retired] += total_adults / 10;
 
 		int divisor = std::max(total_adults, adultToRetireeBase);
 
 		divisor = ((divisor / 40) * 3 + 40) * 4;
 
-		int retiree = mPopulationGrowth[PopulationTable::PersonRole::ROLE_RETIRED] / divisor;
-		mPopulationGrowth[PopulationTable::PersonRole::ROLE_RETIRED] = mPopulationGrowth[PopulationTable::PersonRole::ROLE_RETIRED] % divisor;
+		int retiree = mPopulationGrowth[PopulationTable::Role::Retired] / divisor;
+		mPopulationGrowth[PopulationTable::Role::Retired] = mPopulationGrowth[PopulationTable::Role::Retired] % divisor;
 
-		mPopulation[PopulationTable::PersonRole::ROLE_RETIRED] += retiree;
+		mPopulation[PopulationTable::Role::Retired] += retiree;
 
 		/** Workers retire earlier than scientists. */
-		if (randomNumber.generate(0, 100) <= 45) { if (mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST] > 0) { mPopulation[PopulationTable::PersonRole::ROLE_SCIENTIST] -= retiree; } }
-		else { if (mPopulation[PopulationTable::PersonRole::ROLE_WORKER] > 0) { mPopulation[PopulationTable::PersonRole::ROLE_WORKER] -= retiree; } }
+		if (randomNumber.generate(0, 100) <= 45) { if (mPopulation[PopulationTable::Role::Scientist] > 0) { mPopulation[PopulationTable::Role::Scientist] -= retiree; } }
+		else { if (mPopulation[PopulationTable::Role::Worker] > 0) { mPopulation[PopulationTable::Role::Worker] -= retiree; } }
 	}
 }
 
 
 void Population::kill_children(int morale, int nurseries)
 {
-	if (mPopulation[PopulationTable::PersonRole::ROLE_CHILD] > 0)
+	if (mPopulation[PopulationTable::Role::Child] > 0)
 	{
-		mPopulationDeath[PopulationTable::PersonRole::ROLE_CHILD] += mPopulation[PopulationTable::PersonRole::ROLE_CHILD];
+		mPopulationDeath[PopulationTable::Role::Child] += mPopulation[PopulationTable::Role::Child];
 
 		int divisor = moraleModifierTable[moraleIndex(morale)].mortalityRate + (nurseries * 10);
 
-		int deaths = mPopulationDeath[PopulationTable::PersonRole::ROLE_CHILD] / divisor;
-		mPopulationDeath[PopulationTable::PersonRole::ROLE_CHILD] = mPopulationDeath[PopulationTable::PersonRole::ROLE_CHILD] % divisor;
+		int deaths = mPopulationDeath[PopulationTable::Role::Child] / divisor;
+		mPopulationDeath[PopulationTable::Role::Child] = mPopulationDeath[PopulationTable::Role::Child] % divisor;
 
-		mPopulation[PopulationTable::PersonRole::ROLE_CHILD] -= deaths;
+		mPopulation[PopulationTable::Role::Child] -= deaths;
 		mDeathCount += deaths;
 
-		if (mPopulation[PopulationTable::PersonRole::ROLE_CHILD] <= 0)
+		if (mPopulation[PopulationTable::Role::Child] <= 0)
 		{
-			mPopulationDeath[PopulationTable::PersonRole::ROLE_CHILD] = 0;
-			mPopulationGrowth[PopulationTable::PersonRole::ROLE_STUDENT] = 0;
+			mPopulationDeath[PopulationTable::Role::Child] = 0;
+			mPopulationGrowth[PopulationTable::Role::Student] = 0;
 		}
 	}
 }
@@ -186,28 +186,28 @@ void Population::kill_children(int morale, int nurseries)
 
 void Population::kill_students(int morale, int hospitals)
 {
-	if (mPopulation[PopulationTable::PersonRole::ROLE_CHILD] > 0)
+	if (mPopulation[PopulationTable::Role::Child] > 0)
 	{
-		mPopulationDeath[PopulationTable::PersonRole::ROLE_STUDENT] += mPopulation[PopulationTable::PersonRole::ROLE_STUDENT];
+		mPopulationDeath[PopulationTable::Role::Student] += mPopulation[PopulationTable::Role::Student];
 
 		int divisor = moraleModifierTable[moraleIndex(morale)].mortalityRate + (hospitals * 65);
 
-		int deaths = mPopulationDeath[PopulationTable::PersonRole::ROLE_STUDENT] / divisor;
-		mPopulationDeath[PopulationTable::PersonRole::ROLE_STUDENT] = mPopulationDeath[PopulationTable::PersonRole::ROLE_STUDENT] % divisor;
+		int deaths = mPopulationDeath[PopulationTable::Role::Student] / divisor;
+		mPopulationDeath[PopulationTable::Role::Student] = mPopulationDeath[PopulationTable::Role::Student] % divisor;
 
-		mPopulation[PopulationTable::PersonRole::ROLE_STUDENT] -= deaths;
+		mPopulation[PopulationTable::Role::Student] -= deaths;
 		mDeathCount += deaths;
 
-		if (mPopulation[PopulationTable::PersonRole::ROLE_STUDENT] <= 0)
+		if (mPopulation[PopulationTable::Role::Student] <= 0)
 		{
-			mPopulationDeath[PopulationTable::PersonRole::ROLE_STUDENT] = 0;
-			mPopulationGrowth[PopulationTable::PersonRole::ROLE_WORKER] = 0;
+			mPopulationDeath[PopulationTable::Role::Student] = 0;
+			mPopulationGrowth[PopulationTable::Role::Worker] = 0;
 		}
 	}
 }
 
 
-void Population::kill_adults(PopulationTable::PersonRole role, int morale, int hospitals)
+void Population::kill_adults(PopulationTable::Role role, int morale, int hospitals)
 {
 	// Worker Deaths
 	if (mPopulation[role] > 0)
@@ -302,10 +302,10 @@ int Population::update(int morale, int food, int residences, int universities, i
 	kill_students(morale, hospitals);
 
 	// Workers will die more often than scientists.
-	if (randomNumber.generate(0, 100) <= 45) { kill_adults(PopulationTable::PersonRole::ROLE_SCIENTIST, morale, hospitals); }
-	else { kill_adults(PopulationTable::PersonRole::ROLE_WORKER, morale, hospitals); }
+	if (randomNumber.generate(0, 100) <= 45) { kill_adults(PopulationTable::Role::Scientist, morale, hospitals); }
+	else { kill_adults(PopulationTable::Role::Worker, morale, hospitals); }
 
-	kill_adults(PopulationTable::PersonRole::ROLE_RETIRED, morale, hospitals);
+	kill_adults(PopulationTable::Role::Retired, morale, hospitals);
 
 	return consume_food(food);
 }

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -27,13 +27,13 @@ public:
 private:
 	int adults() const;
 
-	void spawn_children(int morale, int residences, int nurseries);
-	void spawn_students();
-	void spawn_adults(int universities);
-	void spawn_retiree();
+	void spawnChildren(int morale, int residences, int nurseries);
+	void spawnStudents();
+	void spawnAdults(int universities);
+	void spawnRetiree();
 
-	void kill_children(int morale, int nurseries);
-	void kill_students(int morale, int hospitals);
+	void killChildren(int morale, int nurseries);
+	void killStudents(int morale, int hospitals);
 	void kill_adults(PopulationTable::Role role, int morale, int hospitals);
 
 	int consume_food(int food);

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -1,35 +1,24 @@
 #pragma once
 
+#include "PopulationTable.h"
 #include "Morale.h"
-
-#include <array>
 #include <vector>
 
 
 class Population
 {
 public:
-	enum PersonRole
-	{
-		ROLE_CHILD,
-		ROLE_STUDENT,
-		ROLE_WORKER,
-		ROLE_SCIENTIST,
-		ROLE_RETIRED
-	};
-
-
 	Population();
-
-	int size();
-	int size(PersonRole);
 
 	int birthCount() const { return mBirthCount; }
 	int deathCount() const { return mDeathCount; }
 
 	void clear();
+	
+	int size() { return mPopulation.size(); }
+	int size(PopulationTable::PersonRole role) { return mPopulation.size(role); }
 
-	void addPopulation(PersonRole role, int count);
+	void addPopulation(PopulationTable::PersonRole role, int count);
 
 	int update(int morale, int food, int residences, int universities, int nurseries, int hospitals);
 
@@ -45,12 +34,11 @@ private:
 
 	void kill_children(int morale, int nurseries);
 	void kill_students(int morale, int hospitals);
-	void kill_adults(Population::PersonRole role, int morale, int hospitals);
+	void kill_adults(PopulationTable::PersonRole role, int morale, int hospitals);
 
 	int consume_food(int food);
 
 
-	using PopulationTable = std::array<int, 5>;
 	using MoraleModifiers = std::array<MoraleModifier, 5>;
 
 

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -16,9 +16,9 @@ public:
 	void clear();
 	
 	int size() { return mPopulation.size(); }
-	int size(PopulationTable::PersonRole role) { return mPopulation.size(role); }
+	int size(PopulationTable::Role role) { return mPopulation.size(role); }
 
-	void addPopulation(PopulationTable::PersonRole role, int count);
+	void addPopulation(PopulationTable::Role role, int count);
 
 	int update(int morale, int food, int residences, int universities, int nurseries, int hospitals);
 
@@ -34,7 +34,7 @@ private:
 
 	void kill_children(int morale, int nurseries);
 	void kill_students(int morale, int hospitals);
-	void kill_adults(PopulationTable::PersonRole role, int morale, int hospitals);
+	void kill_adults(PopulationTable::Role role, int morale, int hospitals);
 
 	int consume_food(int food);
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -1,0 +1,48 @@
+#include "Population.h"
+
+int& PopulationTable::operator[](int index)
+{
+	return table[index];
+}
+
+// Implementation of [] operator.  This function must return a
+// reference as array element can be put on left side
+int& PopulationTable::operator[](PersonRole role)
+{
+    return table[role];
+}
+
+
+int PopulationTable::operator[](PersonRole role) const
+{
+	return table[role];
+}
+
+
+void PopulationTable::clear()
+{
+    table.fill(0);
+}
+
+
+/**
+ * Gets the size of the entire population.
+ */
+int PopulationTable::size()
+{
+	int count = 0;
+	for (auto& populationRole : table)
+	{
+		count += populationRole;
+	}
+	return count;
+}
+
+
+/**
+ * Gets the size of a specific segment of the population.
+ */
+int PopulationTable::size(PersonRole personRole)
+{
+	return table[personRole];
+}

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -9,13 +9,13 @@ int& PopulationTable::operator[](int index)
 // reference as array element can be put on left side
 int& PopulationTable::operator[](PersonRole role)
 {
-    return table[role];
+    return table[static_cast<int>(role)];
 }
 
 
 int PopulationTable::operator[](PersonRole role) const
 {
-	return table[role];
+	return table[static_cast<int>(role)];
 }
 
 
@@ -44,5 +44,5 @@ int PopulationTable::size()
  */
 int PopulationTable::size(PersonRole personRole)
 {
-	return table[personRole];
+	return table[static_cast<int>(personRole)];
 }

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -7,13 +7,13 @@ int& PopulationTable::operator[](int index)
 
 // Implementation of [] operator.  This function must return a
 // reference as array element can be put on left side
-int& PopulationTable::operator[](PersonRole role)
+int& PopulationTable::operator[](Role role)
 {
     return table[static_cast<int>(role)];
 }
 
 
-int PopulationTable::operator[](PersonRole role) const
+int PopulationTable::operator[](Role role) const
 {
 	return table[static_cast<int>(role)];
 }
@@ -42,7 +42,7 @@ int PopulationTable::size()
 /**
  * Gets the size of a specific segment of the population.
  */
-int PopulationTable::size(PersonRole personRole)
+int PopulationTable::size(Role personRole)
 {
 	return table[static_cast<int>(personRole)];
 }

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -1,6 +1,6 @@
 #include "Population.h"
 
-int& PopulationTable::operator[](int index)
+int& PopulationTable::operator[](std::size_t index)
 {
 	return table[index];
 }
@@ -9,7 +9,7 @@ int& PopulationTable::operator[](int index)
 // reference as array element can be put on left side
 int& PopulationTable::operator[](Role role)
 {
-    return table[static_cast<int>(role)];
+    return table[static_cast<std::size_t>(role)];
 }
 
 
@@ -44,5 +44,5 @@ int PopulationTable::size() const
  */
 int PopulationTable::size(Role personRole) const
 {
-	return table[static_cast<int>(personRole)];
+	return table[static_cast<std::size_t > (personRole)];
 }

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -28,10 +28,10 @@ void PopulationTable::clear()
 /**
  * Gets the size of the entire population.
  */
-int PopulationTable::size()
+int PopulationTable::size() const
 {
 	int count = 0;
-	for (auto& populationRole : table)
+	for (auto populationRole : table)
 	{
 		count += populationRole;
 	}
@@ -42,7 +42,7 @@ int PopulationTable::size()
 /**
  * Gets the size of a specific segment of the population.
  */
-int PopulationTable::size(Role personRole)
+int PopulationTable::size(Role personRole) const
 {
 	return table[static_cast<int>(personRole)];
 }

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -5,7 +5,7 @@
 struct PopulationTable
 {
 public:
-	enum PersonRole
+	enum class PersonRole
 	{
 		ROLE_CHILD,
 		ROLE_STUDENT,

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -5,23 +5,23 @@
 struct PopulationTable
 {
 public:
-	enum class PersonRole
+	enum class Role
 	{
-		ROLE_CHILD,
-		ROLE_STUDENT,
-		ROLE_WORKER,
-		ROLE_SCIENTIST,
-		ROLE_RETIRED
+		Child,
+		Student,
+		Worker,
+		Scientist,
+		Retired
 	};
 
 	int& operator[](int);
-	int& operator[](PersonRole);
-	int operator[](PersonRole) const;
+	int& operator[](Role);
+	int operator[](Role) const;
 
 	void clear();
 
 	int size();
-	int size(PersonRole role);
+	int size(Role role);
 
 private:
 	std::array<int, 5> table;

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <array>
+
+struct PopulationTable
+{
+public:
+	enum PersonRole
+	{
+		ROLE_CHILD,
+		ROLE_STUDENT,
+		ROLE_WORKER,
+		ROLE_SCIENTIST,
+		ROLE_RETIRED
+	};
+
+	int& operator[](int);
+	int& operator[](PersonRole);
+	int operator[](PersonRole) const;
+
+	void clear();
+
+	int size();
+	int size(PersonRole role);
+
+private:
+	std::array<int, 5> table;
+};

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -20,8 +20,8 @@ public:
 
 	void clear();
 
-	int size();
-	int size(Role role);
+	int size() const;
+	int size(Role role)const ;
 
 private:
 	std::array<int, 5> table;

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -14,7 +14,7 @@ public:
 		Retired
 	};
 
-	int& operator[](int);
+	int& operator[](std::size_t);
 	int& operator[](Role);
 	int operator[](Role) const;
 

--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -5,7 +5,7 @@
 
 
 namespace {
-	void BasicCheck(Population::PersonRole role);
+	void BasicCheck(PopulationTable::PersonRole role);
 }
 
 
@@ -24,12 +24,12 @@ void PopulationPool::population(Population* pop)
 /**
  * Gets the amount of population available for a given role.
  */
-int PopulationPool::populationAvailable(Population::PersonRole role)
+int PopulationPool::populationAvailable(PopulationTable::PersonRole role)
 {
 	BasicCheck(role);
 
 	int employed = 0;
-	employed = role == Population::PersonRole::ROLE_SCIENTIST ? scientistsEmployed() : workersEmployed();
+	employed = role == PopulationTable::PersonRole::ROLE_SCIENTIST ? scientistsEmployed() : workersEmployed();
 
 	return mPopulation->size(role) - employed;
 }
@@ -40,7 +40,7 @@ int PopulationPool::populationAvailable(Population::PersonRole role)
  * 
  * \returns	True if available is the same or greater than what is being asked for. False otherwise.
  */
-bool PopulationPool::enoughPopulationAvailable(Population::PersonRole role, int amount)
+bool PopulationPool::enoughPopulationAvailable(PopulationTable::PersonRole role, int amount)
 {
 	BasicCheck(role);
 	return populationAvailable(role) >= amount;
@@ -54,14 +54,14 @@ bool PopulationPool::enoughPopulationAvailable(Population::PersonRole role, int 
  * 
  * \return	Returns true if population was assigned. False if insufficient population.
  */
-bool PopulationPool::usePopulation(Population::PersonRole role, int amount)
+bool PopulationPool::usePopulation(PopulationTable::PersonRole role, int amount)
 {
 	BasicCheck(role);
-	int scientistsAvailable = mPopulation->size(Population::PersonRole::ROLE_SCIENTIST) - (mScientistsAsWorkers + mScientistsUsed);
-	int workersAvailable = mPopulation->size(Population::PersonRole::ROLE_WORKER) - mWorkersUsed;
+	int scientistsAvailable = mPopulation->size(PopulationTable::PersonRole::ROLE_SCIENTIST) - (mScientistsAsWorkers + mScientistsUsed);
+	int workersAvailable = mPopulation->size(PopulationTable::PersonRole::ROLE_WORKER) - mWorkersUsed;
 
 
-	if (role == Population::PersonRole::ROLE_SCIENTIST)
+	if (role == PopulationTable::PersonRole::ROLE_SCIENTIST)
 	{
 		if (amount <= scientistsAvailable)
 		{
@@ -69,7 +69,7 @@ bool PopulationPool::usePopulation(Population::PersonRole role, int amount)
 			return true;
 		}
 	}
-	else if (role == Population::PersonRole::ROLE_WORKER)
+	else if (role == PopulationTable::PersonRole::ROLE_WORKER)
 	{
 		if (amount <= workersAvailable + scientistsAvailable)
 		{
@@ -152,16 +152,16 @@ namespace {
 	 *
 	 * \throws	std::runtime_exception if Child/Student/Retired is asked for.
 	 */
-	void BasicCheck(Population::PersonRole role)
+	void BasicCheck(PopulationTable::PersonRole role)
 	{
-		if (role == Population::PersonRole::ROLE_CHILD || role == Population::PersonRole::ROLE_STUDENT || role == Population::PersonRole::ROLE_RETIRED)
+		if (role == PopulationTable::PersonRole::ROLE_CHILD || role == PopulationTable::PersonRole::ROLE_STUDENT || role == PopulationTable::PersonRole::ROLE_RETIRED)
 		{
 			std::string roleTypeName;
 			switch (role)
 			{
-			case Population::PersonRole::ROLE_CHILD: roleTypeName = "Population::PersonRole::ROLE_CHILD"; break;
-			case Population::PersonRole::ROLE_STUDENT: roleTypeName = "Population::PersonRole::ROLE_STUDENT"; break;
-			case Population::PersonRole::ROLE_RETIRED: roleTypeName = "Population::PersonRole::ROLE_RETIRED"; break;
+			case PopulationTable::PersonRole::ROLE_CHILD: roleTypeName = "Population::PersonRole::ROLE_CHILD"; break;
+			case PopulationTable::PersonRole::ROLE_STUDENT: roleTypeName = "Population::PersonRole::ROLE_STUDENT"; break;
+			case PopulationTable::PersonRole::ROLE_RETIRED: roleTypeName = "Population::PersonRole::ROLE_RETIRED"; break;
 			default: break;
 			}
 

--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -5,7 +5,7 @@
 
 
 namespace {
-	void BasicCheck(PopulationTable::PersonRole role);
+	void BasicCheck(PopulationTable::Role role);
 }
 
 
@@ -24,12 +24,12 @@ void PopulationPool::population(Population* pop)
 /**
  * Gets the amount of population available for a given role.
  */
-int PopulationPool::populationAvailable(PopulationTable::PersonRole role)
+int PopulationPool::populationAvailable(PopulationTable::Role role)
 {
 	BasicCheck(role);
 
 	int employed = 0;
-	employed = role == PopulationTable::PersonRole::ROLE_SCIENTIST ? scientistsEmployed() : workersEmployed();
+	employed = role == PopulationTable::Role::Scientist ? scientistsEmployed() : workersEmployed();
 
 	return mPopulation->size(role) - employed;
 }
@@ -40,7 +40,7 @@ int PopulationPool::populationAvailable(PopulationTable::PersonRole role)
  * 
  * \returns	True if available is the same or greater than what is being asked for. False otherwise.
  */
-bool PopulationPool::enoughPopulationAvailable(PopulationTable::PersonRole role, int amount)
+bool PopulationPool::enoughPopulationAvailable(PopulationTable::Role role, int amount)
 {
 	BasicCheck(role);
 	return populationAvailable(role) >= amount;
@@ -50,18 +50,18 @@ bool PopulationPool::enoughPopulationAvailable(PopulationTable::PersonRole role,
 /**
  * Marks a given amount of the population as set.
  * 
- * \warning	Will throw an exception if any role other than Population::PersonRole::ROLE_SCIENTIST or Population::PersonRole::ROLE_WORKER is specified.
+ * \warning	Will throw an exception if any role other than Population::Role::Scientist or Population::Role::Worker is specified.
  * 
  * \return	Returns true if population was assigned. False if insufficient population.
  */
-bool PopulationPool::usePopulation(PopulationTable::PersonRole role, int amount)
+bool PopulationPool::usePopulation(PopulationTable::Role role, int amount)
 {
 	BasicCheck(role);
-	int scientistsAvailable = mPopulation->size(PopulationTable::PersonRole::ROLE_SCIENTIST) - (mScientistsAsWorkers + mScientistsUsed);
-	int workersAvailable = mPopulation->size(PopulationTable::PersonRole::ROLE_WORKER) - mWorkersUsed;
+	int scientistsAvailable = mPopulation->size(PopulationTable::Role::Scientist) - (mScientistsAsWorkers + mScientistsUsed);
+	int workersAvailable = mPopulation->size(PopulationTable::Role::Worker) - mWorkersUsed;
 
 
-	if (role == PopulationTable::PersonRole::ROLE_SCIENTIST)
+	if (role == PopulationTable::Role::Scientist)
 	{
 		if (amount <= scientistsAvailable)
 		{
@@ -69,7 +69,7 @@ bool PopulationPool::usePopulation(PopulationTable::PersonRole role, int amount)
 			return true;
 		}
 	}
-	else if (role == PopulationTable::PersonRole::ROLE_WORKER)
+	else if (role == PopulationTable::Role::Worker)
 	{
 		if (amount <= workersAvailable + scientistsAvailable)
 		{
@@ -152,16 +152,16 @@ namespace {
 	 *
 	 * \throws	std::runtime_exception if Child/Student/Retired is asked for.
 	 */
-	void BasicCheck(PopulationTable::PersonRole role)
+	void BasicCheck(PopulationTable::Role role)
 	{
-		if (role == PopulationTable::PersonRole::ROLE_CHILD || role == PopulationTable::PersonRole::ROLE_STUDENT || role == PopulationTable::PersonRole::ROLE_RETIRED)
+		if (role == PopulationTable::Role::Child || role == PopulationTable::Role::Student || role == PopulationTable::Role::Retired)
 		{
 			std::string roleTypeName;
 			switch (role)
 			{
-			case PopulationTable::PersonRole::ROLE_CHILD: roleTypeName = "Population::PersonRole::ROLE_CHILD"; break;
-			case PopulationTable::PersonRole::ROLE_STUDENT: roleTypeName = "Population::PersonRole::ROLE_STUDENT"; break;
-			case PopulationTable::PersonRole::ROLE_RETIRED: roleTypeName = "Population::PersonRole::ROLE_RETIRED"; break;
+			case PopulationTable::Role::Child: roleTypeName = "Population::Role::Child"; break;
+			case PopulationTable::Role::Student: roleTypeName = "Population::Role::Student"; break;
+			case PopulationTable::Role::Retired: roleTypeName = "Population::Role::Retired"; break;
 			default: break;
 			}
 

--- a/OPHD/PopulationPool.h
+++ b/OPHD/PopulationPool.h
@@ -8,9 +8,9 @@ class PopulationPool
 public:
 	void population(Population* pop);
 
-	int populationAvailable(PopulationTable::PersonRole role);
-	bool enoughPopulationAvailable(PopulationTable::PersonRole role, int amount);
-	bool usePopulation(PopulationTable::PersonRole role, int amount);
+	int populationAvailable(PopulationTable::Role role);
+	bool enoughPopulationAvailable(PopulationTable::Role role, int amount);
+	bool usePopulation(PopulationTable::Role role, int amount);
 
 	void clear();
 

--- a/OPHD/PopulationPool.h
+++ b/OPHD/PopulationPool.h
@@ -8,9 +8,9 @@ class PopulationPool
 public:
 	void population(Population* pop);
 
-	int populationAvailable(Population::PersonRole role);
-	bool enoughPopulationAvailable(Population::PersonRole role, int amount);
-	bool usePopulation(Population::PersonRole role, int amount);
+	int populationAvailable(PopulationTable::PersonRole role);
+	bool enoughPopulationAvailable(PopulationTable::PersonRole role, int amount);
+	bool usePopulation(PopulationTable::PersonRole role, int amount);
 
 	void clear();
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -100,9 +100,9 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
  */
 void MapViewState::onDeployColonistLander()
 {
-	mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_STUDENT, 10);
-	mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_WORKER, 20);
-	mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_SCIENTIST, 20);
+	mPopulation.addPopulation(PopulationTable::Role::Student, 10);
+	mPopulation.addPopulation(PopulationTable::Role::Worker, 20);
+	mPopulation.addPopulation(PopulationTable::Role::Scientist, 20);
 }
 
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -100,9 +100,9 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
  */
 void MapViewState::onDeployColonistLander()
 {
-	mPopulation.addPopulation(Population::PersonRole::ROLE_STUDENT, 10);
-	mPopulation.addPopulation(Population::PersonRole::ROLE_WORKER, 20);
-	mPopulation.addPopulation(Population::PersonRole::ROLE_SCIENTIST, 20);
+	mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_STUDENT, 10);
+	mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_WORKER, 20);
+	mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_SCIENTIST, 20);
 }
 
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -109,11 +109,11 @@ void MapViewState::save(const std::string& filePath)
 	population->attribute("prev_morale", mPreviousMorale);
 	population->attribute("colonist_landers", mLandersColonist);
 	population->attribute("cargo_landers", mLandersCargo);
-	population->attribute("children", mPopulation.size(PopulationTable::PersonRole::ROLE_CHILD));
-	population->attribute("students", mPopulation.size(PopulationTable::PersonRole::ROLE_STUDENT));
-	population->attribute("workers", mPopulation.size(PopulationTable::PersonRole::ROLE_WORKER));
-	population->attribute("scientists", mPopulation.size(PopulationTable::PersonRole::ROLE_SCIENTIST));
-	population->attribute("retired", mPopulation.size(PopulationTable::PersonRole::ROLE_RETIRED));
+	population->attribute("children", mPopulation.size(PopulationTable::Role::Child));
+	population->attribute("students", mPopulation.size(PopulationTable::Role::Student));
+	population->attribute("workers", mPopulation.size(PopulationTable::Role::Worker));
+	population->attribute("scientists", mPopulation.size(PopulationTable::Role::Scientist));
+	population->attribute("retired", mPopulation.size(PopulationTable::Role::Retired));
 	population->attribute("mean_crime", mPopulationPanel.crimeRate());
 	root->linkEndChild(population);
 
@@ -585,11 +585,11 @@ void MapViewState::readPopulation(Xml::XmlElement* element)
 			attribute = attribute->next();
 		}
 
-		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_CHILD, children);
-		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_STUDENT, students);
-		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_WORKER, workers);
-		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_SCIENTIST, scientists);
-		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_RETIRED, retired);
+		mPopulation.addPopulation(PopulationTable::Role::Child, children);
+		mPopulation.addPopulation(PopulationTable::Role::Student, students);
+		mPopulation.addPopulation(PopulationTable::Role::Worker, workers);
+		mPopulation.addPopulation(PopulationTable::Role::Scientist, scientists);
+		mPopulation.addPopulation(PopulationTable::Role::Retired, retired);
 	}
 }
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -109,11 +109,11 @@ void MapViewState::save(const std::string& filePath)
 	population->attribute("prev_morale", mPreviousMorale);
 	population->attribute("colonist_landers", mLandersColonist);
 	population->attribute("cargo_landers", mLandersCargo);
-	population->attribute("children", mPopulation.size(Population::PersonRole::ROLE_CHILD));
-	population->attribute("students", mPopulation.size(Population::PersonRole::ROLE_STUDENT));
-	population->attribute("workers", mPopulation.size(Population::PersonRole::ROLE_WORKER));
-	population->attribute("scientists", mPopulation.size(Population::PersonRole::ROLE_SCIENTIST));
-	population->attribute("retired", mPopulation.size(Population::PersonRole::ROLE_RETIRED));
+	population->attribute("children", mPopulation.size(PopulationTable::PersonRole::ROLE_CHILD));
+	population->attribute("students", mPopulation.size(PopulationTable::PersonRole::ROLE_STUDENT));
+	population->attribute("workers", mPopulation.size(PopulationTable::PersonRole::ROLE_WORKER));
+	population->attribute("scientists", mPopulation.size(PopulationTable::PersonRole::ROLE_SCIENTIST));
+	population->attribute("retired", mPopulation.size(PopulationTable::PersonRole::ROLE_RETIRED));
 	population->attribute("mean_crime", mPopulationPanel.crimeRate());
 	root->linkEndChild(population);
 
@@ -585,11 +585,11 @@ void MapViewState::readPopulation(Xml::XmlElement* element)
 			attribute = attribute->next();
 		}
 
-		mPopulation.addPopulation(Population::PersonRole::ROLE_CHILD, children);
-		mPopulation.addPopulation(Population::PersonRole::ROLE_STUDENT, students);
-		mPopulation.addPopulation(Population::PersonRole::ROLE_WORKER, workers);
-		mPopulation.addPopulation(Population::PersonRole::ROLE_SCIENTIST, scientists);
-		mPopulation.addPopulation(Population::PersonRole::ROLE_RETIRED, retired);
+		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_CHILD, children);
+		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_STUDENT, students);
+		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_WORKER, workers);
+		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_SCIENTIST, scientists);
+		mPopulation.addPopulation(PopulationTable::PersonRole::ROLE_RETIRED, retired);
 	}
 }
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -23,8 +23,8 @@ namespace
 	 */
 	void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
 	{
-		available[0] = std::min(required[0], populationPool.populationAvailable(Population::PersonRole::ROLE_WORKER));
-		available[1] = std::min(required[1], populationPool.populationAvailable(Population::PersonRole::ROLE_SCIENTIST));
+		available[0] = std::min(required[0], populationPool.populationAvailable(PopulationTable::PersonRole::ROLE_WORKER));
+		available[1] = std::min(required[1], populationPool.populationAvailable(PopulationTable::PersonRole::ROLE_SCIENTIST));
 	}
 
 
@@ -313,8 +313,8 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 
 		if (structure->operational() || structure->isIdle())
 		{
-			population.usePopulation(Population::PersonRole::ROLE_WORKER, populationRequired[0]);
-			population.usePopulation(Population::PersonRole::ROLE_SCIENTIST, populationRequired[1]);
+			population.usePopulation(PopulationTable::PersonRole::ROLE_WORKER, populationRequired[0]);
+			population.usePopulation(PopulationTable::PersonRole::ROLE_SCIENTIST, populationRequired[1]);
 
 			auto consumed = structure->resourcesIn();
 			removeRefinedResources(consumed);

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -23,8 +23,8 @@ namespace
 	 */
 	void fillPopulationRequirements(PopulationPool& populationPool, const PopulationRequirements& required, PopulationRequirements& available)
 	{
-		available[0] = std::min(required[0], populationPool.populationAvailable(PopulationTable::PersonRole::ROLE_WORKER));
-		available[1] = std::min(required[1], populationPool.populationAvailable(PopulationTable::PersonRole::ROLE_SCIENTIST));
+		available[0] = std::min(required[0], populationPool.populationAvailable(PopulationTable::Role::Worker));
+		available[1] = std::min(required[1], populationPool.populationAvailable(PopulationTable::Role::Scientist));
 	}
 
 
@@ -313,8 +313,8 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 
 		if (structure->operational() || structure->isIdle())
 		{
-			population.usePopulation(PopulationTable::PersonRole::ROLE_WORKER, populationRequired[0]);
-			population.usePopulation(PopulationTable::PersonRole::ROLE_SCIENTIST, populationRequired[1]);
+			population.usePopulation(PopulationTable::Role::Worker, populationRequired[0]);
+			population.usePopulation(PopulationTable::Role::Scientist, populationRequired[1]);
 
 			auto consumed = structure->resourcesIn();
 			removeRefinedResources(consumed);

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -101,11 +101,11 @@ void PopulationPanel::update()
 	renderer.drawText(mFontBold, constants::PopulationBreakdown, position);
 	const std::array populationData
 	{
-		std::tuple{NAS2D::Rectangle{0, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_CHILD), std::string("Children")},
-		std::tuple{NAS2D::Rectangle{32, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_STUDENT), std::string("Students")},
-		std::tuple{NAS2D::Rectangle{64, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_WORKER), std::string("Workers")},
-		std::tuple{NAS2D::Rectangle{96, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_SCIENTIST), std::string("Scientists")},
-		std::tuple{NAS2D::Rectangle{128, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_RETIRED), std::string("Retired")},
+		std::tuple{NAS2D::Rectangle{0, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::Role::Child), std::string("Children")},
+		std::tuple{NAS2D::Rectangle{32, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::Role::Student), std::string("Students")},
+		std::tuple{NAS2D::Rectangle{64, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::Role::Worker), std::string("Workers")},
+		std::tuple{NAS2D::Rectangle{96, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::Role::Scientist), std::string("Scientists")},
+		std::tuple{NAS2D::Rectangle{128, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::Role::Retired), std::string("Retired")},
 	};
 
 	position.y += fontBoldHeight + constants::Margin;

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -101,11 +101,11 @@ void PopulationPanel::update()
 	renderer.drawText(mFontBold, constants::PopulationBreakdown, position);
 	const std::array populationData
 	{
-		std::tuple{NAS2D::Rectangle{0, 96, IconSize, IconSize}, mPopulation->size(Population::PersonRole::ROLE_CHILD), std::string("Children")},
-		std::tuple{NAS2D::Rectangle{32, 96, IconSize, IconSize}, mPopulation->size(Population::PersonRole::ROLE_STUDENT), std::string("Students")},
-		std::tuple{NAS2D::Rectangle{64, 96, IconSize, IconSize}, mPopulation->size(Population::PersonRole::ROLE_WORKER), std::string("Workers")},
-		std::tuple{NAS2D::Rectangle{96, 96, IconSize, IconSize}, mPopulation->size(Population::PersonRole::ROLE_SCIENTIST), std::string("Scientists")},
-		std::tuple{NAS2D::Rectangle{128, 96, IconSize, IconSize}, mPopulation->size(Population::PersonRole::ROLE_RETIRED), std::string("Retired")},
+		std::tuple{NAS2D::Rectangle{0, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_CHILD), std::string("Children")},
+		std::tuple{NAS2D::Rectangle{32, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_STUDENT), std::string("Students")},
+		std::tuple{NAS2D::Rectangle{64, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_WORKER), std::string("Workers")},
+		std::tuple{NAS2D::Rectangle{96, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_SCIENTIST), std::string("Scientists")},
+		std::tuple{NAS2D::Rectangle{128, 96, IconSize, IconSize}, mPopulation->size(PopulationTable::PersonRole::ROLE_RETIRED), std::string("Retired")},
 	};
 
 	position.y += fontBoldHeight + constants::Margin;

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -262,6 +262,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClCompile Include="Mine.cpp" />
     <ClCompile Include="PopulationPool.cpp" />
     <ClCompile Include="Population\Population.cpp" />
+    <ClCompile Include="Population\PopulationTable.cpp" />
     <ClCompile Include="ProductPool.cpp" />
     <ClCompile Include="RobotPool.cpp" />
     <ClCompile Include="States\CrimeExecution.cpp" />
@@ -343,6 +344,7 @@ IF NOT "$(VcpkgCurrentInstalledDir)" == "" (
     <ClInclude Include="Map\TileMap.h" />
     <ClInclude Include="MicroPather\micropather.h" />
     <ClInclude Include="Mine.h" />
+    <ClInclude Include="Population\PopulationTable.h" />
     <ClInclude Include="RandomNumberGenerator.h" />
     <ClInclude Include="States\CrimeExecution.h" />
     <ClInclude Include="States\CrimeRateUpdate.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -315,6 +315,9 @@
     <ClCompile Include="States\CrimeExecution.cpp">
       <Filter>Source Files\States</Filter>
     </ClCompile>
+    <ClCompile Include="Population\PopulationTable.cpp">
+      <Filter>Source Files\Population</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -706,6 +709,9 @@
     </ClInclude>
     <ClInclude Include="Things\Structures\MaintenanceFacility.h">
       <Filter>Header Files\Things\Structures</Filter>
+    </ClInclude>
+    <ClInclude Include="Population\PopulationTable.h">
+      <Filter>Header Files\Population</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This branch creates a `PopulationTable`, which is very similar to the `ResourcePool` class to separate some of the logic out of population.h. As a side affect, it allowed turning the `enum PopulationRole` into an `enum class` that I thought worked out really well. 

Looks like I have some wicked merge conflicts with #998. Will need some help untangling.

Also, before merging, I did not mean to commit the change to nas2D submodule in commit: _Rename PopulationTable::Role and members to improve readability and style_. I am having trouble figuring out a simple way to remove it from the commit.