### PR TITLE
Remove mine vein id

### DIFF
--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -337,7 +337,8 @@ void Mine::deserialize(NAS2D::Xml::XmlElement* element)
 	this->active(active);
 	mProductionRate = static_cast<MineProductionRate>(yield);
 
-	mVeins.resize(static_cast<std::size_t>(depth));
+	mVeins.resize(0);
+	mVeins.reserve(static_cast<std::size_t>(depth));
 	for (auto* vein = element->firstChildElement(); vein != nullptr; vein = vein->nextSiblingElement())
 	{
 		const auto veinDictionary = NAS2D::attributesToDictionary(*vein);
@@ -347,8 +348,7 @@ void Mine::deserialize(NAS2D::Xml::XmlElement* element)
 		mineVein[OreType::ORE_COMMON_MINERALS] = veinDictionary.get<int>("common_minerals");
 		mineVein[OreType::ORE_RARE_METALS] = veinDictionary.get<int>("rare_metals");
 		mineVein[OreType::ORE_RARE_MINERALS] = veinDictionary.get<int>("rare_minerals");
-		const auto id = veinDictionary.get<int>("id");
 
-		mVeins[static_cast<std::size_t>(id)] = mineVein;
+		mVeins.push_back(mineVein);
 	}
 }

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -312,7 +312,6 @@ NAS2D::Xml::XmlElement* Mine::serialize(NAS2D::Point<int> location)
 		element->linkEndChild(NAS2D::dictionaryToAttributes(
 			"vein",
 			{{
-				{"id", static_cast<int>(i)},
 				{"common_metals", mineVein[OreType::ORE_COMMON_METALS]},
 				{"common_minerals", mineVein[OreType::ORE_COMMON_MINERALS]},
 				{"rare_metals", mineVein[OreType::ORE_RARE_METALS]},

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -305,10 +305,8 @@ NAS2D::Xml::XmlElement* Mine::serialize(NAS2D::Point<int> location)
 		}}
 	);
 
-	for (std::size_t i = 0; i < mVeins.size(); ++i)
+	for (const auto& mineVein : mVeins)
 	{
-		const MineVein& mineVein = mVeins[i];
-
 		element->linkEndChild(NAS2D::dictionaryToAttributes(
 			"vein",
 			{{


### PR DESCRIPTION
I noticed the mine vein serialization code stored an `"id"` value along with the data representing the index, which was used when loading to write the data back to the array in the same order. Though writing and reading of the array data already preserved order, so the id value was never really needed.

This removes the unnecessary `"id"` field.

Noticed this while working on #1013.
