### PR TITLE
Protected UIContainer

### DIFF
--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -14,10 +14,9 @@ using namespace NAS2D;
 
 
 ComboBox::ComboBox() :
-	mContainer{{&btnDown, &txtField, &lstItems}}
+	UIContainer{{&btnDown, &txtField, &lstItems}}
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().connect(this, &ComboBox::onMouseDown);
 	eventHandler.mouseWheel().connect(this, &ComboBox::onMouseWheel);
 
 	btnDown.image("ui/icons/down.png");
@@ -35,7 +34,6 @@ ComboBox::~ComboBox()
 {
 	lstItems.selectionChanged().disconnect(this, &ComboBox::onListSelectionChange);
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().disconnect(this, &ComboBox::onMouseDown);
 	eventHandler.mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
 }
 
@@ -83,6 +81,8 @@ void ComboBox::onMove(NAS2D::Vector<int> displacement)
  */
 void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	UIContainer::onMouseDown(button, x, y);
+
 	if (!enabled() || !visible()) { return; }
 
 	if (button != EventHandler::MouseButton::Left) { return; }
@@ -188,11 +188,6 @@ void ComboBox::setSelected(std::size_t index) {
 	lstItems.setSelected(index);
 	text(selectionText());
 	mSelectionChanged();
-}
-
-void ComboBox::update()
-{
-	mContainer.update();
 }
 
 void ComboBox::text(const std::string& text) {

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -12,7 +12,7 @@
 #include <cstddef>
 
 
-class ComboBox : public Control
+class ComboBox : public UIContainer
 {
 public:
 	using SelectionChangeSignal = NAS2D::Signal<>;
@@ -36,8 +36,6 @@ public:
 	std::size_t selectedIndex() { return lstItems.selectedIndex(); }
 	void setSelected(std::size_t index);
 
-	void update() override;
-
 	void text(const std::string& text);
 	const std::string& text() const;
 
@@ -47,9 +45,8 @@ private:
 	void onListSelectionChange();
 
 	void onMouseWheel(int x, int y);
-	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
 
-	UIContainer mContainer;
 	Button btnDown;
 	ListBox<> lstItems;
 	TextField txtField;

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -13,7 +13,7 @@
  * 
  * Generally not intended to be used by itself.
  */
-class UIContainer: public Control
+class UIContainer : public Control
 {
 public:
 	UIContainer();

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -16,6 +16,9 @@
 class UIContainer : public Control
 {
 public:
+	void update() override;
+
+protected:
 	UIContainer();
 	UIContainer(std::vector<Control*> controls);
 	~UIContainer() override;
@@ -24,8 +27,6 @@ public:
 	void clear();
 
 	void bringToFront(Control* control);
-
-	void update() override;
 
 	const std::vector<Control*>& controls() const;
 

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -15,9 +15,6 @@
  */
 class UIContainer : public Control
 {
-public:
-	void update() override;
-
 protected:
 	UIContainer();
 	UIContainer(std::vector<Control*> controls);
@@ -27,6 +24,8 @@ protected:
 	void clear();
 
 	void bringToFront(Control* control);
+
+	void update() override;
 
 	const std::vector<Control*>& controls() const;
 

--- a/OPHD/UI/Reports/ReportInterface.h
+++ b/OPHD/UI/Reports/ReportInterface.h
@@ -22,6 +22,8 @@ public:
 
 	ReportInterface() {}
 
+	using UIContainer::update;
+
 	/**
 	 * Instructs the Report UI to clear any selections it may have.
 	 */


### PR DESCRIPTION
Reference: #894, #896

The `UIContainer` class is really intended to be derived from, and used to privately manage `Control` fields of the derived class. As such, marking the methods as `protected` ensures only the derived class can add `Control` objects to itself. This makes it useful mainly for compound controls, such as `ComboBox` controls, or custom report views.

If a public container control is desired, the `protected` methods could be re-exported as `public`.
