### PR TITLE
Fix uninitialized value bug

### DIFF
--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -131,7 +131,7 @@ private:
 
 	NAS2D::Timer mTimer;
 
-	MapCoordinate mMouseTilePosition; /**< Tile the mouse is pointing to. */
+	MapCoordinate mMouseTilePosition{}; /**< Tile the mouse is pointing to. */
 	NAS2D::Point<int> mMousePosition; /**< Current mouse position. */
 	NAS2D::Point<int> mMapViewLocation;
 


### PR DESCRIPTION
Fix uninitialized value bug for z coordinate, introduced in PR #1120 (commit 384e9fadd11a867366e5f0715a4579f793ba4cb2). This one was a bit intermittent, so didn't catch earlier. The old code set a default `z` value of `0`, which that commit missed accounting for when switching to `MapCoordinate` structs.
