### PR TITLE
Fix copy/paste error

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -407,7 +407,7 @@ void MapViewState::readStructures(Xml::XmlElement* element)
 			auto extension = structureElement->firstChildElement("extension");
 			if (extension)
 			{
-				mineFacility.digTimeRemaining(attributesToDictionary(*trucks).get<int>("turns_remaining"));
+				mineFacility.digTimeRemaining(attributesToDictionary(*extension).get<int>("turns_remaining"));
 			}
 		}
 


### PR DESCRIPTION
Fixes what appears to be a copy/paste error in load code that references the wrong XML element.