### PR TITLE
Remove shift tube placement

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -479,8 +479,7 @@ void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, i
 		// Click was within the bounds of the TileMap.
 		if (mDetailMap->isMouseOverTile())
 		{
-			auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-			onClickMap(eventHandler.query_shift());
+			onClickMap();
 		}
 	}
 }
@@ -627,7 +626,7 @@ void MapViewState::onInspectTile(Tile& tile)
 }
 
 
-void MapViewState::onClickMap(bool /*isShiftPressed*/)
+void MapViewState::onClickMap()
 {
 	if (!mDetailMap->isMouseOverTile()) { return; }
 	Tile* tile = &mDetailMap->mouseTile();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -161,9 +161,6 @@ private:
 	void placeStructure(Tile* tile);
 	void placeTubes(Tile* tile);
 
-	void placeTubeStart(Tile* tile);
-	void placeTubeEnd(Tile* tile);
-
 	void placeRobodozer(Tile&);
 	void placeRobodigger(Tile&);
 	void placeRobominer(Tile&);
@@ -363,9 +360,6 @@ private:
 	std::vector<Tile*> mCommRangeOverlay;
 	std::vector<std::vector<Tile*>> mPoliceOverlays;
 	std::vector<Tile*> mTruckRouteOverlay;
-
-	NAS2D::Point<int> mTubeStart;
-	bool mPlacingTube = false;
 
 	bool mLoadingExisting = false;
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -137,7 +137,7 @@ private:
 	void onInspectRobot(Robot& robot);
 	void onInspectTile(Tile& tile);
 
-	void onClickMap(bool isShiftPressed);
+	void onClickMap();
 
 	void onSystemMenu();
 


### PR DESCRIPTION
This feature didn't seem to be working. After some discussion, we decided we'd remove the code for now. It had been coming up a bit during refactoring, and was sometimes a bit difficult to deal with. Given that we are planing some fairly significant changes to how tubes work (auto directional, based on surrounding tube tiles), it seemed to make sense to remove the code for now, and perhaps revisit tube placement in the future. We may also want to re-work how the user interface works for placing multiple tubes.
