### PR TITLE
Remove constants header

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -1,5 +1,5 @@
 #include "Common.h"
-#include "Constants.h"
+#include "Constants/Numbers.h"
 #include "StructureManager.h"
 #include "XmlSerializer.h"
 

--- a/OPHD/Constants.h
+++ b/OPHD/Constants.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include "Constants/Numbers.h"

--- a/OPHD/Constants.h
+++ b/OPHD/Constants.h
@@ -1,4 +1,3 @@
 #pragma once
 
 #include "Constants/Numbers.h"
-#include "Constants/Strings.h"

--- a/OPHD/Constants.h
+++ b/OPHD/Constants.h
@@ -2,4 +2,3 @@
 
 #include "Constants/Numbers.h"
 #include "Constants/Strings.h"
-#include "Constants/UiConstants.h"

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -1,6 +1,7 @@
 #include "TileMap.h"
 
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 #include "../DirectionOffset.h"
 #include "../Mine.h"
 #include "../Things/Structures/Structure.h"

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -1,6 +1,6 @@
 #include "TileMap.h"
 
-#include "../Constants.h"
+#include "../Constants/Numbers.h"
 #include "../Constants/UiConstants.h"
 #include "../DirectionOffset.h"
 #include "../Mine.h"

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Common.h"
-#include "Constants/Numbers.h"
 
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Xml/XmlElement.h>

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Common.h"
-#include "Constants.h"
+#include "Constants/Numbers.h"
 
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Xml/XmlElement.h>

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -1,5 +1,7 @@
 #include "ProductPool.h"
 
+#include "Constants/Strings.h"
+
 #include <NAS2D/ParserHelper.h>
 
 #include <algorithm>

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Common.h"
-#include "Constants.h"
+#include "Constants/Numbers.h"
 
 #include <NAS2D/Dictionary.h>
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -4,7 +4,8 @@
 #include "PlanetSelectState.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
 
 #include "../UI/MessageBox.h"
 

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../Constants.h"
 #include "../UI/FileIo.h"
 
 #include <NAS2D/State.h>

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -1,7 +1,7 @@
 #include "MainReportsUiState.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include "../UI/Reports/ReportInterface.h"
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -4,7 +4,10 @@
 #include "MainReportsUiState.h"
 #include "Route.h"
 
-#include "../Constants.h"
+#include "../Constants/Numbers.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
+
 #include "../DirectionOffset.h"
 #include "../Cache.h"
 #include "../GraphWalker.h"

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -6,8 +6,10 @@
 
 #include "Planet.h"
 
+#include "../Constants/Numbers.h"
+#include "../Constants/UiConstants.h"
+
 #include "../Common.h"
-#include "../Constants.h"
 #include "../StorableResources.h"
 #include "../RobotPool.h"
 #include "../PopulationPool.h"

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -6,7 +6,7 @@
 
 #include "Route.h"
 
-#include "../Constants.h"
+#include "../Constants/UiConstants.h"
 #include "../Common.h"
 #include "../Cache.h"
 #include "../Mine.h"

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -9,7 +9,7 @@
 
 #include "MapViewStateHelper.h"
 
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"
 #include "../DirectionOffset.h"

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -9,7 +9,7 @@
 #include "Route.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../IOHelper.h"
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -9,7 +9,9 @@
 
 #include "MainMenuState.h"
 
-#include "../Constants.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
+
 #include "../DirectionOffset.h"
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -1,6 +1,6 @@
 #include "Planet.h"
 
-#include "../Constants.h"
+#include "../Constants/Numbers.h"
 #include "../XmlSerializer.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -4,7 +4,8 @@
 #include "MapViewState.h"
 #include "MainMenuState.h"
 
-#include "../Constants.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
 #include "../Cache.h"
 #include "../XmlSerializer.h"
 

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -3,6 +3,7 @@
 #include "Planet.h"
 
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include "../UI/Core/Button.h"
 #include "../UI/Core/TextArea.h"

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -2,7 +2,6 @@
 
 #include "Planet.h"
 
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include "../UI/Core/Button.h"

