### PR TITLE
Add `DetailMap::drawGrid()` method

### DIFF
--- a/OPHD/UI/DetailMap.cpp
+++ b/OPHD/UI/DetailMap.cpp
@@ -149,6 +149,24 @@ void DetailMap::draw() const
 }
 
 
+void DetailMap::drawGrid() const
+{
+	auto& renderer = Utility<Renderer>::get();
+
+	const auto viewSize = mMapView.viewSize();
+	const auto incrementY = NAS2D::Vector{-TileSize.x, TileSize.y};
+	const auto leftEdge = mOriginPixelPosition + incrementY * viewSize / 2;
+	const auto rightEdge = mOriginPixelPosition + TileSize * viewSize / 2;
+	for (int index = 0; index <= viewSize; ++index)
+	{
+		const auto offsetX = TileSize * index / 2;
+		const auto offsetY = incrementY * index / 2;
+		renderer.drawLine(leftEdge + offsetX, mOriginPixelPosition + offsetX);
+		renderer.drawLine(mOriginPixelPosition + offsetY, rightEdge + offsetY);
+	}
+}
+
+
 void DetailMap::onMouseMove(NAS2D::Point<int> position)
 {
 	const auto pixelOffset = position - mOriginPixelPosition;

--- a/OPHD/UI/DetailMap.h
+++ b/OPHD/UI/DetailMap.h
@@ -29,6 +29,9 @@ public:
 	void update() override;
 	void draw() const override;
 
+protected:
+	void drawGrid() const;
+
 private:
 	MapView& mMapView;
 	TileMap& mTileMap;


### PR DESCRIPTION
Reference: #1136 (I cleaned up some grid drawing code I used while testing)

Add ability to draw a tile grid overlaid on top of the detail map. This was originally used as a debugging aid while working on the pixel <-> tile conversion code. Most games offer an option to toggle grid display over tile maps, so I thought perhaps I'd clean up the code and make it available for future use.

To see it in action, insert the follow line at the end of `DetailMap::draw()`:
```cpp
drawGrid();
```