### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,82 @@
+Language: Cpp
+AccessModifierOffset: -4
+AlignTrailingComments: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
+
+AllowShortLambdasOnASingleLine: All
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: false
+#BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom #Allman, but not quite
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: false
+
+BreakBeforeBinaryOperators: NonAssignment
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+FixNamespaceComments: false
+IncludeBlocks: Preserve
+IncludeCategories:
+# Prefer project-specific includes first
+#i.e. Prefer "my" includes before other libraries
+#First local multi-folder (usually not in the same directory) includes
+# e.g. #include "NAS2D/Renderer/Renderer.h"
+    - Regex: '\"([[:alnum:]_]+\/)+[[:alnum:]_]+\.(h|c)(pp)?\"'
+    - Priority: 4
+#Then local project-specific includes
+# e.g. #include "Mixer.h" in MixerSDL.h file
+    - Regex: '\"[[:alnum:]_]+\.(h|c)(pp)?\"'
+    - Priority: 3
+#Followed by global STL and Library headers
+# e.g. #include <iostream>
+    - Regex: '\<[[:alnum:]_]+\>'
+    - Priority: 2
+#Lastly, global linked libraries and C and OS-specific headers.
+# e.g. #include <windows.h>
+    - Regex: '\<[[:alnum:]_]+\.h(pp)?\>'
+    - Priority: 1
+
+IndentCaseLabels: false
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Always

--- a/makefile
+++ b/makefile
@@ -112,5 +112,5 @@ cppclean:
 
 .PHONY: format
 format:
-	clang-format --version
+	@clang-format --version
 	find OPHD/ \( -name '*.cpp' -o -name '*.h' \) \! -name 'resource.h' -o -path 'OPHD/MicroPather' -prune -type f | xargs clang-format -i

--- a/makefile
+++ b/makefile
@@ -109,3 +109,8 @@ cppcheck:
 .PHONY: cppclean
 cppclean:
 	cppclean --quiet --include-path "$(NAS2DINCLUDEDIR)" --include-path "/usr/include/SDL2" --exclude "MicroPather" "$(SRCDIR)"
+
+.PHONY: format
+format:
+	clang-format --version
+	find OPHD/ \( -name '*.cpp' -o -name '*.h' \) \! -name 'resource.h' -o -path 'OPHD/MicroPather' -prune -type f | xargs clang-format -i


### PR DESCRIPTION
Add `.clang-format`, copied from NAS2D.

Reference: https://github.com/lairworks/nas2d-core/issues/893

Having this helps migrate the code base over to a certain style. Though I'm uncertain if this should be merged before the code matches that style. I'm not certain how Visual Studio may interpret and use the file, which may be a pain if it automatically applies sweeping changes to the code.
