### PR TITLE
Refactor `Mine::pull` to use `StorableResources`

### DIFF
--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -206,23 +206,19 @@ void Mine::checkExhausted()
 
 
 /**
- * Pulls the specified quantity of Ore from the Mine. If
+ * Pulls the specified quantities of Ore from the Mine. If
  * insufficient ore is available, only pulls what's available.
  */
-int Mine::pull(OreType type, int quantity)
+StorableResources Mine::pull(const StorableResources& maxTransfer)
 {
-	int pullCount = 0;
-
+	StorableResources totalTransferAmount{};
 	for (auto& vein : mVeins)
 	{
-		const auto transferAmount = std::min(vein.resources[type], quantity - pullCount);
-		pullCount += transferAmount;
-		vein.resources[type] -= transferAmount;
-
-		if (pullCount == quantity) { break; }
+		const auto transferAmount = vein.cap(maxTransfer - totalTransferAmount);
+		totalTransferAmount += transferAmount;
+		vein -= transferAmount;
 	}
-
-	return pullCount;
+	return totalTransferAmount;
 }
 
 

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -86,6 +86,13 @@ void Mine::active(bool newActive)
 }
 
 
+std::bitset<4> Mine::miningEnabled() const
+{
+	// We only want ore mining enabled bits
+	return {mFlags.to_ulong() & 0xF};
+}
+
+
 bool Mine::miningCommonMetals() const
 {
 	return mFlags[OreType::ORE_COMMON_METALS];

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -43,6 +43,8 @@ public:
 	StorableResources availableResources() const;
 	StorableResources totalYield() const;
 
+	std::bitset<4> miningEnabled() const;
+
 	bool miningCommonMetals() const;
 	bool miningCommonMinerals() const;
 	bool miningRareMetals() const;

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -55,7 +55,7 @@ public:
 	void miningRareMetals(bool value);
 	void miningRareMinerals(bool value);
 
-	int pull(OreType type, int quantity);
+	StorableResources pull(const StorableResources& maxTransfer);
 
 public:
 	NAS2D::Xml::XmlElement* serialize(NAS2D::Point<int> location);

--- a/OPHD/StorableResources.h
+++ b/OPHD/StorableResources.h
@@ -82,6 +82,17 @@ struct StorableResources
 		return other < *this;
 	}
 
+	constexpr StorableResources cap(const StorableResources& other) const
+	{
+		StorableResources out;
+		for (std::size_t i = 0; i < resources.size(); ++i)
+		{
+			out.resources[i] = std::clamp(resources[i], 0, other.resources[i]);
+		}
+
+		return out;
+	}
+
 	constexpr StorableResources cap(int max) const
 	{
 		StorableResources out;

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -55,6 +55,13 @@ void MineFacility::activated()
 }
 
 
+StorableResources MineFacility::maxTransferAmounts()
+{
+	const auto remainingCapacity = MaxCapacity - production();
+	return remainingCapacity.cap(constants::BaseMineProductionRate);
+}
+
+
 void MineFacility::think()
 {
 	if (forceIdle()) { return; }

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -4,7 +4,10 @@
 #include "../../Constants/Strings.h"
 
 
-const int MineFacilityStorageCapacity = 500;
+namespace
+{
+	const int MineFacilityStorageCapacity = 500;
+}
 
 
 /**

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -101,14 +101,8 @@ void MineFacility::think()
 			return;
 		}
 
-		StorableResources ore;
-
 		const auto maxTransfer = maxTransferAmounts();
-		for (std::size_t i = 0; i < ore.resources.size(); ++i)
-		{
-			ore.resources[i] = mMine->pull(static_cast<Mine::OreType>(i), maxTransfer.resources[i]);
-		}
-
+		const auto ore = mMine->pull(maxTransfer);
 		storage() += ore;
 	}
 	else if (!isIdle())

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -44,7 +44,7 @@ MineFacility::MineFacility(Mine* mine) : Structure(constants::MineFacility,
 
 	requiresCHAP(false);
 	selfSustained(true);
-	storageCapacity(500);
+	storageCapacity(MineFacilityStorageCapacity);
 }
 
 

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -47,7 +47,18 @@ void MineFacility::activated()
 StorableResources MineFacility::maxTransferAmounts()
 {
 	const auto remainingCapacity = MaxCapacity - production();
-	return remainingCapacity.cap(constants::BaseMineProductionRate);
+	auto maxTransfer = remainingCapacity.cap(constants::BaseMineProductionRate);
+
+	const auto enabledBits = mMine->miningEnabled();
+	for (std::size_t i = 0; i < maxTransfer.resources.size(); ++i)
+	{
+		if (!enabledBits[i])
+		{
+			maxTransfer.resources[i] = 0;
+		}
+	}
+
+	return maxTransfer;
 }
 
 
@@ -93,13 +104,9 @@ void MineFacility::think()
 		StorableResources ore;
 
 		const auto maxTransfer = maxTransferAmounts();
-		const auto enabledBits = mMine->miningEnabled();
 		for (std::size_t i = 0; i < ore.resources.size(); ++i)
 		{
-			if (enabledBits[i])
-			{
-				ore.resources[i] = mMine->pull(static_cast<Mine::OreType>(i), maxTransfer.resources[i]);
-			}
+			ore.resources[i] = mMine->pull(static_cast<Mine::OreType>(i), maxTransfer.resources[i]);
 		}
 
 		storage() += ore;

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -17,20 +17,6 @@ namespace
 }
 
 
-/**
- * Computes how many units of ore should be pulled.
- */
-static int pullCount(MineFacility* mineFacility, size_t index)
-{
-	const int storageCapacity = (mineFacility->storageCapacity() / 4);
-	const int remainingCapacity = storageCapacity - mineFacility->production().resources[index];
-
-	const int total = std::clamp(remainingCapacity, 0, constants::BaseMineProductionRate);
-
-	return total;
-}
-
-
 MineFacility::MineFacility(Mine* mine) : Structure(constants::MineFacility,
 	"structures/mine_facility.sprite",
 	StructureClass::Mine,
@@ -103,12 +89,13 @@ void MineFacility::think()
 
 		StorableResources ore;
 
+		const auto maxTransfer = maxTransferAmounts();
 		const auto enabledBits = mMine->miningEnabled();
 		for (std::size_t i = 0; i < ore.resources.size(); ++i)
 		{
 			if (enabledBits[i])
 			{
-				ore.resources[i] = mMine->pull(static_cast<Mine::OreType>(i), pullCount(this, i));
+				ore.resources[i] = mMine->pull(static_cast<Mine::OreType>(i), maxTransfer.resources[i]);
 			}
 		}
 

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -101,9 +101,7 @@ void MineFacility::think()
 			return;
 		}
 
-		const auto maxTransfer = maxTransferAmounts();
-		const auto ore = mMine->pull(maxTransfer);
-		storage() += ore;
+		storage() += mMine->pull(maxTransferAmounts());
 	}
 	else if (!isIdle())
 	{

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -17,10 +17,13 @@ namespace
 }
 
 
