### PR TITLE
Use mining enabled bitset rather than custom methods

### DIFF
--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -88,7 +88,7 @@ std::bitset<4> Mine::miningEnabled() const
 
 void Mine::miningEnabled(OreType oreType, bool value)
 {
-	mFlags[oreType] = value;
+	mFlags[static_cast<int>(oreType)] = value;
 }
 
 

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -93,30 +93,6 @@ std::bitset<4> Mine::miningEnabled() const
 }
 
 
-bool Mine::miningCommonMetals() const
-{
-	return mFlags[OreType::ORE_COMMON_METALS];
-}
-
-
-bool Mine::miningCommonMinerals() const
-{
-	return mFlags[OreType::ORE_COMMON_MINERALS];
-}
-
-
-bool Mine::miningRareMetals() const
-{
-	return mFlags[OreType::ORE_RARE_METALS];
-}
-
-
-bool Mine::miningRareMinerals() const
-{
-	return mFlags[OreType::ORE_RARE_MINERALS];
-}
-
-
 void Mine::miningCommonMetals(bool value)
 {
 	mFlags[OreType::ORE_COMMON_METALS] = value;

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -99,30 +99,6 @@ void Mine::miningEnabled(OreType oreType, bool value)
 }
 
 
-void Mine::miningCommonMetals(bool value)
-{
-	mFlags[OreType::ORE_COMMON_METALS] = value;
-}
-
-
-void Mine::miningCommonMinerals(bool value)
-{
-	mFlags[OreType::ORE_COMMON_MINERALS] = value;
-}
-
-
-void Mine::miningRareMetals(bool value)
-{
-	mFlags[OreType::ORE_RARE_METALS] = value;
-}
-
-
-void Mine::miningRareMinerals(bool value)
-{
-	mFlags[OreType::ORE_RARE_MINERALS] = value;
-}
-
-
 /**
  * Increases the depth of the mine.
  * 

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -93,6 +93,12 @@ std::bitset<4> Mine::miningEnabled() const
 }
 
 
+void Mine::miningEnabled(OreType oreType, bool value)
+{
+	mFlags[oreType] = value;
+}
+
+
 void Mine::miningCommonMetals(bool value)
 {
 	mFlags[OreType::ORE_COMMON_METALS] = value;

--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -35,6 +35,10 @@ namespace
 	};
 
 
+	// [Exhausted, Active, 4x miningEnabled]
+	const std::bitset<6> DefaultFlags{"001111"};
+
+
 	/**
 	 * Helper function that gets the total amount of ore
 	 */
@@ -47,30 +51,19 @@ namespace
 		}
 		return availableResources;
 	}
-
-
-	void setDefaultFlags(std::bitset<6>& flags)
-	{
-		flags[Mine::OreType::ORE_COMMON_METALS] = true;
-		flags[Mine::OreType::ORE_COMMON_MINERALS] = true;
-		flags[Mine::OreType::ORE_RARE_METALS] = true;
-		flags[Mine::OreType::ORE_RARE_MINERALS] = true;
-		flags[4] = false;
-		flags[5] = false;
-	}
 }
 
 
-Mine::Mine()
+Mine::Mine() :
+	mFlags{DefaultFlags}
 {
-	setDefaultFlags(mFlags);
 }
 
 
 Mine::Mine(MineProductionRate rate) :
-	mProductionRate(rate)
+	mProductionRate{rate},
+	mFlags{DefaultFlags}
 {
-	setDefaultFlags(mFlags);
 }
 
 

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -46,11 +46,6 @@ public:
 	std::bitset<4> miningEnabled() const;
 	void miningEnabled(OreType oreType, bool value);
 
-	void miningCommonMetals(bool value);
-	void miningCommonMinerals(bool value);
-	void miningRareMetals(bool value);
-	void miningRareMinerals(bool value);
-
 	StorableResources pull(const StorableResources& maxTransfer);
 
 public:

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -44,6 +44,7 @@ public:
 	StorableResources totalYield() const;
 
 	std::bitset<4> miningEnabled() const;
