### PR TITLE
`ScrollBar` large change

### DIFF
--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -253,9 +253,12 @@ void ScrollBar::onMouseUp(EventHandler::MouseButton button, int x, int y)
 	const auto mousePosition = NAS2D::Point{x, y};
 	if (mTrack.contains(mousePosition) && !mThumb.contains(mousePosition))
 	{
-		const auto isDecrease = (mScrollBarType == ScrollBarType::Vertical) ?
-			(y < mThumb.y) : (x < mThumb.x);
-		changeValue((isDecrease ? -3 : 3));
+		const auto [clickPosition, thumbPosition, viewSize] =
+			(mScrollBarType == ScrollBarType::Vertical) ?
+				std::tuple{y, mThumb.y, mRect.height} : std::tuple{x, mThumb.x, mRect.width};
+		const auto changeAmount = (clickPosition < thumbPosition) ?
+			-viewSize : viewSize;
+		changeValue(changeAmount);
 	}
 }
 

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -253,11 +253,9 @@ void ScrollBar::onMouseUp(EventHandler::MouseButton button, int x, int y)
 	const auto mousePosition = NAS2D::Point{x, y};
 	if (mTrack.contains(mousePosition) && !mThumb.contains(mousePosition))
 	{
-		changeValue(
-			(mScrollBarType == ScrollBarType::Vertical) ?
-				(y < mThumb.y ? -3 : 3) :
-				(x < mThumb.x ? -3 : 3)
-		);
+		const auto isDecrease = (mScrollBarType == ScrollBarType::Vertical) ?
+			(y < mThumb.y) : (x < mThumb.x);
+		changeValue((isDecrease ? -3 : 3));
 	}
 }
 


### PR DESCRIPTION
Reference: #1149

Implement a sensible large increment heuristic. This assumes pixel level scrolling, and the container view size is equal to the `ScrollBar` height (or width), which is generally the case when the `ScrollBar` is attached to the container. In that case, the large change means scrolling by one view size. Effectively, the `ScrollBar` values represent pixel offsets for the view into the container.
