### PR TITLE
Remove `Robot` `id` field

### DIFF
--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -5,9 +5,6 @@
 #include <algorithm>
 
 
-int ROBOT_ID_COUNTER = 0; /// \fixme Kludge
-
-
 RobotPool::RobotPool()
 {}
 
@@ -48,42 +45,24 @@ void RobotPool::erase(Robot* robot)
 /**
  * Adds a robot of specified type to the pool.
  *
- * Generates a new unique ID for the robot.
- *
  * \return Returns a pointer to the robot, or nullptr if type was invalid.
  */
 Robot* RobotPool::addRobot(Robot::Type type)
-{
-	// Generate a new unique ID
-	const auto id = ++ROBOT_ID_COUNTER;
-	return addRobot(type, id);
-}
-
-
-/**
- * Adds a robot of specified type to the pool.
- *
- * \return Returns a pointer to the robot, or nullptr if type was invalid.
- */
-Robot* RobotPool::addRobot(Robot::Type type, int id)
 {
 	switch (type)
 	{
 	case Robot::Type::Dozer:
 		mDozers.push_back(new Robodozer());
-		mDozers.back()->id(id);
 		mRobots.push_back(mDozers.back());
 		return mDozers.back();
 
 	case Robot::Type::Digger:
 		mDiggers.push_back(new Robodigger());
-		mDiggers.back()->id(id);
 		mRobots.push_back(mDiggers.back());
 		return mDiggers.back();
 
 	case Robot::Type::Miner:
 		mMiners.push_back(new Robominer());
-		mMiners.back()->id(id);
 		mRobots.push_back(mMiners.back());
 		return mMiners.back();
 

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -24,7 +24,6 @@ public:
 	~RobotPool();
 
 	Robot* addRobot(Robot::Type type);
-	Robot* addRobot(Robot::Type type, int id);
 
 	Robodigger& getDigger();
 	Robodozer& getDozer();

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -47,6 +47,7 @@
 
 #include <string>
 #include <memory>
+#include <map>
 
 
 namespace NAS2D
@@ -208,7 +209,7 @@ private:
 	void checkNewlyBuiltStructures();
 
 	// SAVE GAME MANAGEMENT FUNCTIONS
-	void readRobots(NAS2D::Xml::XmlElement* element);
+	std::map<int, Robot*> readRobots(NAS2D::Xml::XmlElement* element);
 	void readStructures(NAS2D::Xml::XmlElement* element);
 	void readTurns(NAS2D::Xml::XmlElement* element);
 	void readPopulation(NAS2D::Xml::XmlElement* element);

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -210,7 +210,7 @@ private:
 
 	// SAVE GAME MANAGEMENT FUNCTIONS
 	std::map<int, Robot*> readRobots(NAS2D::Xml::XmlElement* element);
-	void readStructures(NAS2D::Xml::XmlElement* element);
+	void readStructures(NAS2D::Xml::XmlElement* element, const std::map<int, Robot*>& idToRobotMap);
 	void readTurns(NAS2D::Xml::XmlElement* element);
 	void readPopulation(NAS2D::Xml::XmlElement* element);
 	void readMoraleChanges(NAS2D::Xml::XmlElement*);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -545,13 +545,14 @@ NAS2D::Dictionary robotToDictionary(RobotTileTable& robotTileTable, Robot& robot
 }
 
 
-NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap)
+NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap, std::map<const Robot*, int> robotToIdMap)
 {
 	auto* robots = new NAS2D::Xml::XmlElement("robots");
 
 	for (auto robot : robotPool.robots())
 	{
 		auto dictionary = robotToDictionary(robotMap, *robot);
+		dictionary["id"] = robotToIdMap[robot];
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -13,6 +13,8 @@
 
 #include "../Map/MapCoordinate.h"
 
+#include <map>
+
 
 namespace NAS2D
 {
@@ -61,7 +63,7 @@ int pullResource(int& resource, int amount);
 void resetTileIndexFromDozer(Robot* robot, Tile* tile);
 
 // Serialize / Deserialize
-NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap);
+NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap, std::map<const Robot*, int> robotToIdMap);
 
 void updateRobotControl(RobotPool& robotPool);
 void deleteRobotsInRCC(RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& rtt);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -24,7 +24,6 @@
 #include <NAS2D/Xml/XmlMemoryBuffer.h>
 #include <NAS2D/ParserHelper.h>
 
-#include <map>
 #include <string>
 #include <vector>
 #include <stdexcept>
@@ -266,11 +265,13 @@ void MapViewState::load(const std::string& filePath)
 }
 
 
