### PR TITLE
Remove enum `None` and `Count` names

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -141,7 +141,6 @@ NAS2D::Xml::XmlElement* MapViewState::serializeProperties()
 
 void MapViewState::load(const std::string& filePath)
 {
-	mPlanetAttributes = Planet::Attributes();
 	resetUi();
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -172,6 +171,7 @@ void MapViewState::load(const std::string& filePath)
 	NAS2D::Xml::XmlElement* map = root->firstChildElement("properties");
 	const auto dictionary = NAS2D::attributesToDictionary(*map);
 
+	mPlanetAttributes = Planet::Attributes();
 	mPlanetAttributes.maxDepth = dictionary.get<int>("diggingdepth");
 	mPlanetAttributes.mapImagePath = dictionary.get("sitemap");
 	mPlanetAttributes.tilesetPath = dictionary.get("tset");

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -25,7 +25,7 @@ Planet::Planet(const Attributes& attributes) :
 	mAttributes(attributes),
 	mImage(NAS2D::Image(attributes.imagePath))
 {
-	if (attributes.type == PlanetType::None || attributes.type == PlanetType::Count)
+	if (attributes.type == PlanetType::None)
 	{
 		throw std::runtime_error("Instantiated Planet class with an invalid planet type.");
 	}

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -81,7 +81,6 @@ namespace
 
 	const std::unordered_map<std::string, Planet::Hostility> hostilityTable
 	{
-		{"None", Planet::Hostility::None},
 		{"Low", Planet::Hostility::Low},
 		{"Medium", Planet::Hostility::Medium},
 		{"High", Planet::Hostility::High}

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -25,11 +25,6 @@ Planet::Planet(const Attributes& attributes) :
 	mAttributes(attributes),
 	mImage(NAS2D::Image(attributes.imagePath))
 {
-	if (attributes.type == PlanetType::None)
-	{
-		throw std::runtime_error("Instantiated Planet class with an invalid planet type.");
-	}
-
 	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect(this, &Planet::onMouseMove);
 }
 
@@ -79,7 +74,6 @@ namespace
 
 	const std::unordered_map<std::string, Planet::PlanetType> planetTypeTable
 	{
-		{"None", Planet::PlanetType::None},
 		{"Mercury", Planet::PlanetType::Mercury},
 		{"Mars", Planet::PlanetType::Mars},
 		{"Ganymede", Planet::PlanetType::Ganymede}

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -22,8 +22,6 @@ public:
 
 	enum class Hostility
 	{
-		None,
-
 		Low,
 		Medium,
 		High
@@ -33,7 +31,7 @@ public:
 	{
 		PlanetType type;
 		std::string imagePath;
-		Hostility hostility = Hostility::None;
+		Hostility hostility;
 		int maxDepth = 0;
 		int maxMines = 0;
 		std::string mapImagePath;

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -20,8 +20,6 @@ public:
 		Mercury,
 		Mars,
 		Ganymede,
-
-		Count
 	};
 
 	enum class Hostility

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -15,8 +15,6 @@ class Planet
 public:
 	enum class PlanetType
 	{
-		None,
-
 		Mercury,
 		Mars,
 		Ganymede,
@@ -33,7 +31,7 @@ public:
 
 	struct Attributes
 	{
-		PlanetType type = PlanetType::None;
+		PlanetType type;
 		std::string imagePath;
 		Hostility hostility = Hostility::None;
 		int maxDepth = 0;


### PR DESCRIPTION
Reference: #1175 (for some cleanup that enables these changes)

When enums don't contain explicit invalid values, you don't really need to check for invalid values anymore. This helps simplify the code.
