### PR TITLE
Add `MapViewState::addRobot` and refactor code

### DIFF
--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -54,23 +54,20 @@ Robot* RobotPool::addRobot(Robot::Type type)
 	case Robot::Type::Dozer:
 		mDozers.push_back(new Robodozer());
 		mRobots.push_back(mDozers.back());
-		return mDozers.back();
-
+		break;
 	case Robot::Type::Digger:
 		mDiggers.push_back(new Robodigger());
 		mRobots.push_back(mDiggers.back());
-		return mDiggers.back();
-
+		break;
 	case Robot::Type::Miner:
 		mMiners.push_back(new Robominer());
 		mRobots.push_back(mMiners.back());
-		return mMiners.back();
-
+		break;
 	default:
 		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));
 	}
 
-	return nullptr;
+	return mRobots.back();
 }
 
 

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -67,7 +67,7 @@ Robot* RobotPool::addRobot(Robot::Type type)
 		return mMiners.back();
 
 	default:
-		break;
+		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));
 	}
 
 	return nullptr;

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -47,7 +47,7 @@ void RobotPool::erase(Robot* robot)
  *
  * \return Returns a pointer to the robot, or nullptr if type was invalid.
  */
-Robot* RobotPool::addRobot(Robot::Type type)
+Robot& RobotPool::addRobot(Robot::Type type)
 {
 	switch (type)
 	{
@@ -67,7 +67,7 @@ Robot* RobotPool::addRobot(Robot::Type type)
 		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));
 	}
 
-	return mRobots.back();
+	return *mRobots.back();
 }
 
 

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -23,7 +23,7 @@ public:
 	RobotPool();
 	~RobotPool();
 
-	Robot* addRobot(Robot::Type type);
+	Robot& addRobot(Robot::Type type);
 
 	Robodigger& getDigger();
 	Robodozer& getDozer();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -723,6 +723,156 @@ void MapViewState::placeTubes(Tile* tile)
 }
 
 
+/**
+ * Places a structure into the map.
+ */
+void MapViewState::placeStructure(Tile* tile)
+{
+	if (mCurrentStructure == StructureID::SID_NONE) { throw std::runtime_error("MapViewState::placeStructure() called but mCurrentStructure == STRUCTURE_NONE"); }
+
+	if (!structureIsLander(mCurrentStructure) && !selfSustained(mCurrentStructure) &&
+		!isPointInRange(tile->xy(), ccLocation(), constants::RobotCommRange))
+	{
+		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOutOfRange);
+		return;
+	}
+
+	if (tile->mine())
+	{
+		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureMineInWay);
+		return;
+	}
+
+	if (tile->thing())
+	{
+		if (tile->thingIsStructure())
+		{
+			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTileObstructed);
+		}
+		else
+		{
+			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTileThing);
+		}
+		return;
+	}
+
+	if ((!tile->bulldozed() && !structureIsLander(mCurrentStructure)))
+	{
+		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTerrain);
+		return;
+	}
+
+	if (!tile->excavated())
+	{
+		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureExcavated);
+		return;
+	}
+
+	// The player may only place one seed lander per game.
+	if (mCurrentStructure == StructureID::SID_SEED_LANDER)
+	{
+		insertSeedLander(mMouseTilePosition.xy);
+	}
+	else if (mCurrentStructure == StructureID::SID_COLONIST_LANDER)
+	{
+		if (!validLanderSite(*tile)) { return; }
+
+		ColonistLander* s = new ColonistLander(tile);
+		s->deploySignal().connect(this, &MapViewState::onDeployColonistLander);
+		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
+
+		--mLandersColonist;
+		if (mLandersColonist == 0)
+		{
+			clearMode();
+			resetUi();
+			populateStructureMenu();
+		}
+	}
+	else if (mCurrentStructure == StructureID::SID_CARGO_LANDER)
+	{
+		if (!validLanderSite(*tile)) { return; }
+
+		CargoLander* cargoLander = new CargoLander(tile);
+		cargoLander->deploySignal().connect(this, &MapViewState::onDeployCargoLander);
+		NAS2D::Utility<StructureManager>::get().addStructure(cargoLander, tile);
+
+		--mLandersCargo;
+		if (mLandersCargo == 0)
+		{
+			clearMode();
+			resetUi();
+			populateStructureMenu();
+		}
+	}
+	else
+	{
+		if (!validStructurePlacement(*mTileMap, mMouseTilePosition) && !selfSustained(mCurrentStructure))
+		{
+			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureNoTube);
+			return;
+		}
+
+		// Check build cost
+		if (!StructureCatalogue::canBuild(mResourcesCount, mCurrentStructure))
+		{
+			resourceShortageMessage(mResourcesCount, mCurrentStructure);
+			return;
+		}
+
+		Structure* structure = StructureCatalogue::get(mCurrentStructure);
+		if (!structure) { throw std::runtime_error("MapViewState::placeStructure(): NULL Structure returned from StructureCatalog."); }
+
+		NAS2D::Utility<StructureManager>::get().addStructure(structure, tile);
+
+		// FIXME: Ugly
+		if (structure->isFactory())
+		{
+			static_cast<Factory*>(structure)->productionComplete().connect(this, &MapViewState::onFactoryProductionComplete);
+			static_cast<Factory*>(structure)->resourcePool(&mResourcesCount);
+		}
+
+		if (structure->structureId() == StructureID::SID_MAINTENANCE_FACILITY)
+		{
+			static_cast<MaintenanceFacility*>(structure)->resources(mResourcesCount);
+		}
+
+		auto cost = StructureCatalogue::costToBuild(mCurrentStructure);
+		removeRefinedResources(cost);
+		updatePlayerResources();
+		updateStructuresAvailability();
+	}
+}
+
+
+void MapViewState::placeRobot(Tile* tile)
+{
+	if (!tile->excavated()) { return; }
+	if (!mRobotPool.robotCtrlAvailable()) { return; }
+
+	if (!inCommRange(tile->xy()))
+	{
+		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertOutOfCommRange);
+		return;
+	}
+
+	switch (mCurrentRobot)
+	{
+	case Robot::Type::Dozer:
+		placeRobodozer(*tile);
+		break;
+	case Robot::Type::Digger:
+		placeRobodigger(*tile);
+		break;
+	case Robot::Type::Miner:
+		placeRobominer(*tile);
+		break;
+	default:
+		break;
+	}
+}
+
+
 void MapViewState::placeRobodozer(Tile& tile)
 {
 	auto& robot = mRobotPool.getDozer();
@@ -957,34 +1107,6 @@ void MapViewState::placeRobominer(Tile& tile)
 }
 
 
