### PR TITLE
Fix crash on first turn when clicking the police overlay

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -115,6 +115,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
 {
+	resetPoliceOverlays();
 	ccLocation() = CcNotPlaced;
 	Utility<EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);
 }
@@ -129,6 +130,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mMapDisplay{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION)},
 	mHeightMap{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_TERRAIN_EXTENSION)}
 {
+	resetPoliceOverlays();
 	difficulty(selectedDifficulty);
 	ccLocation() = CcNotPlaced;
 	Utility<EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);
@@ -1444,11 +1446,7 @@ void MapViewState::checkCommRangeOverlay()
 
 void MapViewState::checkSurfacePoliceOverlay()
 {
-	mPoliceOverlays.clear();
-	for (int i = 0; i <= mTileMap->maxDepth(); ++i)
-	{
-		mPoliceOverlays.push_back(TileList());
-	}
+	resetPoliceOverlays();
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
@@ -1469,6 +1467,16 @@ void MapViewState::checkSurfacePoliceOverlay()
 		auto depth = structureManager.tileFromStructure(undergroundPoliceStation).depth();
 		auto& centerTile = structureManager.tileFromStructure(undergroundPoliceStation);
 		fillRangedAreaList(mPoliceOverlays[depth], centerTile, undergroundPoliceStation->getRange(), depth);
+	}
+}
+
+
+void MapViewState::resetPoliceOverlays()
+{
+	mPoliceOverlays.clear();
+	for (int i = 0; i <= mTileMap->maxDepth(); ++i)
+	{
+		mPoliceOverlays.push_back(TileList());
 	}
 }
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -155,6 +155,7 @@ private:
 
 	void checkCommRangeOverlay();
 	void checkSurfacePoliceOverlay();
+	void resetPoliceOverlays();
 	void fillRangedAreaList(TileList& tileList, Tile& centerTile, int range);
 	void fillRangedAreaList(TileList& tileList, Tile& centerTile, int range, int depth);
 	void checkConnectedness();


### PR DESCRIPTION
Caused by the police overlays container being empty on the first turn. It was only being initialized after the first turn. This issue likely affects loading a saved game as well until the first turn is taken.

Closes #1006