### PR TITLE
Simplify TileMap pixel to tile conversion

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -28,11 +28,8 @@ namespace {
 	const int TILE_WIDTH = 128;
 	const int TILE_HEIGHT = 64;
 
-	const int TILE_HALF_WIDTH = TILE_WIDTH / 2;
-
 	const int TILE_HEIGHT_OFFSET = 9;
 	const int TILE_HEIGHT_ABSOLUTE = TILE_HEIGHT - TILE_HEIGHT_OFFSET;
-	const int TILE_HEIGHT_HALF_ABSOLUTE = TILE_HEIGHT_ABSOLUTE / 2;
 
 	const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
@@ -396,7 +393,7 @@ void TileMap::draw() const
 
 			if (tile.excavated())
 			{
-				const auto position = mOriginPixelPosition + NAS2D::Vector{(col - row) * TILE_HALF_WIDTH, (col + row) * TILE_HEIGHT_HALF_ABSOLUTE};
+				const auto position = mOriginPixelPosition + NAS2D::Vector{(col - row) * TILE_WIDTH / 2, (col + row) * TILE_HEIGHT_ABSOLUTE / 2};
 				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 
@@ -435,7 +432,7 @@ void TileMap::updateTileHighlight()
 	}
 
 	/// In the case of even edge lengths, we need to adjust the mouse picking code a bit.
-	const int evenEdgeLengthAdjust = (edgeLength() % 2 == 0) ? TILE_HALF_WIDTH : 0;
+	const int evenEdgeLengthAdjust = (edgeLength() % 2 == 0) ? TILE_WIDTH / 2 : 0;
 	const int offsetX = ((mMousePixelPosition.x - mMapBoundingBox.x - evenEdgeLengthAdjust) / TILE_WIDTH);
 	const int offsetY = ((mMousePixelPosition.y - mMapBoundingBox.y) / TILE_HEIGHT_ABSOLUTE);
 	const int transform = (mOriginPixelPosition.x - mMapBoundingBox.x) / TILE_WIDTH;

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -431,39 +431,9 @@ void TileMap::updateTileHighlight()
 		return;
 	}
 
-	/// In the case of even edge lengths, we need to adjust the mouse picking code a bit.
-	const int evenEdgeLengthAdjust = (edgeLength() % 2 == 0) ? TILE_WIDTH / 2 : 0;
-	const int offsetX = ((mMousePixelPosition.x - mMapBoundingBox.x - evenEdgeLengthAdjust) / TILE_WIDTH);
-	const int offsetY = ((mMousePixelPosition.y - mMapBoundingBox.y) / TILE_HEIGHT_ABSOLUTE);
-	const int transform = (mOriginPixelPosition.x - mMapBoundingBox.x) / TILE_WIDTH;
-	NAS2D::Vector<int> highlightOffset = {-transform + offsetY + offsetX, transform + offsetY - offsetX};
-
-	const int mmOffsetX = std::clamp((mMousePixelPosition.x - mMapBoundingBox.x - evenEdgeLengthAdjust) % TILE_WIDTH, 0, TILE_WIDTH);
-	const int mmOffsetY = (mMousePixelPosition.y - mMapBoundingBox.y) % TILE_HEIGHT_ABSOLUTE;
-
-	switch (getMouseMapRegion(mmOffsetX, mmOffsetY))
-	{
-	case MouseMapRegion::MMR_TOP_RIGHT:
-		--highlightOffset.y;
-		break;
-
-	case MouseMapRegion::MMR_TOP_LEFT:
-		--highlightOffset.x;
-		break;
-
-	case MouseMapRegion::MMR_BOTTOM_RIGHT:
-		++highlightOffset.x;
-		break;
-
-	case MouseMapRegion::MMR_BOTTOM_LEFT:
-		++highlightOffset.y;
-		break;
-
-	default:
-		break;
-	}
-
-	mMouseTilePosition.xy = mOriginTilePosition + highlightOffset;
+	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + NAS2D::Vector{TILE_WIDTH / 2, TILE_HEIGHT_OFFSET});
+	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TILE_HEIGHT_ABSOLUTE + pixelOffset.y * TILE_WIDTH, pixelOffset.y * TILE_WIDTH - pixelOffset.x * TILE_HEIGHT_ABSOLUTE} / (TILE_WIDTH * TILE_HEIGHT_ABSOLUTE);
+	mMouseTilePosition.xy = mOriginTilePosition + tileOffset;
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -94,7 +94,6 @@ TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int
 	mMineBeacon("structures/mine_beacon.png")
 {
 	buildTerrainMap(mapPath);
-	buildMouseMap();
 	initMapDrawParams(Utility<Renderer>::get().size());
 
 	if (shouldSetupMines) { setupMines(mineCount, hostility); }
@@ -234,55 +233,6 @@ NAS2D::Point<int> TileMap::findSurroundingMineLocation(NAS2D::Point<int> centerP
 		}
 	}
 	return centerPoint;
