### PR TITLE
Add `TileMap` constructor for loading saved games

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -91,17 +91,19 @@ namespace {
 }
 
 
-TileMap::TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
+TileMap::TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility) :
+	TileMap{mapPath, maxDepth}
+{
+	mMineLocations = generateMineLocations(mSizeInTiles, mineCount);
+	placeMines(*this, hostility, mMineLocations);
+}
+
+
+TileMap::TileMap(const std::string& mapPath, int maxDepth) :
 	mSizeInTiles{MapSize},
 	mMaxDepth{maxDepth}
 {
 	buildTerrainMap(mapPath);
-
-	if (shouldSetupMines)
-	{
-		mMineLocations = generateMineLocations(mSizeInTiles, mineCount);
-		placeMines(*this, hostility, mMineLocations);
-	}
 }
 
 

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -91,7 +91,7 @@ namespace {
 }
 
 
-TileMap::TileMap(const std::string& mapPath, const std::string& /*tilesetPath*/, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
+TileMap::TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool shouldSetupMines) :
 	mSizeInTiles{MapSize},
 	mMaxDepth{maxDepth}
 {

--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -25,15 +25,6 @@ namespace {
 	const std::string MapTerrainExtension = "_a.png";
 	const auto MapSize = NAS2D::Vector{300, 150};
 
-	// Relative proportion of mines with yields {low, med, high}
-	const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYields =
-	{
-		{Planet::Hostility::Low, {30, 50, 20}},
-		{Planet::Hostility::Medium, {45, 35, 20}},
-		{Planet::Hostility::High, {35, 20, 45}},
-	};
-
-
 	std::vector<NAS2D::Point<int>> generateMineLocations(NAS2D::Vector<int> mapSize, std::size_t mineCount)
 	{
 		auto randPoint = [mapSize]() {
@@ -69,9 +60,8 @@ namespace {
 	}
 
 
-	void placeMines(TileMap& tileMap, Planet::Hostility hostility, const std::vector<NAS2D::Point<int>>& locations)
+	void placeMines(TileMap& tileMap, const std::vector<NAS2D::Point<int>>& locations, const TileMap::MineYields& mineYields)
 	{
-		const auto& mineYields = HostilityMineYields.at(hostility);
 		const auto total = std::accumulate(mineYields.begin(), mineYields.end(), 0);
 
 		const auto randYield = [mineYields, total]() {
@@ -91,11 +81,11 @@ namespace {
 }
 
 
-TileMap::TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility) :
+TileMap::TileMap(const std::string& mapPath, int maxDepth, int mineCount, const MineYields& mineYields) :
 	TileMap{mapPath, maxDepth}
 {
 	mMineLocations = generateMineLocations(mSizeInTiles, mineCount);
-	placeMines(*this, hostility, mMineLocations);
+	placeMines(*this, mMineLocations, mineYields);
 }
 
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -29,7 +29,8 @@ enum class Direction;
 class TileMap : public micropather::Graph
 {
 public:
-	TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool setupMines = true);
+	TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility);
+	TileMap(const std::string& mapPath, int maxDepth);
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -29,7 +29,7 @@ enum class Direction;
 class TileMap : public micropather::Graph
 {
 public:
-	TileMap(const std::string& mapPath, const std::string& tilesetPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool setupMines = true);
+	TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility, bool setupMines = true);
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;
 

--- a/OPHD/Map/TileMap.h
+++ b/OPHD/Map/TileMap.h
@@ -2,7 +2,6 @@
 
 #include "Tile.h"
 
-#include "../States/Planet.h"
 #include "../MicroPather/micropather.h"
 
 #include <NAS2D/Math/Point.h>
@@ -12,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <array>
 #include <utility>
 
 
@@ -29,7 +29,9 @@ enum class Direction;
 class TileMap : public micropather::Graph
 {
 public:
-	TileMap(const std::string& mapPath, int maxDepth, int mineCount, Planet::Hostility hostility);
+	using MineYields = std::array<int, 3>; // {low, med, high}
+
+	TileMap(const std::string& mapPath, int maxDepth, int mineCount, const MineYields& mineYields);
 	TileMap(const std::string& mapPath, int maxDepth);
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -115,7 +115,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) :
 	mMainReportsState(mainReportsState),
-	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.tilesetPath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
+	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
 	mMapView{std::make_unique<MapView>(*mTileMap)},
 	mCrimeExecution(mNotificationArea),
 	mPlanetAttributes(planetAttributes),

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -44,6 +44,18 @@ NAS2D::Rectangle<int> POPULATION_PANEL_PIN{675, 1, 8, 19};
 const NAS2D::Font* MAIN_FONT = nullptr;
 
 
+namespace
+{
+	// Relative proportion of mines with yields {low, med, high}
+	const std::map<Planet::Hostility, std::array<int, 3>> HostilityMineYields =
+	{
+		{Planet::Hostility::Low, {30, 50, 20}},
+		{Planet::Hostility::Medium, {45, 35, 20}},
+		{Planet::Hostility::High, {35, 20, 45}},
+	};
+}
+
+
 /** \fixme Find a sane place for these */
 struct RobotMeta
 {
@@ -115,7 +127,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) :
 	mMainReportsState(mainReportsState),
-	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, planetAttributes.hostility)),
+	mTileMap(new TileMap(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, HostilityMineYields.at(planetAttributes.hostility))),
 	mMapView{std::make_unique<MapView>(*mTileMap)},
 	mCrimeExecution(mNotificationArea),
 	mPlanetAttributes(planetAttributes),

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -53,61 +53,59 @@ namespace
 		{Planet::Hostility::Medium, {45, 35, 20}},
 		{Planet::Hostility::High, {35, 20, 45}},
 	};
-}
 
