### PR TITLE
Add check to ensure that an invalid index can't be used.

### DIFF
--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -107,7 +107,7 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 	}
 
 	const auto index = notificationIndex({x, y});
-	if (index != NoSelection)
+	if (index != NoSelection && index < mNotificationList.size())
 	{
 		if (button == EventHandler::MouseButton::Left)
 		{


### PR DESCRIPTION
Noticed that the notification area can throw an out of bounds exception because the index provided is never checked for validity.