### PR TITLE
Update NAS2D submodule for new Filesystem methods

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -130,7 +130,7 @@ void MapViewState::save(const std::string& filePath)
 	XmlMemoryBuffer buff;
 	doc.accept(&buff);
 
-	Utility<Filesystem>::get().write(File(buff.buffer(), filePath));
+	Utility<Filesystem>::get().write(filePath, buff.buffer());
 }
 
 

--- a/OPHD/XmlSerializer.cpp
+++ b/OPHD/XmlSerializer.cpp
@@ -8,7 +8,7 @@ using namespace NAS2D;
 Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
 {
 	Xml::XmlDocument xmlDocument;
-	xmlDocument.parse(Utility<Filesystem>::get().open(filename).raw_bytes());
+	xmlDocument.parse(Utility<Filesystem>::get().read(filename).c_str());
 
 	if (xmlDocument.error())
 	{


### PR DESCRIPTION
Update NAS2D submodule for new `Filesystem` methods `read` and `write`. These methods return or take a `std::string` for the data, rather than using a `File` object.

Reference: https://github.com/lairworks/nas2d-core/pull/904
