### PR TITLE
Remove unnecessary `<cmath>` includes

### DIFF
--- a/OPHD/Map/Tile.cpp
+++ b/OPHD/Map/Tile.cpp
@@ -4,8 +4,6 @@
 #include "../Things/Robots/Robot.h"
 #include "../Things/Structures/Structure.h"
 
-#include <cmath>
-
 
 Tile::Tile(const MapCoordinate& position, TerrainType index) :
 	mIndex{index},

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -24,7 +24,6 @@
 #include <NAS2D/Dictionary.h>
 #include <NAS2D/ParserHelper.h>
 
-#include <cmath>
 #include <algorithm>
 
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -24,8 +24,6 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
-#include <cmath>
-
 
 extern NAS2D::Point<int> MOUSE_COORDS;
 

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -12,6 +12,7 @@
 #include <NAS2D/Xml/Xml.h>
 
 #include <stdexcept>
+#include <unordered_map>
 
 
 namespace

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -5,7 +5,6 @@
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Resource/Image.h>
 
-#include <cmath>
 #include <string>
 #include <unordered_map>
 

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -6,7 +6,6 @@
 #include <NAS2D/Resource/Image.h>
 
 #include <string>
-#include <unordered_map>
 
 
 class Planet

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -15,7 +15,6 @@
 #include <vector>
 #include <utility>
 #include <cstddef>
-#include <cmath>
 
 
 namespace NAS2D

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -8,7 +8,6 @@
 #include <NAS2D/Math/MathUtils.h>
 
 #include <algorithm>
-#include <cmath>
 
 
 using namespace NAS2D;


### PR DESCRIPTION
Reference: #1175 (Noticed the `<cmath>` includes while working on that)

Documentation:
[`<cmath>`](https://en.cppreference.com/w/cpp/header/cmath)

The only thing provided by that header that we currently use is `std::sin`, which is used once in the all of OPHD. (There are a few uses in NAS2D).