-
-/** \fixme Find a sane place for these */
-struct RobotMeta
-{
-	std::string name;
-	const int sheetIndex;
-};
-
-const std::map<Robot::Type, RobotMeta> RobotMetaTable
-{
-	{Robot::Type::Digger, RobotMeta{constants::Robodigger, constants::RobodiggerSheetId}},
-	{Robot::Type::Dozer, RobotMeta{constants::Robodozer, constants::RobodozerSheetId}},
-	{Robot::Type::Miner, RobotMeta{constants::Robominer, constants::RobominerSheetId}}
-};
-
-
-static NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int radius)
-{
-	const NAS2D::Point areaStartPoint
+	struct RobotMeta
 	{
-		std::clamp(centerTile.xy().x - radius, 0, 299),
-		std::clamp(centerTile.xy().y - radius, 0, 149)
+		std::string name;
+		const int sheetIndex;
 	};
 
-	const NAS2D::Point areaEndPoint
+	const std::map<Robot::Type, RobotMeta> RobotMetaTable
 	{
-		std::clamp(centerTile.xy().x + radius, 0, 299),
-		std::clamp(centerTile.xy().y + radius, 0, 149)
+		{Robot::Type::Digger, RobotMeta{constants::Robodigger, constants::RobodiggerSheetId}},
+		{Robot::Type::Dozer, RobotMeta{constants::Robodozer, constants::RobodozerSheetId}},
+		{Robot::Type::Miner, RobotMeta{constants::Robominer, constants::RobominerSheetId}}
 	};
 
-	return NAS2D::Rectangle<int>::Create(areaStartPoint, areaEndPoint);
-}
 
