### PR TITLE
Swap std::clamp parameter order to ensure behavior is defined

### DIFF
--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -14,7 +14,7 @@ static int pullCount(MineFacility* mineFacility, size_t index)
 	const int storageCapacity = (mineFacility->storageCapacity() / 4);
 	const int remainingCapacity = storageCapacity - mineFacility->production().resources[index];
 
-	const int total = std::clamp(constants::BaseMineProductionRate, 0, remainingCapacity);
+	const int total = std::clamp(remainingCapacity, 0, constants::BaseMineProductionRate);
 
 	return total;
 }


### PR DESCRIPTION
Documentation:
https://en.cppreference.com/w/cpp/algorithm/clamp

Behavior is undefined if `lo` is less than `hi`. Best practice is to put the variable parameter first, and then any fixed bounds as the second and third parameters.

The way the code was written before, `remainingCapacity` could potentially have been negative, leading to undefined behavior.
