### PR TITLE
It's dead Jim

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -96,13 +96,11 @@ TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int
 	mTileset(tilesetPath),
 	mMineBeacon("structures/mine_beacon.png")
 {
-	std::cout << "Loading '" << mapPath << "'... ";
 	buildTerrainMap(mapPath);
 	buildMouseMap();
 	initMapDrawParams(Utility<Renderer>::get().size());
 
 	if (shouldSetupMines) { setupMines(mineCount, hostility); }
-	std::cout << "finished!" << std::endl;
 }
 
 

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -3,7 +3,6 @@
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Resource/Sprite.h>
 
-#include <iostream>
 #include <string>
 
 
@@ -23,9 +22,6 @@ public:
 
 	virtual ~Thing()
 	{
-		#ifdef _DEBUG
-		std::cout << mName << ": He's dead Jim!" << std::endl;
-		#endif
 	}
 
 	virtual void update() = 0;

--- a/OPHD/Things/Thing.h
+++ b/OPHD/Things/Thing.h
@@ -20,9 +20,7 @@ public:
 		mSprite(spritePath, initialAction)
 	{}
 
-	virtual ~Thing()
-	{
-	}
+	virtual ~Thing() = default;
 
 	virtual void update() = 0;
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -10,6 +10,9 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <array>
+#include <string>
+#include <iterator>
+#include <algorithm>
 
 
 using namespace NAS2D;


### PR DESCRIPTION
Reference: #138, PR #1113, PR #1114

Removes the last uses of `cout` outside of `main` from OPHD.

Considering how many files would indirectly include `Thing`, which included `<iostream>`, 
an often rather hefty standard library header, it's probably good to get rid of that include.
