### PR TITLE
Split `DetailMap` from `TileMap`

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -23,11 +23,7 @@ using namespace NAS2D;
 
 namespace {
 	const std::string MapTerrainExtension = "_a.png";
-
 	const auto MapSize = NAS2D::Vector{300, 150};
-	const auto TileSize = NAS2D::Vector{128, 55};
-	const auto TileDrawSize = NAS2D::Vector{128, 64};
-	const auto TileDrawOffset = NAS2D::Vector{TileDrawSize.x / 2, TileDrawSize.y - TileSize.y};
 
 	// Relative proportion of mines with yields {low, med, high}
 	const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYields =
@@ -36,34 +32,6 @@ namespace {
 		{Planet::Hostility::Medium, {45, 35, 20}},
 		{Planet::Hostility::High, {35, 20, 45}},
 	};
-
-
-	const std::map<Tile::Overlay, NAS2D::Color> OverlayColors =
-	{
-		{Tile::Overlay::None, NAS2D::Color::Normal},
-		{Tile::Overlay::Communications, {125, 200, 255}},
-		{Tile::Overlay::Connectedness, NAS2D::Color::Green},
-		{Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange},
-		{Tile::Overlay::Police, NAS2D::Color::Red}
-	};
-
-	const std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColors =
-	{
-		{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
-		{Tile::Overlay::Communications, {100, 180, 230}},
-		{Tile::Overlay::Connectedness, NAS2D::Color{71, 224, 146}},
-		{Tile::Overlay::TruckingRoutes, NAS2D::Color{125, 200, 255}},
-		{Tile::Overlay::Police, NAS2D::Color{100, 180, 230}}
-	};
-
-	const double ThrobSpeed = 250.0; // Throb speed of mine beacon
-	NAS2D::Timer throbTimer;
-
-
-	const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
-	{
-		return (isHighlighted ? OverlayHighlightColors : OverlayColors).at(overlay);
-	}
 
 
 	std::vector<NAS2D::Point<int>> generateMineLocations(NAS2D::Vector<int> mapSize, std::size_t mineCount)
@@ -123,16 +91,11 @@ namespace {
 }
 
 
-TileMap::TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
+TileMap::TileMap(const std::string& mapPath, const std::string& /*tilesetPath*/, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
 	mSizeInTiles{MapSize},
-	mMaxDepth(maxDepth),
-	mMapPath(mapPath),
-	mTsetPath(tilesetPath),
-	mTileset(tilesetPath),
-	mMineBeacon("structures/mine_beacon.png")
+	mMaxDepth(maxDepth)
 {
 	buildTerrainMap(mapPath);
-	onResize(Utility<Renderer>::get().size());
 
 	if (shouldSetupMines)
 	{
@@ -208,17 +171,6 @@ void TileMap::buildTerrainMap(const std::string& path)
 }
 
 
-void TileMap::onResize(NAS2D::Vector<int> size)
-{
-	// Set up map draw position
-	const auto sizeInTiles = size.skewInverseBy(TileSize);
-	mEdgeLength = std::max(3, std::min(sizeInTiles.x, sizeInTiles.y));
-
-	// Find top left corner of rectangle containing top tile of diamond
-	mOriginPixelPosition = NAS2D::Point{size.x / 2, TileDrawOffset.y + (size.y - constants::BottomUiHeight - mEdgeLength * TileSize.y) / 2};
-}
-
-
 NAS2D::Rectangle<int> TileMap::viewArea() const
 {
 	return {mOriginTilePosition.xy.x, mOriginTilePosition.xy.y, mEdgeLength, mEdgeLength};
@@ -262,81 +214,15 @@ void TileMap::currentDepth(int i)
 }
 
 
-/**
- * Returns true if the current tile highlight is actually within the visible diamond map.
- */
-bool TileMap::isMouseOverTile() const
+int TileMap::viewSize() const
 {
-	return isVisibleTile(mouseTilePosition());
+	return mEdgeLength;
 }
 
 
-Tile& TileMap::mouseTile()
+void TileMap::viewSize(int sizeInTiles)
 {
-	if (!isMouseOverTile())
-	{
-		throw std::runtime_error("Mouse not over a tile");
-	}
-	return getTile(mouseTilePosition());
-}
-
-
-void TileMap::update()
-{
-	for (const auto tilePosition : PointInRectangleRange{viewArea()})
-	{
-		auto& tile = getTile({tilePosition, mOriginTilePosition.z});
-
-		if (tile.thing())
-		{
-			tile.thing()->sprite().update();
-		}
-	}
-}
-
-
-void TileMap::draw() const
-{
-	auto& renderer = Utility<Renderer>::get();
-
-	int tsetOffset = mOriginTilePosition.z > 0 ? TileDrawSize.y : 0;
-
-	for (const auto tilePosition : PointInRectangleRange{viewArea()})
-	{
-		auto& tile = getTile({tilePosition, mOriginTilePosition.z});
-
-		if (tile.excavated())
-		{
-			const auto offset = tilePosition - mOriginTilePosition.xy;
-			const auto position = mOriginPixelPosition - TileDrawOffset + NAS2D::Vector{(offset.x - offset.y) * TileSize.x / 2, (offset.x + offset.y) * TileSize.y / 2};
-			const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TileDrawSize.x, tsetOffset, TileDrawSize.x, TileDrawSize.y};
-			const bool isTileHighlighted = tilePosition == mMouseTilePosition;
-
-			renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
-
-			// Draw a beacon on an unoccupied tile with a mine
-			if (tile.mine() != nullptr && !tile.thing())
-			{
-				uint8_t glow = static_cast<uint8_t>(120 + sin(throbTimer.tick() / ThrobSpeed) * 57);
-				renderer.drawImage(mMineBeacon, position + NAS2D::Vector{0, -64});
-				renderer.drawSubImage(mMineBeacon, position + NAS2D::Vector{59, 15}, NAS2D::Rectangle{59, 79, 10, 7}, NAS2D::Color{glow, glow, glow});
-			}
-
-			// Tell an occupying thing to update itself.
-			if (tile.thing())
-			{
-				tile.thing()->sprite().draw(position);
-			}
-		}
-	}
-}
-
-
-void TileMap::onMouseMove(NAS2D::Point<int> position)
-{
-	const auto pixelOffset = position - mOriginPixelPosition;
-	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);
-	mMouseTilePosition = mOriginTilePosition.xy + tileOffset;
+	mEdgeLength = std::max(3, sizeInTiles);
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -93,7 +93,7 @@ namespace {
 
 TileMap::TileMap(const std::string& mapPath, const std::string& /*tilesetPath*/, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
 	mSizeInTiles{MapSize},
-	mMaxDepth(maxDepth)
+	mMaxDepth{maxDepth}
 {
 	buildTerrainMap(mapPath);
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -54,17 +54,10 @@ public:
 	int currentDepth() const { return mOriginTilePosition.z; }
 	void currentDepth(int i);
 
+	int viewSize() const;
+	void viewSize(int sizeInTiles);
+
 	bool isVisibleTile(const MapCoordinate& position) const;
-	bool isMouseOverTile() const;
-
-	MapCoordinate mouseTilePosition() const { return {mMouseTilePosition, mOriginTilePosition.z}; }
-	Tile& mouseTile();
-
-	void onMouseMove(NAS2D::Point<int> position);
-	void onResize(NAS2D::Vector<int>);
-
-	void update();
-	void draw() const;
 
 	void serialize(NAS2D::Xml::XmlElement* element);
 	void deserialize(NAS2D::Xml::XmlElement* element);
@@ -87,17 +80,10 @@ private:
 	std::vector<NAS2D::Point<int>> mMineLocations;
 
 	std::string mMapPath;
-	std::string mTsetPath;
-
-	const NAS2D::Image mTileset;
-	const NAS2D::Image mMineBeacon;
 
 	int mEdgeLength = 0;
 
 	MapCoordinate mOriginTilePosition{{0, 0}, 0}; // Top tile of detail view diamond, or top left corner of minimap view box
-	NAS2D::Point<int> mOriginPixelPosition; // Top pixel at top of diamond
-
-	NAS2D::Point<int> mMouseTilePosition;
 
 	std::pair<void*, void*> mPathStartEndPair = {nullptr, nullptr};
 };

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -33,8 +33,9 @@
 #include "../UI/TileInspector.h"
 #include "../UI/WarehouseInspector.h"
 #include "../UI/ResourceInfoBar.h"
-#include "../UI/MiniMap.h"
 #include "../UI/RobotDeploymentSummary.h"
+#include "../UI/MiniMap.h"
+#include "../UI/DetailMap.h"
 #include "../UI/NavControl.h"
 
 #include "../UI/Core/WindowStack.h"
@@ -371,7 +372,8 @@ private:
 	std::string mExistingToLoad; /**< Filename of the existing game to load. */
 
 	ResourceInfoBar mResourceInfoBar;
-	std::unique_ptr<MiniMap> mMiniMap;
 	RobotDeploymentSummary mRobotDeploymentSummary;
+	std::unique_ptr<MiniMap> mMiniMap;
+	std::unique_ptr<DetailMap> mDetailMap;
 	std::unique_ptr<NavControl> mNavControl;
 };

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -187,6 +187,7 @@ void MapViewState::load(const std::string& filePath)
 	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.tilesetPath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 	mMiniMap = std::make_unique<MiniMap>(mTileMap, mRobotList, mPlanetAttributes.mapImagePath);
+	mDetailMap = std::make_unique<DetailMap>(*mTileMap, mPlanetAttributes.tilesetPath);
 	mNavControl = std::make_unique<NavControl>(*mTileMap);
 
 	delete mPathSolver;

--- a/OPHD/UI/DetailMap.cpp
+++ b/OPHD/UI/DetailMap.cpp
@@ -1,0 +1,154 @@
+#include "DetailMap.h"
+
+#include "../Constants/UiConstants.h"
+#include "../Map/Tile.h"
+#include "../Map/TileMap.h"
+#include "../Things/Thing.h"
+
+#include <NAS2D/Renderer/Color.h>
+#include <NAS2D/Renderer/Renderer.h>
+#include <NAS2D/Utility.h>
+#include <NAS2D/Math/PointInRectangleRange.h>
+
+#include <map>
+
+
+using namespace NAS2D;
+
+
+namespace {
+	const auto TileSize = NAS2D::Vector{128, 55};
+	const auto TileDrawSize = NAS2D::Vector{128, 64};
+	const auto TileDrawOffset = NAS2D::Vector{TileDrawSize.x / 2, TileDrawSize.y - TileSize.y};
+
+	const std::map<Tile::Overlay, NAS2D::Color> OverlayColors =
+	{
+		{Tile::Overlay::None, NAS2D::Color::Normal},
+		{Tile::Overlay::Communications, {125, 200, 255}},
+		{Tile::Overlay::Connectedness, NAS2D::Color::Green},
+		{Tile::Overlay::TruckingRoutes, NAS2D::Color::Orange},
+		{Tile::Overlay::Police, NAS2D::Color::Red}
+	};
+
+	const std::map<Tile::Overlay, NAS2D::Color> OverlayHighlightColors =
+	{
+		{Tile::Overlay::None, NAS2D::Color{125, 200, 255}},
+		{Tile::Overlay::Communications, {100, 180, 230}},
+		{Tile::Overlay::Connectedness, NAS2D::Color{71, 224, 146}},
+		{Tile::Overlay::TruckingRoutes, NAS2D::Color{125, 200, 255}},
+		{Tile::Overlay::Police, NAS2D::Color{100, 180, 230}}
+	};
+
+	const double ThrobSpeed = 250.0; // Throb speed of mine beacon
+	NAS2D::Timer throbTimer;
+
+
+	const NAS2D::Color& overlayColor(Tile::Overlay overlay, bool isHighlighted)
+	{
+		return (isHighlighted ? OverlayHighlightColors : OverlayColors).at(overlay);
+	}
+}
+
+
+DetailMap::DetailMap(TileMap& tileMap, const std::string& tilesetPath) :
+	mTileMap{tileMap},
+	mTileset(tilesetPath),
+	mMineBeacon("structures/mine_beacon.png")
+{
+	resize(Utility<Renderer>::get().size());
+}
+
+
+void DetailMap::resize(NAS2D::Vector<int> size)
+{
+	// Set up map draw position
+	const auto sizeInTiles = size.skewInverseBy(TileSize);
+	mTileMap.viewSize(std::min(sizeInTiles.x, sizeInTiles.y));
+
+	// Find top left corner of rectangle containing top tile of diamond
+	mOriginPixelPosition = NAS2D::Point{size.x / 2, TileDrawOffset.y + (size.y - constants::BottomUiHeight - mTileMap.viewSize() * TileSize.y) / 2};
+}
+
+
+/**
+ * Returns true if the current tile highlight is actually within the visible diamond map.
+ */
+bool DetailMap::isMouseOverTile() const
+{
+	return mTileMap.isVisibleTile(mouseTilePosition());
+}
+
+
+MapCoordinate DetailMap::mouseTilePosition() const
+{
+	return {mMouseTilePosition, mTileMap.currentDepth()};
+}
+
+
+Tile& DetailMap::mouseTile()
+{
+	if (!isMouseOverTile())
+	{
+		throw std::runtime_error("Mouse not over a tile");
+	}
+	return mTileMap.getTile(mouseTilePosition());
+}
+
+
+void DetailMap::update()
+{
+	for (const auto tilePosition : PointInRectangleRange{mTileMap.viewArea()})
+	{
+		auto& tile = mTileMap.getTile({tilePosition, mTileMap.currentDepth()});
+
+		if (tile.thing())
+		{
+			tile.thing()->sprite().update();
+		}
+	}
+}
+
+
+void DetailMap::draw() const
+{
+	auto& renderer = Utility<Renderer>::get();
+
+	int tsetOffset = mTileMap.currentDepth() > 0 ? TileDrawSize.y : 0;
+
+	for (const auto tilePosition : PointInRectangleRange{mTileMap.viewArea()})
+	{
+		auto& tile = mTileMap.getTile({tilePosition, mTileMap.currentDepth()});
+
+		if (tile.excavated())
+		{
+			const auto offset = tilePosition - mTileMap.viewArea().startPoint();
+			const auto position = mOriginPixelPosition - TileDrawOffset + NAS2D::Vector{(offset.x - offset.y) * TileSize.x / 2, (offset.x + offset.y) * TileSize.y / 2};
+			const auto subImageRect = NAS2D::Rectangle{static_cast<int>(tile.index()) * TileDrawSize.x, tsetOffset, TileDrawSize.x, TileDrawSize.y};
+			const bool isTileHighlighted = tilePosition == mMouseTilePosition;
+
+			renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
+
+			// Draw a beacon on an unoccupied tile with a mine
+			if (tile.mine() != nullptr && !tile.thing())
+			{
+				uint8_t glow = static_cast<uint8_t>(120 + sin(throbTimer.tick() / ThrobSpeed) * 57);
+				renderer.drawImage(mMineBeacon, position + NAS2D::Vector{0, -64});
+				renderer.drawSubImage(mMineBeacon, position + NAS2D::Vector{59, 15}, NAS2D::Rectangle{59, 79, 10, 7}, NAS2D::Color{glow, glow, glow});
+			}
+
+			// Tell an occupying thing to update itself.
+			if (tile.thing())
+			{
+				tile.thing()->sprite().draw(position);
+			}
+		}
+	}
+}
+
+
+void DetailMap::onMouseMove(NAS2D::Point<int> position)
+{
+	const auto pixelOffset = position - mOriginPixelPosition;
+	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);
+	mMouseTilePosition = mTileMap.viewArea().startPoint() + tileOffset;
+}

--- a/OPHD/UI/DetailMap.cpp
+++ b/OPHD/UI/DetailMap.cpp
@@ -52,8 +52,8 @@ namespace {
 
 DetailMap::DetailMap(TileMap& tileMap, const std::string& tilesetPath) :
 	mTileMap{tileMap},
-	mTileset(tilesetPath),
-	mMineBeacon("structures/mine_beacon.png")
+	mTileset{tilesetPath},
+	mMineBeacon{"structures/mine_beacon.png"}
 {
 	resize(Utility<Renderer>::get().size());
 }

--- a/OPHD/UI/DetailMap.h
+++ b/OPHD/UI/DetailMap.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Core/Control.h"
+
+#include "../Map/MapCoordinate.h"
+
+#include <NAS2D/Resource/Image.h>
+#include <NAS2D/Timer.h>
+
+
+class TileMap;
+class Tile;
+
+
+class DetailMap : public Control
+{
+public:
+	DetailMap(TileMap& tileMap, const std::string& tilesetPath);
+
+	bool isMouseOverTile() const;
+
+	MapCoordinate mouseTilePosition() const;
+	Tile& mouseTile();
+
+	void onMouseMove(NAS2D::Point<int> position);
+	void resize(NAS2D::Vector<int>);
+
+	void update() override;
+	void draw() const override;
+
+private:
+	TileMap& mTileMap;
+	const NAS2D::Image mTileset;
+	const NAS2D::Image mMineBeacon;
+
+	NAS2D::Point<int> mOriginPixelPosition; // Top pixel at top of diamond
+	NAS2D::Point<int> mMouseTilePosition;
+};

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -282,6 +282,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="UI\Core\UIContainer.cpp" />
     <ClCompile Include="UI\Core\Window.cpp" />
     <ClCompile Include="UI\Core\WindowStack.cpp" />
+    <ClCompile Include="UI\DetailMap.cpp" />
     <ClCompile Include="UI\DiggerDirection.cpp" />
     <ClCompile Include="UI\FactoryListBox.cpp" />
     <ClCompile Include="UI\FactoryProduction.cpp" />
@@ -417,6 +418,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClInclude Include="UI\Core\UIContainer.h" />
     <ClInclude Include="UI\Core\Window.h" />
     <ClInclude Include="UI\Core\WindowStack.h" />
+    <ClInclude Include="UI\DetailMap.h" />
     <ClInclude Include="UI\DiggerDirection.h" />
     <ClInclude Include="UI\FactoryProduction.h" />
     <ClInclude Include="UI\FileIo.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="Things\Structures\Structure.cpp">
       <Filter>Source Files\Things\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="UI\DetailMap.cpp">
+      <Filter>Source Files\UI</Filter>
+    </ClCompile>
     <ClCompile Include="UI\DiggerDirection.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
@@ -400,6 +403,9 @@
     </ClInclude>
     <ClInclude Include="Things\Structures\Structures.h">
       <Filter>Header Files\Things\Structures</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\DetailMap.h">
+      <Filter>Header Files\UI</Filter>
     </ClInclude>
     <ClInclude Include="UI\DiggerDirection.h">
       <Filter>Header Files\UI</Filter>


### PR DESCRIPTION
Reference: #650 (or at least very strongly related)

Split `DetailMap` from `TileMap` and update `MapViewState` to use the new split off `Control`.
