### PR TITLE
Population bulk operations

### DIFF
--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -87,19 +87,23 @@ PopulationTable Population::spawnRoles(const PopulationTable& growth, const Popu
 }
 
 
-void Population::killRole(PopulationTable::Role role, int divisor)
+void Population::killRoles(const PopulationTable& divisor)
 {
-	mPopulationDeath[role] += mPopulation[role];
+	mPopulationDeath += mPopulation;
 
-	int deaths = std::min(mPopulationDeath[role] / divisor, mPopulation[role]);
-	mPopulationDeath[role] = mPopulationDeath[role] % divisor;
+	const auto deaths = (mPopulationDeath / divisor).cap(mPopulation);
+	mPopulationDeath = mPopulationDeath % divisor;
 
-	mPopulation[role] -= deaths;
-	mDeathCount += deaths;
+	mPopulation -= deaths;
+	mDeathCount += deaths.size();
 
-	if (mPopulation[role] == 0)
+	const auto roleCount = sizeof(PopulationTable) / sizeof(int);
+	for (std::size_t role = 0; role < roleCount; ++role)
 	{
-		mPopulationDeath[role] = 0;
+		if (mPopulation[role] == 0)
+		{
+			mPopulationDeath[role] = 0;
+		}
 	}
 }
 
@@ -112,11 +116,7 @@ void Population::killPopulation(int morale, int nurseries, int hospitals)
 	int divisorStudent = mortalityRate + (hospitals * 65);
 	int divisorAdult = mortalityRate + 250 + (hospitals * 60);
 
-	killRole(PopulationTable::Role::Child, divisorChild);
-	killRole(PopulationTable::Role::Student, divisorStudent);
-	killRole(PopulationTable::Role::Worker, divisorAdult * 2 - 50);
-	killRole(PopulationTable::Role::Scientist, divisorAdult * 2 + 50);
-	killRole(PopulationTable::Role::Retired, divisorAdult);
+	killRoles({divisorChild, divisorStudent, divisorAdult * 2 - 50, divisorAdult * 2 + 50, divisorAdult});
 
 	if (mPopulation.child <= 0)
 	{

--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <array>
 
 
 namespace

--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -71,9 +71,9 @@ void Population::spawnPopulation(int morale, int residences, int nurseries, int 
 	mPopulation.student -= (newRoles.worker + newRoles.scientist);
 
 	/** Workers retire earlier than scientists. */
-	const auto retireRole = randomNumber.generate(0, 100) <= 45 ?
-		PopulationTable::Role::Scientist : PopulationTable::Role::Worker;
-	if (mPopulation[retireRole] > 0) { mPopulation[retireRole] -= newRoles.retiree; }
+	auto& retireRole = randomNumber.generate(0, 100) <= 45 ?
+		mPopulation.scientist : mPopulation.worker;
+	if (retireRole > 0) { retireRole -= newRoles.retiree; }
 }
 
 

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -3,8 +3,6 @@
 #include "Morale.h"
 #include "PopulationTable.h"
 
-#include <vector>
-
 
 class Population
 {

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -24,7 +24,7 @@ private:
 	PopulationTable spawnRoles(const PopulationTable& growth, const PopulationTable& divisor);
 	void spawnPopulation(int morale, int residences, int nurseries, int universities);
 
-	void killRole(PopulationTable::Role role, int divisor);
+	void killRoles(const PopulationTable& divisor);
 	void killPopulation(int morale, int nurseries, int hospitals);
 
 	int consumeFood(int food);

--- a/OPHD/Population/Population.h
+++ b/OPHD/Population/Population.h
@@ -21,7 +21,7 @@ public:
 	void starveRate(float rate) { mStarveRate = rate; }
 
 private:
-	int spawnRole(PopulationTable::Role role, int growth, int divisor);
+	PopulationTable spawnRoles(const PopulationTable& growth, const PopulationTable& divisor);
 	void spawnPopulation(int morale, int residences, int nurseries, int universities);
 
 	void killRole(PopulationTable::Role role, int divisor);

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -69,6 +69,30 @@ PopulationTable& PopulationTable::operator+=(const PopulationTable& other)
 }
 
 
+PopulationTable PopulationTable::operator/(const PopulationTable& other) const
+{
+	return {
+		child / other.child,
+		student / other.student,
+		worker / other.worker,
+		scientist / other.scientist,
+		retiree / other.retiree,
+	};
+}
+
+
+PopulationTable PopulationTable::operator%(const PopulationTable& other) const
+{
+	return {
+		child % other.child,
+		student % other.student,
+		worker % other.worker,
+		scientist % other.scientist,
+		retiree % other.retiree,
+	};
+}
+
+
 /**
  * Gets the size of the entire population.
  */

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -6,6 +6,12 @@
 #include <algorithm>
 
 
+int PopulationTable::employable() const
+{
+	return worker + scientist;
+}
+
+
 int PopulationTable::adults() const
 {
 	return student + worker + scientist + retiree;

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -1,6 +1,5 @@
 #include "PopulationTable.h"
 
-#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <algorithm>

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -8,7 +8,7 @@
 
 int PopulationTable::adults() const
 {
-	return size() - child;
+	return student + worker + scientist + retiree;
 }
 
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -46,18 +46,6 @@ int PopulationTable::operator[](std::size_t index) const
 }
 
 
-int& PopulationTable::operator[](Role role)
-{
-	return operator[](static_cast<std::size_t>(role));
-}
-
-
-int PopulationTable::operator[](Role role) const
-{
-	return operator[](static_cast<std::size_t>(role));
-}
-
-
 PopulationTable& PopulationTable::operator+=(const PopulationTable& other)
 {
 	child += other.child;

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -3,6 +3,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <string>
+#include <algorithm>
 
 
 int& PopulationTable::operator[](std::size_t index)
@@ -89,6 +90,18 @@ PopulationTable PopulationTable::operator%(const PopulationTable& other) const
 		worker % other.worker,
 		scientist % other.scientist,
 		retiree % other.retiree,
+	};
+}
+
+
+PopulationTable PopulationTable::cap(const PopulationTable& other) const
+{
+	return {
+		std::min(child, other.child),
+		std::min(student, other.student),
+		std::min(worker, other.worker),
+		std::min(scientist, other.scientist),
+		std::min(retiree, other.retiree),
 	};
 }
 

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -70,6 +70,18 @@ PopulationTable& PopulationTable::operator+=(const PopulationTable& other)
 }
 
 
