### PR TITLE
Add GitHub Actions config for Windows builds

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,32 @@
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -39,4 +39,6 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: |
+        vcpkg integrate install
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -35,7 +35,7 @@ jobs:
       id: cache
       with:
         path: C:\vcpkg\installed\
-        key: ${{ runner.os }}-${{ hashFiles('nas2d-core\InstallVcpkgDeps.bat') }}
+        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('nas2d-core\InstallVcpkgDeps.bat') }}
 
     - name: Install vcpkg dependencies
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -31,9 +31,9 @@ jobs:
         path: C:\vcpkg\installed\
         key: ${{ runner.os }}-${{ hashFiles('nas2d-core\InstallVcpkgDeps.bat') }}
 
-    - name: Restore NuGet packages
+    - name: Install vcpkg dependencies
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+      run: nas2d-core\InstallVcpkgDeps.bat
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -13,7 +13,13 @@ env:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x86, x64]
     runs-on: windows-latest
+    env:
+      PLATFORM: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Checkout NAS2D
+      run: git submodule update --init nas2d-core/
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -24,6 +24,13 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
+    - name: Restore vcpkg dependency cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: C:\vcpkg\installed\
+        key: ${{ runner.os }}-${{ hashFiles('nas2d-core\InstallVcpkgDeps.bat') }}
+
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}


### PR DESCRIPTION
GitHub Actions provides runners for Windows, Mac, and Linux. I was experimenting with the Windows builds, since currently that's the slowest for us. Our existing Windows builds on AppVeyor were running serially, taking about 4 minutes per configuration, with 2 configurations, so about 8 minutes per build. The equivalent pipeline using GitHub Actions runs the configurations in parallel, so both will complete in under 4 minutes.

Here are some details on the service offering:
[Usage limits, billing, and administration](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration)
> GitHub plan | Total concurrent jobs | Maximum concurrent macOS jobs
> -- | -- | --
> Free | 20 | 5
> Pro | 40 | 5
> Team | 60 | 5
> Enterprise | 180 | 50

We're of course on the Free plan. Having up to 20 concurrent jobs sounds amazing. We could potentially do builds for all supported platforms and configurations in parallel from a single CI provider.

This may even help with release packaging if we do all builds on a single provider.

As a bonus, it seems there is a preview for VS2022 available.
