### PR TITLE
Decouple Sprite::update and Sprite::draw

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -392,7 +392,8 @@ void TileMap::draw()
 				if (tile.thing())
 				{
 					auto& sprite = tile.thing()->sprite();
-					sprite.update(position);
+					sprite.update();
+					sprite.draw(position);
 				}
 			}
 		}

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -389,7 +389,11 @@ void TileMap::draw()
 				}
 
 				// Tell an occupying thing to update itself.
-				if (tile.thing()) { tile.thing()->sprite().update(position); }
+				if (tile.thing())
+				{
+					auto& sprite = tile.thing()->sprite();
+					sprite.update(position);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/995

Updated NAS2D submodule for decoupling `Sprite::update` and `Sprite::draw`.
