### PR TITLE
Fix retire bug

### DIFF
--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <iostream>
 #include <array>
+#include <stdexcept>
+#include <string>
 
 
 namespace
@@ -70,6 +72,11 @@ void Population::spawnPopulation(int morale, int residences, int nurseries, int 
 	mBirthCount = newRoles.child;
 	mPopulation.child -= newRoles.student;
 	mPopulation.student -= (newRoles.worker + newRoles.scientist);
+
+	if (newRoles.retiree > mPopulation.employable())
+	{
+		throw std::runtime_error("Retiring more people than employable population: Retiring: " + std::to_string(newRoles.retiree));
+	}
 
 	for (int toRetire = newRoles.retiree; toRetire > 0;)
 	{


### PR DESCRIPTION
Closes #1044

Ensures we don't retire more workers or scientists than are available. Add an exception to display if we try to retire more than the number of employable people.

This also means both scientists and workers can potentially retire in the same turn, in a mixed batch.
