### PR TITLE
Split `MapView` from `TileMap`

### DIFF
--- a/OPHD/Map/MapView.cpp
+++ b/OPHD/Map/MapView.cpp
@@ -1,0 +1,112 @@
+#include "MapView.h"
+
+#include "TileMap.h"
+#include "../DirectionOffset.h"
+
+#include <NAS2D/ParserHelper.h>
+#include <NAS2D/Xml/XmlElement.h>
+
+#include <algorithm>
+
+
+MapView::MapView(TileMap& tileMap) :
+	mTileMap{tileMap}
+{}
+
+
+Tile& MapView::getTile(NAS2D::Point<int> position)
+{
+	return mTileMap.getTile({position, mOriginTilePosition.z});
+}
+
+
+NAS2D::Rectangle<int> MapView::viewArea() const
+{
+	return {mOriginTilePosition.xy.x, mOriginTilePosition.xy.y, mEdgeLength, mEdgeLength};
+}
+
+
+void MapView::mapViewLocation(const MapCoordinate& position)
+{
+	const auto sizeInTiles = mTileMap.size();
+	mOriginTilePosition.xy = {
+		std::clamp(position.xy.x, 0, sizeInTiles.x - mEdgeLength),
+		std::clamp(position.xy.y, 0, sizeInTiles.y - mEdgeLength)
+	};
+	currentDepth(position.z);
+}
+
+
+void MapView::centerOn(NAS2D::Point<int> point)
+{
+	centerOn({point, mOriginTilePosition.z});
+}
+
+
+void MapView::centerOn(const MapCoordinate& position)
+{
+	mapViewLocation({position.xy - NAS2D::Vector{mEdgeLength, mEdgeLength} / 2, position.z});
+}
+
+
+void MapView::moveView(Direction direction)
+{
+	mapViewLocation({
+		mOriginTilePosition.xy + directionEnumToOffset(direction),
+		mOriginTilePosition.z + directionEnumToVerticalOffset(direction)
+	});
+}
+
+
+void MapView::currentDepth(int i)
+{
+	mOriginTilePosition.z = std::clamp(i, 0, mTileMap.maxDepth());
+}
+
+
+int MapView::viewSize() const
+{
+	return mEdgeLength;
+}
+
+
+void MapView::viewSize(int sizeInTiles)
+{
+	mEdgeLength = std::max(3, sizeInTiles);
+}
+
+
+bool MapView::isVisibleTile(const MapCoordinate& position) const
+{
+	return viewArea().contains(position.xy) && position.z == mOriginTilePosition.z;
+}
+
+
+void MapView::serialize(NAS2D::Xml::XmlElement* element)
+{
+	// ==========================================
+	// VIEW PARAMETERS
+	// ==========================================
+	element->linkEndChild(NAS2D::dictionaryToAttributes(
+		"view_parameters",
+		{{
+			{"currentdepth", mOriginTilePosition.z},
+			{"viewlocation_x", mOriginTilePosition.xy.x},
+			{"viewlocation_y", mOriginTilePosition.xy.y},
+		}}
+	));
+}
+
+
+void MapView::deserialize(NAS2D::Xml::XmlElement* element)
+{
+	// VIEW PARAMETERS
+	auto* viewParameters = element->firstChildElement("view_parameters");
+	const auto dictionary = NAS2D::attributesToDictionary(*viewParameters);
+
+	const auto viewX = dictionary.get<int>("viewlocation_x");
+	const auto viewY = dictionary.get<int>("viewlocation_y");
+	const auto viewDepth = dictionary.get<int>("currentdepth");
+
+	mapViewLocation({{viewX, viewY}, viewDepth});
+}