-void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
+std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 {
 	mRobotPool.clear();
 	mRobotList.clear();
 	mRobots.clear();
+
+	std::map<int, Robot*> idToRobotMap{};
 
 	ROBOT_ID_COUNTER = 0;
 	for (NAS2D::Xml::XmlElement* robotElement = element->firstChildElement(); robotElement; robotElement = robotElement->nextSiblingElement())
@@ -315,6 +316,8 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		// but may be better here as an explicit statement.
 		if (!robot) { continue; }
 
+		idToRobotMap[id] = robot;
+
 		robot->fuelCellAge(age);
 
 		if (production_time > 0)
@@ -331,6 +334,8 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 	}
 
 	populateRobotMenu();
+
+	return idToRobotMap;
 }
 
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -57,6 +57,17 @@ static void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idT
 }
 
 
+static std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robots)
+{
+	std::map<const Robot*, int> robotToIdMap{};
+	for (const auto* robot : robots)
+	{
+		robotToIdMap[robot] = robot->id();
+	}
+	return robotToIdMap;
+}
+
+
 
 /*****************************************************************************
  * CLASS FUNCTIONS
@@ -78,11 +89,13 @@ void MapViewState::save(const std::string& filePath)
 	);
 	doc.linkEndChild(root);
 
+	const auto robotToIdMap = generateRobotToIdMap(mRobotPool.robots());
+
 	root->linkEndChild(serializeProperties());
 	mTileMap->serialize(root);
 	mMapView->serialize(root);
-	root->linkEndChild(NAS2D::Utility<StructureManager>::get().serialize());
-	root->linkEndChild(writeRobots(mRobotPool, mRobotList));
+	root->linkEndChild(NAS2D::Utility<StructureManager>::get().serialize(robotToIdMap));
+	root->linkEndChild(writeRobots(mRobotPool, mRobotList, robotToIdMap));
 	root->linkEndChild(writeResources(mResourceBreakdownPanel.previousResources(), "prev_resources"));
 
 	root->linkEndChild(NAS2D::dictionaryToAttributes("turns", {{{"count", mTurnCount}}}));

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -32,10 +32,6 @@
 extern std::map<int, std::string> LEVEL_STRING_TABLE;
 
 
-extern int ROBOT_ID_COUNTER; /// \fixme Kludge
-
-
-
 /*****************************************************************************
  * LOCAL FUNCTIONS
  *****************************************************************************/
@@ -280,7 +276,6 @@ std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 
 	std::map<int, Robot*> idToRobotMap{};
 
-	ROBOT_ID_COUNTER = 0;
 	for (NAS2D::Xml::XmlElement* robotElement = element->firstChildElement(); robotElement; robotElement = robotElement->nextSiblingElement())
 	{
 		const auto dictionary = NAS2D::attributesToDictionary(*robotElement);
@@ -294,24 +289,22 @@ std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		const auto depth = dictionary.get<int>("depth", 0);
 		const auto direction = dictionary.get<int>("direction", 0);
 
-		ROBOT_ID_COUNTER = std::max(ROBOT_ID_COUNTER, id);
-
 		Robot* robot = nullptr;
 		switch (static_cast<Robot::Type>(type))
 		{
 		case Robot::Type::Digger:
-			robot = mRobotPool.addRobot(Robot::Type::Digger, id);
+			robot = mRobotPool.addRobot(Robot::Type::Digger);
 			robot->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
 			static_cast<Robodigger*>(robot)->direction(static_cast<Direction>(direction));
 			break;
 
 		case Robot::Type::Dozer:
-			robot = mRobotPool.addRobot(Robot::Type::Dozer, id);
+			robot = mRobotPool.addRobot(Robot::Type::Dozer);
 			robot->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
 			break;
 
 		case Robot::Type::Miner:
-			robot = mRobotPool.addRobot(Robot::Type::Miner, id);
+			robot = mRobotPool.addRobot(Robot::Type::Miner);
 			robot->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
 			break;
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -60,9 +60,10 @@ static void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idT
 static std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robots)
 {
 	std::map<const Robot*, int> robotToIdMap{};
+	int currentId = 0;
 	for (const auto* robot : robots)
 	{
-		robotToIdMap[robot] = robot->id();
+		robotToIdMap[robot] = currentId++;
 	}
 	return robotToIdMap;
 }

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -32,7 +32,7 @@ namespace
 	}
 
 
