### PR TITLE
Move overlay highlight

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -7,48 +7,6 @@
 #include <cmath>
 
 
-std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
-{
-	{Tile::Overlay::None, NAS2D::Color::Normal},
-	{Tile::Overlay::Communications, {125, 200, 255}},
-	{Tile::Overlay::Connectedness, NAS2D::Color::Green},
-	{Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange},
-	{Tile::Overlay::Police, NAS2D::Color::Red}
-};
-
-std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
-{
-	{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
-	{Tile::Overlay::Communications, {100, 180, 230}},
-	{Tile::Overlay::Connectedness, NAS2D::Color{71, 224, 146}},
-	{Tile::Overlay::TruckingRoutes, NAS2D::Color{125, 200, 255}},
-	{Tile::Overlay::Police, NAS2D::Color{100, 180, 230}}
-};
-
-
-const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
-{
-	if (isHighlighted)
-	{
-		return overlayHighlightColor(overlay);
-	}
-
-	return overlayColor(overlay);
-}
-
-
-const NAS2D::Color& overlayColor(Tile::Overlay overlay)
-{
-	return OverlayColorTable.at(overlay);
-}
-
-
-const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay)
-{
-	return OverlayHighlightColorTable.at(overlay);
-}
-
-
 Tile::Tile(const MapCoordinate& position, TerrainType index) :
 	mIndex{index},
 	mPosition{position}

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -89,8 +89,4 @@ private:
 	bool mConnected = false; /**< Flag indicating that this tile is connected to the Command Center. */
 };
 
-const NAS2D::Color& overlayColor(Tile::Overlay, bool);
-const NAS2D::Color& overlayColor(Tile::Overlay);
-const NAS2D::Color& overlayHighlightColor(Tile::Overlay);
-
 using TileList = std::vector<Tile*>;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -18,70 +18,72 @@
 using namespace NAS2D;
 
 