--- a/OPHD/Map/MapView.h
+++ b/OPHD/Map/MapView.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "../Map/MapCoordinate.h"
+
+#include <NAS2D/Math/Rectangle.h>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+}
+
+class Tile;
+class TileMap;
+
+
+class MapView
+{
+public:
+	MapView(TileMap& tileMap);
+
+	Tile& getTile(NAS2D::Point<int> position);
+
+	NAS2D::Rectangle<int> viewArea() const;
+	void mapViewLocation(const MapCoordinate& position);
+	void centerOn(NAS2D::Point<int> point);
+	void centerOn(const MapCoordinate& position);
+	void moveView(Direction direction);
+
+	int currentDepth() const { return mOriginTilePosition.z; }
+	void currentDepth(int i);
+
+	int viewSize() const;
+	void viewSize(int sizeInTiles);
+
+	bool isVisibleTile(const MapCoordinate& position) const;
+
+	void serialize(NAS2D::Xml::XmlElement* element);
+	void deserialize(NAS2D::Xml::XmlElement* element);
+
+private:
+	TileMap& mTileMap;
+	int mEdgeLength = 0;
+	MapCoordinate mOriginTilePosition{{0, 0}, 0}; // Top tile of detail view diamond, or top left corner of minimap view box
+};

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -40,24 +40,9 @@ public:
 
 	const Tile& getTile(const MapCoordinate& position) const;
 	Tile& getTile(const MapCoordinate& position);
-	Tile& getTile(NAS2D::Point<int> position) { return getTile({position, mOriginTilePosition.z}); }
 
 	const std::vector<NAS2D::Point<int>>& mineLocations() const { return mMineLocations; }
 	void removeMineLocation(const NAS2D::Point<int>& pt);
-
-	NAS2D::Rectangle<int> viewArea() const;
-	void mapViewLocation(const MapCoordinate& position);
-	void centerOn(NAS2D::Point<int> point);
-	void centerOn(const MapCoordinate& position);
-	void moveView(Direction direction);
-
-	int currentDepth() const { return mOriginTilePosition.z; }
-	void currentDepth(int i);
-
-	int viewSize() const;
-	void viewSize(int sizeInTiles);
-
-	bool isVisibleTile(const MapCoordinate& position) const;
 
 	void serialize(NAS2D::Xml::XmlElement* element);
 	void deserialize(NAS2D::Xml::XmlElement* element);
@@ -80,10 +65,6 @@ private:
 	std::vector<NAS2D::Point<int>> mMineLocations;
 
 	std::string mMapPath;
-
-	int mEdgeLength = 0;
-
-	MapCoordinate mOriginTilePosition{{0, 0}, 0}; // Top tile of detail view diamond, or top left corner of minimap view box
 
 	std::pair<void*, void*> mPathStartEndPair = {nullptr, nullptr};
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1136,7 +1136,7 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 
 		SeedLander* s = new SeedLander(point);
 		s->deploySignal().connect(this, &MapViewState::onDeploySeedLander);
-		NAS2D::Utility<StructureManager>::get().addStructure(s, &mTileMap->getTile(point)); // Can only ever be placed on depth level 0
+		NAS2D::Utility<StructureManager>::get().addStructure(s, &mTileMap->getTile({point, 0})); // Can only ever be placed on depth level 0
 
 		clearMode();
 		resetUi();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -16,6 +16,7 @@
 
 #include "../Map/Tile.h"
 #include "../Map/TileMap.h"
+#include "../Map/MapView.h"
 
 #include "../Things/Robots/Robots.h"
 #include "../Things/Structures/Structures.h"
@@ -115,13 +116,14 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) :
 	mMainReportsState(mainReportsState),
 	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
