### PR TITLE
Refactor TileMap

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -471,9 +471,6 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		tile.index(TerrainType::Dozed);
 
 		mMineLocations.push_back(Point{x, y});
-
-		/// \fixme	Legacy code to assist in updating older versions of save games between 0.7.5 and 0.7.6. Remove in 0.8.0
-		if (mine->depth() == 0 && mine->active()) { mine->increaseDepth(); }
 	}
 
 	// TILES AT INDEX 0 WITH NO THINGS

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -401,7 +401,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 
 	for (const auto& location : mMineLocations)
 	{
-		auto& mine = *getTile({location, TileMapLevel::LEVEL_SURFACE}).mine();
+		auto& mine = *getTile({location, 0}).mine();
 		mines->linkEndChild(mine.serialize(location));
 	}
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -23,16 +23,6 @@ enum class Direction;
 class TileMap : public micropather::Graph
 {
 public:
-	enum TileMapLevel
-	{
-		LEVEL_SURFACE = 0,
-		LEVEL_UG_1,
-		LEVEL_UG_2,
-		LEVEL_UG_3,
-		LEVEL_UG_4
-	};
-
-
 	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility /*= constants::Hostility::None*/, bool setupMines = true);
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -30,7 +30,7 @@ enum class Direction;
 class TileMap : public micropather::Graph
 {
 public:
-	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility /*= constants::Hostility::None*/, bool setupMines = true);
+	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool setupMines = true);
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -5,8 +5,11 @@
 #include "../States/Planet.h"
 #include "../MicroPather/micropather.h"
 
+#include <NAS2D/Timer.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
+#include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Resource/Image.h>
 
 
 namespace NAS2D

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -11,6 +11,10 @@
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Resource/Image.h>
 
+#include <string>
+#include <vector>
+#include <utility>
+
 
 namespace NAS2D
 {


### PR DESCRIPTION
Remove largely unused `TileMapLevel` enum. Add missing header includes. Remove commented out default settings. Remove legacy code that was scheduled to be removed in 0.8.0.