-MineFacility::MineFacility(Mine* mine) : Structure(constants::MineFacility,
-	"structures/mine_facility.sprite",
-	StructureClass::Mine,
-	StructureID::SID_MINE_FACILITY),
+MineFacility::MineFacility(Mine* mine) :
+	Structure(
+		constants::MineFacility,
+		"structures/mine_facility.sprite",
+		StructureClass::Mine,
+		StructureID::SID_MINE_FACILITY
+	),
 	mMine(mine)
 {
 	sprite().play(constants::StructureStateConstruction);

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -92,24 +92,13 @@ void MineFacility::think()
 
 		StorableResources ore;
 
-		if (mMine->miningCommonMetals())
+		const auto enabledBits = mMine->miningEnabled();
+		for (std::size_t i = 0; i < ore.resources.size(); ++i)
 		{
-			ore.resources[0] = mMine->pull(Mine::OreType::ORE_COMMON_METALS, pullCount(this, 0));
-		}
-
-		if (mMine->miningCommonMinerals())
-		{
-			ore.resources[1] = mMine->pull(Mine::OreType::ORE_COMMON_MINERALS, pullCount(this, 1));
-		}
-
-		if (mMine->miningRareMetals())
-		{
-			ore.resources[2] = mMine->pull(Mine::OreType::ORE_RARE_METALS, pullCount(this, 2));
-		}
-
-		if (mMine->miningRareMinerals())
-		{
-			ore.resources[3] = mMine->pull(Mine::OreType::ORE_RARE_MINERALS, pullCount(this, 3));
+			if (enabledBits[i])
+			{
+				ore.resources[i] = mMine->pull(static_cast<Mine::OreType>(i), pullCount(this, i));
+			}
 		}
 
 		storage() += ore;

--- a/OPHD/Things/Structures/MineFacility.cpp
+++ b/OPHD/Things/Structures/MineFacility.cpp
@@ -7,6 +7,13 @@
 namespace
 {
 	const int MineFacilityStorageCapacity = 500;
+
+	const StorableResources MaxCapacity{
+		MineFacilityStorageCapacity / 4,
+		MineFacilityStorageCapacity / 4,
+		MineFacilityStorageCapacity / 4,
+		MineFacilityStorageCapacity / 4,
+	};
 }
 
 
@@ -65,15 +72,9 @@ void MineFacility::think()
 		return;
 	}
 
-	static const StorableResources capacity{ MineFacilityStorageCapacity / 4,
-		MineFacilityStorageCapacity / 4,
-		MineFacilityStorageCapacity / 4,
-		MineFacilityStorageCapacity / 4
-	};
-
 	if (isIdle() && mMine->active())
 	{
-		if (storage() < capacity)
+		if (storage() < MaxCapacity)
 		{
 			enable();
 		}
@@ -87,7 +88,7 @@ void MineFacility::think()
 
 	if (mMine->active())
 	{
-		if (storage() >= capacity)
+		if (storage() >= MaxCapacity)
 		{
 			idle(IdleReason::InternalStorageFull);
 			return;

--- a/OPHD/Things/Structures/MineFacility.h
+++ b/OPHD/Things/Structures/MineFacility.h
@@ -3,6 +3,8 @@
 #include "Structure.h"
 
 #include "../../Mine.h"
+#include "../../StorableResources.h"
+
 
 /**
  * Implements the Mine Facility.
@@ -38,6 +40,8 @@ public:
 
 protected:
 	friend class MapViewState;
+
+	StorableResources maxTransferAmounts();
 
 	void assignedTrucks(int count) { mAssignedTrucks = count; }
 	void digTimeRemaining(int count) { mDigTurnsRemaining = count; }


### PR DESCRIPTION
Refactor `Mine::pull` to work with `StorableResources` objects. It's now possible to transfer all resource amounts in a single call, rather than having to iterate over each component.
