### PR TITLE
Refactor TileMap constants

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -27,7 +27,7 @@ namespace {
 	const auto TileDrawSize = NAS2D::Vector{128, 64};
 	const auto TileDrawOffset = NAS2D::Vector{TileDrawSize.x / 2, TileDrawSize.y - TileSize.y};
 
-	const double THROB_SPEED = 250.0; // Throb speed of mine beacon
+	const double ThrobSpeed = 250.0; // Throb speed of mine beacon
 
 	/** Array indicates percent of mines that should be of yields LOW, MED, HIGH */
 	const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYieldTable =
@@ -344,7 +344,7 @@ void TileMap::draw() const
 				// Draw a beacon on an unoccupied tile with a mine
 				if (tile.mine() != nullptr && !tile.thing())
 				{
-					uint8_t glow = static_cast<uint8_t>(120 + sin(mTimer.tick() / THROB_SPEED) * 57);
+					uint8_t glow = static_cast<uint8_t>(120 + sin(mTimer.tick() / ThrobSpeed) * 57);
 					const auto mineBeaconPosition = position + NAS2D::Vector{0, -64};
 
 					renderer.drawImage(mMineBeacon, mineBeaconPosition);

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -239,8 +239,8 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	mEdgeLength = std::max(3, std::min(lengthX, lengthY));
 
 	// Find top left corner of rectangle containing top tile of diamond
-	mOriginPixelPosition = NAS2D::Point{(size.x - TileSize.x) / 2, (size.y - constants::BottomUiHeight - mEdgeLength * TileSize.y) / 2};
-	mMapBoundingBox = {(size.x - TileSize.x * mEdgeLength) / 2, mOriginPixelPosition.y, TileSize.x * mEdgeLength, TileSize.y * mEdgeLength};
+	mOriginPixelPosition = NAS2D::Point{(size.x - TileSize.x) / 2, (size.y - constants::BottomUiHeight - mEdgeLength * TileSize.y) / 2} + TileDrawOffset;
+	mMapBoundingBox = {(size.x - TileSize.x * mEdgeLength) / 2, mOriginPixelPosition.y - TileDrawOffset.y, TileSize.x * mEdgeLength, TileSize.y * mEdgeLength};
 }
 
 
@@ -335,7 +335,7 @@ void TileMap::draw() const
 
 			if (tile.excavated())
 			{
-				const auto position = mOriginPixelPosition + NAS2D::Vector{(col - row) * TileSize.x / 2, (col + row) * TileSize.y / 2};
+				const auto position = mOriginPixelPosition - TileDrawOffset + NAS2D::Vector{(col - row) * TileSize.x / 2, (col + row) * TileSize.y / 2};
 				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TileDrawSize.x, tsetOffset, TileDrawSize.x, TileDrawSize.y};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 
@@ -373,7 +373,7 @@ void TileMap::updateTileHighlight()
 		return;
 	}
 
