### PR TITLE
Call Control::onMove event when calling Control::area

### DIFF
--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -6,7 +6,9 @@ using namespace NAS2D;
 
 void Control::area(const NAS2D::Rectangle<int>& area)
 {
+	const auto displacement = area.startPoint() - mRect.startPoint();
 	mRect = area;
+	onMove(displacement);
 	onResize();
 }
 


### PR DESCRIPTION
Fix for commit cde7d30285c18a1827f97c8e8f71a5ba7dfafbcb from PR #1118.

Setting `Control::area` affects both `position` and `size`, so should raise both `onMove` and `onResize` events.