--- a/OPHD/States/SplashState.h
+++ b/OPHD/States/SplashState.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../Constants.h"
-
 #include <NAS2D/State.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Timer.h>

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -1,6 +1,6 @@
 #include "StructureManager.h"
 
-#include "Constants.h"
+#include "Constants/Numbers.h"
 #include "ProductPool.h"
 #include "IOHelper.h"
 #include "PopulationPool.h"

--- a/OPHD/Things/Structures/Agridome.h
+++ b/OPHD/Things/Structures/Agridome.h
@@ -2,7 +2,7 @@
 
 #include "FoodProduction.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 #include <algorithm>
 

--- a/OPHD/Things/Structures/AirShaft.h
+++ b/OPHD/Things/Structures/AirShaft.h
@@ -3,6 +3,7 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class AirShaft : public Structure

--- a/OPHD/Things/Structures/AirShaft.h
+++ b/OPHD/Things/Structures/AirShaft.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Numbers.h"
 #include "../../Constants/Strings.h"
 
 

--- a/OPHD/Things/Structures/CHAP.h
+++ b/OPHD/Things/Structures/CHAP.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class CHAP : public Structure

--- a/OPHD/Things/Structures/CargoLander.h
+++ b/OPHD/Things/Structures/CargoLander.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../Map/Tile.h"
 
 

--- a/OPHD/Things/Structures/ColonistLander.h
+++ b/OPHD/Things/Structures/ColonistLander.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../Map/Tile.h"
 
 

--- a/OPHD/Things/Structures/CommTower.h
+++ b/OPHD/Things/Structures/CommTower.h
@@ -3,6 +3,7 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 
 class CommTower : public Structure

--- a/OPHD/Things/Structures/CommTower.h
+++ b/OPHD/Things/Structures/CommTower.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 
 

--- a/OPHD/Things/Structures/CommandCenter.h
+++ b/OPHD/Things/Structures/CommandCenter.h
@@ -2,7 +2,7 @@
 
 #include "FoodProduction.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Numbers.h"
 #include "../../Constants/Strings.h"
 
 

--- a/OPHD/Things/Structures/CommandCenter.h
+++ b/OPHD/Things/Structures/CommandCenter.h
@@ -3,6 +3,7 @@
 #include "FoodProduction.h"
 
 #include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 /**

--- a/OPHD/Things/Structures/Commercial.h
+++ b/OPHD/Things/Structures/Commercial.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class Commercial : public Structure

--- a/OPHD/Things/Structures/FusionReactor.h
+++ b/OPHD/Things/Structures/FusionReactor.h
@@ -2,7 +2,7 @@
 
 #include "PowerStructure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 #include <string>
 

--- a/OPHD/Things/Structures/HotLaboratory.h
+++ b/OPHD/Things/Structures/HotLaboratory.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class HotLaboratory : public Structure

--- a/OPHD/Things/Structures/Laboratory.h
+++ b/OPHD/Things/Structures/Laboratory.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class Laboratory : public Structure

--- a/OPHD/Things/Structures/MaintenanceFacility.h
+++ b/OPHD/Things/Structures/MaintenanceFacility.h
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../StorableResources.h"
 
 #include "../../States/MapViewStateHelper.h" // yuck

--- a/OPHD/Things/Structures/MedicalCenter.h
+++ b/OPHD/Things/Structures/MedicalCenter.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class MedicalCenter : public Structure

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -1,6 +1,6 @@
 #include "MineFacility.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Numbers.h"
 #include "../../Constants/Strings.h"
 
 

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -1,6 +1,7 @@
 #include "MineFacility.h"
 
 #include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 const int MineFacilityStorageCapacity = 500;

--- a/OPHD/Things/Structures/MineShaft.h
+++ b/OPHD/Things/Structures/MineShaft.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class MineShaft : public Structure