+	mMapView{std::make_unique<MapView>(*mTileMap)},
 	mCrimeExecution(mNotificationArea),
 	mPlanetAttributes(planetAttributes),
 	mResourceInfoBar{mResourcesCount, mPopulation, mCurrentMorale, mPreviousMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
-	mMiniMap{std::make_unique<MiniMap>(mTileMap, mRobotList, planetAttributes.mapImagePath)},
-	mDetailMap{std::make_unique<DetailMap>(*mTileMap, planetAttributes.tilesetPath)},
-	mNavControl{std::make_unique<NavControl>(*mTileMap)}
+	mMiniMap{std::make_unique<MiniMap>(*mMapView, mTileMap, mRobotList, planetAttributes.mapImagePath)},
+	mDetailMap{std::make_unique<DetailMap>(*mMapView, *mTileMap, planetAttributes.tilesetPath)},
+	mNavControl{std::make_unique<NavControl>(*mMapView, *mTileMap)}
 {
 	difficulty(selectedDifficulty);
 	ccLocation() = CcNotPlaced;
@@ -226,7 +228,7 @@ void MapViewState::_deactivate()
 void MapViewState::focusOnStructure(Structure* structure)
 {
 	if (!structure) { return; }
-	mTileMap->centerOn(NAS2D::Utility<StructureManager>::get().tileFromStructure(structure).xyz());
+	mMapView->centerOn(NAS2D::Utility<StructureManager>::get().tileFromStructure(structure).xyz());
 }
 
 
@@ -334,22 +336,22 @@ void MapViewState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
 	{
 		case NAS2D::EventHandler::KeyCode::KEY_w:
 		case NAS2D::EventHandler::KeyCode::KEY_UP:
-			mTileMap->moveView(Direction::North);
+			mMapView->moveView(Direction::North);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_s:
 		case NAS2D::EventHandler::KeyCode::KEY_DOWN:
-			mTileMap->moveView(Direction::South);
+			mMapView->moveView(Direction::South);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_a:
 		case NAS2D::EventHandler::KeyCode::KEY_LEFT:
-			mTileMap->moveView(Direction::West);
+			mMapView->moveView(Direction::West);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_d:
 		case NAS2D::EventHandler::KeyCode::KEY_RIGHT:
-			mTileMap->moveView(Direction::East);
+			mMapView->moveView(Direction::East);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_0:
@@ -373,11 +375,11 @@ void MapViewState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEUP:
-			changeViewDepth(mTileMap->currentDepth() - 1);
+			changeViewDepth(mMapView->currentDepth() - 1);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEDOWN:
-			changeViewDepth(mTileMap->currentDepth() + 1);
+			changeViewDepth(mMapView->currentDepth() + 1);
 			break;
 
 
@@ -466,11 +468,11 @@ void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, i
 			onSystemMenu();
 		}
 
-		const auto oldDepth = mTileMap->currentDepth();
+		const auto oldDepth = mMapView->currentDepth();
 		mNavControl->onClick(MOUSE_COORDS);
-		if (oldDepth != mTileMap->currentDepth())
+		if (oldDepth != mMapView->currentDepth())
 		{
-			changeViewDepth(mTileMap->currentDepth());
+			changeViewDepth(mMapView->currentDepth());
 		}
 
 		// MiniMap Check
@@ -660,10 +662,10 @@ void MapViewState::changeViewDepth(int depth)
 {
 	if (mBtnTogglePoliceOverlay.toggled())
 	{
-		changePoliceOverlayDepth(mTileMap->currentDepth(), depth);
+		changePoliceOverlayDepth(mMapView->currentDepth(), depth);
 	}
 
-	mTileMap->currentDepth(depth);
+	mMapView->currentDepth(depth);
 
 	if (mInsertMode != InsertMode::Robot) { clearMode(); }
 	populateStructureMenu();
@@ -708,7 +710,7 @@ void MapViewState::placeTubes(Tile* tile)
 
 	if (validTubeConnection(*mTileMap, mMouseTilePosition, cd))
 	{
-		insertTube(cd, mTileMap->currentDepth(), &mTileMap->getTile(mMouseTilePosition));
+		insertTube(cd, mMapView->currentDepth(), &mTileMap->getTile(mMouseTilePosition));
 
 		// FIXME: Naive approach -- will be slow with larger colonies.
 		NAS2D::Utility<StructureManager>::get().disconnectAll();
@@ -896,13 +898,13 @@ void MapViewState::placeRobodigger(Tile& tile)
 		}
 	}
 
-	if (!tile.thing() && mTileMap->currentDepth() > 0) { mDiggerDirection.cardinalOnlyEnabled(); }
+	if (!tile.thing() && mMapView->currentDepth() > 0) { mDiggerDirection.cardinalOnlyEnabled(); }
 	else { mDiggerDirection.downOnlyEnabled(); }
 
 	mDiggerDirection.setParameters(&tile);
 
 	// If we're placing on the top level we can only ever go down.
-	if (mTileMap->currentDepth() == constants::DepthSurface)
+	if (mMapView->currentDepth() == constants::DepthSurface)
 	{
 		mDiggerDirection.selectDown();
 	}
@@ -931,7 +933,7 @@ void MapViewState::placeRobominer(Tile& tile)
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMinerTileObstructed);
 		return;
 	}
-	if (mTileMap->currentDepth() != constants::DepthSurface)
+	if (mMapView->currentDepth() != constants::DepthSurface)
 	{
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMinerSurfaceOnly);
 		return;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -65,6 +65,7 @@ namespace micropather
 struct MapCoordinate;
 class Tile;
 class TileMap;
+class MapView;
 class MainReportsUiState;
 
 
