### PR TITLE
Remove Ubuntu 18.04 build from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,6 @@ jobs:
       - run: git submodule update --init nas2d-core/
       - brew-install
       - build
-  build-linux:
-    docker:
-      - image: outpostuniverse/nas2d:1.4
-    steps:
-      - checkout
-      - run: git submodule update --init nas2d-core/
-      - build
   build-linux-gcc:
     docker:
       - image: outpostuniverse/nas2d-gcc:1.3
@@ -70,7 +63,6 @@ workflows:
   build:
     jobs:
       - build-macos
-      - build-linux
       - build-linux-gcc
       - build-linux-clang
       - build-linux-mingw


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/1006

Dropping support for Ubuntu 18.04, as it's too old for the packaged compilers to support the C++20 standard.