--- a/OPHD/Things/Structures/Nursery.h
+++ b/OPHD/Things/Structures/Nursery.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class Nursery : public Structure

--- a/OPHD/Things/Structures/Park.h
+++ b/OPHD/Things/Structures/Park.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class Park : public Structure

--- a/OPHD/Things/Structures/PowerStructure.h
+++ b/OPHD/Things/Structures/PowerStructure.h
@@ -2,7 +2,6 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <string>

--- a/OPHD/Things/Structures/PowerStructure.h
+++ b/OPHD/Things/Structures/PowerStructure.h
@@ -3,6 +3,7 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <string>
 

--- a/OPHD/Things/Structures/RecreationCenter.h
+++ b/OPHD/Things/Structures/RecreationCenter.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class RecreationCenter : public Structure

--- a/OPHD/Things/Structures/Recycling.h
+++ b/OPHD/Things/Structures/Recycling.h
@@ -3,6 +3,7 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/StringUtils.h>
 

--- a/OPHD/Things/Structures/Recycling.h
+++ b/OPHD/Things/Structures/Recycling.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/StringUtils.h>

--- a/OPHD/Things/Structures/RedLightDistrict.h
+++ b/OPHD/Things/Structures/RedLightDistrict.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class RedLightDistrict : public Structure

--- a/OPHD/Things/Structures/Residence.h
+++ b/OPHD/Things/Structures/Residence.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 #include <algorithm>
 

--- a/OPHD/Things/Structures/RobotCommand.cpp
+++ b/OPHD/Things/Structures/RobotCommand.cpp
@@ -1,7 +1,7 @@
 #include "RobotCommand.h"
 
 #include "../Robots/Robot.h"
-#include "../../Constants.h"
+#include "../../Constants/Numbers.h"
 
 #include <string>
 #include <stdexcept>

--- a/OPHD/Things/Structures/RobotCommand.h
+++ b/OPHD/Things/Structures/RobotCommand.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 #include <vector>
 

--- a/OPHD/Things/Structures/SeedFactory.h
+++ b/OPHD/Things/Structures/SeedFactory.h
@@ -2,7 +2,7 @@
 
 #include "Factory.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class SeedFactory : public Factory

--- a/OPHD/Things/Structures/SeedLander.h
+++ b/OPHD/Things/Structures/SeedLander.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 #include <NAS2D/Math/Point.h>
 

--- a/OPHD/Things/Structures/SeedPower.h
+++ b/OPHD/Things/Structures/SeedPower.h
@@ -2,7 +2,7 @@
 
 #include "PowerStructure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 #include <string>
 

--- a/OPHD/Things/Structures/SeedSmelter.h
+++ b/OPHD/Things/Structures/SeedSmelter.h
@@ -2,7 +2,7 @@
 
 #include "OreRefining.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class SeedSmelter : public OreRefining

--- a/OPHD/Things/Structures/Smelter.h
+++ b/OPHD/Things/Structures/Smelter.h
@@ -2,7 +2,7 @@
 
 #include "OreRefining.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class Smelter : public OreRefining

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -2,7 +2,7 @@
 
 #include "PowerStructure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 const int SOLAR_PANEL_BASE_PRODUCUCTION = 50;

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -2,7 +2,7 @@
 
 #include "PowerStructure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 const int SOLAR_PLANT_BASE_PRODUCUCTION = 2000;

--- a/OPHD/Things/Structures/StorageTanks.h
+++ b/OPHD/Things/Structures/StorageTanks.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 const int StorageTanksCapacity = 1000;

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -1,7 +1,7 @@
 #include "Structure.h"
 
 #include "../../RandomNumberGenerator.h"
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include <algorithm>
 
 

--- a/OPHD/Things/Structures/SurfaceFactory.h
+++ b/OPHD/Things/Structures/SurfaceFactory.h
@@ -2,7 +2,7 @@
 
 #include "Factory.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class SurfaceFactory : public Factory