@@ -271,6 +272,7 @@ private:
 private:
 	MainReportsUiState& mMainReportsState;
 	TileMap* mTileMap{nullptr};
+	std::unique_ptr<MapView> mMapView;
 	CrimeRateUpdate mCrimeRateUpdate;
 	CrimeExecution mCrimeExecution;
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -130,7 +130,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	// Bulldoze lander region
 	for (const auto& direction : DirectionScan3x3)
 	{
-		mTileMap->getTile(point + direction).index(TerrainType::Dozed);
+		mTileMap->getTile({point + direction, 0}).index(TerrainType::Dozed);
 	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
@@ -138,15 +138,15 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	// Place initial tubes
 	for (const auto& direction : DirectionClockwise4)
 	{
-		structureManager.addStructure(new Tube(ConnectorDir::CONNECTOR_INTERSECTION, false), &mTileMap->getTile(point + direction));
+		structureManager.addStructure(new Tube(ConnectorDir::CONNECTOR_INTERSECTION, false), &mTileMap->getTile({point + direction, 0}));
 	}
 
 	// TOP ROW
-	structureManager.addStructure(new SeedPower(), &mTileMap->getTile(point + DirectionNorthWest));
+	structureManager.addStructure(new SeedPower(), &mTileMap->getTile({point + DirectionNorthWest, 0}));
 
 	CommandCenter* cc = static_cast<CommandCenter*>(StructureCatalogue::get(StructureID::SID_COMMAND_CENTER));
 	cc->sprite().setFrame(3);
-	structureManager.addStructure(cc, &mTileMap->getTile(point + DirectionNorthEast));
+	structureManager.addStructure(cc, &mTileMap->getTile({point + DirectionNorthEast, 0}));
 	ccLocation() = point + DirectionNorthEast;
 
 	// BOTTOM ROW
@@ -154,11 +154,11 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	sf->resourcePool(&mResourcesCount);
 	sf->productionComplete().connect(this, &MapViewState::onFactoryProductionComplete);
 	sf->sprite().setFrame(7);
-	structureManager.addStructure(sf, &mTileMap->getTile(point + DirectionSouthWest));
+	structureManager.addStructure(sf, &mTileMap->getTile({point + DirectionSouthWest, 0}));
 
 	SeedSmelter* ss = static_cast<SeedSmelter*>(StructureCatalogue::get(StructureID::SID_SEED_SMELTER));
 	ss->sprite().setFrame(10);
-	structureManager.addStructure(ss, &mTileMap->getTile(point + DirectionSouthEast));
+	structureManager.addStructure(ss, &mTileMap->getTile({point + DirectionSouthEast, 0}));
 
 	// Robots only become available after the SEED Factory is deployed.
 	mRobots.addItem(constants::Robodozer, constants::RobodozerSheetId, static_cast<int>(Robot::Type::Dozer));

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -160,7 +160,7 @@ bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position)
 {
 	for (const auto& offset : DirectionScan3x3)
 	{
-		auto& tile = tilemap.getTile(position + offset);
+		auto& tile = tilemap.getTile({position + offset, 0});
 
 		if (tile.index() == TerrainType::Impassable)
 		{

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -17,6 +17,7 @@
 #include "../StructureManager.h"
 #include "../Map/MapCoordinate.h"
 #include "../Map/TileMap.h"
+#include "../Map/MapView.h"
 
 #include "../UI/MessageBox.h"
 
@@ -301,12 +302,12 @@ void MapViewState::populateStructureMenu()
 	// Above Ground structures only
 	if (NAS2D::Utility<StructureManager>::get().count() == 0)
 	{
-		if (mTileMap->currentDepth() == constants::DepthSurface)
+		if (mMapView->currentDepth() == constants::DepthSurface)
 		{
 			mStructures.addItem(constants::SeedLander, 0, StructureID::SID_SEED_LANDER);
 		}
 	}
-	else if (mTileMap->currentDepth() == constants::DepthSurface)
+	else if (mMapView->currentDepth() == constants::DepthSurface)
 	{
 		mStructures.addItem(constants::Agridome, 5, StructureID::SID_AGRIDOME);
 		mStructures.addItem(constants::Chap, 3, StructureID::SID_CHAP);
@@ -430,7 +431,7 @@ void MapViewState::clearOverlays()
 {
 	clearOverlay(mConnectednessOverlay);
 	clearOverlay(mCommRangeOverlay);
-	clearOverlay(mPoliceOverlays[mTileMap->currentDepth()]);
+	clearOverlay(mPoliceOverlays[mMapView->currentDepth()]);
 	clearOverlay(mTruckRouteOverlay);
 }
 
@@ -496,7 +497,7 @@ void MapViewState::onTogglePoliceOverlay()
 		mBtnToggleConnectedness.toggle(false);
 		mBtnToggleRouteOverlay.toggle(false);
 
-		setOverlay(mPoliceOverlays[mTileMap->currentDepth()], Tile::Overlay::Police);
+		setOverlay(mPoliceOverlays[mMapView->currentDepth()], Tile::Overlay::Police);
 	}
 }
 
@@ -690,7 +691,7 @@ void MapViewState::onFileIoAction(const std::string& filePath, FileIo::FileOpera
 
 void MapViewState::onNotificationWindowTakeMeThere(const MapCoordinate& position)
 {
-	mTileMap->centerOn(position);
+	mMapView->centerOn(position);
 }
 
 

--- a/OPHD/UI/DetailMap.h
+++ b/OPHD/UI/DetailMap.h
@@ -8,14 +8,15 @@
 #include <NAS2D/Timer.h>
 
 
-class TileMap;
 class Tile;
+class TileMap;
+class MapView;
 
 
 class DetailMap : public Control
 {
 public:
-	DetailMap(TileMap& tileMap, const std::string& tilesetPath);
+	DetailMap(MapView& mapView, TileMap& tileMap, const std::string& tilesetPath);
 
 	bool isMouseOverTile() const;
 
@@ -29,6 +30,7 @@ public:
 	void draw() const override;
 
 private:
+	MapView& mMapView;
 	TileMap& mTileMap;
 	const NAS2D::Image mTileset;
 	const NAS2D::Image mMineBeacon;

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Map/TileMap.h"
+#include "../Map/MapView.h"
 #include "../Things/Robots/Robot.h"
 #include "../States/Route.h"
 #include "../StructureManager.h"
@@ -22,7 +23,8 @@ namespace
 }
 
 
-MiniMap::MiniMap(TileMap* tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName) :
+MiniMap::MiniMap(MapView& mapView, TileMap* tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName) :
+	mMapView{mapView},
 	mTileMap{tileMap},
 	mRobotList{robotList},
 	mIsHeightMapVisible{false},
@@ -108,7 +110,7 @@ void MiniMap::draw() const
 		renderer.drawPoint(robotPosition + miniMapOffset, NAS2D::Color::Cyan);
 	}
 
-	const auto& viewArea = mTileMap->viewArea();
+	const auto& viewArea = mMapView.viewArea();
 	renderer.drawBox(viewArea.offset(miniMapOffset + NAS2D::Vector{1, 1}), NAS2D::Color{0, 0, 0, 180});
 	renderer.drawBox(viewArea.offset(miniMapOffset), NAS2D::Color::White);
 
@@ -158,5 +160,5 @@ void MiniMap::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
 void MiniMap::onSetView(NAS2D::Point<int> mousePixel)
 {
 	const auto position = NAS2D::Point{0, 0} + (mousePixel - mRect.startPoint());
-	mTileMap->centerOn(position);
+	mMapView.centerOn(position);
 }

--- a/OPHD/UI/MiniMap.h
+++ b/OPHD/UI/MiniMap.h
@@ -12,6 +12,7 @@
 
 class Tile;
 class TileMap;
+class MapView;
 class Robot;
 class MapViewState;
 
@@ -19,7 +20,7 @@ class MapViewState;
 class MiniMap : public Control
 {
 public:
-	MiniMap(TileMap* tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName);
+	MiniMap(MapView& mapView, TileMap* tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName);
 
 	bool heightMapVisible() const;
 	void heightMapVisible(bool isVisible);
@@ -35,6 +36,7 @@ protected:
 	void onSetView(NAS2D::Point<int> mousePixel);
 
 private:
+	MapView& mMapView;
 	TileMap* mTileMap;
 	const std::map<Robot*, Tile*>& mRobotList;
 	bool mIsHeightMapVisible;

--- a/OPHD/UI/NavControl.cpp
+++ b/OPHD/UI/NavControl.cpp
@@ -4,6 +4,7 @@
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../Map/TileMap.h"
+#include "../Map/MapView.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -27,7 +28,8 @@ namespace
 }
 
 
-NavControl::NavControl(TileMap& tileMap) :
+NavControl::NavControl(MapView& mapView, TileMap& tileMap) :
+	mMapView{mapView},
 	mTileMap{tileMap},
 	mUiIcons{imageCache.load("ui/icons.png")}
 {
@@ -69,7 +71,7 @@ void NavControl::onClick(NAS2D::Point<int> mousePosition)
 	{
 		if (iconRect.contains(mousePosition))
 		{
-			mTileMap.moveView(direction);
+			mMapView.moveView(direction);
 		}
 	}
 }
@@ -106,14 +108,14 @@ void NavControl::draw() const
 	{
 		const auto levelString = (i == 0) ? std::string{"S"} : std::to_string(i);
 		const auto textSize = font.size(levelString);
-		bool isCurrentDepth = i == mTileMap.currentDepth();
+		bool isCurrentDepth = i == mMapView.currentDepth();
 		NAS2D::Color color = isCurrentDepth ? NAS2D::Color::Red : NAS2D::Color{200, 200, 200};
 		renderer.drawText(font, levelString, position - textSize, color);
 		position.x -= stepSizeWidth;
 	}
 
 	// Explicit current level
-	const auto& currentLevelString = LevelStringTable[mTileMap.currentDepth()];
+	const auto& currentLevelString = LevelStringTable[mMapView.currentDepth()];
 	const auto& fontBoldMedium = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium);
 	const auto currentLevelPosition = mRect.endPoint() - fontBoldMedium.size(currentLevelString) - NAS2D::Vector{constants::Margin, constants::Margin};
 	renderer.drawText(fontBoldMedium, currentLevelString, currentLevelPosition, NAS2D::Color::White);

--- a/OPHD/UI/NavControl.h
+++ b/OPHD/UI/NavControl.h
@@ -13,13 +13,14 @@ namespace NAS2D
 }
 
 class TileMap;
