### PR TITLE
Add check to pushThing to ensure we detect a double add

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -100,6 +100,10 @@ void Tile::pushThing(Thing* thing)
 {
 	if (mThing)
 	{
+		if (mThing == thing)
+		{
+			throw std::runtime_error("Attempting to pushThing on a tile where it's already set");
+		}
 		deleteThing();
 	}
 


### PR DESCRIPTION
Reference: #905

In the event of a double add, the code would previously delete the current `thing`, and the re-set the `mThing` pointer back to the object that was just deleted. That could potentially lead to use after free, and double free errors.