+	void miningEnabled(OreType oreType, bool value);
 
 	void miningCommonMetals(bool value);
 	void miningCommonMinerals(bool value);

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -14,7 +14,7 @@ struct StorableResources;
 class Mine
 {
 public:
-	enum OreType
+	enum class OreType
 	{
 		ORE_COMMON_METALS,
 		ORE_COMMON_MINERALS,

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -16,10 +16,10 @@ class Mine
 public:
 	enum class OreType
 	{
-		ORE_COMMON_METALS,
-		ORE_COMMON_MINERALS,
-		ORE_RARE_METALS,
-		ORE_RARE_MINERALS,
+		CommonMetals,
+		CommonMinerals,
+		RareMetals,
+		RareMinerals,
 	};
 
 	using MineVein = StorableResources;

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -45,11 +45,6 @@ public:
 
 	std::bitset<4> miningEnabled() const;
 
-	bool miningCommonMetals() const;
-	bool miningCommonMinerals() const;
-	bool miningRareMetals() const;
-	bool miningRareMinerals() const;
-
 	void miningCommonMetals(bool value);
 	void miningCommonMinerals(bool value);
 	void miningRareMetals(bool value);

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -145,25 +145,25 @@ void MineOperationsWindow::onUnassignTruck()
 
 void MineOperationsWindow::onCheckBoxCommonMetalsChange()
 {
-	mFacility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_METALS, chkResources[0].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::CommonMetals, chkResources[0].checked());
 }
 
 
 void MineOperationsWindow::onCheckBoxCommonMineralsChange()
 {
-	mFacility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_MINERALS, chkResources[1].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::CommonMinerals, chkResources[1].checked());
 }
 
 
 void MineOperationsWindow::onCheckBoxRareMetalsChange()
 {
-	mFacility->mine()->miningEnabled(Mine::OreType::ORE_RARE_METALS, chkResources[2].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::RareMetals, chkResources[2].checked());
 }
 
 
 void MineOperationsWindow::onCheckBoxRareMineralsChange()
 {
-	mFacility->mine()->miningEnabled(Mine::OreType::ORE_RARE_MINERALS, chkResources[3].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::RareMinerals, chkResources[3].checked());
 }
 
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -145,25 +145,25 @@ void MineOperationsWindow::onUnassignTruck()
 
 void MineOperationsWindow::onCheckBoxCommonMetalsChange()
 {
-	mFacility->mine()->miningCommonMetals(chkResources[0].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_METALS, chkResources[0].checked());
 }
 
 
 void MineOperationsWindow::onCheckBoxCommonMineralsChange()
 {
-	mFacility->mine()->miningCommonMinerals(chkResources[1].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_MINERALS, chkResources[1].checked());
 }
 
 
 void MineOperationsWindow::onCheckBoxRareMetalsChange()
 {
-	mFacility->mine()->miningRareMetals(chkResources[2].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::ORE_RARE_METALS, chkResources[2].checked());
 }
 
 
 void MineOperationsWindow::onCheckBoxRareMineralsChange()
 {
-	mFacility->mine()->miningRareMinerals(chkResources[3].checked());
+	mFacility->mine()->miningEnabled(Mine::OreType::ORE_RARE_MINERALS, chkResources[3].checked());
 }
 
 

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -86,10 +86,11 @@ void MineOperationsWindow::mineFacility(MineFacility* facility)
 	mFacility = facility;
 	if (!mFacility) { return; }
 
-	chkResources[0].checked(mFacility->mine()->miningCommonMetals());
-	chkResources[1].checked(mFacility->mine()->miningCommonMinerals());
-	chkResources[2].checked(mFacility->mine()->miningRareMetals());
-	chkResources[3].checked(mFacility->mine()->miningRareMinerals());
+	const auto enabledBits = mFacility->mine()->miningEnabled();
+	chkResources[0].checked(enabledBits[0]);
+	chkResources[1].checked(enabledBits[1]);
+	chkResources[2].checked(enabledBits[2]);
+	chkResources[3].checked(enabledBits[3]);
 
 	btnIdle.toggle(mFacility->forceIdle());
 	btnExtendShaft.enabled(mFacility->canExtend());

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -331,10 +331,11 @@ void MineReport::onMineFacilitySelectionChange()
 	btnDigNewLevel.toggle(facility->extending());
 	btnDigNewLevel.enabled(facility->canExtend() && (mSelectedFacility->operational() || mSelectedFacility->isIdle()));
 
-	chkResources[0].checked(facility->mine()->miningCommonMetals());
-	chkResources[1].checked(facility->mine()->miningCommonMinerals());
-	chkResources[2].checked(facility->mine()->miningRareMetals());
-	chkResources[3].checked(facility->mine()->miningRareMinerals());
+	const auto enabledBits = facility->mine()->miningEnabled();
+	chkResources[0].checked(enabledBits[0]);
+	chkResources[1].checked(enabledBits[1]);
+	chkResources[2].checked(enabledBits[2]);
+	chkResources[3].checked(enabledBits[3]);
 }
 
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -270,28 +270,28 @@ void MineReport::onRemoveTruck()
 void MineReport::onCheckBoxCommonMetalsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_METALS, chkResources[0].checked());
+	facility->mine()->miningEnabled(Mine::OreType::CommonMetals, chkResources[0].checked());
 }
 
 
 void MineReport::onCheckBoxCommonMineralsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_MINERALS, chkResources[1].checked());
+	facility->mine()->miningEnabled(Mine::OreType::CommonMinerals, chkResources[1].checked());
 }
 
 
 void MineReport::onCheckBoxRareMetalsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningEnabled(Mine::OreType::ORE_RARE_METALS, chkResources[2].checked());
+	facility->mine()->miningEnabled(Mine::OreType::RareMetals, chkResources[2].checked());
 }
 
 
 void MineReport::onCheckBoxRareMineralsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningEnabled(Mine::OreType::ORE_RARE_MINERALS, chkResources[3].checked());
+	facility->mine()->miningEnabled(Mine::OreType::RareMinerals, chkResources[3].checked());
 }
 
 

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -270,28 +270,28 @@ void MineReport::onRemoveTruck()
 void MineReport::onCheckBoxCommonMetalsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningCommonMetals(chkResources[0].checked());
+	facility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_METALS, chkResources[0].checked());
 }
 
 
 void MineReport::onCheckBoxCommonMineralsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningCommonMinerals(chkResources[1].checked());
+	facility->mine()->miningEnabled(Mine::OreType::ORE_COMMON_MINERALS, chkResources[1].checked());
 }
 
 
 void MineReport::onCheckBoxRareMetalsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningRareMetals(chkResources[2].checked());
+	facility->mine()->miningEnabled(Mine::OreType::ORE_RARE_METALS, chkResources[2].checked());
 }
 
 
 void MineReport::onCheckBoxRareMineralsChange()
 {
 	MineFacility* facility = static_cast<MineFacility*>(mSelectedFacility);
-	facility->mine()->miningRareMinerals(chkResources[3].checked());
+	facility->mine()->miningEnabled(Mine::OreType::ORE_RARE_MINERALS, chkResources[3].checked());
 }
 
 


### PR DESCRIPTION
Reference: #1172

Use generic indexed `miningEnabled` bits, rather than specifically named custom methods.