-	NAS2D::Xml::XmlElement* serializeStructure(Structure* structure, Tile* tile)
+	NAS2D::Xml::XmlElement* serializeStructure(Structure* structure, Tile* tile, std::map<const Robot*, int> robotToIdMap)
 	{
 		const auto position = tile->xyz();
 		NAS2D::Dictionary dictionary =
@@ -69,7 +69,7 @@ namespace
 		{
 			const auto& robots = static_cast<RobotCommand*>(structure)->robots();
 
-			const auto robotToIdString = [](const Robot* robot){ return NAS2D::stringFrom(robot->id()); };
+			const auto robotToIdString = [&robotToIdMap](const Robot* robot){ return NAS2D::stringFrom(robotToIdMap.at(robot)); };
 			const auto idsString = NAS2D::join(NAS2D::mapToVector(robots, robotToIdString), ",");
 
 			structureElement->linkEndChild(
@@ -516,13 +516,13 @@ Tile& StructureManager::tileFromStructure(Structure* structure)
 }
 
 
-NAS2D::Xml::XmlElement* StructureManager::serialize()
+NAS2D::Xml::XmlElement* StructureManager::serialize(std::map<const Robot*, int> robotToIdMap)
 {
 	auto* structures = new NAS2D::Xml::XmlElement("structures");
 
 	for (auto& [structure, tile] : mStructureTileTable)
 	{
-		structures->linkEndChild(serializeStructure(structure, tile));
+		structures->linkEndChild(serializeStructure(structure, tile, robotToIdMap));
 	}
 
 	return structures;

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -3,6 +3,8 @@
 #include "Things/Structures/Structure.h"
 #include "Things/Structures/Structures.h"
 
+#include <map>
+
 
 namespace NAS2D
 {
@@ -128,7 +130,7 @@ public:
 
 	void update(const StorableResources&, PopulationPool&);
 
-	NAS2D::Xml::XmlElement* serialize();
+	NAS2D::Xml::XmlElement* serialize(std::map<const Robot*, int> robotToIdMap);
 
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;

--- a/OPHD/Things/Robots/Robot.cpp
+++ b/OPHD/Things/Robots/Robot.cpp
@@ -22,7 +22,6 @@ void Robot::startTask(int turns)
 NAS2D::Dictionary Robot::getDataDict() const
 {
 	return {{
-		{"id", mId},
 		{"type", static_cast<int>(mType)},
 		{"age", mFuelCellAge},
 		{"production", mTurnsToCompleteTask},

--- a/OPHD/Things/Robots/Robot.h
+++ b/OPHD/Things/Robots/Robot.h
@@ -41,9 +41,6 @@ public:
 
 	TaskSignal::Source& taskComplete() { return mTaskCompleteSignal; }
 
-	void id(int newId) { mId = newId; }
-	int id() const { return mId; }
-
 	virtual NAS2D::Dictionary getDataDict() const;
 
 protected:
@@ -51,7 +48,6 @@ protected:
 	void updateTask();
 
 private:
-	int mId = 0;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
 


### PR DESCRIPTION
Remove long term storage for `Robot` `id` fields.

We only need the ID temporarily during save/load to convert between `Robot*` and an ID value that can be serialized. These IDs are now generated during save, then reconstructed and discarded after loading. The mappings are now effectively local variables to the save/load code.

This change should have no impact on existing saved games. Whatever ID mapping was generated during save will be respected during load, with either the new or old code.