--- a/OPHD/Things/Structures/SurfacePolice.h
+++ b/OPHD/Things/Structures/SurfacePolice.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class SurfacePolice : public Structure

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -3,6 +3,7 @@
 #include "Structure.h"
 
 #include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../Common.h"
 
 

--- a/OPHD/Things/Structures/Tube.h
+++ b/OPHD/Things/Structures/Tube.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Numbers.h"
 #include "../../Constants/Strings.h"
 #include "../../Common.h"
 

--- a/OPHD/Things/Structures/UndergroundFactory.h
+++ b/OPHD/Things/Structures/UndergroundFactory.h
@@ -2,7 +2,7 @@
 
 #include "Factory.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class UndergroundFactory : public Factory

--- a/OPHD/Things/Structures/UndergroundPolice.h
+++ b/OPHD/Things/Structures/UndergroundPolice.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class UndergroundPolice : public Structure

--- a/OPHD/Things/Structures/University.h
+++ b/OPHD/Things/Structures/University.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 
 
 class University : public Structure

--- a/OPHD/Things/Structures/Warehouse.h
+++ b/OPHD/Things/Structures/Warehouse.h
@@ -2,7 +2,7 @@
 
 #include "Structure.h"
 
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
 #include "../../ProductPool.h"
 
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -3,6 +3,7 @@
 #include "../../Cache.h"
 #include "../../Common.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -2,7 +2,6 @@
 
 #include "../../Cache.h"
 #include "../../Common.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -16,6 +16,7 @@
 
 #include "../../Cache.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -15,7 +15,6 @@
 #include "CheckBox.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -1,7 +1,6 @@
 #include "Label.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -1,7 +1,8 @@
 #include "Label.h"
 
-#include "../../Constants.h"
 #include "../../Cache.h"
+#include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -1,6 +1,6 @@
 #include "ListBox.h"
 
-#include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Renderer/Renderer.h>
 

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -1,6 +1,6 @@
 #include "ListBoxBase.h"
 
-#include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -1,7 +1,7 @@
 #include "RadioButtonGroup.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/RadioButtonGroup.h
+++ b/OPHD/UI/Core/RadioButtonGroup.h
@@ -4,6 +4,7 @@
 #include "Label.h"
 #include "../../Cache.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Signal/Delegate.h>

--- a/OPHD/UI/Core/RadioButtonGroup.h
+++ b/OPHD/UI/Core/RadioButtonGroup.h
@@ -3,7 +3,6 @@
 #include "TextControl.h"
 #include "Label.h"
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Signal/Signal.h>

--- a/OPHD/UI/Core/RadioButtonGroup.h
+++ b/OPHD/UI/Core/RadioButtonGroup.h
@@ -19,38 +19,38 @@
 class RadioButtonGroup : public Control
 {
 private:
-    class RadioButton : public TextControl
-    {
-    public:
-        RadioButton(RadioButtonGroup* parentContainer, std::string newText, NAS2D::Delegate<void()> delegate);
-        ~RadioButton() override;
+	class RadioButton : public TextControl
+	{
+	public:
+		RadioButton(RadioButtonGroup* parentContainer, std::string newText, NAS2D::Delegate<void()> delegate);
+		~RadioButton() override;
 
-        // TODO: Best to delete these, but they need to exist for now
-        // The default methods do not properly handle global event connect/disconnect
-        RadioButton(const RadioButton&) = default;
-        RadioButton(RadioButton&&) = default;
+		// TODO: Best to delete these, but they need to exist for now
+		// The default methods do not properly handle global event connect/disconnect
+		RadioButton(const RadioButton&) = default;
+		RadioButton(RadioButton&&) = default;
 
-        void checked(bool toggle);
-        bool checked() const;
+		void checked(bool toggle);
+		bool checked() const;
 
-        void text(const std::string& text);
-        const std::string& text() const;
+		void text(const std::string& text);
+		const std::string& text() const;
 
-        void update() override;
+		void update() override;
 
-    protected:
-        void onResize() override;
-        void onTextChange() override;
-        void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	protected:
+		void onResize() override;
+		void onTextChange() override;
+		void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 
-    private:
-        const NAS2D::Font& mFont;
-        const NAS2D::Image& mSkin;
-        Label mLabel;
-        RadioButtonGroup* mParentContainer{nullptr};
-        bool mChecked{false};
-        NAS2D::Signal<> mSignal;
-    };
+	private:
+		const NAS2D::Font& mFont;
+		const NAS2D::Image& mSkin;
+		Label mLabel;
+		RadioButtonGroup* mParentContainer{nullptr};
+		bool mChecked{false};
+		NAS2D::Signal<> mSignal;
+	};
 
 public:
 	struct ButtonInfo
@@ -73,6 +73,6 @@ protected:
 	void onMove(NAS2D::Vector<int> displacement) override;
 
 private:
-    std::size_t mIndex = constants::NoSelection;
-    std::vector<RadioButton> mRadioButtons;
+	std::size_t mIndex = constants::NoSelection;
+	std::vector<RadioButton> mRadioButtons;
 };

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -2,6 +2,7 @@
 
 #include "../../Cache.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/Slider.cpp