-	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + TileDrawOffset);
+	const auto pixelOffset = mMousePixelPosition - mOriginPixelPosition;
 	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);
 	mMouseTilePosition.xy = mOriginTilePosition + tileOffset;
 }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -24,8 +24,8 @@ namespace {
 
 	const auto MapSize = NAS2D::Vector{300, 150};
 	const auto TileSize = NAS2D::Vector{128, 55};
+	const auto TileDrawSize = NAS2D::Vector{128, 64};
 
-	const int TILE_HEIGHT = 64;
 	const int TILE_HEIGHT_OFFSET = 9;
 
 	const double THROB_SPEED = 250.0; // Throb speed of mine beacon
@@ -325,7 +325,7 @@ void TileMap::draw() const
 {
 	auto& renderer = Utility<Renderer>::get();
 
-	int tsetOffset = mMouseTilePosition.z > 0 ? TILE_HEIGHT : 0;
+	int tsetOffset = mMouseTilePosition.z > 0 ? TileDrawSize.y : 0;
 	const auto highlightOffset = mMouseTilePosition.xy - mOriginTilePosition;
 
 	for (int row = 0; row < mEdgeLength; row++)
@@ -337,7 +337,7 @@ void TileMap::draw() const
 			if (tile.excavated())
 			{
 				const auto position = mOriginPixelPosition + NAS2D::Vector{(col - row) * TileSize.x / 2, (col + row) * TileSize.y / 2};
-				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TileSize.x, tsetOffset, TileSize.x, TILE_HEIGHT};
+				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TileDrawSize.x, tsetOffset, TileDrawSize.x, TileDrawSize.y};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 
 				renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -25,8 +25,7 @@ namespace {
 	const auto MapSize = NAS2D::Vector{300, 150};
 	const auto TileSize = NAS2D::Vector{128, 55};
 	const auto TileDrawSize = NAS2D::Vector{128, 64};
-
-	const int TILE_HEIGHT_OFFSET = 9;
+	const auto TileDrawOffset = NAS2D::Vector{TileDrawSize.x / 2, TileDrawSize.y - TileSize.y};
 
 	const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
@@ -374,7 +373,7 @@ void TileMap::updateTileHighlight()
 		return;
 	}
 
-	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + NAS2D::Vector{TileSize.x / 2, TILE_HEIGHT_OFFSET});
+	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + TileDrawOffset);
 	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);
 	mMouseTilePosition.xy = mOriginTilePosition + tileOffset;
 }

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -22,8 +22,7 @@ using namespace NAS2D;
 namespace {
 	const std::string MAP_TERRAIN_EXTENSION = "_a.png";
 
-	const int MAP_WIDTH = 300;
-	const int MAP_HEIGHT = 150;
+	const auto MapSize = NAS2D::Vector{300, 150};
 
 	const int TILE_WIDTH = 128;
 	const int TILE_HEIGHT = 64;
@@ -142,7 +141,7 @@ namespace {
 
 
 TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
-	mSizeInTiles{MAP_WIDTH, MAP_HEIGHT},
+	mSizeInTiles{MapSize},
 	mMaxDepth(maxDepth),
 	mMapPath(mapPath),
 	mTsetPath(tilesetPath),

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -20,7 +20,7 @@ using namespace NAS2D;
 
 
 namespace {
-	const std::string MAP_TERRAIN_EXTENSION = "_a.png";
+	const std::string MapTerrainExtension = "_a.png";
 
 	const auto MapSize = NAS2D::Vector{300, 150};
 	const auto TileSize = NAS2D::Vector{128, 55};
@@ -199,7 +199,7 @@ Tile& TileMap::getTile(const MapCoordinate& position)
  */
 void TileMap::buildTerrainMap(const std::string& path)
 {
-	const Image heightmap(path + MAP_TERRAIN_EXTENSION);
+	const Image heightmap(path + MapTerrainExtension);
 
 	const auto levelCount = static_cast<std::size_t>(mMaxDepth) + 1;
 	mTileMap.resize(mSizeInTiles.x * mSizeInTiles.y * levelCount);

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -239,7 +239,7 @@ void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 	mEdgeLength = std::max(3, std::min(lengthX, lengthY));
 
 	// Find top left corner of rectangle containing top tile of diamond
-	mOriginPixelPosition = NAS2D::Point{(size.x - TileSize.x) / 2, (size.y - constants::BottomUiHeight - mEdgeLength * TileSize.y) / 2} + TileDrawOffset;
+	mOriginPixelPosition = NAS2D::Point{size.x / 2, TileDrawOffset.y + (size.y - constants::BottomUiHeight - mEdgeLength * TileSize.y) / 2};
 	mMapBoundingBox = {(size.x - TileSize.x * mEdgeLength) / 2, mOriginPixelPosition.y - TileDrawOffset.y, TileSize.x * mEdgeLength, TileSize.y * mEdgeLength};
 }
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -23,12 +23,10 @@ namespace {
 	const std::string MAP_TERRAIN_EXTENSION = "_a.png";
 
 	const auto MapSize = NAS2D::Vector{300, 150};
+	const auto TileSize = NAS2D::Vector{128, 55};
 
-	const int TILE_WIDTH = 128;
 	const int TILE_HEIGHT = 64;
-
 	const int TILE_HEIGHT_OFFSET = 9;
-	const int TILE_HEIGHT_ABSOLUTE = TILE_HEIGHT - TILE_HEIGHT_OFFSET;
 
 	const double THROB_SPEED = 250.0; // Throb speed of mine beacon
 
@@ -237,13 +235,13 @@ void TileMap::buildTerrainMap(const std::string& path)
 void TileMap::initMapDrawParams(NAS2D::Vector<int> size)
 {
 	// Set up map draw position
-	const auto lengthX = size.x / TILE_WIDTH;
-	const auto lengthY = size.y / TILE_HEIGHT_ABSOLUTE;
+	const auto lengthX = size.x / TileSize.x;
+	const auto lengthY = size.y / TileSize.y;
 	mEdgeLength = std::max(3, std::min(lengthX, lengthY));
 
 	// Find top left corner of rectangle containing top tile of diamond
-	mOriginPixelPosition = NAS2D::Point{(size.x - TILE_WIDTH) / 2, (size.y - constants::BottomUiHeight - mEdgeLength * TILE_HEIGHT_ABSOLUTE) / 2};
-	mMapBoundingBox = {(size.x - TILE_WIDTH * mEdgeLength) / 2, mOriginPixelPosition.y, TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
+	mOriginPixelPosition = NAS2D::Point{(size.x - TileSize.x) / 2, (size.y - constants::BottomUiHeight - mEdgeLength * TileSize.y) / 2};
+	mMapBoundingBox = {(size.x - TileSize.x * mEdgeLength) / 2, mOriginPixelPosition.y, TileSize.x * mEdgeLength, TileSize.y * mEdgeLength};
 }
 
 
@@ -338,8 +336,8 @@ void TileMap::draw() const
 
 			if (tile.excavated())
 			{
-				const auto position = mOriginPixelPosition + NAS2D::Vector{(col - row) * TILE_WIDTH / 2, (col + row) * TILE_HEIGHT_ABSOLUTE / 2};
-				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TILE_WIDTH, tsetOffset, TILE_WIDTH, TILE_HEIGHT};
+				const auto position = mOriginPixelPosition + NAS2D::Vector{(col - row) * TileSize.x / 2, (col + row) * TileSize.y / 2};
+				const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TileSize.x, tsetOffset, TileSize.x, TILE_HEIGHT};
 				const bool isTileHighlighted = NAS2D::Vector{col, row} == highlightOffset;
 
 				renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
@@ -376,8 +374,8 @@ void TileMap::updateTileHighlight()
 		return;
 	}
 
-	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + NAS2D::Vector{TILE_WIDTH / 2, TILE_HEIGHT_OFFSET});
-	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TILE_HEIGHT_ABSOLUTE + pixelOffset.y * TILE_WIDTH, pixelOffset.y * TILE_WIDTH - pixelOffset.x * TILE_HEIGHT_ABSOLUTE} / (TILE_WIDTH * TILE_HEIGHT_ABSOLUTE);
+	const auto pixelOffset = mMousePixelPosition - (mOriginPixelPosition + NAS2D::Vector{TileSize.x / 2, TILE_HEIGHT_OFFSET});
+	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);
 	mMouseTilePosition.xy = mOriginTilePosition + tileOffset;
 }
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -112,7 +112,7 @@ private:
 	NAS2D::Point<int> mMousePixelPosition;
 
 	NAS2D::Point<int> mOriginTilePosition; // Top tile of detail view diamond, or top left corner of minimap view box
-	NAS2D::Point<int> mOriginPixelPosition; // Top left pixel of tile at top of diamond
+	NAS2D::Point<int> mOriginPixelPosition; // Top pixel at top of diamond
 
 	NAS2D::Rectangle<int> mMapBoundingBox; // Tightest pixel area containing all drawn tiles
 


### PR DESCRIPTION
Use `NAS2D::Vector` to hold `TileMap` constants. Rename constants to UpperCamelCase.

Redefine `mOriginPixelPosition` to be the top point of the drawn diamond (logical, not including the draw overhang). This makes for a more natural "origin" when converting between pixel and tile coordinates. Previously that variable held the position of the top left pixel of a rectangle that contained the diamond for the top tile, including the draw overhang.
