### PR TITLE
MineFacility now sets storage full idle reason instead of mine exhausted

### DIFF
--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -86,7 +86,7 @@ void MineFacility::think()
 	{
 		if (storage() >= capacity)
 		{
-			idle(IdleReason::MineExhausted);
+			idle(IdleReason::InternalStorageFull);
 			return;
 		}
 


### PR DESCRIPTION
Semi-related to #1161. This isn't the root cause but it's a defect none-the-less that needs to be fixed. Opted for a separate PR for this.