### PR TITLE
Refactor ProductionCost

### DIFF
--- a/OPHD/ProductionCost.h
+++ b/OPHD/ProductionCost.h
@@ -19,15 +19,6 @@ public:
 		mRareMinerals(rareMinerals)
 	{}
 
-	void clear()
-	{
-		mTurnsToBuild = 0;
-		mCommonMetals = 0;
-		mCommonMinerals = 0;
-		mRareMetals = 0;
-		mRareMinerals = 0;
-	}
-
 	int turnsToBuild() const { return mTurnsToBuild; }
 	int commonMetals() const { return mCommonMetals; }
 	int commonMinerals() const { return mCommonMinerals; }

--- a/OPHD/ProductionCost.h
+++ b/OPHD/ProductionCost.h
@@ -1,34 +1,16 @@
 #pragma once
 
+#include "StorableResources.h"
+
+
 /**
  * Defines cost in materials per turn.
  *
  * Basically just a storage class used to contain resource costs per turn and turn count
  * needed to produce a particular item.
  */
-class ProductionCost
+struct ProductionCost
 {
-public:
-	ProductionCost() = default;
-
-	ProductionCost(int turns, int commonMetals, int commonMinerals, int rareMetals, int rareMinerals) :
-		mTurnsToBuild(turns),
-		mCommonMetals(commonMetals),
-		mCommonMinerals(commonMinerals),
-		mRareMetals(rareMetals),
-		mRareMinerals(rareMinerals)
-	{}
-
-	int turnsToBuild() const { return mTurnsToBuild; }
-	int commonMetals() const { return mCommonMetals; }
-	int commonMinerals() const { return mCommonMinerals; }
-	int rareMetals() const { return mRareMetals; }
-	int rareMinerals() const { return mRareMinerals; }
-
-private:
-	int mTurnsToBuild = 0;
-	int mCommonMetals = 0;
-	int mCommonMinerals = 0;
-	int mRareMetals = 0;
-	int mRareMinerals = 0;
+	int turnsToBuild;
+	StorableResources resourceCost;
 };

--- a/OPHD/ProductionCost.h
+++ b/OPHD/ProductionCost.h
@@ -2,7 +2,7 @@
 
 /**
  * Defines cost in materials per turn.
- * 
+ *
  * Basically just a storage class used to contain resource costs per turn and turn count
  * needed to produce a particular item.
  */

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -13,7 +13,7 @@
  *			produce. It is up to the individual factory to determine what they are
  *			allowed to build.
  */
-const std::map<ProductType, ProductionCost> PRODUCTION_TYPE_TABLE =
+const std::map<ProductType, ProductionCost> ProductionCostTable =
 {
 	{ProductType::PRODUCT_NONE, ProductionCost{}},
 
@@ -32,7 +32,7 @@ const std::map<ProductType, ProductionCost> PRODUCTION_TYPE_TABLE =
 
 const ProductionCost& productCost(ProductType productType)
 {
-	return PRODUCTION_TYPE_TABLE.at(productType);
+	return ProductionCostTable.at(productType);
 }
 
 

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -20,16 +20,16 @@ const ProductionTypeTable PRODUCTION_TYPE_TABLE =
 {
 	{ProductType::PRODUCT_NONE, ProductionCost{}},
 
-	{ProductType::PRODUCT_DIGGER, ProductionCost{5, 10, 5, 5, 2}},
-	{ProductType::PRODUCT_DOZER, ProductionCost{5, 10, 5, 5, 2}},
-	{ProductType::PRODUCT_EXPLORER, ProductionCost{5, 10, 5, 5, 2}},
-	{ProductType::PRODUCT_MINER, ProductionCost{5, 10, 5, 5, 2}},
-	{ProductType::PRODUCT_TRUCK, ProductionCost{3, 6, 3, 2, 1}},
+	{ProductType::PRODUCT_DIGGER, ProductionCost{5, {10, 5, 5, 2}}},
+	{ProductType::PRODUCT_DOZER, ProductionCost{5, {10, 5, 5, 2}}},
+	{ProductType::PRODUCT_EXPLORER, ProductionCost{5, {10, 5, 5, 2}}},
+	{ProductType::PRODUCT_MINER, ProductionCost{5, {10, 5, 5, 2}}},
+	{ProductType::PRODUCT_TRUCK, ProductionCost{3, {6, 3, 2, 1}}},
 
-	{ProductType::PRODUCT_MAINTENANCE_PARTS, ProductionCost{2, 2, 2, 1, 1}},
+	{ProductType::PRODUCT_MAINTENANCE_PARTS, ProductionCost{2, {2, 2, 1, 1}}},
 
-	{ProductType::PRODUCT_CLOTHING, ProductionCost{1, 0, 1, 0, 0}},
-	{ProductType::PRODUCT_MEDICINE, ProductionCost{1, 0, 2, 0, 1}},
+	{ProductType::PRODUCT_CLOTHING, ProductionCost{1, {0, 1, 0, 0}}},
+	{ProductType::PRODUCT_MEDICINE, ProductionCost{1, {0, 2, 0, 1}}},
 };
 
 
@@ -65,7 +65,7 @@ void Factory::productType(ProductType type)
 
 	productionResetTurns();
 
-	mTurnsToComplete = PRODUCTION_TYPE_TABLE.at(mProduct).turnsToBuild();
+	mTurnsToComplete = PRODUCTION_TYPE_TABLE.at(mProduct).turnsToBuild;
 }
 
 
