### PR TITLE
Remove PopulationPanel from CrimeRateUpdate module

### DIFF
--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -4,19 +4,19 @@
 #include "../Common.h"
 #include <vector>
 #include <map>
+#include <string>
+#include <utility>
 
-class PopulationPanel;
 class Structure;
 
 
 class CrimeRateUpdate
 {
 public:
-	CrimeRateUpdate(PopulationPanel& populationPanel);
-
 	void update(const std::vector<TileList>& policeOverlays);
 
-	int moraleChange() const { return mMoraleChange; }
+	int meanCrimeRate() const { return mMeanCrimeRate; }
+	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
 	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
 	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
@@ -31,11 +31,11 @@ private:
 	};
 
 	Difficulty mDifficulty{ Difficulty::Medium };
-	PopulationPanel& mPopulationPanel;
-	int mMoraleChange{ 0 };
+	int mMeanCrimeRate{ 0 };
+	std::vector<std::pair<std::string, int>> mMoraleChanges;
 	std::vector<Structure*> mStructuresCommittingCrimes;
 
 	bool isProtectedByPolice(const std::vector<TileList>& policeOverlays, Structure* structure);
-	int calculateMoraleChange(int meanCrimeRate);
-	void updateCrimeOnPopulationPanel(int moraleChange, int meanCrimeRate);
+	int calculateMoraleChange();
+	void updateMoraleChanges();
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -110,7 +110,6 @@ static void pushAgingRobotMessage(const Robot* robot, const Point<int> position,
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
 	mMainReportsState(mainReportsState),
-	mCrimeRateUpdate(mPopulationPanel),
 	mCrimeExecution(mNotificationArea),
 	mLoadingExisting(true),
 	mExistingToLoad(savegame)
@@ -123,7 +122,6 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) :
 	mMainReportsState(mainReportsState),
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
-	mCrimeRateUpdate(mPopulationPanel),
 	mCrimeExecution(mNotificationArea),
 	mPlanetAttributes(planetAttributes),
 	mMapDisplay{std::make_unique<Image>(planetAttributes.mapImagePath + MAP_DISPLAY_EXTENSION)},

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -215,6 +215,14 @@ void MapViewState::updateMorale()
 	mPopulationPanel.addMoraleReason(moraleString(Morale::BiowasteOverflow), bioWasteAccumulation * -2);
 	mPopulationPanel.addMoraleReason(moraleString(Morale::StructuresDisabled), -structuresDisabled);
 	mPopulationPanel.addMoraleReason(moraleString(Morale::StructuresDestroyed), -structuresDestroyed);
+	
+	for (const auto& moraleReason : mCrimeRateUpdate.moraleChanges())
+	{
+		mPopulationPanel.addMoraleReason(moraleReason.first, moraleReason.second);
+		mCurrentMorale += moraleReason.second;
+	}
+
+	mPopulationPanel.crimeRate(mCrimeRateUpdate.meanCrimeRate());
 
 	// Push notifications
 	if (birthCount)
@@ -601,7 +609,6 @@ void MapViewState::nextTurn()
 	transferFoodToCommandCenter();
 
 	mCrimeRateUpdate.update(mPoliceOverlays);
-	mCurrentMorale += mCrimeRateUpdate.moraleChange();
 	auto structuresCommittingCrimes = mCrimeRateUpdate.structuresCommittingCrimes();
 	mCrimeExecution.executeCrimes(structuresCommittingCrimes);
 


### PR DESCRIPTION
Morale changes listed in the population panel were clearing changes from `CrimeRateUpdate`. By pulling the logic out of `CrimeRateUpdate`, I was able to update the `PopulationPanel` in the same portion of `MapViewState` where all other morale changes occur to eliminate the bug.