### PR TITLE
Add ButtonSkin constructor parameter

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -66,6 +66,13 @@ Button::Button(std::string newText, ClickSignal::DelegateType clickHandler) : Bu
 }
 
 
+Button::Button(const ButtonSkin& buttonSkin, ClickSignal::DelegateType clickHandler) :
+	mButtonSkin{buttonSkin}
+{
+	mSignal.connect(clickHandler);
+}
+
+
 Button::~Button()
 {
 	auto& eventHandler = Utility<EventHandler>::get();

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -13,38 +13,40 @@ using namespace NAS2D;
 
 
 Button::Button(std::string newText) :
-	mSkinNormal{
-		imageCache.load("ui/skin/button_top_left.png"),
-		imageCache.load("ui/skin/button_top_middle.png"),
-		imageCache.load("ui/skin/button_top_right.png"),
-		imageCache.load("ui/skin/button_middle_left.png"),
-		imageCache.load("ui/skin/button_middle_middle.png"),
-		imageCache.load("ui/skin/button_middle_right.png"),
-		imageCache.load("ui/skin/button_bottom_left.png"),
-		imageCache.load("ui/skin/button_bottom_middle.png"),
-		imageCache.load("ui/skin/button_bottom_right.png")
-	},
-	mSkinHover{
-		imageCache.load("ui/skin/button_hover_top_left.png"),
-		imageCache.load("ui/skin/button_hover_top_middle.png"),
-		imageCache.load("ui/skin/button_hover_top_right.png"),
-		imageCache.load("ui/skin/button_hover_middle_left.png"),
-		imageCache.load("ui/skin/button_hover_middle_middle.png"),
-		imageCache.load("ui/skin/button_hover_middle_right.png"),
-		imageCache.load("ui/skin/button_hover_bottom_left.png"),
-		imageCache.load("ui/skin/button_hover_bottom_middle.png"),
-		imageCache.load("ui/skin/button_hover_bottom_right.png")
-	},
-	mSkinPressed{
-		imageCache.load("ui/skin/button_pressed_top_left.png"),
-		imageCache.load("ui/skin/button_pressed_top_middle.png"),
-		imageCache.load("ui/skin/button_pressed_top_right.png"),
-		imageCache.load("ui/skin/button_pressed_middle_left.png"),
-		imageCache.load("ui/skin/button_pressed_middle_middle.png"),
-		imageCache.load("ui/skin/button_pressed_middle_right.png"),
-		imageCache.load("ui/skin/button_pressed_bottom_left.png"),
-		imageCache.load("ui/skin/button_pressed_bottom_middle.png"),
-		imageCache.load("ui/skin/button_pressed_bottom_right.png")
+	mButtonSkin{
+		{
+			imageCache.load("ui/skin/button_top_left.png"),
+			imageCache.load("ui/skin/button_top_middle.png"),
+			imageCache.load("ui/skin/button_top_right.png"),
+			imageCache.load("ui/skin/button_middle_left.png"),
+			imageCache.load("ui/skin/button_middle_middle.png"),
+			imageCache.load("ui/skin/button_middle_right.png"),
+			imageCache.load("ui/skin/button_bottom_left.png"),
+			imageCache.load("ui/skin/button_bottom_middle.png"),
+			imageCache.load("ui/skin/button_bottom_right.png")
+		},
+		{
+			imageCache.load("ui/skin/button_hover_top_left.png"),
+			imageCache.load("ui/skin/button_hover_top_middle.png"),
+			imageCache.load("ui/skin/button_hover_top_right.png"),
+			imageCache.load("ui/skin/button_hover_middle_left.png"),
+			imageCache.load("ui/skin/button_hover_middle_middle.png"),
+			imageCache.load("ui/skin/button_hover_middle_right.png"),
+			imageCache.load("ui/skin/button_hover_bottom_left.png"),
+			imageCache.load("ui/skin/button_hover_bottom_middle.png"),
+			imageCache.load("ui/skin/button_hover_bottom_right.png")
+		},
+		{
+			imageCache.load("ui/skin/button_pressed_top_left.png"),
+			imageCache.load("ui/skin/button_pressed_top_middle.png"),
+			imageCache.load("ui/skin/button_pressed_top_right.png"),
+			imageCache.load("ui/skin/button_pressed_middle_left.png"),
+			imageCache.load("ui/skin/button_pressed_middle_middle.png"),
+			imageCache.load("ui/skin/button_pressed_middle_right.png"),
+			imageCache.load("ui/skin/button_pressed_bottom_left.png"),
+			imageCache.load("ui/skin/button_pressed_bottom_middle.png"),
+			imageCache.load("ui/skin/button_pressed_bottom_right.png")
+		}
 	}
 {
 	text(newText);
@@ -171,8 +173,8 @@ void Button::draw()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	const auto& skin = (mState == State::Pressed) ? mSkinPressed :
-		(enabled() && mMouseHover) ? mSkinHover : mSkinNormal;
+	const auto& skin = (mState == State::Pressed) ? mButtonSkin.pressed :
+		(enabled() && mMouseHover) ? mButtonSkin.hover : mButtonSkin.normal;
 	skin.draw(renderer, mRect);
 
 	if (mImage)

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -31,6 +31,7 @@ public:
 
 	Button(std::string newText = "");
 	Button(std::string newText, ClickSignal::DelegateType clickHandler);
+	Button(const ButtonSkin& buttonSkin, ClickSignal::DelegateType clickHandler);
 	~Button() override;
 
 	void type(Type type);

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -65,10 +65,8 @@ private:
 	State mState = State::Normal; /**< Current state of the Button. */
 	Type mType = Type::BUTTON_NORMAL; /**< Modifies Button behavior. */
 
-	const NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
-
 	ButtonSkin mButtonSkin;
-
+	const NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
 	const NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 
 	ClickSignal mSignal; /**< Object to notify when the Button is activated. */

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -65,7 +65,7 @@ private:
 	State mState = State::Normal; /**< Current state of the Button. */
 	Type mType = Type::BUTTON_NORMAL; /**< Modifies Button behavior. */
 
-	ButtonSkin mButtonSkin;
+	const ButtonSkin mButtonSkin;
 	const NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
 	const NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -20,6 +20,13 @@ public:
 		BUTTON_TOGGLE
 	};
 
+	struct ButtonSkin
+	{
+		NAS2D::RectangleSkin normal;
+		NAS2D::RectangleSkin hover;
+		NAS2D::RectangleSkin pressed;
+	};
+
 	using ClickSignal = NAS2D::Signal<>;
 
 	Button(std::string newText = "");
@@ -59,9 +66,7 @@ private:
 
 	const NAS2D::Image* mImage = nullptr; /**< Image to draw centered on the Button. */
 
-	NAS2D::RectangleSkin mSkinNormal;
-	NAS2D::RectangleSkin mSkinHover;
-	NAS2D::RectangleSkin mSkinPressed;
+	ButtonSkin mButtonSkin;
 
 	const NAS2D::Font* mFont = nullptr; /**< Buttons can have different font sizes. */
 


### PR DESCRIPTION
Collect `Button` skin parameters into a single data type `ButtonSkin`. Expose these settings through an extra constructor overload on the `Button` class.

Related: #893
Being able to set `Button` skins will allow `Button` objects to be used in a `ScrollBar` class. The current `Slider` class basically re-implements buttons for the up/down buttons, and then applies a custom skin. By exposing the skinning ability, we can re-use existing code here. We will also get more consistent behaviour, as currently the re-implemented buttons don't support hover or pressed graphics.