-const std::string MAP_TERRAIN_EXTENSION = "_a.png";
+namespace {
+	const std::string MAP_TERRAIN_EXTENSION = "_a.png";
 
-const int MAP_WIDTH = 300;
-const int MAP_HEIGHT = 150;
+	const int MAP_WIDTH = 300;
+	const int MAP_HEIGHT = 150;
 
-const int TILE_WIDTH = 128;
-const int TILE_HEIGHT = 64;
+	const int TILE_WIDTH = 128;
+	const int TILE_HEIGHT = 64;
 
-const int TILE_HALF_WIDTH = TILE_WIDTH / 2;
+	const int TILE_HALF_WIDTH = TILE_WIDTH / 2;
 
-const int TILE_HEIGHT_OFFSET = 9;
-const int TILE_HEIGHT_ABSOLUTE = TILE_HEIGHT - TILE_HEIGHT_OFFSET;
-const int TILE_HEIGHT_HALF_ABSOLUTE = TILE_HEIGHT_ABSOLUTE / 2;
+	const int TILE_HEIGHT_OFFSET = 9;
+	const int TILE_HEIGHT_ABSOLUTE = TILE_HEIGHT - TILE_HEIGHT_OFFSET;
+	const int TILE_HEIGHT_HALF_ABSOLUTE = TILE_HEIGHT_ABSOLUTE / 2;
 
-const double THROB_SPEED = 250.0; // Throb speed of mine beacon
+	const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
-/** Array indicates percent of mines that should be of yields LOW, MED, HIGH */
-const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYieldTable =
-{
-	{Planet::Hostility::Low, {30, 50, 20}},
-	{Planet::Hostility::Medium, {45, 35, 20}},
-	{Planet::Hostility::High, {35, 20, 45}},
-};
-
-
-std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
-{
-	{Tile::Overlay::None, NAS2D::Color::Normal},
-	{Tile::Overlay::Communications, {125, 200, 255}},
-	{Tile::Overlay::Connectedness, NAS2D::Color::Green},
-	{Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange},
-	{Tile::Overlay::Police, NAS2D::Color::Red}
-};
-
-std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
-{
-	{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
-	{Tile::Overlay::Communications, {100, 180, 230}},
-	{Tile::Overlay::Connectedness, NAS2D::Color{71, 224, 146}},
-	{Tile::Overlay::TruckingRoutes, NAS2D::Color{125, 200, 255}},
-	{Tile::Overlay::Police, NAS2D::Color{100, 180, 230}}
-};
-
-
-const NAS2D::Color& overlayColor(Tile::Overlay overlay)
-{
-	return OverlayColorTable.at(overlay);
-}
-
-
-const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay)
-{
-	return OverlayHighlightColorTable.at(overlay);
-}
-
-
-const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
-{
-	if (isHighlighted)
+	/** Array indicates percent of mines that should be of yields LOW, MED, HIGH */
+	const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYieldTable =
 	{
-		return overlayHighlightColor(overlay);
+		{Planet::Hostility::Low, {30, 50, 20}},
+		{Planet::Hostility::Medium, {45, 35, 20}},
+		{Planet::Hostility::High, {35, 20, 45}},
+	};
+
+
+	std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
+	{
+		{Tile::Overlay::None, NAS2D::Color::Normal},
+		{Tile::Overlay::Communications, {125, 200, 255}},
+		{Tile::Overlay::Connectedness, NAS2D::Color::Green},
+		{Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange},
+		{Tile::Overlay::Police, NAS2D::Color::Red}
+	};
+
+	std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
+	{
+		{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
+		{Tile::Overlay::Communications, {100, 180, 230}},
+		{Tile::Overlay::Connectedness, NAS2D::Color{71, 224, 146}},
+		{Tile::Overlay::TruckingRoutes, NAS2D::Color{125, 200, 255}},
+		{Tile::Overlay::Police, NAS2D::Color{100, 180, 230}}
+	};
+
+
+	const NAS2D::Color& overlayColor(Tile::Overlay overlay)
+	{
+		return OverlayColorTable.at(overlay);
 	}
 
-	return overlayColor(overlay);
+
+	const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay)
+	{
+		return OverlayHighlightColorTable.at(overlay);
+	}
+
+
+	const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
+	{
+		if (isHighlighted)
+		{
+			return overlayHighlightColor(overlay);
+		}
+
+		return overlayColor(overlay);
+	}
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -43,6 +43,48 @@ const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYieldTable =
 };
 
 
+std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
+{
+	{Tile::Overlay::None, NAS2D::Color::Normal},
+	{Tile::Overlay::Communications, {125, 200, 255}},
+	{Tile::Overlay::Connectedness, NAS2D::Color::Green},
+	{Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange},
+	{Tile::Overlay::Police, NAS2D::Color::Red}
+};
+
+std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
+{
+	{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
+	{Tile::Overlay::Communications, {100, 180, 230}},
+	{Tile::Overlay::Connectedness, NAS2D::Color{71, 224, 146}},
+	{Tile::Overlay::TruckingRoutes, NAS2D::Color{125, 200, 255}},
+	{Tile::Overlay::Police, NAS2D::Color{100, 180, 230}}
+};
+
+
+const NAS2D::Color& overlayColor(Tile::Overlay overlay)
+{
+	return OverlayColorTable.at(overlay);
+}
+
+
+const NAS2D::Color& overlayHighlightColor(Tile::Overlay overlay)
+{
+	return OverlayHighlightColorTable.at(overlay);
+}
+
+
+const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
+{
+	if (isHighlighted)
+	{
+		return overlayHighlightColor(overlay);
+	}
+
+	return overlayColor(overlay);
+}
+
+
 TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
 	mSizeInTiles{MAP_WIDTH, MAP_HEIGHT},
 	mMaxDepth(maxDepth),

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -44,7 +44,7 @@ namespace {
 	};
 
 
-	std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
+	const std::map<Tile::Overlay, NAS2D::Color> OverlayColorTable =
 	{
 		{Tile::Overlay::None, NAS2D::Color::Normal},
 		{Tile::Overlay::Communications, {125, 200, 255}},
@@ -53,7 +53,7 @@ namespace {
 		{Tile::Overlay::Police, NAS2D::Color::Red}
 	};
 
-	std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
+	const std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColorTable =
 	{
 		{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
 		{Tile::Overlay::Communications, {100, 180, 230}},


### PR DESCRIPTION
Move overlay highlight data and support code from **Tile.cpp** to **TileMap.cpp**. Wrap in unnamed namespace.

Reference: #138 (spotted with `cppclean`)