@@ -126,12 +126,7 @@ void Factory::updateProduction()
 	}
 
 	const auto& productionCost = PRODUCTION_TYPE_TABLE.at(mProduct);
-	StorableResources cost{
-		productionCost.commonMetals(),
-		productionCost.commonMinerals(),
-		productionCost.rareMetals(),
-		productionCost.rareMinerals()
-	};
+	auto cost = productionCost.resourceCost;
 
 	removeRefinedResources(cost);
 
@@ -161,14 +156,8 @@ bool Factory::enoughResourcesAvailable()
 {
 	if (mResources == nullptr) { throw std::runtime_error("Factory::enoughResourcesAvailable() called with a null Resource Pool set"); }
 
-	/**
-	 * \todo	Have this use operator>= once the production table is converted to using StorableResources
-	 */
 	const auto& productionCost = PRODUCTION_TYPE_TABLE.at(mProduct);
-	if (mResources->resources[0] >= productionCost.commonMetals() &&
-		mResources->resources[1] >= productionCost.commonMinerals() &&
-		mResources->resources[2] >= productionCost.rareMetals() &&
-		mResources->resources[3] >= productionCost.rareMinerals())
+	if (*mResources >= productionCost.resourceCost)
 	{
 		return true;
 	}

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -6,9 +6,6 @@
 #include <algorithm>
 
 
-using ProductionTypeTable = std::map<ProductType, ProductionCost>;
-
-
 /**
  * Table with production information for each product that factories can produce.
  *
@@ -16,7 +13,7 @@ using ProductionTypeTable = std::map<ProductType, ProductionCost>;
  *			produce. It is up to the individual factory to determine what they are
  *			allowed to build.
  */
-const ProductionTypeTable PRODUCTION_TYPE_TABLE =
+const std::map<ProductType, ProductionCost> PRODUCTION_TYPE_TABLE =
 {
 	{ProductType::PRODUCT_NONE, ProductionCost{}},
 

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -65,7 +65,7 @@ void Factory::productType(ProductType type)
 
 	productionResetTurns();
 
-	mTurnsToComplete = PRODUCTION_TYPE_TABLE.at(mProduct).turnsToBuild;
+	mTurnsToComplete = productCost(mProduct).turnsToBuild;
 }
 
 
@@ -125,7 +125,7 @@ void Factory::updateProduction()
 		return;
 	}
 
-	const auto& productionCost = PRODUCTION_TYPE_TABLE.at(mProduct);
+	const auto& productionCost = productCost(mProduct);
 	auto cost = productionCost.resourceCost;
 
 	removeRefinedResources(cost);
