### PR TITLE
Refactor Mine::pull

### DIFF
--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -262,18 +262,18 @@ void Mine::checkExhausted()
  */
 int Mine::pull(OreType type, int quantity)
 {
-	int pulled_count = 0;
+	int pullCount = 0;
 
 	for (auto& vein : mVeins)
 	{
-		const auto transferAmount = std::min(vein[type], quantity - pulled_count);
-		pulled_count += transferAmount;
+		const auto transferAmount = std::min(vein[type], quantity - pullCount);
+		pullCount += transferAmount;
 		vein[type] -= transferAmount;
 
-		if (pulled_count == quantity) { break; }
+		if (pullCount == quantity) { break; }
 	}
 
-	return pulled_count;
+	return pullCount;
 }
 
 

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 
+#include <algorithm>
 #include <array>
 #include <map>
 
@@ -261,22 +262,15 @@ void Mine::checkExhausted()
  */
 int Mine::pull(OreType type, int quantity)
 {
-	int pulled_count = 0, to_pull = quantity;
+	int pulled_count = 0;
 
 	for (auto& vein : mVeins)
 	{
-		if (vein[type] >= to_pull)
-		{
-			pulled_count = to_pull;
-			vein[type] -= to_pull;
-			break;
-		}
-		else if (vein[type] < to_pull)
-		{
-			pulled_count += vein[type];
-			to_pull = to_pull - vein[type];
-			vein[type] = 0;
-		}
+		const auto transferAmount = std::min(vein[type], quantity - pulled_count);
+		pulled_count += transferAmount;
+		vein[type] -= transferAmount;
+
+		if (pulled_count == quantity) { break; }
 	}
 
 	return pulled_count;

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -263,10 +263,8 @@ int Mine::pull(OreType type, int quantity)
 {
 	int pulled_count = 0, to_pull = quantity;
 
-	for (std::size_t i = 0; i < mVeins.size(); ++i)
+	for (auto& vein : mVeins)
 	{
-		MineVein& vein = mVeins[i];
-
 		if (vein[type] >= to_pull)
 		{
 			pulled_count = to_pull;


### PR DESCRIPTION
Refactor `Mine::pull`, using range-for, and shortening the code by using `std::min`.

Noticed this while working on #1014.
