### PR TITLE
Remove `cout` in State classes

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -10,8 +10,6 @@
 #include <NAS2D/Xml/XmlDocument.h>
 #include <NAS2D/Xml/XmlElement.h>
 
-#include <iostream>
-
 
 using namespace NAS2D;
 

--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -4,7 +4,6 @@
 #include "../RandomNumberGenerator.h"
 
 #include <algorithm>
-#include <iostream>
 #include <array>
 #include <stdexcept>
 #include <string>

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -970,7 +970,14 @@ void MapViewState::placeRobodozer(Tile& tile)
 		/**
 		 * \todo	This could/should be some sort of alert message to the user instead of dumped to the console
 		 */
-		if (!recycledResources.isEmpty()) { std::cout << "Resources wasted demolishing " << structure->name() << std::endl; }
+		if (!recycledResources.isEmpty())
+		{
+			mNotificationArea.push(
+				"Resources wasted",
+				"Resources wasted demolishing " + structure->name(),
+				tile.xyz(),
+				NotificationArea::NotificationType::Warning);
+		}
 
 		updatePlayerResources();
 		updateStructuresAvailability();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -945,7 +945,19 @@ void MapViewState::placeRobodozer(Tile& tile)
 
 		if (structure->isRobotCommand())
 		{
-			deleteRobotsInRCC(&robot, static_cast<RobotCommand*>(structure), mRobotPool, mRobotList, &tile);
+			auto* rcc = static_cast<RobotCommand*>(structure);
+			if (rcc->isControlling(&robot))
+			{
+				mNotificationArea.push(
+					"Cannot bulldoze",
+					"Cannot bulldoze Robot Command Center by a Robot under its command.",
+					tile.xyz(),
+					NotificationArea::NotificationType::Information);
+			}
+			else
+			{
+				deleteRobotsInRCC(rcc, mRobotPool, mRobotList);
+			}
 		}
 
 		if (structure->isFactory() && static_cast<Factory*>(structure) == mFactoryProduction.factory())

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1335,8 +1335,6 @@ void MapViewState::updateRobots()
 
 		if (robot->dead())
 		{
-			std::cout << "dead robot" << std::endl;
-
 			const auto robotLocationText = "(" +  std::to_string(position.xy.x) + ", " + std::to_string(position.xy.y) + ")";
 
 			if (robot->selfDestruct())

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1025,7 +1025,11 @@ void MapViewState::placeRobodigger(Tile& tile)
 		if (!doYesNoMessage(constants::AlertDiggerMineTile, constants::AlertDiggerMine)) { return; }
 
 		const auto position = tile.xy();
-		std::cout << "Digger destroyed a Mine at (" << position.x << ", " << position.y << ")." << std::endl;
+		mNotificationArea.push(
+			"Mine destroyed",
+			"Digger destroyed a Mine at (" + std::to_string(position.x) + ", " + std::to_string(position.y) + ").",
+			tile.xyz(),
+			NotificationArea::NotificationType::Information);
 		mTileMap->removeMineLocation(position);
 	}
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -13,6 +13,8 @@
 
 #include <NAS2D/Utility.h>
 
+#include <stdexcept>
+
 
 void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 {
@@ -89,8 +91,7 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
 		}
 
 	default:
-		std::cout << "Unknown Product." << std::endl;
-		break;
+		throw std::runtime_error("Unknown product completed");
 	}
 }
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -183,14 +183,8 @@ bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position)
 }
 
 
-void deleteRobotsInRCC(Robot* robotToDelete, RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt, Tile* /*tile*/)
+void deleteRobotsInRCC(RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt)
 {
-	if (rcc->isControlling(robotToDelete))
-	{
-		std::cout << "Cannot bulldoze Robot Command Center by a Robot under its command." << std::endl;
-		return;
-	}
-
 	const RobotList& rl = rcc->robots();
 
 	for (auto robot : rl)

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -64,4 +64,4 @@ void resetTileIndexFromDozer(Robot* robot, Tile* tile);
 NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap);
 
 void updateRobotControl(RobotPool& robotPool);
-void deleteRobotsInRCC(Robot* robot, RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt, Tile* tile);
+void deleteRobotsInRCC(RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -311,8 +311,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 			break;
 
 		default:
-			std::cout << "Unknown robot type in savegame." << std::endl;
-			break;
+			throw std::runtime_error("Unknown robot type in savegame.");
 		}
 
 		// Could be done in the default handler in the above switch

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -27,7 +27,6 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
-#include <iostream>
 
 
 /// \fixme	Fugly, find a sane way to do this.


### PR DESCRIPTION
Reference: #138, PR #1113

Remove uses of `cout` in the `State` derived classes. Mostly that meant converting them to exceptions or notifications.