+++ b/OPHD/UI/Core/Slider.cpp
@@ -1,7 +1,6 @@
 #include "Slider.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -1,7 +1,6 @@
 #include "TextArea.h"
 
 #include "../../Common.h"
-#include "../../Constants.h"
 #include "../../Cache.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -8,7 +8,6 @@
 #include "TextField.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -9,6 +9,7 @@
 
 #include "../../Cache.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -2,6 +2,7 @@
 
 #include "../../Cache.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -1,7 +1,6 @@
 #include "ToolTip.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/EventHandler.h>

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -3,6 +3,7 @@
 #include "../../Cache.h"
 #include "../../Common.h"
 #include "../../Constants.h"
+#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -2,7 +2,6 @@
 
 #include "../../Cache.h"
 #include "../../Common.h"
-#include "../../Constants.h"
 #include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -3,7 +3,8 @@
 #include "../Things/Structures/Factory.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -1,6 +1,7 @@
 #include "FactoryProduction.h"
 
 #include "StringTable.h"
+#include "../Constants/Strings.h"
 #include "../Things/Structures/Factory.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/FactoryProduction.h
+++ b/OPHD/UI/FactoryProduction.h
@@ -5,7 +5,7 @@
 #include "Core/CheckBox.h"
 #include "IconGrid.h"
 
-#include "../Constants.h"
+#include "../Constants/UiConstants.h"
 #include "../Common.h"
 #include "../ProductionCost.h"
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -1,6 +1,7 @@
 #include "FileIo.h"
 
-#include "../Constants.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
 #include "../Common.h"
 
 #include "MessageBox.h"

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -1,6 +1,6 @@
 #include "GameOptionsDialog.h"
 
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 
 #include <array>
 

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/GameOverDialog.cpp
+++ b/OPHD/UI/GameOverDialog.cpp
@@ -1,7 +1,6 @@
 #include "GameOverDialog.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -1,7 +1,7 @@
 #include "IconGrid.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/MajorEventAnnouncement.cpp
+++ b/OPHD/UI/MajorEventAnnouncement.cpp
@@ -1,7 +1,6 @@
 #include "MajorEventAnnouncement.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -6,6 +6,7 @@
 #include "../Cache.h"
 #include "../Common.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 #include "../StructureManager.h"
 #include "../Things/Structures/MineFacility.h"
 #include "../Things/Structures/Warehouse.h"

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -5,7 +5,7 @@
 
 #include "../Cache.h"
 #include "../Common.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../StructureManager.h"
 #include "../Things/Structures/MineFacility.h"

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/NotificationWindow.cpp
+++ b/OPHD/UI/NotificationWindow.cpp
@@ -1,7 +1,6 @@
 #include "NotificationWindow.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -2,7 +2,7 @@
 
 #include "../Cache.h"
 #include "../Common.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../Population/Population.h"
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -3,6 +3,7 @@
 #include "../Cache.h"
 #include "../Common.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 #include "../Population/Population.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -1,6 +1,6 @@
 #include "ProductListBox.h"
 
