### PR TITLE
Return XmlElement from StructureManager::serialize()

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -94,7 +94,7 @@ void MapViewState::save(const std::string& filePath)
 
 	root->linkEndChild(serializeProperties());
 	mTileMap->serialize(root);
-	Utility<StructureManager>::get().serialize(root);
+	root->linkEndChild(Utility<StructureManager>::get().serialize());
 	root->linkEndChild(writeRobots(mRobotPool, mRobotList));
 	root->linkEndChild(writeResources(mResourceBreakdownPanel.previousResources(), "prev_resources"));
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -515,7 +515,7 @@ Tile& StructureManager::tileFromStructure(Structure* structure)
 }
 
 
-void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
+NAS2D::Xml::XmlElement* StructureManager::serialize()
 {
 	auto* structures = new NAS2D::Xml::XmlElement("structures");
 
@@ -524,7 +524,7 @@ void StructureManager::serialize(NAS2D::Xml::XmlElement* element)
 		structures->linkEndChild(serializeStructure(structure, tile));
 	}
 
-	element->linkEndChild(structures);
+	return structures;
 }
 
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -126,7 +126,7 @@ public:
 
 	void update(const StorableResources&, PopulationPool&);
 
-	void serialize(NAS2D::Xml::XmlElement* element);
+	NAS2D::Xml::XmlElement* serialize();
 
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;


### PR DESCRIPTION
Reference: #830

Update `StructureManager::serialize()` to return the generated `XmlElement`. This makes the function more consistent with other functions.

----

Still one odd function out with the way `TileMap` is serialized, though perhaps that should be broken into parts.
