### PR TITLE
Re-order resource display: common metal/mineral, rare metal/mineral

### DIFF
--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -157,8 +157,8 @@ void MapViewState::drawResourceInfo()
 	const std::array resources
 	{
 		std::tuple{NAS2D::Rectangle{64, 16, iconSize, iconSize}, mResourcesCount.resources[0], offsetX},
-		std::tuple{NAS2D::Rectangle{80, 16, iconSize, iconSize}, mResourcesCount.resources[2], x + offsetX},
 		std::tuple{NAS2D::Rectangle{96, 16, iconSize, iconSize}, mResourcesCount.resources[1], x + offsetX},
+		std::tuple{NAS2D::Rectangle{80, 16, iconSize, iconSize}, mResourcesCount.resources[2], x + offsetX},
 		std::tuple{NAS2D::Rectangle{112, 16, iconSize, iconSize}, mResourcesCount.resources[3], 0},
 	};
 

--- a/OPHD/Things/Structures/OreRefining.h
+++ b/OPHD/Things/Structures/OreRefining.h
@@ -30,8 +30,8 @@ public:
 			{
 				"",
 				"Common Metal",
-				"Rare Metal",
 				"Common Minerals",
+				"Rare Metal",
 				"Rare Minerals"
 			});
 
@@ -48,11 +48,11 @@ public:
 		stringTable[{1, 1}].text = writeStorageAmount(resources[0]);
 		stringTable[{2, 1}].text = std::to_string(OreConversionDivisor[0]) + " : 1";
 
-		stringTable[{1, 2}].text = writeStorageAmount(resources[2]);
-		stringTable[{2, 2}].text = std::to_string(OreConversionDivisor[2]) + " : 1";
+		stringTable[{1, 2}].text = writeStorageAmount(resources[1]);
+		stringTable[{2, 2}].text = std::to_string(OreConversionDivisor[1]) + " : 1";
 
-		stringTable[{1, 3}].text = writeStorageAmount(resources[1]);
-		stringTable[{2, 3}].text = std::to_string(OreConversionDivisor[1]) + " : 1";
+		stringTable[{1, 3}].text = writeStorageAmount(resources[2]);
+		stringTable[{2, 3}].text = std::to_string(OreConversionDivisor[2]) + " : 1";
 
 		stringTable[{1, 4}].text = writeStorageAmount(resources[3]);
 		stringTable[{2, 4}].text = std::to_string(OreConversionDivisor[3]) + " : 1";

--- a/OPHD/Things/Structures/StorageTanks.h
+++ b/OPHD/Things/Structures/StorageTanks.h
@@ -33,8 +33,8 @@ public:
 			{
 				"Storage Capacity",
 				ResourceNamesRefined[0],
-				ResourceNamesRefined[2],
 				ResourceNamesRefined[1],
+				ResourceNamesRefined[2],
 				ResourceNamesRefined[3],
 			});
 
@@ -43,8 +43,8 @@ public:
 			{
 				std::to_string(storage().total()) + " / " + std::to_string(storageCapacity()),
 				storage().resources[0],
-				storage().resources[2],
 				storage().resources[1],
+				storage().resources[2],
 				storage().resources[3]
 			});
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -50,15 +50,15 @@ void ResourceBreakdownPanel::update()
 	};
 
 	const auto commonMetalImageRect = NAS2D::Rectangle{64, 16, 16, 16};
-	const auto rareMetalImageRect = NAS2D::Rectangle{80, 16, 16, 16};
 	const auto commonMineralImageRect = NAS2D::Rectangle{96, 16, 16, 16};
+	const auto rareMetalImageRect = NAS2D::Rectangle{80, 16, 16, 16};
 	const auto rareMineralImageRect = NAS2D::Rectangle{112, 16, 16, 16};
 
 	const std::array resources
 	{
 		std::tuple{commonMetalImageRect, ResourceNamesRefined[0], mPlayerResources->resources[0], mPreviousResources.resources[0]},
-		std::tuple{rareMetalImageRect, ResourceNamesRefined[2], mPlayerResources->resources[2], mPreviousResources.resources[2]},
 		std::tuple{commonMineralImageRect, ResourceNamesRefined[1], mPlayerResources->resources[1], mPreviousResources.resources[1]},
+		std::tuple{rareMetalImageRect, ResourceNamesRefined[2], mPlayerResources->resources[2], mPreviousResources.resources[2]},
 		std::tuple{rareMineralImageRect, ResourceNamesRefined[3], mPlayerResources->resources[3], mPreviousResources.resources[3]},
 	};
 


### PR DESCRIPTION
Re-order main resource display:
- Common metals
- Common minerals
- Rare metals
- Rare minerals

This matches the order shown for factory production lists and the mine report view. It also matches the declared resource order.

Closes #135
Closes #985