-}
-
-
-/**
- * Build a logic map for determining what tile the mouse is pointing at.
- */
-void TileMap::buildMouseMap()
-{
-	const Image mousemap("ui/mouse_map.png");
-
-	// More sanity checks (mousemap should match dimensions of tile)
-	if (mousemap.size() != Vector{TILE_WIDTH, TILE_HEIGHT_ABSOLUTE})
-	{
-		throw std::runtime_error("Mouse map is the wrong dimensions.");
-	}
-
-	mMouseMap.resize(TILE_HEIGHT_ABSOLUTE);
-	for (std::size_t i = 0; i < mMouseMap.size(); i++)
-	{
-		mMouseMap[i].resize(TILE_WIDTH);
-	}
-
-	for (std::size_t row = 0; row < TILE_HEIGHT_ABSOLUTE; row++)
-	{
-		for (std::size_t col = 0; col < TILE_WIDTH; col++)
-		{
-			const Color c = mousemap.pixelColor({static_cast<int>(col), static_cast<int>(row)});
-			if (c == NAS2D::Color::Yellow)
-			{
-				mMouseMap[row][col] = MouseMapRegion::MMR_BOTTOM_RIGHT;
-			}
-			else if (c == NAS2D::Color::Red)
-			{
-				mMouseMap[row][col] = MouseMapRegion::MMR_TOP_LEFT;
-			}
-			else if (c == NAS2D::Color::Blue)
-			{
-				mMouseMap[row][col] = MouseMapRegion::MMR_TOP_RIGHT;
-			}
-			else if (c == NAS2D::Color::Green)
-			{
-				mMouseMap[row][col] = MouseMapRegion::MMR_BOTTOM_LEFT;
-			}
-			else
-			{
-				mMouseMap[row][col] = MouseMapRegion::MMR_MIDDLE;
-			}
-		}
-	}
 }
 
 
@@ -434,18 +384,6 @@ void TileMap::updateTileHighlight()
 	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + NAS2D::Vector{TILE_WIDTH / 2, TILE_HEIGHT_OFFSET});
 	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TILE_HEIGHT_ABSOLUTE + pixelOffset.y * TILE_WIDTH, pixelOffset.y * TILE_WIDTH - pixelOffset.x * TILE_HEIGHT_ABSOLUTE} / (TILE_WIDTH * TILE_HEIGHT_ABSOLUTE);
 	mMouseTilePosition.xy = mOriginTilePosition + tileOffset;
-}
-
-
-/**
- * Takes a point and determines where in the mouse map that point lies.
- *
- * \note	Assumes coords are normalized to the boundaries of a tile.
- */
-TileMap::MouseMapRegion TileMap::getMouseMapRegion(int x, int y)
-{
-	const auto mapPosition = NAS2D::Point{x, y}.to<std::size_t>();
-	return mMouseMap[mapPosition.y][mapPosition.x];
 }
 
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -89,28 +89,13 @@ public:
 
 	void pathStartAndEnd(void* start, void* end);
 
-protected:
-	enum MouseMapRegion
-	{
-		MMR_MIDDLE,
-		MMR_TOP_RIGHT,
-		MMR_TOP_LEFT,
-		MMR_BOTTOM_RIGHT,
-		MMR_BOTTOM_LEFT
-	};
-
-	std::vector<std::vector<MouseMapRegion>> mMouseMap;
-
 private:
-	void buildMouseMap();
 	void buildTerrainMap(const std::string& path);
 	void setupMines(int, Planet::Hostility);
 	void addMineSet(NAS2D::Point<int> suggestedMineLocation, Point2dList& plist, MineProductionRate rate);
 	NAS2D::Point<int> findSurroundingMineLocation(NAS2D::Point<int> centerPoint);
 
 	void updateTileHighlight();
-
-	MouseMapRegion getMouseMapRegion(int x, int y);
 
 
 	const NAS2D::Vector<int> mSizeInTiles;


### PR DESCRIPTION
Vastly simplify the code that converts from mouse pixel coordinates back to tile coordinates for the `TileMap`.

The formulas were derived by inverting the reverse process used in the `draw()` method that converts tile coordinates to pixel coordinates. This can be done with a bit of linear algebra to solve the system of equations for the reverse direction.

There is also a bit of a bug fix here. The drawing code used "half" values, that were pre-rounded. That may have been unintentional. It resulted in the y-axis tracking being a bit off gradually over time, due to a rounding error for that axis. By replacing the half values with the full values, the multiplication can be done first, and then the final value can be divided by 2 to minimize rounding issues. This fixes the y-axis tracking. It also means it will remove some of the slight squishing that was being done to the y-axis when drawing the maps.

With this update, the code no longer needs to load and parse bitmaps to fix mouse tracking. Now it just works.