-void MapViewState::placeRobot(Tile* tile)
-{
-	if (!tile->excavated()) { return; }
-	if (!mRobotPool.robotCtrlAvailable()) { return; }
-
-	if (!inCommRange(tile->xy()))
-	{
-		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertOutOfCommRange);
-		return;
-	}
-
-	switch (mCurrentRobot)
-	{
-	case Robot::Type::Dozer:
-		placeRobodozer(*tile);
-		break;
-	case Robot::Type::Digger:
-		placeRobodigger(*tile);
-		break;
-	case Robot::Type::Miner:
-		placeRobominer(*tile);
-		break;
-	default:
-		break;
-	}
-}
-
-
 /**
  * Checks the robot selection interface and if the robot is not available in it, adds
  * it back in.
@@ -999,128 +1121,6 @@ void MapViewState::populateRobotMenu()
 		{
 			mRobots.addItemSorted(robotMeta.name, robotMeta.sheetIndex, static_cast<int>(robotType));
 		}
-	}
-}
-
-
-/**
- * Places a structure into the map.
- */
-void MapViewState::placeStructure(Tile* tile)
-{
-	if (mCurrentStructure == StructureID::SID_NONE) { throw std::runtime_error("MapViewState::placeStructure() called but mCurrentStructure == STRUCTURE_NONE"); }
-
-	if (!structureIsLander(mCurrentStructure) && !selfSustained(mCurrentStructure) &&
-		!isPointInRange(tile->xy(), ccLocation(), constants::RobotCommRange))
-	{
-		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOutOfRange);
-		return;
-	}
-
-	if (tile->mine())
-	{
-		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureMineInWay);
-		return;
-	}
-
-	if (tile->thing())
-	{
-		if (tile->thingIsStructure())
-		{
-			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTileObstructed);
-		}
-		else
-		{
-			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTileThing);
-		}
-		return;
-	}
-
-	if ((!tile->bulldozed() && !structureIsLander(mCurrentStructure)))
-	{
-		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTerrain);
-		return;
-	}
-
-	if (!tile->excavated())
-	{
-		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureExcavated);
-		return;
-	}
-
-	// The player may only place one seed lander per game.
-	if (mCurrentStructure == StructureID::SID_SEED_LANDER)
-	{
-		insertSeedLander(mMouseTilePosition.xy);
-	}
-	else if (mCurrentStructure == StructureID::SID_COLONIST_LANDER)
-	{
-		if (!validLanderSite(*tile)) { return; }
-
-		ColonistLander* s = new ColonistLander(tile);
-		s->deploySignal().connect(this, &MapViewState::onDeployColonistLander);
-		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
-
-		--mLandersColonist;
-		if (mLandersColonist == 0)
-		{
-			clearMode();
-			resetUi();
-			populateStructureMenu();
-		}
-	}
-	else if (mCurrentStructure == StructureID::SID_CARGO_LANDER)
-	{
-		if (!validLanderSite(*tile)) { return; }
-
-		CargoLander* cargoLander = new CargoLander(tile);
-		cargoLander->deploySignal().connect(this, &MapViewState::onDeployCargoLander);
-		NAS2D::Utility<StructureManager>::get().addStructure(cargoLander, tile);
-
-		--mLandersCargo;
-		if (mLandersCargo == 0)
-		{
-			clearMode();
-			resetUi();
-			populateStructureMenu();
-		}
-	}
-	else
-	{
-		if (!validStructurePlacement(*mTileMap, mMouseTilePosition) && !selfSustained(mCurrentStructure))
-		{
-			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureNoTube);
-			return;
-		}
-
-		// Check build cost
-		if (!StructureCatalogue::canBuild(mResourcesCount, mCurrentStructure))
-		{
-			resourceShortageMessage(mResourcesCount, mCurrentStructure);
-			return;
-		}
-
-		Structure* structure = StructureCatalogue::get(mCurrentStructure);
-		if (!structure) { throw std::runtime_error("MapViewState::placeStructure(): NULL Structure returned from StructureCatalog."); }
-
-		NAS2D::Utility<StructureManager>::get().addStructure(structure, tile);
-
-		// FIXME: Ugly
-		if (structure->isFactory())
-		{
-			static_cast<Factory*>(structure)->productionComplete().connect(this, &MapViewState::onFactoryProductionComplete);
-			static_cast<Factory*>(structure)->resourcePool(&mResourcesCount);
-		}
-
-		if (structure->structureId() == StructureID::SID_MAINTENANCE_FACILITY)
-		{
-			static_cast<MaintenanceFacility*>(structure)->resources(mResourcesCount);
-		}
-
-		auto cost = StructureCatalogue::costToBuild(mCurrentStructure);
-		removeRefinedResources(cost);
-		updatePlayerResources();
-		updateStructuresAvailability();
 	}
 }
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1107,6 +1107,26 @@ void MapViewState::placeRobominer(Tile& tile)
 }
 
 
