### PR TITLE
Refactor PopulationTable

### DIFF
--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -37,7 +37,7 @@ namespace
  */
 void Population::clear()
 {
-	mPopulation.clear();
+	mPopulation = {};
 }
 
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -42,12 +42,6 @@ PopulationTable& PopulationTable::operator+=(const PopulationTable& other)
 }
 
 
-void PopulationTable::clear()
-{
-	table.fill(0);
-}
-
-
 /**
  * Gets the size of the entire population.
  */

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -22,13 +22,13 @@ int PopulationTable::operator[](std::size_t index) const
 
 int& PopulationTable::operator[](Role role)
 {
-	return table[static_cast<std::size_t>(role)];
+	return operator[](static_cast<std::size_t>(role));
 }
 
 
 int PopulationTable::operator[](Role role) const
 {
-	return table[static_cast<std::size_t>(role)];
+	return operator[](static_cast<std::size_t>(role));
 }
 
 
@@ -56,7 +56,7 @@ int PopulationTable::size() const
  */
 int PopulationTable::size(Role personRole) const
 {
-	return table[static_cast<std::size_t>(personRole)];
+	return operator[](static_cast<std::size_t>(personRole));
 }
 
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -1,22 +1,47 @@
 #include "PopulationTable.h"
+
 #include <numeric>
-
-
-PopulationTable::PopulationTable(std::array<int, 5> values) :
-	table(values)
-{
-}
+#include <stdexcept>
+#include <string>
 
 
 int& PopulationTable::operator[](std::size_t index)
 {
-	return table[index];
+	switch (index)
+	{
+		case 0:
+			return child;
+		case 1:
+			return student;
+		case 2:
+			return worker;
+		case 3:
+			return scientist;
+		case 4:
+			return retiree;
+		default:
+			throw std::runtime_error("Invalid index to PopulationTable::operator[]: " + std::to_string(index));
+	}
 }
 
 
 int PopulationTable::operator[](std::size_t index) const
 {
-	return table[index];
+	switch (index)
+	{
+		case 0:
+			return child;
+		case 1:
+			return student;
+		case 2:
+			return worker;
+		case 3:
+			return scientist;
+		case 4:
+			return retiree;
+		default:
+			throw std::runtime_error("Invalid index to PopulationTable::operator[]: " + std::to_string(index));
+	}
 }
 
 
@@ -34,10 +59,12 @@ int PopulationTable::operator[](Role role) const
 
 PopulationTable& PopulationTable::operator+=(const PopulationTable& other)
 {
-	for (std::size_t i = 0; i < table.size(); ++i)
-	{
-		table[i] += other.table[i];
-	}
+	child += other.child;
+	student += other.student;
+	worker += other.worker;
+	scientist += other.scientist;
+	retiree += other.retiree;
+
 	return *this;
 }
 
@@ -47,7 +74,7 @@ PopulationTable& PopulationTable::operator+=(const PopulationTable& other)
  */
 int PopulationTable::size() const
 {
-	return std::accumulate(table.begin(), table.end(), 0);
+	return child + student + worker + scientist + retiree;
 }
 
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -28,7 +28,7 @@ int& PopulationTable::operator[](Role role)
 
 int PopulationTable::operator[](Role role) const
 {
-	return table[static_cast<int>(role)];
+	return table[static_cast<std::size_t>(role)];
 }
 
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -78,15 +78,6 @@ int PopulationTable::size() const
 }
 
 
-/**
- * Gets the size of a specific segment of the population.
- */
-int PopulationTable::size(Role personRole) const
-{
-	return operator[](static_cast<std::size_t>(personRole));
-}
-
-
 int PopulationTable::adults() const
 {
 	return size() - child;

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -89,5 +89,5 @@ int PopulationTable::size(Role personRole) const
 
 int PopulationTable::adults() const
 {
-	return size() - size(PopulationTable::Role::Child);
+	return size() - child;
 }

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -29,6 +29,5 @@ struct PopulationTable
 	PopulationTable& operator+=(const PopulationTable& other);
 
 	int size() const;
-	int size(Role role) const;
 	int adults() const;
 };

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -25,8 +25,6 @@ public:
 
 	PopulationTable& operator+=(const PopulationTable& other);
 
-	void clear();
-
 	int size() const;
 	int size(Role role) const;
 	int adults() const;

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -4,7 +4,13 @@
 
 struct PopulationTable
 {
-public:
+	int child;
+	int student;
+	int worker;
+	int scientist;
+	int retiree;
+
+
 	enum class Role
 	{
 		Child,
@@ -13,9 +19,6 @@ public:
 		Scientist,
 		Retired
 	};
-
-	PopulationTable() = default;
-	PopulationTable(std::array<int, 5> values);
 
 	int& operator[](std::size_t);
 	int operator[](std::size_t) const;
@@ -28,7 +31,4 @@ public:
 	int size() const;
 	int size(Role role) const;
 	int adults() const;
-
-private:
-	std::array<int, 5> table;
 };

