### PR TITLE
Ref syntax map view state helper

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -800,7 +800,7 @@ void MapViewState::placeTubes()
 	 */
 	auto cd = static_cast<ConnectorDir>(mConnections.selectionIndex() + 1);
 
-	if (validTubeConnection(mTileMap, mTileMapMouseHover, cd))
+	if (validTubeConnection(*mTileMap, mTileMapMouseHover, cd))
 	{
 		insertTube(cd, mTileMap->currentDepth(), &mTileMap->getTile(mTileMapMouseHover));
 
@@ -829,7 +829,7 @@ void MapViewState::placeTubeStart()
 	 */
 	ConnectorDir cd = static_cast<ConnectorDir>(mConnections.selectionIndex() + 1);
 
-	if (!validTubeConnection(mTileMap, mTileMapMouseHover, cd))
+	if (!validTubeConnection(*mTileMap, mTileMapMouseHover, cd))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertTubeInvalidLocation);
 		return;
@@ -887,7 +887,7 @@ void MapViewState::placeTubeEnd()
 			endReach = true;
 		}else if (tile->thing() || tile->mine() || !tile->bulldozed() || !tile->excavated()){
 			endReach = true;
-		}else if (!validTubeConnection(mTileMap, position, cd)){
+		}else if (!validTubeConnection(*mTileMap, position, cd)){
 			endReach = true;
 		}else{
 			insertTube(cd, mTileMap->currentDepth(), &mTileMap->getTile(position));

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1292,7 +1292,7 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 	if (NAS2D::Rectangle<int>::Create({4, 4}, NAS2D::Point{-4, -4} + mTileMap->size()).contains(point))
 	{
 		// check for obstructions
-		if (!landingSiteSuitable(mTileMap, point))
+		if (!landingSiteSuitable(*mTileMap, point))
 		{
 			return;
 		}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1244,7 +1244,7 @@ void MapViewState::placeStructure()
 	}
 	else
 	{
-		if (!validStructurePlacement(mTileMap, mTileMapMouseHover) && !selfSustained(mCurrentStructure))
+		if (!validStructurePlacement(*mTileMap, mTileMapMouseHover) && !selfSustained(mCurrentStructure))
 		{
 			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureNoTube);
 			return;

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -89,15 +89,13 @@ bool checkStructurePlacement(Tile& tile, Direction dir)
 
 /**
  * Checks to see if a tile is a valid tile to place a tube onto.
- * 
- * \warning		Assumes \c tilemap is never nullptr.
  */
-bool validTubeConnection(TileMap* tilemap, NAS2D::Point<int> point, ConnectorDir dir)
+bool validTubeConnection(TileMap& tilemap, NAS2D::Point<int> point, ConnectorDir dir)
 {
-	return checkTubeConnection(tilemap->getTile({point + DirectionEast, tilemap->currentDepth()}), Direction::East, dir) ||
-		checkTubeConnection(tilemap->getTile({point + DirectionWest, tilemap->currentDepth()}), Direction::West, dir) ||
-		checkTubeConnection(tilemap->getTile({point + DirectionSouth, tilemap->currentDepth()}), Direction::South, dir) ||
-		checkTubeConnection(tilemap->getTile({point + DirectionNorth, tilemap->currentDepth()}), Direction::North, dir);
+	return checkTubeConnection(tilemap.getTile({point + DirectionEast, tilemap.currentDepth()}), Direction::East, dir) ||
+		checkTubeConnection(tilemap.getTile({point + DirectionWest, tilemap.currentDepth()}), Direction::West, dir) ||
+		checkTubeConnection(tilemap.getTile({point + DirectionSouth, tilemap.currentDepth()}), Direction::South, dir) ||
+		checkTubeConnection(tilemap.getTile({point + DirectionNorth, tilemap.currentDepth()}), Direction::North, dir);
 }
 
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -147,11 +147,11 @@ bool validLanderSite(Tile& tile)
  * \note	This function will trigger modal dialog boxes to alert
  *			the user as to why the landing site isn't suitable.
  */
-bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position)
+bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position)
 {
 	for (const auto& offset : DirectionScan3x3)
 	{
-		auto& tile = tilemap->getTile(position + offset);
+		auto& tile = tilemap.getTile(position + offset);
 
 		if (tile.index() == TerrainType::Impassable)
 		{

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -101,15 +101,13 @@ bool validTubeConnection(TileMap& tilemap, NAS2D::Point<int> point, ConnectorDir
 
 /**
  * Checks a tile to see if a valid Tube connection is available for Structure placement.
- *
- * \warning		Assumes \c tilemap is never nullptr.
  */
-bool validStructurePlacement(TileMap* tilemap, NAS2D::Point<int> point)
+bool validStructurePlacement(TileMap& tilemap, NAS2D::Point<int> point)
 {
-	return checkStructurePlacement(tilemap->getTile({point + DirectionNorth, tilemap->currentDepth()}), Direction::North) ||
-		checkStructurePlacement(tilemap->getTile({point + DirectionEast, tilemap->currentDepth()}), Direction::East) ||
-		checkStructurePlacement(tilemap->getTile({point + DirectionSouth, tilemap->currentDepth()}), Direction::South) ||
-		checkStructurePlacement(tilemap->getTile({point + DirectionWest, tilemap->currentDepth()}), Direction::West);
+	return checkStructurePlacement(tilemap.getTile({point + DirectionNorth, tilemap.currentDepth()}), Direction::North) ||
+		checkStructurePlacement(tilemap.getTile({point + DirectionEast, tilemap.currentDepth()}), Direction::East) ||
+		checkStructurePlacement(tilemap.getTile({point + DirectionSouth, tilemap.currentDepth()}), Direction::South) ||
+		checkStructurePlacement(tilemap.getTile({point + DirectionWest, tilemap.currentDepth()}), Direction::West);
 }
 
 

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -35,7 +35,7 @@ NAS2D::Point<int>& ccLocation();
 
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile& tile, Direction dir);
-bool validTubeConnection(TileMap* tilemap, NAS2D::Point<int> point, ConnectorDir dir);
+bool validTubeConnection(TileMap& tilemap, NAS2D::Point<int> point, ConnectorDir dir);
 bool validStructurePlacement(TileMap* tilemap, NAS2D::Point<int> point);
 bool validLanderSite(Tile& t);
 bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position);

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -38,7 +38,7 @@ bool checkStructurePlacement(Tile& tile, Direction dir);
 bool validTubeConnection(TileMap& tilemap, NAS2D::Point<int> point, ConnectorDir dir);
 bool validStructurePlacement(TileMap& tilemap, NAS2D::Point<int> point);
 bool validLanderSite(Tile& t);
-bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position);
+bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position);
 bool structureIsLander(StructureID id);
 bool inCommRange(NAS2D::Point<int> position);
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -36,7 +36,7 @@ NAS2D::Point<int>& ccLocation();
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile& tile, Direction dir);
 bool validTubeConnection(TileMap& tilemap, NAS2D::Point<int> point, ConnectorDir dir);
-bool validStructurePlacement(TileMap* tilemap, NAS2D::Point<int> point);
+bool validStructurePlacement(TileMap& tilemap, NAS2D::Point<int> point);
 bool validLanderSite(Tile& t);
 bool landingSiteSuitable(TileMap* tilemap, NAS2D::Point<int> position);
 bool structureIsLander(StructureID id);


### PR DESCRIPTION
Use reference syntax for MapViewStateHelper methods.

Related: #1070