-
-static void pushAgingRobotMessage(const Robot* robot, const MapCoordinate& position, NotificationArea& notificationArea)
-{
-	const auto robotLocationText = "(" + std::to_string(position.xy.x) + ", " + std::to_string(position.xy.y) + ")";
-
-	if (robot->fuelCellAge() == 190) /// \fixme magic number
+	NAS2D::Rectangle<int> buildAreaRectFromTile(const Tile& centerTile, int radius)
 	{
-		notificationArea.push({
-			"Aging Robot",
-			"Robot '" + robot->name() + "' at location " + robotLocationText + " is approaching its maximum age.",
-			position,
-			NotificationArea::NotificationType::Warning});
+		const NAS2D::Point areaStartPoint
+		{
+			std::clamp(centerTile.xy().x - radius, 0, 299),
+			std::clamp(centerTile.xy().y - radius, 0, 149)
+		};
+
+		const NAS2D::Point areaEndPoint
+		{
+			std::clamp(centerTile.xy().x + radius, 0, 299),
+			std::clamp(centerTile.xy().y + radius, 0, 149)
+		};
+
+		return NAS2D::Rectangle<int>::Create(areaStartPoint, areaEndPoint);
 	}
-	else if (robot->fuelCellAge() == 195) /// \fixme magic number
+
+
+	void pushAgingRobotMessage(const Robot* robot, const MapCoordinate& position, NotificationArea& notificationArea)
 	{
-		notificationArea.push({
-			"Aging Robot",
-			"Robot '" + robot->name() + "' at location " + robotLocationText + " will fail in a few turns. Replace immediately.",
-			position,
-			NotificationArea::NotificationType::Critical});
+		const auto robotLocationText = "(" + std::to_string(position.xy.x) + ", " + std::to_string(position.xy.y) + ")";
+
+		if (robot->fuelCellAge() == 190) /// \fixme magic number
+		{
+			notificationArea.push({
+				"Aging Robot",
+				"Robot '" + robot->name() + "' at location " + robotLocationText + " is approaching its maximum age.",
+				position,
+				NotificationArea::NotificationType::Warning});
+		}
+		else if (robot->fuelCellAge() == 195) /// \fixme magic number
+		{
+			notificationArea.push({
+				"Aging Robot",
+				"Robot '" + robot->name() + "' at location " + robotLocationText + " will fail in a few turns. Replace immediately.",
+				position,
+				NotificationArea::NotificationType::Critical});
+		}
 	}
 }
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -180,7 +180,7 @@ void MapViewState::load(const std::string& filePath)
 	difficulty(stringToEnum(difficultyTable, dictionary.get("difficulty", std::string{"Medium"})));
 
 	StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
-	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.tilesetPath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
+	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
 	mTileMap->deserialize(root);
 	mMapView = std::make_unique<MapView>(*mTileMap);
 	mMapView->deserialize(root);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -180,7 +180,7 @@ void MapViewState::load(const std::string& filePath)
 	difficulty(stringToEnum(difficultyTable, dictionary.get("difficulty", std::string{"Medium"})));
 
 	StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
-	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.maxDepth, 0, Planet::Hostility::None, false);
+	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.maxDepth);
 	mTileMap->deserialize(root);
 	mMapView = std::make_unique<MapView>(*mTileMap);
 	mMapView->deserialize(root);

--- a/OPHD/UI/DetailMap.cpp
+++ b/OPHD/UI/DetailMap.cpp
@@ -133,7 +133,7 @@ void DetailMap::draw() const
 			// Draw a beacon on an unoccupied tile with a mine
 			if (tile.mine() != nullptr && !tile.thing())
 			{
-				uint8_t glow = static_cast<uint8_t>(120 + sin(throbTimer.tick() / ThrobSpeed) * 57);
+				uint8_t glow = static_cast<uint8_t>(120 + std::sin(throbTimer.tick() / ThrobSpeed) * 57);
 				renderer.drawImage(mMineBeacon, position + NAS2D::Vector{0, -64});
 				renderer.drawSubImage(mMineBeacon, position + NAS2D::Vector{59, 15}, NAS2D::Rectangle{59, 79, 10, 7}, NAS2D::Color{glow, glow, glow});
 			}

--- a/OPHD/UI/DetailMap.cpp
+++ b/OPHD/UI/DetailMap.cpp
@@ -12,6 +12,7 @@
 #include <NAS2D/Math/PointInRectangleRange.h>
 
 #include <map>
+#include <cmath>
 
 
 using namespace NAS2D;


### PR DESCRIPTION
Some of the `TileMap` constructor parameters only made sense for new games. It makes sense to have two separate constructors for the two cases.

From another perspective, `bool` parameters are awful for self documentation at the call site. Usually when you have a `bool` parameter, it's an indication you should split the function into two versions.

----

The `MineYields` table is no longer stored in `TileMap`. Instead it has become a parameter, replacing the `Hostility` parameter. The `TileMap` really didn't care about `Hostility`, only the number of mines that should be generated for new maps.

This opens up the possibility of the `MineYields` table being directly associated with the `PlanetAttributes`, rather than being derived from a single `Hostility` parameter stored in `PlanetAttributes`. But, that's a discussion for another day. At the very least, the `MineYields` can come from somewhere other than a hardcoded table in the `TileMap` code. For now it's a hardcoded table moved to the `MapViewState` code.
