### PR TITLE
Default to Debug builds on Linux and MacOS

### DIFF
--- a/OPHD/ShellOpenPath.cpp
+++ b/OPHD/ShellOpenPath.cpp
@@ -2,6 +2,7 @@
 
 #include <string_view>
 #include <cstdlib>
+#include <tuple>
 
 
 namespace
@@ -20,5 +21,6 @@ namespace
 
 void shellOpenPath(const std::string& path)
 {
-	std::system((std::string{ShellOpenCommand} + " " + path).c_str());
+	// Explicitly ignore implementation defined return value
+	std::ignore = std::system((std::string{ShellOpenCommand} + " " + path).c_str());
 }

--- a/makefile
+++ b/makefile
@@ -1,5 +1,10 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
+CONFIG := debug
+debug_CXX_FLAGS := -Og -g
+release_CXX_FLAGS := -O3
+CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
+
 SRCDIR := OPHD/
 BUILDDIR := .build/
 OBJDIR := $(BUILDDIR)obj/
@@ -21,7 +26,7 @@ OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++17 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs $(OpenGL_LIBS)
 


### PR DESCRIPTION
Closes #428
Reference: https://github.com/lairworks/nas2d-core/issues/867

Add **debug** and **release** config flags. Set **debug** flags as default.

To build a release, run:
```
make CONFIG=release
```

----

Explicitly ignore the return value to `std::system`, as otherwise we get warnings when compiling in debug mode.

Reference: #1165 (Collect calls to `std::system` to one place)

Documentation:
[`std::system`](https://en.cppreference.com/w/cpp/utility/program/system)
> Return value
> Implementation-defined value. If command is a null pointer, returns a nonzero value if and only if the command processor exists.

[`std::ignore`](https://en.cppreference.com/w/cpp/utility/tuple/ignore)
>An object of unspecified type such that any value can be assigned to it with no effect.
> ...
> It can also be used to avoid warnings from unused return values of [[nodiscard]] functions.

[CppCore Guidelines: ES.48: Avoid casts: Note](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#notes-4)
> Never cast to (void) to ignore a [[nodiscard]]return value. If you deliberately want to discard such a result, first think hard about whether that is really a good idea (there is usually a good reason the author of the function or of the return type used [[nodiscard]] in the first place). If you still think it's appropriate and your code reviewer agrees, use std::ignore = to turn off the warning which is simple, portable, and easy to grep.

Since the return value is implementation defined, there isn't much we can assume about it, so it may be best to just ignore it. The consequences of ignoring errors for these calls are pretty low considering the context.