@@ -156,7 +156,7 @@ bool Factory::enoughResourcesAvailable()
 {
 	if (mResources == nullptr) { throw std::runtime_error("Factory::enoughResourcesAvailable() called with a null Resource Pool set"); }
 
-	const auto& productionCost = PRODUCTION_TYPE_TABLE.at(mProduct);
+	const auto& productionCost = productCost(mProduct);
 	return (*mResources >= productionCost.resourceCost);
 }
 

--- a/OPHD/Things/Structures/Factory.cpp
+++ b/OPHD/Things/Structures/Factory.cpp
@@ -157,12 +157,7 @@ bool Factory::enoughResourcesAvailable()
 	if (mResources == nullptr) { throw std::runtime_error("Factory::enoughResourcesAvailable() called with a null Resource Pool set"); }
 
 	const auto& productionCost = PRODUCTION_TYPE_TABLE.at(mProduct);
-	if (*mResources >= productionCost.resourceCost)
-	{
-		return true;
-	}
-
-	return false;
+	return (*mResources >= productionCost.resourceCost);
 }
 
 

--- a/OPHD/Things/Structures/Factory.h
+++ b/OPHD/Things/Structures/Factory.h
@@ -5,7 +5,7 @@
 #include "../../StorableResources.h"
 
 
-class ProductionCost;
+struct ProductionCost;
 
 
 /**

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -43,7 +43,7 @@ FactoryProduction::FactoryProduction() :
 void FactoryProduction::clearProduct()
 {
 	mProduct = ProductType::PRODUCT_NONE;
-	mProductCost.clear();
+	mProductCost = {};
 	mProductGrid.clearSelection();
 }
 
@@ -62,7 +62,7 @@ void FactoryProduction::onProductSelectionChange(const IconGrid::IconGridItem* i
 
 	if (!item)
 	{
-		mProductCost.clear();
+		mProductCost = {};
 		return;
 	}
 

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -165,13 +165,14 @@ void FactoryProduction::update()
 			ResourceNamesRefined[3] + ":",
 		});
 
+	const auto totalCost = mProductCost.resourceCost * mProductCost.turnsToBuild;
 	stringTable.setColumnText(1,
 		{
-			std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild()),
-			mProductCost.commonMetals()* mProductCost.turnsToBuild(),
-			mProductCost.commonMinerals()* mProductCost.turnsToBuild(),
-			mProductCost.rareMetals()* mProductCost.turnsToBuild(),
-			mProductCost.rareMinerals()* mProductCost.turnsToBuild()
+			std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild),
+			totalCost.resources[0],
+			totalCost.resources[1],
+			totalCost.resources[2],
+			totalCost.resources[3],
 		});
 
 	stringTable.computeRelativeCellPositions();

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -452,10 +452,10 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 	// MINERAL RESOURCES
 	const ProductionCost& productionCost = productCost(selectedFactory->productType());
 	const std::array requiredResources{
-		std::pair{ResourceNamesRefined[0], productionCost.commonMetals()},
-		std::pair{ResourceNamesRefined[1], productionCost.commonMinerals()},
-		std::pair{ResourceNamesRefined[2], productionCost.rareMetals()},
-		std::pair{ResourceNamesRefined[3], productionCost.rareMinerals()},
+		std::pair{ResourceNamesRefined[0], productionCost.resourceCost.resources[0]},
+		std::pair{ResourceNamesRefined[1], productionCost.resourceCost.resources[1]},
+		std::pair{ResourceNamesRefined[2], productionCost.resourceCost.resources[2]},
+		std::pair{ResourceNamesRefined[3], productionCost.resourceCost.resources[3]},
 	};
 	auto position = startPoint + NAS2D::Vector{138, 80};
 	for (auto [title, value] : requiredResources)


### PR DESCRIPTION
Refactor `ProductionCost` to be a `struct` rather than a `class`, and to use `StorableResources` for the `resourceCost` field.

Eliminates a source code "\todo" comment.