-#include "../Constants.h"
+#include "../Constants/UiConstants.h"
 #include "../Cache.h"
 #include "../ProductPool.h"
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -2,7 +2,8 @@
 
 #include "../TextRender.h"
 #include "../../Cache.h"
-#include "../../Constants.h"
+#include "../../Constants/Strings.h"
+#include "../../Constants/UiConstants.h"
 #include "../../StructureManager.h"
 #include "../../ProductionCost.h"
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -2,8 +2,11 @@
 
 #include "../TextRender.h"
 
+#include "../../Constants/Numbers.h"
+#include "../../Constants/Strings.h"
+#include "../../Constants/UiConstants.h"
+
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../StructureManager.h"
 #include "../../ProductionCost.h"
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -1,7 +1,6 @@
 #include "WarehouseReport.h"
 
 #include "../../Cache.h"
-#include "../../Constants.h"
 #include "../../StructureManager.h"
 #include "../../Things/Structures/Structure.h"
 #include "../../Things/Structures/Warehouse.h"

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -2,7 +2,6 @@
 
 #include "../Cache.h"
 #include "../Common.h"
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/StringUtils.h>

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -3,6 +3,7 @@
 #include "../Cache.h"
 #include "../Common.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/StringUtils.h>
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -2,7 +2,7 @@
 #include "TextRender.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -3,6 +3,7 @@
 
 #include "../Cache.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -1,7 +1,7 @@
 #include "StructureInspector.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../Things/Structures/Structure.h"
 #include "StringTable.h"
 #include "TextRender.h"

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -2,7 +2,6 @@
 
 #include "../Things/Structures/Structure.h"
 
-#include "../Constants.h"
 #include "../Cache.h"
 
 #include <NAS2D/Utility.h>

--- a/OPHD/UI/TextRender.cpp
+++ b/OPHD/UI/TextRender.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/TextRender.cpp
+++ b/OPHD/UI/TextRender.cpp
@@ -1,7 +1,6 @@
 #include "TextRender.h"
 
 #include "../Cache.h"
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Resource/Font.h>

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -1,7 +1,7 @@
 #include "TileInspector.h"
 
 #include "TextRender.h"
-#include "../Constants.h"
+#include "../Constants/Strings.h"
 #include "../Mine.h"
 
 #include <map>

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -2,6 +2,7 @@
 
 #include "TextRender.h"
 #include "../Constants.h"
+#include "../Constants/UiConstants.h"
 
 #include "../Things/Structures/Warehouse.h"
 

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -1,7 +1,6 @@
 #include "WarehouseInspector.h"
 
 #include "TextRender.h"
-#include "../Constants.h"
 #include "../Constants/UiConstants.h"
 
 #include "../Things/Structures/Warehouse.h"

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -1,6 +1,6 @@
 #include "Cache.h"
 #include "Common.h"
-#include "Constants.h"
+#include "Constants/Numbers.h"
 #include "WindowEventWrapper.h"
 
 #include "States/GameState.h"

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -313,7 +313,6 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
   <ItemGroup>
     <ClInclude Include="Cache.h" />
     <ClInclude Include="Common.h" />
-    <ClInclude Include="Constants.h" />
     <ClInclude Include="Constants\Numbers.h" />
     <ClInclude Include="Constants\Strings.h" />
     <ClInclude Include="Constants\UiConstants.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -434,9 +434,6 @@
     <ClInclude Include="States\Planet.h">
       <Filter>Header Files\States</Filter>
     </ClInclude>
-    <ClInclude Include="Constants.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Constants\Numbers.h">
       <Filter>Header Files\Constants</Filter>
     </ClInclude>


### PR DESCRIPTION
Reference: #138

Remove **Constants.h** and force including of more specific headers individually. This has a rather noticeable impact on the dependency graph, significantly reducing transitive dependencies.
