### PR TITLE
Split NavControl from MapViewState

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -119,7 +119,8 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mPlanetAttributes(planetAttributes),
 	mResourceInfoBar{mResourcesCount, mPopulation, mCurrentMorale, mPreviousMorale, mFood},
 	mMiniMap{std::make_unique<MiniMap>(mTileMap, mRobotList, planetAttributes.mapImagePath)},
-	mRobotDeploymentSummary{mRobotPool}
+	mRobotDeploymentSummary{mRobotPool},
+	mNavControl{std::make_unique<NavControl>(mTileMap)}
 {
 	difficulty(selectedDifficulty);
 	ccLocation() = CcNotPlaced;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -35,6 +35,7 @@
 #include "../UI/ResourceInfoBar.h"
 #include "../UI/MiniMap.h"
 #include "../UI/RobotDeploymentSummary.h"
+#include "../UI/NavControl.h"
 
 #include "../UI/Core/WindowStack.h"
 #include "../UI/Core/ToolTip.h"
@@ -137,8 +138,6 @@ private:
 
 	// DRAWING FUNCTIONS
 	void drawUI();
-
-	void drawNavInfo() const;
 	void drawSystemButton() const;
 
 	// INSERT OBJECT HANDLING
@@ -374,4 +373,5 @@ private:
 	ResourceInfoBar mResourceInfoBar;
 	std::unique_ptr<MiniMap> mMiniMap;
 	RobotDeploymentSummary mRobotDeploymentSummary;
+	std::unique_ptr<NavControl> mNavControl;
 };

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -22,18 +22,6 @@
 
 extern NAS2D::Point<int> MOUSE_COORDS;
 
-namespace
-{
-	std::map<int, std::string> LevelStringTable =
-	{
-		{constants::DepthSurface, constants::LevelSurface},
-		{constants::DepthUnderground1, constants::Levelunderground1},
-		{constants::DepthUnderground2, constants::Levelunderground2},
-		{constants::DepthUnderground3, constants::Levelunderground3},
-		{constants::DepthUnderground4, constants::Levelunderground4}
-	};
-}
-
 
 void MapViewState::drawSystemButton() const
 {
@@ -53,49 +41,4 @@ void MapViewState::drawSystemButton() const
 	int menuGearHighlightOffsetX = isMouseInMenu ? 144 : 128;
 	const auto menuImageRect = NAS2D::Rectangle{menuGearHighlightOffsetX, 32, constants::ResourceIconSize, constants::ResourceIconSize};
 	renderer.drawSubImage(mUiIcons, position, menuImageRect);
-}
-
-
-/**
- * Draws navigation UI.
- */
-void MapViewState::drawNavInfo() const
-{
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-
-	const std::array buttonDrawAreas
-	{
-		std::tuple{mMoveDownIconRect, NAS2D::Rectangle{64, 128, 32, 32}},
-		std::tuple{mMoveUpIconRect, NAS2D::Rectangle{96, 128, 32, 32}},
-		std::tuple{mMoveEastIconRect, NAS2D::Rectangle{32, 128, 32, 16}},
-		std::tuple{mMoveWestIconRect, NAS2D::Rectangle{32, 144, 32, 16}},
-		std::tuple{mMoveNorthIconRect, NAS2D::Rectangle{0, 128, 32, 16}},
-		std::tuple{mMoveSouthIconRect, NAS2D::Rectangle{0, 144, 32, 16}},
-	};
-	for (const auto& [currentIconBounds, subImageBounds] : buttonDrawAreas)
-	{
-		bool isMouseInIcon = currentIconBounds.contains(MOUSE_COORDS);
-		NAS2D::Color color = isMouseInIcon ? NAS2D::Color::Red : NAS2D::Color::White;
-		renderer.drawSubImage(mUiIcons, currentIconBounds.startPoint(), subImageBounds, color);
-	}
-
-	// Display the levels "bar"
-	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
-	const auto stepSizeWidth = font.width("IX");
-	auto position = NAS2D::Point{renderer.size().x - 5, mMiniMapBoundingBox.y - 30};
-	for (int i = mTileMap->maxDepth(); i >= 0; i--)
-	{
-		const auto levelString = (i == 0) ? std::string{"S"} : std::to_string(i);
-		const auto textSize = font.size(levelString);
-		bool isCurrentDepth = i == mTileMap->currentDepth();
-		NAS2D::Color color = isCurrentDepth ? NAS2D::Color::Red : NAS2D::Color{200, 200, 200};
-		renderer.drawText(font, levelString, position - textSize, color);
-		position.x -= stepSizeWidth;
-	}
-
-	// Explicit current level
-	const auto& currentLevelString = LevelStringTable[mTileMap->currentDepth()];
-	const auto& fontBoldMedium = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium);
-	const auto currentLevelPosition = mMiniMapBoundingBox.crossXPoint() - fontBoldMedium.size(currentLevelString) - NAS2D::Vector{0, 12};
-	renderer.drawText(fontBoldMedium, currentLevelString, currentLevelPosition, NAS2D::Color::White);
 }

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -187,6 +187,7 @@ void MapViewState::load(const std::string& filePath)
 	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.tilesetPath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 	mMiniMap = std::make_unique<MiniMap>(mTileMap, mRobotList, mPlanetAttributes.mapImagePath);
