### PR TITLE
TileMap 1D array

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -130,7 +130,8 @@ const Tile& TileMap::getTile(const MapCoordinate& position) const
 		throw std::runtime_error("Tile coordinates out of bounds: {" + std::to_string(position.xy.x) + ", " + std::to_string(position.xy.y) + ", " + std::to_string(position.z) + "}");
 	}
 	const auto mapPosition = position.xy.to<std::size_t>();
-	return mTileMap[static_cast<std::size_t>(position.z)][mapPosition.y][mapPosition.x];
+	const auto level = static_cast<std::size_t>(position.z);
+	return mTileMap[((level * mSizeInTiles.y) + mapPosition.y) * mSizeInTiles.x + mapPosition.x];
 }
 
 
@@ -149,15 +150,7 @@ void TileMap::buildTerrainMap(const std::string& path)
 	const Image heightmap(path + MAP_TERRAIN_EXTENSION);
 
 	const auto levelCount = static_cast<std::size_t>(mMaxDepth) + 1;
-	mTileMap.resize(levelCount);
-	for (std::size_t level = 0; level < levelCount; level++)
-	{
-		mTileMap[level].resize(static_cast<std::size_t>(mSizeInTiles.y));
-		for (std::size_t i = 0; i < mTileMap[level].size(); i++)
-		{
-			mTileMap[level][i].resize(static_cast<std::size_t>(mSizeInTiles.x));
-		}
-	}
+	mTileMap.resize(mSizeInTiles.x * mSizeInTiles.y * levelCount);
 
 	/**
 	 * Builds a terrain map based on the pixel color values in

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -102,8 +102,6 @@ protected:
 	std::vector<std::vector<MouseMapRegion>> mMouseMap;
 
 private:
-	using TileArray = std::vector<Tile>;
-
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
 	void setupMines(int, Planet::Hostility);
@@ -117,7 +115,7 @@ private:
 
 	const NAS2D::Vector<int> mSizeInTiles;
 	const int mMaxDepth = 0;
-	TileArray mTileMap;
+	std::vector<Tile> mTileMap;
 	Point2dList mMineLocations;
 
 	std::string mMapPath;

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -102,8 +102,7 @@ protected:
 	std::vector<std::vector<MouseMapRegion>> mMouseMap;
 
 private:
-	using TileGrid = std::vector<std::vector<Tile>>;
-	using TileArray = std::vector<TileGrid>;
+	using TileArray = std::vector<Tile>;
 
 	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);


### PR DESCRIPTION
Using a 1D array means fewer allocations, and less fragmented memory.

Data is organized so adjacent X coordinates are next to each other in memory. That roughly matches the previous order. It also means access is most efficient when iterating though x in inner loops. Adjacent Z data is furthest from each other, which makes sense since you only view a single plane at a time.
