### PR TITLE
Fix ReportsView state crash bug

### DIFF
--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -168,9 +168,12 @@ void GameState::onShowReports()
  */
 void GameState::onHideReports()
 {
-	mActiveState->deactivate();
-	mActiveState = mMapView.get();
-	mActiveState->activate();
+	if (mMapView)
+	{
+		mActiveState->deactivate();
+		mActiveState = mMapView.get();
+		mActiveState->activate();
+	}
 }
 
 

--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -151,9 +151,12 @@ void GameState::onQuit()
  */
 void GameState::onShowReports()
 {
-	mActiveState->deactivate();
-	mActiveState = mMainReportsState.get();
-	mActiveState->activate();
+	if (mMainReportsState)
+	{
+		mActiveState->deactivate();
+		mActiveState = mMainReportsState.get();
+		mActiveState->activate();
+	}
 }
 
 


### PR DESCRIPTION
Closes #996

Fix crash bug when trying to switch to the ReportsView too quickly after loading a saved game. State switching is now guarded by ensuring the destination state is not null.
