### PR TITLE
Refactor TileMap and sort into data and view sections

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -343,6 +343,12 @@ void TileMap::moveView(Direction direction)
 }
 
 
+void TileMap::currentDepth(int i)
+{
+	mMouseTilePosition.z = std::clamp(i, 0, mMaxDepth);
+}
+
+
 /**
  * Returns true if the current tile highlight is actually within the visible diamond map.
  */

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -321,6 +321,12 @@ void TileMap::mapViewLocation(const MapCoordinate& position)
 }
 
 
+void TileMap::centerOn(const MapCoordinate& position)
+{
+	mapViewLocation({position.xy - NAS2D::Vector{mEdgeLength, mEdgeLength} / 2, position.z});
+}
+
+
 /**
  * Convenience function to focus the TileMap's view on a specified tile.
  * 
@@ -330,7 +336,7 @@ void TileMap::centerMapOnTile(Tile* tile)
 {
 	if (!tile) { return; }
 
-	mapViewLocation({tile->xy() - NAS2D::Vector{mEdgeLength, mEdgeLength} / 2, tile->depth()});
+	centerOn(tile->xyz());
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -327,19 +327,6 @@ void TileMap::centerOn(const MapCoordinate& position)
 }
 
 
-/**
- * Convenience function to focus the TileMap's view on a specified tile.
- * 
- * \param	tile	Pointer to a Tile. Safe to pass nullptr.
- */
-void TileMap::centerMapOnTile(Tile* tile)
-{
-	if (!tile) { return; }
-
-	centerOn(tile->xyz());
-}
-
-
 void TileMap::moveView(Direction direction)
 {
 	mapViewLocation({

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -52,26 +52,24 @@ public:
 	const Point2dList& mineLocations() const { return mMineLocations; }
 	void removeMineLocation(const NAS2D::Point<int>& pt);
 
-	Tile* getVisibleTile(const MapCoordinate& position);
-	Tile* getVisibleTile() { return getVisibleTile(mouseTilePosition()); }
-
-	bool isVisibleTile(const MapCoordinate& position) const;
-
-	const NAS2D::Rectangle<int>& boundingBox() const { return mMapBoundingBox; }
-
 	const NAS2D::Point<int>& mapViewLocation() const { return mOriginTilePosition; }
 	void mapViewLocation(NAS2D::Point<int> point);
 	void mapViewLocation(const MapCoordinate& position);
 	void centerMapOnTile(Tile*);
 	void moveView(Direction direction);
 
-	bool tileHighlightVisible() const;
-	const MapCoordinate& mouseTilePosition() const { return mMouseTilePosition; }
-
-	int edgeLength() const { return mEdgeLength; }
-
 	int currentDepth() const { return mMouseTilePosition.z; }
 	void currentDepth(int i) { mMouseTilePosition.z = std::clamp(i, 0, mMaxDepth); }
+
+	bool isVisibleTile(const MapCoordinate& position) const;
+	bool tileHighlightVisible() const;
+
+	const MapCoordinate& mouseTilePosition() const { return mMouseTilePosition; }
+	Tile* getVisibleTile(const MapCoordinate& position);
+	Tile* getVisibleTile() { return getVisibleTile(mouseTilePosition()); }
+
+	int edgeLength() const { return mEdgeLength; }
+	const NAS2D::Rectangle<int>& boundingBox() const { return mMapBoundingBox; }
 
 	void injectMouse(NAS2D::Point<int> position) { mMousePixelPosition = position; }
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -54,7 +54,6 @@ public:
 	void mapViewLocation(NAS2D::Point<int> point);
 	void mapViewLocation(const MapCoordinate& position);
 	void centerOn(const MapCoordinate& position);
-	void centerMapOnTile(Tile*);
 	void moveView(Direction direction);
 
 	int currentDepth() const { return mMouseTilePosition.z; }

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -53,6 +53,7 @@ public:
 	const NAS2D::Point<int>& mapViewLocation() const { return mOriginTilePosition; }
 	void mapViewLocation(NAS2D::Point<int> point);
 	void mapViewLocation(const MapCoordinate& position);
+	void centerOn(const MapCoordinate& position);
 	void centerMapOnTile(Tile*);
 	void moveView(Direction direction);
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -8,8 +8,6 @@
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
 
-#include <algorithm>
-
 
 namespace NAS2D
 {

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -59,7 +59,7 @@ public:
 	void moveView(Direction direction);
 
 	int currentDepth() const { return mMouseTilePosition.z; }
-	void currentDepth(int i) { mMouseTilePosition.z = std::clamp(i, 0, mMaxDepth); }
+	void currentDepth(int i);
 
 	bool isVisibleTile(const MapCoordinate& position) const;
 	bool tileHighlightVisible() const;

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -41,10 +41,16 @@ public:
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;
 
+	NAS2D::Vector<int> size() const { return mSizeInTiles; }
+	int maxDepth() const { return mMaxDepth; }
+
 	bool isValidPosition(const MapCoordinate& position) const;
 
 	Tile& getTile(const MapCoordinate& position);
 	Tile& getTile(NAS2D::Point<int> position) { return getTile({position, mMouseTilePosition.z}); }
+
+	const Point2dList& mineLocations() const { return mMineLocations; }
+	void removeMineLocation(const NAS2D::Point<int>& pt);
 
 	Tile* getVisibleTile(const MapCoordinate& position);
 	Tile* getVisibleTile() { return getVisibleTile(mouseTilePosition()); }
@@ -62,16 +68,10 @@ public:
 	bool tileHighlightVisible() const;
 	const MapCoordinate& mouseTilePosition() const { return mMouseTilePosition; }
 
-	const Point2dList& mineLocations() const { return mMineLocations; }
-	void removeMineLocation(const NAS2D::Point<int>& pt);
-
 	int edgeLength() const { return mEdgeLength; }
-	NAS2D::Vector<int> size() const { return mSizeInTiles; }
 
 	int currentDepth() const { return mMouseTilePosition.z; }
 	void currentDepth(int i) { mMouseTilePosition.z = std::clamp(i, 0, mMaxDepth); }
-
-	int maxDepth() const { return mMaxDepth; }
 
 	void injectMouse(NAS2D::Point<int> position) { mMousePixelPosition = position; }
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -225,7 +225,7 @@ void MapViewState::_deactivate()
 void MapViewState::focusOnStructure(Structure* structure)
 {
 	if (!structure) { return; }
-	mTileMap->centerMapOnTile(&NAS2D::Utility<StructureManager>::get().tileFromStructure(structure));
+	mTileMap->centerOn(NAS2D::Utility<StructureManager>::get().tileFromStructure(structure).xyz());
 }
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -690,8 +690,7 @@ void MapViewState::onFileIoAction(const std::string& filePath, FileIo::FileOpera
 
 void MapViewState::onNotificationWindowTakeMeThere(const MapCoordinate& position)
 {
-	mTileMap->centerMapOnTile(&mTileMap->getTile(position.xy));
-	mTileMap->currentDepth(position.z);
+	mTileMap->centerOn(position);
 }
 
 


### PR DESCRIPTION
Reference: #650

A bit of cleanup for `TileMap`. I'm kind of thinking we may want to split this class into a data portion and a view portion. Or perhaps split off the drawing related code related to drawing the detail map.
