### PR TITLE
Change default integrity to 100 when loading saved games

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -330,7 +330,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element, const std::ma
 		const auto idle_reason = dictionary.get<int>("idle_reason");
 
 		const auto crime_rate = dictionary.get<int>("crime_rate", 0);
-		const auto integrity = dictionary.get<int>("integrity", 0);
+		const auto integrity = dictionary.get<int>("integrity", 100);
 
 		const auto production_completed = dictionary.get<int>("production_completed", 0);
 		const auto production_type = dictionary.get<int>("production_type", 0);


### PR DESCRIPTION
For old saved games with no integrity value, we should probably assume structures still have full integrity, rather than no integrity. After all, decay wasn't implemented before. Though more practically, it prevents an entire colony from decaying into a non functioning mess when calculating the next turn.

This has kind of been bothering me for a while, when I load old saved games to try and quickly test something.