+Robot& MapViewState::addRobot(Robot::Type type)
+{
+	const std::map<Robot::Type, void (MapViewState::*)(Robot*)> RobotTypeToHandler
+	{
+		{Robot::Type::Digger, &MapViewState::onDiggerTaskComplete},
+		{Robot::Type::Dozer, &MapViewState::onDozerTaskComplete},
+		{Robot::Type::Miner, &MapViewState::onMinerTaskComplete},
+	};
+
+	if (RobotTypeToHandler.find(type) == RobotTypeToHandler.end())
+	{
+		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));
+	}
+
+	auto& robot = mRobotPool.addRobot(type);
+	robot.taskComplete().connect(this, RobotTypeToHandler.at(type));
+	return robot;
+}
+
+
 /**
  * Checks the robot selection interface and if the robot is not available in it, adds
  * it back in.

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -167,6 +167,8 @@ private:
 	void placeRobodigger(Tile&);
 	void placeRobominer(Tile&);
 
+	Robot& addRobot(Robot::Type type);
+
 	void setStructureID(StructureID type, InsertMode mode);
 
 	// MISCELLANEOUS UTILITY FUNCTIONS

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -159,9 +159,9 @@ private:
 	void insertSeedLander(NAS2D::Point<int> point);
 	void insertTube(ConnectorDir dir, int depth, Tile* tile);
 
-	void placeRobot(Tile* tile);
-	void placeStructure(Tile* tile);
 	void placeTubes(Tile* tile);
+	void placeStructure(Tile* tile);
+	void placeRobot(Tile* tile);
 
 	void placeRobodozer(Tile&);
 	void placeRobodigger(Tile&);

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -27,19 +27,19 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 		switch (pt)
 		{
 		case ProductType::PRODUCT_DIGGER:
-			robot = mRobotPool.addRobot(Robot::Type::Digger);
+			robot = &mRobotPool.addRobot(Robot::Type::Digger);
 			robot->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
 			factory.pullProduct();
 			break;
 
 		case ProductType::PRODUCT_DOZER:
-			robot = mRobotPool.addRobot(Robot::Type::Dozer);
+			robot = &mRobotPool.addRobot(Robot::Type::Dozer);
 			robot->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
 			factory.pullProduct();
 			break;
 
 		case ProductType::PRODUCT_MINER:
-			robot = mRobotPool.addRobot(Robot::Type::Miner);
+			robot = &mRobotPool.addRobot(Robot::Type::Miner);
 			robot->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
 			factory.pullProduct();
 			break;
@@ -165,9 +165,9 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	mRobots.addItem(constants::Robominer, constants::RobominerSheetId, static_cast<int>(Robot::Type::Miner));
 	mRobots.sort();
 
-	mRobotPool.addRobot(Robot::Type::Dozer)->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
-	mRobotPool.addRobot(Robot::Type::Digger)->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
-	mRobotPool.addRobot(Robot::Type::Miner)->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
+	mRobotPool.addRobot(Robot::Type::Dozer).taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
+	mRobotPool.addRobot(Robot::Type::Digger).taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
+	mRobotPool.addRobot(Robot::Type::Miner).taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
 }
 
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -29,24 +29,19 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 		case ProductType::PRODUCT_DIGGER:
 			robot = &mRobotPool.addRobot(Robot::Type::Digger);
 			robot->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
-			factory.pullProduct();
 			break;
-
 		case ProductType::PRODUCT_DOZER:
 			robot = &mRobotPool.addRobot(Robot::Type::Dozer);
 			robot->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
-			factory.pullProduct();
 			break;
-
 		case ProductType::PRODUCT_MINER:
 			robot = &mRobotPool.addRobot(Robot::Type::Miner);
 			robot->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
-			factory.pullProduct();
 			break;
-
 		default:
 			throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
 		}
+		factory.pullProduct();
 
 		populateRobotMenu();
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -35,12 +35,12 @@ void MapViewState::pullRobotFromFactory(ProductType productType, Factory& factor
 
 	if ((robotCommand != nullptr) || mRobotPool.commandCapacityAvailable())
 	{
-		auto* robot = &addRobot(robotType);
+		auto& robot = addRobot(robotType);
 		factory.pullProduct();
 
 		populateRobotMenu();
 
-		if (robotCommand != nullptr) { robotCommand->addRobot(robot); }
+		if (robotCommand != nullptr) { robotCommand->addRobot(&robot); }
 	}
 	else
 	{

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -27,7 +27,7 @@ void MapViewState::pullRobotFromFactory(ProductType productType, Factory& factor
 
 	if (ProductTypeToRobotType.find(productType) == ProductTypeToRobotType.end())
 	{
-		throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
+		throw std::runtime_error("pullRobotFromFactory():: unsuitable ProductType: " + std::to_string(static_cast<int>(productType)));
 	}
 
 	const auto robotType = ProductTypeToRobotType.at(productType);

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -18,29 +18,24 @@
 
 void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 {
+	const std::map<ProductType, Robot::Type> ProductTypeToRobotType
+	{
+		{ProductType::PRODUCT_DIGGER, Robot::Type::Digger},
+		{ProductType::PRODUCT_DOZER, Robot::Type::Dozer},
+		{ProductType::PRODUCT_MINER, Robot::Type::Miner},
+	};
+
+	if (ProductTypeToRobotType.find(pt) == ProductTypeToRobotType.end())
+	{
+		throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
+	}
+
+	const auto robotType = ProductTypeToRobotType.at(pt);
 	RobotCommand* robotCommand = getAvailableRobotCommand();
 
 	if ((robotCommand != nullptr) || mRobotPool.commandCapacityAvailable())
 	{
-		Robot* robot = nullptr;
-
-		switch (pt)
-		{
-		case ProductType::PRODUCT_DIGGER:
-			robot = &mRobotPool.addRobot(Robot::Type::Digger);
-			robot->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
-			break;
-		case ProductType::PRODUCT_DOZER:
-			robot = &mRobotPool.addRobot(Robot::Type::Dozer);
-			robot->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
-			break;
-		case ProductType::PRODUCT_MINER:
-			robot = &mRobotPool.addRobot(Robot::Type::Miner);
-			robot->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
-			break;
-		default:
-			throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
-		}
+		auto* robot = &addRobot(robotType);
 		factory.pullProduct();
 
 		populateRobotMenu();
@@ -51,7 +46,6 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 	{
 		factory.idle(IdleReason::FactoryInsufficientRobotCommandCapacity);
 	}
-
 }
 
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -16,7 +16,7 @@
 #include <stdexcept>
 
 
-void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
+void MapViewState::pullRobotFromFactory(ProductType productType, Factory& factory)
 {
 	const std::map<ProductType, Robot::Type> ProductTypeToRobotType
 	{
@@ -25,12 +25,12 @@ void MapViewState::pullRobotFromFactory(ProductType pt, Factory& factory)
 		{ProductType::PRODUCT_MINER, Robot::Type::Miner},
 	};
 
-	if (ProductTypeToRobotType.find(pt) == ProductTypeToRobotType.end())
+	if (ProductTypeToRobotType.find(productType) == ProductTypeToRobotType.end())
 	{
 		throw std::runtime_error("pullRobotFromFactory():: unsuitable robot type.");
 	}
 
-	const auto robotType = ProductTypeToRobotType.at(pt);
+	const auto robotType = ProductTypeToRobotType.at(productType);
 	RobotCommand* robotCommand = getAvailableRobotCommand();
 
 	if ((robotCommand != nullptr) || mRobotPool.commandCapacityAvailable())

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -29,9 +29,6 @@
 #include <stdexcept>
 
 
-extern std::map<int, std::string> LEVEL_STRING_TABLE;
-
-
 namespace
 {
 	void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, StorableResources& resources)

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -282,26 +282,26 @@ std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		const auto direction = dictionary.get<int>("direction", 0);
 
 		const auto robotType = static_cast<Robot::Type>(type);
-		auto* robot = &addRobot(robotType);
+		auto& robot = addRobot(robotType);
 		if (robotType == Robot::Type::Digger)
 		{
-			static_cast<Robodigger*>(robot)->direction(static_cast<Direction>(direction));
+			static_cast<Robodigger&>(robot).direction(static_cast<Direction>(direction));
 		}
 
-		idToRobotMap[id] = robot;
+		idToRobotMap[id] = &robot;
 
-		robot->fuelCellAge(age);
+		robot.fuelCellAge(age);
 
 		if (production_time > 0)
 		{
-			robot->startTask(production_time);
-			mRobotPool.insertRobotIntoTable(mRobotList, robot, &mTileMap->getTile({{x, y}, depth}));
-			mRobotList[robot]->index(TerrainType::Dozed);
+			robot.startTask(production_time);
+			mRobotPool.insertRobotIntoTable(mRobotList, &robot, &mTileMap->getTile({{x, y}, depth}));
+			mRobotList[&robot]->index(TerrainType::Dozed);
 		}
 
 		if (depth > 0)
 		{
-			mRobotList[robot]->excavated(true);
+			mRobotList[&robot]->excavated(true);
 		}
 	}
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -34,34 +34,34 @@ extern std::map<int, std::string> LEVEL_STRING_TABLE;
 
 namespace
 {
-void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, StorableResources& resources)
-{
-	if (!element) { return; }
-
-	resources = readResources(element);
-}
-
-
-void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idToRobotMap, RobotCommand& robotCommand)
-{
-	for (const auto& string : NAS2D::split(robotIds, ','))
+	void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, StorableResources& resources)
 	{
-		const auto robotId = NAS2D::stringTo<int>(string);
-		robotCommand.addRobot(idToRobotMap.at(robotId));
+		if (!element) { return; }
+
+		resources = readResources(element);
 	}
-}
 
 
-std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robots)
-{
-	std::map<const Robot*, int> robotToIdMap{};
-	int currentId = 0;
-	for (const auto* robot : robots)
+	void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idToRobotMap, RobotCommand& robotCommand)
 	{
-		robotToIdMap[robot] = currentId++;
+		for (const auto& string : NAS2D::split(robotIds, ','))
+		{
+			const auto robotId = NAS2D::stringTo<int>(string);
+			robotCommand.addRobot(idToRobotMap.at(robotId));
+		}
 	}
-	return robotToIdMap;
-}
+
+
+	std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robots)
+	{
+		std::map<const Robot*, int> robotToIdMap{};
+		int currentId = 0;
+		for (const auto* robot : robots)
+		{
+			robotToIdMap[robot] = currentId++;
+		}
+		return robotToIdMap;
+	}
 }
 
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -281,27 +281,11 @@ std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		const auto depth = dictionary.get<int>("depth", 0);
 		const auto direction = dictionary.get<int>("direction", 0);
 
-		Robot* robot = nullptr;
-		switch (static_cast<Robot::Type>(type))
+		const auto robotType = static_cast<Robot::Type>(type);
+		auto* robot = &addRobot(robotType);
+		if (robotType == Robot::Type::Digger)
 		{
-		case Robot::Type::Digger:
-			robot = &mRobotPool.addRobot(Robot::Type::Digger);
-			robot->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
 			static_cast<Robodigger*>(robot)->direction(static_cast<Direction>(direction));
-			break;
-
-		case Robot::Type::Dozer:
-			robot = &mRobotPool.addRobot(Robot::Type::Dozer);
-			robot->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
-			break;
-
-		case Robot::Type::Miner:
-			robot = &mRobotPool.addRobot(Robot::Type::Miner);
-			robot->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
-			break;
-
-		default:
-			throw std::runtime_error("Unknown robot type in savegame.");
 		}
 
 		// Could be done in the default handler in the above switch

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -288,10 +288,6 @@ std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 			static_cast<Robodigger*>(robot)->direction(static_cast<Direction>(direction));
 		}
 
-		// Could be done in the default handler in the above switch
-		// but may be better here as an explicit statement.
-		if (!robot) { continue; }
-
 		idToRobotMap[id] = robot;
 
 		robot->fuelCellAge(age);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -285,18 +285,18 @@ std::map<int, Robot*> MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		switch (static_cast<Robot::Type>(type))
 		{
 		case Robot::Type::Digger:
-			robot = mRobotPool.addRobot(Robot::Type::Digger);
+			robot = &mRobotPool.addRobot(Robot::Type::Digger);
 			robot->taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
 			static_cast<Robodigger*>(robot)->direction(static_cast<Direction>(direction));
 			break;
 
 		case Robot::Type::Dozer:
-			robot = mRobotPool.addRobot(Robot::Type::Dozer);
+			robot = &mRobotPool.addRobot(Robot::Type::Dozer);
 			robot->taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
 			break;
 
 		case Robot::Type::Miner:
-			robot = mRobotPool.addRobot(Robot::Type::Miner);
+			robot = &mRobotPool.addRobot(Robot::Type::Miner);
 			robot->taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
 			break;
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -32,10 +32,9 @@
 extern std::map<int, std::string> LEVEL_STRING_TABLE;
 
 
-/*****************************************************************************
- * LOCAL FUNCTIONS
- *****************************************************************************/
-static void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, StorableResources& resources)
+namespace
+{
+void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, StorableResources& resources)
 {
 	if (!element) { return; }
 
@@ -43,7 +42,7 @@ static void loadResorucesFromXmlElement(NAS2D::Xml::XmlElement* element, Storabl
 }
 
 
-static void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idToRobotMap, RobotCommand& robotCommand)
+void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idToRobotMap, RobotCommand& robotCommand)
 {
 	for (const auto& string : NAS2D::split(robotIds, ','))
 	{
@@ -53,7 +52,7 @@ static void readRccRobots(std::string robotIds, const std::map<int, Robot*>& idT
 }
 
 
-static std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robots)
+std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robots)
 {
 	std::map<const Robot*, int> robotToIdMap{};
 	int currentId = 0;
@@ -63,12 +62,8 @@ static std::map<const Robot*, int> generateRobotToIdMap(std::vector<Robot*> robo
 	}
 	return robotToIdMap;
 }
+}
 
-
-
-/*****************************************************************************
- * CLASS FUNCTIONS
- *****************************************************************************/
 
 void MapViewState::save(const std::string& filePath)
 {


### PR DESCRIPTION
Reference: #1167

Replace `switch` blocks with `std::map` lookup. Pre-check using exceptions, rather than post check with sentinel values. Use reference syntax instead of pointers. Re-order functions so .cpp and .h are consistent. Use unnamed namespace for local functions rather than declare them as `static`.