+class MapView;
 class MapViewState;
 
 
 class NavControl : public Control
 {
 public:
-	NavControl(TileMap& tileMap);
+	NavControl(MapView& mapView, TileMap& tileMap);
 
 	void draw() const override;
 
@@ -30,6 +31,7 @@ protected:
 	void onClick(NAS2D::Point<int> mousePosition);
 
 private:
+	MapView& mMapView;
 	TileMap& mTileMap;
 	const NAS2D::Image& mUiIcons;
 

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -234,6 +234,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="IOHelper.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Map\MapCoordinate.cpp" />
+    <ClCompile Include="Map\MapView.cpp" />
     <ClCompile Include="Map\Tile.cpp" />
     <ClCompile Include="Map\TileMap.cpp" />
     <ClCompile Include="MicroPather\micropather.cpp" />
@@ -324,6 +325,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClInclude Include="GraphWalker.h" />
     <ClInclude Include="IOHelper.h" />
     <ClInclude Include="Map\MapCoordinate.h" />
+    <ClInclude Include="Map\MapView.h" />
     <ClInclude Include="Map\Tile.h" />
     <ClInclude Include="Map\TileMap.h" />
     <ClInclude Include="MicroPather\micropather.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -162,6 +162,9 @@
     <ClCompile Include="Map\MapCoordinate.cpp">
       <Filter>Source Files\Map</Filter>
     </ClCompile>
+    <ClCompile Include="Map\MapView.cpp">
+      <Filter>Source Files\Map</Filter>
+    </ClCompile>
     <ClCompile Include="Map\Tile.cpp">
       <Filter>Source Files\Map</Filter>
     </ClCompile>
@@ -528,6 +531,9 @@
       <Filter>Header Files\Population</Filter>
     </ClInclude>
     <ClInclude Include="Map\MapCoordinate.h">
+      <Filter>Header Files\Map</Filter>
+    </ClInclude>
+    <ClInclude Include="Map\MapView.h">
       <Filter>Header Files\Map</Filter>
     </ClInclude>
     <ClInclude Include="Map\Tile.h">


### PR DESCRIPTION
Reference: #650 (mostly related to this work)

Split current view parameters into `MapView`, while leaving core data fields in `TileMap`.

As an aside, this could potentially allow for a split screen view, displaying two areas of the map simultaneously. Mostly though, the split was done to try and keep the classes small and focused on just one thing. In this case, data, and a view of that data.