+PopulationTable& PopulationTable::operator-=(const PopulationTable& other)
+{
+	child -= other.child;
+	student -= other.student;
+	worker -= other.worker;
+	scientist -= other.scientist;
+	retiree -= other.retiree;
+
+	return *this;
+}
+
+
 PopulationTable PopulationTable::operator/(const PopulationTable& other) const
 {
 	return {

--- a/OPHD/Population/PopulationTable.cpp
+++ b/OPHD/Population/PopulationTable.cpp
@@ -6,6 +6,21 @@
 #include <algorithm>
 
 
+int PopulationTable::adults() const
+{
+	return size() - child;
+}
+
+
+/**
+ * Gets the size of the entire population.
+ */
+int PopulationTable::size() const
+{
+	return child + student + worker + scientist + retiree;
+}
+
+
 int& PopulationTable::operator[](std::size_t index)
 {
 	switch (index)
@@ -103,19 +118,4 @@ PopulationTable PopulationTable::cap(const PopulationTable& other) const
 		std::min(scientist, other.scientist),
 		std::min(retiree, other.retiree),
 	};
-}
-
-
-/**
- * Gets the size of the entire population.
- */
-int PopulationTable::size() const
-{
-	return child + student + worker + scientist + retiree;
-}
-
-
-int PopulationTable::adults() const
-{
-	return size() - child;
 }

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -11,20 +11,8 @@ struct PopulationTable
 	int retiree;
 
 
-	enum class Role
-	{
-		Child,
-		Student,
-		Worker,
-		Scientist,
-		Retired
-	};
-
 	int& operator[](std::size_t);
 	int operator[](std::size_t) const;
-
-	int& operator[](Role);
-	int operator[](Role) const;
 
 	PopulationTable& operator+=(const PopulationTable& other);
 	PopulationTable& operator-=(const PopulationTable& other);

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -11,6 +11,7 @@ struct PopulationTable
 	int retiree;
 
 
+	int employable() const;
 	int adults() const;
 	int size() const;
 

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -11,6 +11,9 @@ struct PopulationTable
 	int retiree;
 
 
+	int adults() const;
+	int size() const;
+
 	int& operator[](std::size_t);
 	int operator[](std::size_t) const;
 
@@ -21,7 +24,4 @@ struct PopulationTable
 	PopulationTable operator%(const PopulationTable& other) const;
 
 	PopulationTable cap(const PopulationTable& other) const;
-
-	int size() const;
-	int adults() const;
 };

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <array>
+#include <cstddef>
+
 
 struct PopulationTable
 {

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -31,6 +31,8 @@ struct PopulationTable
 	PopulationTable operator/(const PopulationTable& other) const;
 	PopulationTable operator%(const PopulationTable& other) const;
 
+	PopulationTable cap(const PopulationTable& other) const;
+
 	int size() const;
 	int adults() const;
 };

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -27,6 +27,7 @@ struct PopulationTable
 	int operator[](Role) const;
 
 	PopulationTable& operator+=(const PopulationTable& other);
+	PopulationTable& operator-=(const PopulationTable& other);
 
 	PopulationTable operator/(const PopulationTable& other) const;
 	PopulationTable operator%(const PopulationTable& other) const;

--- a/OPHD/Population/PopulationTable.h
+++ b/OPHD/Population/PopulationTable.h
@@ -28,6 +28,9 @@ struct PopulationTable
 
 	PopulationTable& operator+=(const PopulationTable& other);
 
+	PopulationTable operator/(const PopulationTable& other) const;
+	PopulationTable operator%(const PopulationTable& other) const;
+
 	int size() const;
 	int adults() const;
 };


### PR DESCRIPTION
Closes #1020

Implement bulk operations on `PopulationTable`, and use them in the `Population` model code. Remove the now unused `Role` enum. Implement the suggested `PopulationTable::employable()` method.

@ldicker83 : In the commit near the end to re-implement `.adults()`, it was noticed the `student` component was included in `adults`. Is this correct? It looks like they may have been included by accident.