+	mNavControl = std::make_unique<NavControl>(mTileMap);
 
 	delete mPathSolver;
 	mPathSolver = new micropather::MicroPather(mTileMap);

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -196,6 +196,10 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mMiniMapBoundingBox = {size.x - 300 - constants::Margin, mBottomUiRect.y + constants::Margin, 300, 150};
 	mMiniMap->area(mMiniMapBoundingBox);
 
+	const auto navControlEndPoint = NAS2D::Point{size.x, mBottomUiRect.y};
+	const auto navControlSize = NAS2D::Vector{navIconSpacing * 3, 99};
+	mNavControl->area(NAS2D::Rectangle<int>::Create(navControlEndPoint - navControlSize, navControlSize));
+
 	// Position UI Buttons
 	mBtnTurns.position(NAS2D::Point{mMiniMapBoundingBox.x - constants::MainButtonSize - constants::MarginTight, size.y - constants::Margin - constants::MainButtonSize});
 	mBtnToggleHeightmap.position({mBtnTurns.positionX(), mMiniMapBoundingBox.y});
@@ -392,9 +396,7 @@ void MapViewState::drawUI()
 	renderer.drawLine(NAS2D::Point{mBottomUiRect.x + 1, mBottomUiRect.y}, NAS2D::Point{mBottomUiRect.x + mBottomUiRect.width - 2, mBottomUiRect.y}, NAS2D::Color{56, 56, 56});
 
 	mMiniMap->draw();
-
-	drawNavInfo();
-
+	mNavControl->draw();
 	mRobotDeploymentSummary.draw();
 
 	if (mResourceInfoBar.isPopulationPanelVisible()) { mPopulationPanel.update(); }

--- a/OPHD/UI/NavControl.cpp
+++ b/OPHD/UI/NavControl.cpp
@@ -1,0 +1,97 @@
+#include "NavControl.h"
+
+#include "../Cache.h"
+#include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
+#include "../Map/TileMap.h"
+
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+#include <NAS2D/Renderer/Color.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Resource/Font.h>
+
+
+extern NAS2D::Point<int> MOUSE_COORDS;
+
+namespace
+{
+	std::map<int, std::string> LevelStringTable =
+	{
+		{constants::DepthSurface, constants::LevelSurface},
+		{constants::DepthUnderground1, constants::Levelunderground1},
+		{constants::DepthUnderground2, constants::Levelunderground2},
+		{constants::DepthUnderground3, constants::Levelunderground3},
+		{constants::DepthUnderground4, constants::Levelunderground4}
+	};
+}
+
+
+NavControl::NavControl(const TileMap* tileMap) :
+	mTileMap{tileMap},
+	mUiIcons{imageCache.load("ui/icons.png")}
+{
+	onMove({0, 0});
+}
+
+
+void NavControl::onMove(NAS2D::Vector<int> displacement)
+{
+	Control::onMove(displacement);
+
+	// NAVIGATION BUTTONS
+	const auto position = mRect.startPoint();
+	const auto navIconSpacing = 32 + constants::MarginTight;
+	// Top line
+	mMoveWestIconRect = {position.x, position.y + 8, 32, 16};
+	mMoveNorthIconRect = {position.x + navIconSpacing, position.y + 8, 32, 16};
+	mMoveUpIconRect = {position.x + 2 * navIconSpacing, position.y, 32, 32};
+	// Bottom line
+	mMoveSouthIconRect = {position.x, position.y + navIconSpacing + 8, 32, 16};
+	mMoveEastIconRect = {position.x + navIconSpacing, position.y + navIconSpacing + 8, 32, 16};
+	mMoveDownIconRect = {position.x + 2 * navIconSpacing, position.y + navIconSpacing, 32, 32};
+}
+
+/**
+ * Draws navigation UI.
+ */
+void NavControl::draw() const
+{
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+
+	const std::array buttonDrawAreas
+	{
+		std::tuple{mMoveDownIconRect, NAS2D::Rectangle{64, 128, 32, 32}},
+		std::tuple{mMoveUpIconRect, NAS2D::Rectangle{96, 128, 32, 32}},
+		std::tuple{mMoveEastIconRect, NAS2D::Rectangle{32, 128, 32, 16}},
+		std::tuple{mMoveWestIconRect, NAS2D::Rectangle{32, 144, 32, 16}},
+		std::tuple{mMoveNorthIconRect, NAS2D::Rectangle{0, 128, 32, 16}},
+		std::tuple{mMoveSouthIconRect, NAS2D::Rectangle{0, 144, 32, 16}},
+	};
+	for (const auto& [currentIconBounds, subImageBounds] : buttonDrawAreas)
+	{
+		bool isMouseInIcon = currentIconBounds.contains(MOUSE_COORDS);
+		NAS2D::Color color = isMouseInIcon ? NAS2D::Color::Red : NAS2D::Color::White;
+		renderer.drawSubImage(mUiIcons, currentIconBounds.startPoint(), subImageBounds, color);
+	}
+
+	// Display the levels "bar"
+	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const auto stepSizeWidth = font.width("IX");
+	auto position = mRect.endPoint() - NAS2D::Vector{5, 30 - constants::Margin};
+	for (int i = mTileMap->maxDepth(); i >= 0; i--)
+	{
+		const auto levelString = (i == 0) ? std::string{"S"} : std::to_string(i);
+		const auto textSize = font.size(levelString);
+		bool isCurrentDepth = i == mTileMap->currentDepth();
+		NAS2D::Color color = isCurrentDepth ? NAS2D::Color::Red : NAS2D::Color{200, 200, 200};
+		renderer.drawText(font, levelString, position - textSize, color);
+		position.x -= stepSizeWidth;
+	}
+
+	// Explicit current level
+	const auto& currentLevelString = LevelStringTable[mTileMap->currentDepth()];
+	const auto& fontBoldMedium = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium);
+	const auto currentLevelPosition = mRect.endPoint() - fontBoldMedium.size(currentLevelString) - NAS2D::Vector{constants::Margin, constants::Margin};
+	renderer.drawText(fontBoldMedium, currentLevelString, currentLevelPosition, NAS2D::Color::White);
+}

