### PR TITLE
Add missing include for `<algorithm>` to `PopulationPool`

### DIFF
--- a/OPHD/PopulationPool.cpp
+++ b/OPHD/PopulationPool.cpp
@@ -1,6 +1,7 @@
 #include "PopulationPool.h"
 #include "Population/Population.h"
 
+#include <algorithm>
 #include <string>
 #include <stdexcept>
 


### PR DESCRIPTION
Reference: #138

I tried compiling with Visual Studio in a VM and noticed it complained about a use of `std::min` due to a missing include for `<algorithm>`. Not sure why AppVeyor didn't fail. Maybe it used a different version of the C++ standard library, with a different include graph.
