### PR TITLE
Add foley text when resources or food are stolen

### DIFF
--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -50,7 +50,7 @@ void CrimeExecution::stealFood(FoodProduction& structure)
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
 		
 		mNotificationArea.push("Food Stolen",
-			NAS2D::stringFrom(foodStolen) + " units of food was pilfered from a " + structure.name() + ".",
+			NAS2D::stringFrom(foodStolen) + " units of food was pilfered from a " + structure.name() + ". " + getReasonForStealing() + ".",
 			structureTile.position(),
 			NotificationArea::NotificationType::Warning);
 	}
@@ -91,7 +91,7 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
 
 	mNotificationArea.push("Resources Stolen",
-		NAS2D::stringFrom(amountStolen) + " units of " + resourceNames[indexToStealFrom] + " were stolen from a " + structure.name() + ".",
+		NAS2D::stringFrom(amountStolen) + " units of " + resourceNames[indexToStealFrom] + " were stolen from a " + structure.name() + ". " + getReasonForStealing() + ".",
 		structureTile.position(),
 		NotificationArea::NotificationType::Warning);
 }
@@ -101,4 +101,9 @@ int CrimeExecution::calcAmountForStealing(int unadjustedMin, int unadjustedMax)
 	auto amountToSteal = randomNumber.generate(unadjustedMin, unadjustedMax);
 	
 	return static_cast<int>(stealingMultipliers.at(mDifficulty) * amountToSteal);
+}
+
+std::string CrimeExecution::getReasonForStealing()
+{
+	return stealingResoureReasons[randomNumber.generate<std::size_t>(0, stealingResoureReasons.size() - 1)];
 }

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <array>
 #include <map>
+#include <string>
 
 
 class CrimeExecution 
@@ -30,9 +31,20 @@ private:
 		{Difficulty::Hard, 1.5f}
 	};
 
+	const static inline std::vector<std::string> stealingResoureReasons
+	{
+		"There are no identified suspects",
+		"An investigation has been opened",
+		"A local crime syndicate is under investigation",
+		"A suspect was aprehended but the goods remain unaccounted for",
+		"A separatist political movement has claimed responsibility",
+		"The rebel faction is suspected in preparation for a splinter colony"
+	};
+
 	Difficulty mDifficulty{ Difficulty::Medium };
 	NotificationArea& mNotificationArea;
 
 	void stealResources(Structure& structure, const std::array<std::string, 4>& resourceNames);
 	int calcAmountForStealing(int unadjustedMin, int unadjustedMax);
+	std::string getReasonForStealing();
 };


### PR DESCRIPTION
I would like to look at preventing the foley text about rebel and separatist factions only appear if morale is low enough in the near future.

<img width="285" alt="Stealing1" src="https://user-images.githubusercontent.com/15183337/124679638-cbc1cf80-de92-11eb-8f4a-60b98ea6acfb.png">

<img width="278" alt="Stealing2" src="https://user-images.githubusercontent.com/15183337/124679640-ccf2fc80-de92-11eb-90e6-1ec3a2ec09d6.png">

Related to #911 