### PR TITLE
Refactor MapViewStateHelper serialize code

### DIFF
--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -19,6 +19,8 @@
 #include "../Things/Structures/Warehouse.h"
 
 #include <NAS2D/Utility.h>
+#include <NAS2D/Dictionary.h>
+#include <NAS2D/ParserHelper.h>
 
 #include <cmath>
 
@@ -565,24 +567,26 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
  */
 XmlElement* checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
 {
-	XmlElement* robotElement = new XmlElement("robot");
-
-	robotElement->attribute("id", robot->id());
-	robotElement->attribute("type", static_cast<int>(type));
-	robotElement->attribute("age", robot->fuelCellAge());
-	robotElement->attribute("production", robot->turnsToCompleteTask());
+	NAS2D::Dictionary dictionary{{
+		{"id", robot->id()},
+		{"type", static_cast<int>(type)},
+		{"age", robot->fuelCellAge()},
+		{"production", robot->turnsToCompleteTask()},
+	}};
 
 	const auto it = robotTileTable.find(robot);
 	if (it != robotTileTable.end())
 	{
 		const auto& tile = *it->second;
 		const auto position = tile.position();
-		robotElement->attribute("x", position.x);
-		robotElement->attribute("y", position.y);
-		robotElement->attribute("depth", tile.depth());
+		dictionary += NAS2D::Dictionary{{
+			{"x", position.x},
+			{"y", position.y},
+			{"depth", tile.depth()},
+		}};
 	}
 
-	return robotElement;
+	return NAS2D::dictionaryToAttributes("robot", dictionary);
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -30,10 +30,10 @@ using namespace NAS2D::Xml;
 
 
 const NAS2D::Point<int> CcNotPlaced{-1, -1};
-static Point<int> commandCenterLocation = CcNotPlaced;
+static NAS2D::Point<int> commandCenterLocation = CcNotPlaced;
 
 
-Point<int>& ccLocation()
+NAS2D::Point<int>& ccLocation()
 {
 	return commandCenterLocation;
 }

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -589,7 +589,7 @@ NAS2D::Dictionary robotToDictionary(RobotTileTable& robotTileTable, Robot& robot
 
 NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap)
 {
-	XmlElement* robots = new XmlElement("robots");
+	auto* robots = new XmlElement("robots");
 
 	for (auto digger : robotPool.diggers())
 	{

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -562,9 +562,6 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 // = CONVENIENCE FUNCTIONS FOR WRITING OUT GAME STATE INFORMATION
 // ==============================================================
 
-/** 
- * Document me!
- */
 NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
 {
 	NAS2D::Dictionary dictionary{{
@@ -590,11 +587,6 @@ NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot* ro
 }
 
 
-/** 
- * Document me!
- * 
- * Convenience function
- */
 void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTileTable& robotMap)
 {
 	XmlElement* robots = new XmlElement("robots");

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -25,10 +25,6 @@
 #include <cmath>
 
 
-using namespace NAS2D;
-using namespace NAS2D::Xml;
-
-
 const NAS2D::Point<int> CcNotPlaced{-1, -1};
 static NAS2D::Point<int> commandCenterLocation = CcNotPlaced;
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -204,9 +204,6 @@ bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position)
 }
 
 
-/**
- * Document me!
- */
 void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt, Tile* /*tile*/)
 {
 	if (rcc->isControlling(robotToDelete))
@@ -231,9 +228,6 @@ void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robot
 }
 
 
-/**
- * Document me!
- */
 void updateRobotControl(RobotPool& robotPool)
 {
 	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -562,7 +562,7 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 // = CONVENIENCE FUNCTIONS FOR WRITING OUT GAME STATE INFORMATION
 // ==============================================================
 
-NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot& robot, Robot::Type type)
+NAS2D::Dictionary robotToDictionary(RobotTileTable& robotTileTable, Robot& robot, Robot::Type type)
 {
 	NAS2D::Dictionary dictionary{{
 		{"id", robot.id()},
@@ -593,20 +593,20 @@ NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotM
 
 	for (auto digger : robotPool.diggers())
 	{
-		auto dictionary = checkRobotDeployment(robotMap, *digger, Robot::Type::Digger);
+		auto dictionary = robotToDictionary(robotMap, *digger, Robot::Type::Digger);
 		dictionary.set("direction", static_cast<int>(digger->direction()));
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	for (auto dozer : robotPool.dozers())
 	{
-		auto dictionary = checkRobotDeployment(robotMap, *dozer, Robot::Type::Dozer);
+		auto dictionary = robotToDictionary(robotMap, *dozer, Robot::Type::Dozer);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	for (auto miner : robotPool.miners())
 	{
-		auto dictionary = checkRobotDeployment(robotMap, *miner, Robot::Type::Miner);
+		auto dictionary = robotToDictionary(robotMap, *miner, Robot::Type::Miner);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -565,7 +565,7 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 /** 
  * Document me!
  */
-XmlElement* checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
+NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
 {
 	NAS2D::Dictionary dictionary{{
 		{"id", robot->id()},
@@ -586,7 +586,7 @@ XmlElement* checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, R
 		}};
 	}
 
-	return NAS2D::dictionaryToAttributes("robot", dictionary);
+	return dictionary;
 }
 
 
@@ -603,23 +603,23 @@ void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTil
 
 	for (auto digger : diggers)
 	{
-		auto* robot = checkRobotDeployment(robotMap, digger, Robot::Type::Digger);
-		robot->attribute("direction", static_cast<int>(digger->direction()));
-		robots->linkEndChild(robot);
+		auto dictionary = checkRobotDeployment(robotMap, digger, Robot::Type::Digger);
+		dictionary.set("direction", static_cast<int>(digger->direction()));
+		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	RobotPool::DozerList& dozers = robotPool.dozers();
 	for (auto dozer : dozers)
 	{
-		auto* robot = checkRobotDeployment(robotMap, dozer, Robot::Type::Dozer);
-		robots->linkEndChild(robot);
+		auto dictionary = checkRobotDeployment(robotMap, dozer, Robot::Type::Dozer);
+		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	RobotPool::MinerList& miners = robotPool.miners();
 	for (auto miner : miners)
 	{
-		auto* robot = checkRobotDeployment(robotMap, miner, Robot::Type::Miner);
-		robots->linkEndChild(robot);
+		auto dictionary = checkRobotDeployment(robotMap, miner, Robot::Type::Miner);
+		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	element->linkEndChild(robots);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -240,8 +240,8 @@ void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robot
  */
 void updateRobotControl(RobotPool& robotPool)
 {
-	const auto& commandCenters = Utility<StructureManager>::get().getStructures<CommandCenter>();
-	const auto& robotCommands = Utility<StructureManager>::get().getStructures<RobotCommand>();
+	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().getStructures<RobotCommand>();
 
 	// 3 for the first command center
 	uint32_t maxRobots = 0;
@@ -287,7 +287,7 @@ bool selfSustained(StructureID id)
  */
 bool inCommRange(NAS2D::Point<int> position)
 {
-	auto& structureManager = Utility<StructureManager>::get();
+	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
 	const auto& seedLanders = structureManager.getStructures<SeedLander>();
 	for (auto lander : seedLanders)
@@ -343,7 +343,7 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
 {
-	for (auto warehouse : Utility<StructureManager>::get().getStructures<Warehouse>())
+	for (auto warehouse : NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>())
 	{
 		if (!warehouse->operational())
 		{
@@ -371,7 +371,7 @@ Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
  */
 RobotCommand* getAvailableRobotCommand()
 {
-	for (auto robotCommand : Utility<StructureManager>::get().getStructures<RobotCommand>())
+	for (auto robotCommand : NAS2D::Utility<StructureManager>::get().getStructures<RobotCommand>())
 	{
 		if (robotCommand->operational() && robotCommand->commandCapacityAvailable())
 		{
@@ -394,7 +394,7 @@ RobotCommand* getAvailableRobotCommand()
 bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
 	ProductPool sourcePool = sourceWarehouse->products();
-	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
+	const auto& warehouses = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouses)
 	{
 		if (warehouse->operational())
@@ -425,7 +425,7 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
  */
 void moveProducts(Warehouse* sourceWarehouse)
 {
-	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
+	const auto& warehouses = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouses)
 	{
 		if (warehouse->operational())

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -563,8 +563,10 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 /** 
  * Document me!
  */
-void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
+XmlElement* checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
 {
+	XmlElement* robotElement = new XmlElement("robot");
+
 	robotElement->attribute("id", robot->id());
 	robotElement->attribute("type", static_cast<int>(type));
 	robotElement->attribute("age", robot->fuelCellAge());
@@ -579,6 +581,8 @@ void checkRobotDeployment(XmlElement* robotElement, RobotTileTable& robotTileTab
 		robotElement->attribute("y", position.y);
 		robotElement->attribute("depth", tile.depth());
 	}
+
+	return robotElement;
 }
 
 
@@ -595,8 +599,7 @@ void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTil
 
 	for (auto digger : diggers)
 	{
-		XmlElement* robot = new XmlElement("robot");
-		checkRobotDeployment(robot, robotMap, digger, Robot::Type::Digger);
+		auto* robot = checkRobotDeployment(robotMap, digger, Robot::Type::Digger);
 		robot->attribute("direction", static_cast<int>(digger->direction()));
 		robots->linkEndChild(robot);
 	}
@@ -604,16 +607,14 @@ void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTil
 	RobotPool::DozerList& dozers = robotPool.dozers();
 	for (auto dozer : dozers)
 	{
-		XmlElement* robot = new XmlElement("robot");
-		checkRobotDeployment(robot, robotMap, dozer, Robot::Type::Dozer);
+		auto* robot = checkRobotDeployment(robotMap, dozer, Robot::Type::Dozer);
 		robots->linkEndChild(robot);
 	}
 
 	RobotPool::MinerList& miners = robotPool.miners();
 	for (auto miner : miners)
 	{
-		XmlElement* robot = new XmlElement("robot");
-		checkRobotDeployment(robot, robotMap, miner, Robot::Type::Miner);
+		auto* robot = checkRobotDeployment(robotMap, miner, Robot::Type::Miner);
 		robots->linkEndChild(robot);
 	}
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -589,7 +589,7 @@ NAS2D::Dictionary robotToDictionary(RobotTileTable& robotTileTable, Robot& robot
 
 NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap)
 {
-	auto* robots = new XmlElement("robots");
+	auto* robots = new NAS2D::Xml::XmlElement("robots");
 
 	for (auto digger : robotPool.diggers())
 	{

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -587,7 +587,7 @@ NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot& ro
 }
 
 
-void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTileTable& robotMap)
+NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap)
 {
 	XmlElement* robots = new XmlElement("robots");
 
@@ -610,5 +610,5 @@ void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTil
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
-	element->linkEndChild(robots);
+	return robots;
 }

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -599,24 +599,20 @@ void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTil
 {
 	XmlElement* robots = new XmlElement("robots");
 
-	RobotPool::DiggerList& diggers = robotPool.diggers();
-
-	for (auto digger : diggers)
+	for (auto digger : robotPool.diggers())
 	{
 		auto dictionary = checkRobotDeployment(robotMap, digger, Robot::Type::Digger);
 		dictionary.set("direction", static_cast<int>(digger->direction()));
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
-	RobotPool::DozerList& dozers = robotPool.dozers();
-	for (auto dozer : dozers)
+	for (auto dozer : robotPool.dozers())
 	{
 		auto dictionary = checkRobotDeployment(robotMap, dozer, Robot::Type::Dozer);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
-	RobotPool::MinerList& miners = robotPool.miners();
-	for (auto miner : miners)
+	for (auto miner : robotPool.miners())
 	{
 		auto dictionary = checkRobotDeployment(robotMap, miner, Robot::Type::Miner);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -562,16 +562,16 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile)
 // = CONVENIENCE FUNCTIONS FOR WRITING OUT GAME STATE INFORMATION
 // ==============================================================
 
-NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot* robot, Robot::Type type)
+NAS2D::Dictionary checkRobotDeployment(RobotTileTable& robotTileTable, Robot& robot, Robot::Type type)
 {
 	NAS2D::Dictionary dictionary{{
-		{"id", robot->id()},
+		{"id", robot.id()},
 		{"type", static_cast<int>(type)},
-		{"age", robot->fuelCellAge()},
-		{"production", robot->turnsToCompleteTask()},
+		{"age", robot.fuelCellAge()},
+		{"production", robot.turnsToCompleteTask()},
 	}};
 
-	const auto it = robotTileTable.find(robot);
+	const auto it = robotTileTable.find(&robot);
 	if (it != robotTileTable.end())
 	{
 		const auto& tile = *it->second;
@@ -593,20 +593,20 @@ void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTil
 
 	for (auto digger : robotPool.diggers())
 	{
-		auto dictionary = checkRobotDeployment(robotMap, digger, Robot::Type::Digger);
+		auto dictionary = checkRobotDeployment(robotMap, *digger, Robot::Type::Digger);
 		dictionary.set("direction", static_cast<int>(digger->direction()));
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	for (auto dozer : robotPool.dozers())
 	{
-		auto dictionary = checkRobotDeployment(robotMap, dozer, Robot::Type::Dozer);
+		auto dictionary = checkRobotDeployment(robotMap, *dozer, Robot::Type::Dozer);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 
 	for (auto miner : robotPool.miners())
 	{
-		auto dictionary = checkRobotDeployment(robotMap, miner, Robot::Type::Miner);
+		auto dictionary = checkRobotDeployment(robotMap, *miner, Robot::Type::Miner);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -57,7 +57,7 @@ int pullResource(int& resource, int amount);
 void resetTileIndexFromDozer(Robot* robot, Tile* tile);
 
 // Serialize / Deserialize
-void writeRobots(NAS2D::Xml::XmlElement* element, RobotPool& robotPool, RobotTileTable& robotMap);
+NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap);
 
 void updateRobotControl(RobotPool& robotPool);
 void deleteRobotsInRCC(Robot* robot, RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt, Tile* tile);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -95,7 +95,7 @@ void MapViewState::save(const std::string& filePath)
 	root->linkEndChild(serializeProperties());
 	mTileMap->serialize(root);
 	Utility<StructureManager>::get().serialize(root);
-	writeRobots(root, mRobotPool, mRobotList);
+	root->linkEndChild(writeRobots(mRobotPool, mRobotList));
 	root->linkEndChild(writeResources(mResourceBreakdownPanel.previousResources(), "prev_resources"));
 
 	root->linkEndChild(dictionaryToAttributes("turns", {{{"count", mTurnCount}}}));


### PR DESCRIPTION
Reference: #830

Refactor serialization code in MapViewStateHelper.cpp to make it less directly dependent on XML.

Includes a bit of code style changes regarding `using namespace` clauses, and low value comment removal.