--- a/OPHD/UI/NavControl.h
+++ b/OPHD/UI/NavControl.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Core/Control.h"
+
+#include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Math/Vector.h>
+
+
+namespace NAS2D
+{
+	class Image;
+}
+
+class TileMap;
+
+
+class NavControl : public Control
+{
+public:
+	NavControl(const TileMap* tileMap);
+
+	void draw() const override;
+
+protected:
+	void onMove(NAS2D::Vector<int> displacement) override;
+
+private:
+	const TileMap* const mTileMap;
+	const NAS2D::Image& mUiIcons;
+
+	NAS2D::Rectangle<int> mMoveNorthIconRect;
+	NAS2D::Rectangle<int> mMoveSouthIconRect;
+	NAS2D::Rectangle<int> mMoveEastIconRect;
+	NAS2D::Rectangle<int> mMoveWestIconRect;
+	NAS2D::Rectangle<int> mMoveUpIconRect;
+	NAS2D::Rectangle<int> mMoveDownIconRect;
+	NAS2D::Rectangle<int> mBottomUiRect;
+};

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -293,6 +293,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="UI\MessageBox.cpp" />
     <ClCompile Include="UI\MineOperationsWindow.cpp" />
     <ClCompile Include="UI\MiniMap.cpp" />
+    <ClCompile Include="UI\NavControl.cpp" />
     <ClCompile Include="UI\NotificationArea.cpp" />
     <ClCompile Include="UI\NotificationWindow.cpp" />
     <ClCompile Include="UI\PopulationPanel.cpp" />
@@ -426,6 +427,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClInclude Include="UI\MessageBox.h" />
     <ClInclude Include="UI\MineOperationsWindow.h" />
     <ClInclude Include="UI\MiniMap.h" />
+    <ClInclude Include="UI\NavControl.h" />
     <ClInclude Include="UI\NotificationArea.h" />
     <ClInclude Include="UI\NotificationWindow.h" />
     <ClInclude Include="UI\PopulationPanel.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -216,6 +216,9 @@
     <ClCompile Include="UI\MiniMap.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
+    <ClCompile Include="UI\NavControl.cpp">
+      <Filter>Source Files\UI</Filter>
+    </ClCompile>
     <ClCompile Include="States\MainReportsUiState.cpp">
       <Filter>Source Files\States</Filter>
     </ClCompile>
@@ -597,6 +600,9 @@
       <Filter>Header Files\UI</Filter>
     </ClInclude>
     <ClInclude Include="UI\MiniMap.h">
+      <Filter>Header Files\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\NavControl.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
     <ClInclude Include="States\Wrapper.h">


### PR DESCRIPTION
Reference: #650

Extract `NavControl` from `MapViewState`, and use the new control for drawing.

Currently the event handling code to handle moving the view is still in `MapViewState`. That means a bit of duplication of code/state tracking where those buttons are on screen. That will be addressed later. Currently the focus is on the draw code.