--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -18,13 +18,13 @@ void PopulationPool::population(Population* pop)
 
 int PopulationPool::availableWorkers()
 {
-	return mPopulation->getPopulations().size(PopulationTable::Role::Worker) - workersEmployed();
+	return mPopulation->getPopulations().worker - workersEmployed();
 }
 
 
 int PopulationPool::availableScientists()
 {
-	return mPopulation->getPopulations().size(PopulationTable::Role::Scientist) - scientistsEmployed();
+	return mPopulation->getPopulations().scientist - scientistsEmployed();
 }
 
 
@@ -33,8 +33,8 @@ bool PopulationPool::usePopulation(PopulationRequirements populationRequirements
 	const auto [workersRequired, scientistsRequired] = populationRequirements;
 
 	const auto population = mPopulation->getPopulations();
-	const auto scientistsAvailable = population.size(PopulationTable::Role::Scientist) - (mScientistsAsWorkers + mScientistsUsed);
-	const auto workersAvailable = population.size(PopulationTable::Role::Worker) - mWorkersUsed;
+	const auto scientistsAvailable = population.scientist - (mScientistsAsWorkers + mScientistsUsed);
+	const auto workersAvailable = population.worker - mWorkersUsed;
 
 	if ((scientistsRequired > scientistsAvailable) || (workersRequired > workersAvailable + (scientistsAvailable - scientistsRequired)))
 	{

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -100,7 +100,7 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
  */
 void MapViewState::onDeployColonistLander()
 {
-	mPopulation.addPopulation(PopulationTable{{0, 10, 20, 20, 0}});
+	mPopulation.addPopulation(PopulationTable{0, 10, 20, 20, 0});
 }
 
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -100,7 +100,7 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
  */
 void MapViewState::onDeployColonistLander()
 {
-	mPopulation.addPopulation(PopulationTable{0, 10, 20, 20, 0});
+	mPopulation.addPopulation({0, 10, 20, 20, 0});
 }
 
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -554,7 +554,7 @@ void MapViewState::readPopulation(Xml::XmlElement* element)
 		mPopulationPanel.old_morale(mPreviousMorale);
 		mPopulationPanel.crimeRate(meanCrimeRate);
 
-		mPopulation.addPopulation(PopulationTable{{children, students, workers, scientists, retired}});
+		mPopulation.addPopulation(PopulationTable{children, students, workers, scientists, retired});
 	}
 }
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -554,7 +554,7 @@ void MapViewState::readPopulation(Xml::XmlElement* element)
 		mPopulationPanel.old_morale(mPreviousMorale);
 		mPopulationPanel.crimeRate(meanCrimeRate);
 
-		mPopulation.addPopulation(PopulationTable{children, students, workers, scientists, retired});
+		mPopulation.addPopulation({children, students, workers, scientists, retired});
 	}
 }
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -108,11 +108,11 @@ void MapViewState::save(const std::string& filePath)
 			{"prev_morale", mPreviousMorale},
 			{"colonist_landers", mLandersColonist},
 			{"cargo_landers", mLandersCargo},
-			{"children", population.size(PopulationTable::Role::Child)},
-			{"students", population.size(PopulationTable::Role::Student)},
-			{"workers", population.size(PopulationTable::Role::Worker)},
-			{"scientists", population.size(PopulationTable::Role::Scientist)},
-			{"retired", population.size(PopulationTable::Role::Retired)},
+			{"children", population.child},
+			{"students", population.student},
+			{"workers", population.worker},
+			{"scientists", population.scientist},
+			{"retired", population.retiree},
 			{"mean_crime", mPopulationPanel.crimeRate()},
 		}}
 	));

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -102,11 +102,11 @@ void PopulationPanel::update()
 	const auto population = mPopulation->getPopulations();
 	const std::array populationData
 	{
-		std::tuple{NAS2D::Rectangle{0, 96, IconSize, IconSize}, population.size(PopulationTable::Role::Child), std::string("Children")},
-		std::tuple{NAS2D::Rectangle{32, 96, IconSize, IconSize}, population.size(PopulationTable::Role::Student), std::string("Students")},
-		std::tuple{NAS2D::Rectangle{64, 96, IconSize, IconSize}, population.size(PopulationTable::Role::Worker), std::string("Workers")},
-		std::tuple{NAS2D::Rectangle{96, 96, IconSize, IconSize}, population.size(PopulationTable::Role::Scientist), std::string("Scientists")},
-		std::tuple{NAS2D::Rectangle{128, 96, IconSize, IconSize}, population.size(PopulationTable::Role::Retired), std::string("Retired")},
+		std::tuple{NAS2D::Rectangle{0, 96, IconSize, IconSize}, population.child, std::string("Children")},
+		std::tuple{NAS2D::Rectangle{32, 96, IconSize, IconSize}, population.student, std::string("Students")},
+		std::tuple{NAS2D::Rectangle{64, 96, IconSize, IconSize}, population.worker, std::string("Workers")},
+		std::tuple{NAS2D::Rectangle{96, 96, IconSize, IconSize}, population.scientist, std::string("Scientists")},
+		std::tuple{NAS2D::Rectangle{128, 96, IconSize, IconSize}, population.retiree, std::string("Retired")},
 	};
 
 	position.y += fontBoldHeight + constants::Margin;


### PR DESCRIPTION
Reference: #1020, PR #1075, PR #1076

Change `PopulationTable` struct to have named public member fields, rather than a private `std::array`. Update much of the code using this struct to use direct field access rather than using the `Role` enum.
