### PR TITLE
Implement structure availability

### DIFF
--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -3,6 +3,7 @@
 #include "Wrapper.h"
 #include "CrimeRateUpdate.h"
 #include "CrimeExecution.h"
+#include "StructureTracker.h"
 
 #include "Planet.h"
 
@@ -283,6 +284,8 @@ private:
 	std::unique_ptr<MapView> mMapView;
 	CrimeRateUpdate mCrimeRateUpdate;
 	CrimeExecution mCrimeExecution;
+
+	StructureTracker mStructureTracker;
 
 	ResearchTracker mResearchTracker;
 	TechnologyCatalog mTechnologyReader;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -194,6 +194,7 @@ private:
 	void onMineFacilityExtend(MineFacility* mf);
 
 	void updatePlayerResources();
+	void updateResearch();
 
 	// TURN LOGIC
 	void checkColonyShip();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -326,6 +326,7 @@ void MapViewState::load(const std::string& filePath)
 	findMineRoutes();
 	updateFood();
 	updatePlayerResources();
+	updateResearch();
 
 	if (mTurnCount == 0)
 	{

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -24,6 +24,13 @@
 
 namespace
 {
+	const std::map<std::string, StructureID> StructureIdStringTable =
+	{
+		{"SID_FUSION_REACTOR", SID_FUSION_REACTOR},
+		{"SID_SOLAR_PLANT", SID_SOLAR_PLANT}
+	};
+
+
 	int consumeFood(FoodProduction& producer, int amountToConsume)
 	{
 		const auto foodLevel = producer.foodLevel();

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -629,6 +629,16 @@ void MapViewState::updateResearch()
 	}
 	
 	// copy list of unlocked structures to available structure list
+	std::vector<StructureID> availableStructures;
+	for (const auto& tech : unlockedStructures)
+	{
+		for (const auto& unlock : tech->unlocks)
+		{
+			const auto structureId = StructureIdStringTable.at(unlock.value);
+			availableStructures.push_back(structureId);
+		}
+	}
+	
 	// remove obsolete structures from available structure list
 }
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -600,7 +600,27 @@ void MapViewState::updateResearch()
 {
 	// Update research points
 	// get list of completed technologies
+	const auto& completedTechs = mResearchTracker.completedResearch();
+	std::vector<const Technology*> techList;
+	for (const auto techId : completedTechs)
+	{
+		techList.push_back(&mTechnologyReader.technologyFromId(techId));
+	}
+
 	// get list of completed technologies that unlock buildings
+	std::vector<const Technology*> unlockedStructures;
+	
+	for (auto tech : techList)
+	{
+		for (const auto& unlock : (*tech).unlocks)
+		{
+			if (unlock.unlocks == Technology::Unlock::Unlocks::Structure)
+			{
+				unlockedStructures.push_back(tech);
+			}
+		}
+	}
+	
 	// copy list of unlocked structures to available structure list
 	// remove obsolete structures from available structure list
 }

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -24,10 +24,10 @@
 
 namespace
 {
-	const std::map<std::string, StructureID> StructureIdStringTable =
+	const std::map<std::string, StructureTracker::StructureItem> StructureItemFromString =
 	{
-		{"SID_FUSION_REACTOR", SID_FUSION_REACTOR},
-		{"SID_SOLAR_PLANT", SID_SOLAR_PLANT}
+		{"SID_FUSION_REACTOR", {constants::FusionReactor, 21, SID_FUSION_REACTOR}},
+		{"SID_SOLAR_PLANT", {constants::SolarPlant, 10, StructureID::SID_SOLAR_PLANT}}
 	};
 
 
@@ -628,14 +628,12 @@ void MapViewState::updateResearch()
 		}
 	}
 	
-	// copy list of unlocked structures to available structure list
-	std::vector<StructureID> availableStructures;
 	for (const auto& tech : unlockedStructures)
 	{
 		for (const auto& unlock : tech->unlocks)
 		{
-			const auto structureId = StructureIdStringTable.at(unlock.value);
-			availableStructures.push_back(structureId);
+			const auto& structureItem = StructureItemFromString.at(unlock.value);
+			mStructureTracker.addUnlockedSurfaceStructure(structureItem);
 		}
 	}
 	

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -596,6 +596,16 @@ void MapViewState::updateOverlays()
 }
 
 
+void MapViewState::updateResearch()
+{
+	// Update research points
+	// get list of completed technologies
+	// get list of completed technologies that unlock buildings
+	// copy list of unlocked structures to available structure list
+	// remove obsolete structures from available structure list
+}
+
+
 void MapViewState::nextTurn()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -648,6 +658,8 @@ void MapViewState::nextTurn()
 	{
 		factory->updateProduction();
 	}
+
+	updateResearch();
 
 	populateRobotMenu();
 	populateStructureMenu();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -28,6 +28,18 @@
 extern NAS2D::Point<int> MOUSE_COORDS;
 
 
+namespace
+{
+	void fillList(IconGrid& grid, const StructureTracker::StructureItemList& itemList)
+	{
+		for (const auto& item : itemList)
+		{
+			grid.addItem(item.name, item.sheetIndex, item.id);
+		}
+	}
+};
+
+
 /**
  * Sets up the user interface elements
  * 
@@ -307,24 +319,8 @@ void MapViewState::populateStructureMenu()
 	}
 	else if (mMapView->currentDepth() == constants::DepthSurface)
 	{
-		/*
-		mStructures.addItem(constants::Agridome, 5, StructureID::SID_AGRIDOME);
-		mStructures.addItem(constants::Chap, 3, StructureID::SID_CHAP);
-		mStructures.addItem(constants::CommTower, 22, StructureID::SID_COMM_TOWER);
-		mStructures.addItem(constants::FusionReactor, 21, StructureID::SID_FUSION_REACTOR);
-		mStructures.addItem(constants::HotLaboratory, 18, StructureID::SID_HOT_LABORATORY);
-		mStructures.addItem(constants::MaintenanceFacility, 54, StructureID::SID_MAINTENANCE_FACILITY);
-		mStructures.addItem(constants::Recycling, 16, StructureID::SID_RECYCLING);
-		mStructures.addItem(constants::Road, 24, StructureID::SID_ROAD);
-		mStructures.addItem(constants::RobotCommand, 14, StructureID::SID_ROBOT_COMMAND);
-		mStructures.addItem(constants::Smelter, 4, StructureID::SID_SMELTER);
-		mStructures.addItem(constants::SolarPanel1, 33, StructureID::SID_SOLAR_PANEL1);
-		mStructures.addItem(constants::SolarPlant, 10, StructureID::SID_SOLAR_PLANT);
-		mStructures.addItem(constants::StorageTanks, 8, StructureID::SID_STORAGE_TANKS);
-		mStructures.addItem(constants::SurfaceFactory, 11, StructureID::SID_SURFACE_FACTORY);
-		mStructures.addItem(constants::SurfacePolice, 23, StructureID::SID_SURFACE_POLICE);
-		mStructures.addItem(constants::Warehouse, 9, StructureID::SID_WAREHOUSE);
-		*/
+		fillList(mStructures, mStructureTracker.defaultSurfaceStructures());
+		fillList(mStructures, mStructureTracker.unlockedSurfaceStructures());
 
 		mConnections.addItem(constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION);
 		mConnections.addItem(constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_RIGHT);
@@ -336,19 +332,8 @@ void MapViewState::populateStructureMenu()
 	}
 	else
 	{
-		/*
-		mStructures.addItem(constants::Laboratory, 58, StructureID::SID_LABORATORY);
-		mStructures.addItem(constants::Park, 75, StructureID::SID_PARK);
-		mStructures.addItem(constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE);
-		mStructures.addItem(constants::RecreationCenter, 73, StructureID::SID_RECREATION_CENTER);
-		mStructures.addItem(constants::Residence, 55, StructureID::SID_RESIDENCE);
-		mStructures.addItem(constants::UndergroundFactory, 69, StructureID::SID_UNDERGROUND_FACTORY);
-		mStructures.addItem(constants::MedicalCenter, 62, StructureID::SID_MEDICAL_CENTER);
-		mStructures.addItem(constants::Nursery, 77, StructureID::SID_NURSERY);
-		mStructures.addItem(constants::Commercial, 66, StructureID::SID_COMMERCIAL);
-		mStructures.addItem(constants::RedLightDistrict, 76, StructureID::SID_RED_LIGHT_DISTRICT);
-		mStructures.addItem(constants::University, 63, StructureID::SID_UNIVERSITY);
-		*/
+		fillList(mStructures, mStructureTracker.defaultUndergroundStructures());
+		fillList(mStructures, mStructureTracker.unlockedUndergroundStructures());
 
 		mConnections.addItem(constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION);
 		mConnections.addItem(constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_RIGHT);

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -37,7 +37,7 @@ namespace
 			grid.addItem(item.name, item.sheetIndex, item.id);
 		}
 	}
-};
+}
 
 
 /**

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -307,6 +307,7 @@ void MapViewState::populateStructureMenu()
 	}
 	else if (mMapView->currentDepth() == constants::DepthSurface)
 	{
+		/*
 		mStructures.addItem(constants::Agridome, 5, StructureID::SID_AGRIDOME);
 		mStructures.addItem(constants::Chap, 3, StructureID::SID_CHAP);
 		mStructures.addItem(constants::CommTower, 22, StructureID::SID_COMM_TOWER);
@@ -323,6 +324,7 @@ void MapViewState::populateStructureMenu()
 		mStructures.addItem(constants::SurfaceFactory, 11, StructureID::SID_SURFACE_FACTORY);
 		mStructures.addItem(constants::SurfacePolice, 23, StructureID::SID_SURFACE_POLICE);
 		mStructures.addItem(constants::Warehouse, 9, StructureID::SID_WAREHOUSE);
+		*/
 
 		mConnections.addItem(constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION);
 		mConnections.addItem(constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_RIGHT);
@@ -334,6 +336,7 @@ void MapViewState::populateStructureMenu()
 	}
 	else
 	{
+		/*
 		mStructures.addItem(constants::Laboratory, 58, StructureID::SID_LABORATORY);
 		mStructures.addItem(constants::Park, 75, StructureID::SID_PARK);
 		mStructures.addItem(constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE);
@@ -345,6 +348,7 @@ void MapViewState::populateStructureMenu()
 		mStructures.addItem(constants::Commercial, 66, StructureID::SID_COMMERCIAL);
 		mStructures.addItem(constants::RedLightDistrict, 76, StructureID::SID_RED_LIGHT_DISTRICT);
 		mStructures.addItem(constants::University, 63, StructureID::SID_UNIVERSITY);
+		*/
 
 		mConnections.addItem(constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION);
 		mConnections.addItem(constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_RIGHT);

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -2,17 +2,28 @@
 
 namespace
 {
+	void addItemToList(const StructureTracker::StructureItem& structureItem, StructureTracker::StructureItemList& list)
+	{
+		for (const auto& item : list)
+		{
+			if (item.id == structureItem.id)
+			{
+				return;
+			}
+		}
 
+		list.push_back(structureItem);
+	}
 };
 
 
 void StructureTracker::addUnlockedSurfaceStructure(const StructureItem& structureItem)
 {
-
+	addItemToList(structureItem, mUnlockedSurfaceStructures);
 }
 
 
 void StructureTracker::addUnlockedUndergroundStructure(const StructureItem& structureItem)
 {
-
+	addItemToList(structureItem, mUnlockedUndergroundStructures);
 }

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -1,0 +1,2 @@
+#include "StructuresTracker.h"
+

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -16,7 +16,7 @@ namespace
 
 		list.push_back(structureItem);
 	}
-};
+}
 
 
 StructureTracker::StructureTracker()

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -1,2 +1,18 @@
-#include "StructuresTracker.h"
+#include "StructureTracker.h"
 
+namespace
+{
+
+};
+
+
+void StructureTracker::addUnlockedSurfaceStructure(const StructureItem& structureItem)
+{
+
+}
+
+
+void StructureTracker::addUnlockedUndergroundStructure(const StructureItem& structureItem)
+{
+
+}

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -1,5 +1,7 @@
 #include "StructureTracker.h"
 
+#include "../Constants/Strings.h"
+
 namespace
 {
 	void addItemToList(const StructureTracker::StructureItem& structureItem, StructureTracker::StructureItemList& list)
@@ -15,6 +17,37 @@ namespace
 		list.push_back(structureItem);
 	}
 };
+
+
+StructureTracker::StructureTracker()
+{
+	mDefaultSurfaceStructures.push_back({constants::Agridome, 5, StructureID::SID_AGRIDOME});
+	mDefaultSurfaceStructures.push_back({constants::Chap, 3, StructureID::SID_CHAP});
+	mDefaultSurfaceStructures.push_back({constants::CommTower, 22, StructureID::SID_COMM_TOWER});
+	mDefaultSurfaceStructures.push_back({constants::HotLaboratory, 18, StructureID::SID_HOT_LABORATORY});
+	mDefaultSurfaceStructures.push_back({constants::MaintenanceFacility, 54, StructureID::SID_MAINTENANCE_FACILITY});
+	mDefaultSurfaceStructures.push_back({constants::Recycling, 16, StructureID::SID_RECYCLING});
+	mDefaultSurfaceStructures.push_back({constants::Road, 24, StructureID::SID_ROAD});
+	mDefaultSurfaceStructures.push_back({constants::RobotCommand, 14, StructureID::SID_ROBOT_COMMAND});
+	mDefaultSurfaceStructures.push_back({constants::Smelter, 4, StructureID::SID_SMELTER});
+	mDefaultSurfaceStructures.push_back({constants::SolarPanel1, 33, StructureID::SID_SOLAR_PANEL1});
+	mDefaultSurfaceStructures.push_back({constants::StorageTanks, 8, StructureID::SID_STORAGE_TANKS});
+	mDefaultSurfaceStructures.push_back({constants::SurfaceFactory, 11, StructureID::SID_SURFACE_FACTORY});
+	mDefaultSurfaceStructures.push_back({constants::SurfacePolice, 23, StructureID::SID_SURFACE_POLICE});
+	mDefaultSurfaceStructures.push_back({constants::Warehouse, 9, StructureID::SID_WAREHOUSE});
+
+	mDefaultUndergroundStructures.push_back({constants::Laboratory, 58, StructureID::SID_LABORATORY});
+	mDefaultUndergroundStructures.push_back({constants::Park, 75, StructureID::SID_PARK});
+	mDefaultUndergroundStructures.push_back({constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE});
+	mDefaultUndergroundStructures.push_back({constants::RecreationCenter, 73, StructureID::SID_RECREATION_CENTER});
+	mDefaultUndergroundStructures.push_back({constants::Residence, 55, StructureID::SID_RESIDENCE});
+	mDefaultUndergroundStructures.push_back({constants::UndergroundFactory, 69, StructureID::SID_UNDERGROUND_FACTORY});
+	mDefaultUndergroundStructures.push_back({constants::MedicalCenter, 62, StructureID::SID_MEDICAL_CENTER});
+	mDefaultUndergroundStructures.push_back({constants::Nursery, 77, StructureID::SID_NURSERY});
+	mDefaultUndergroundStructures.push_back({constants::Commercial, 66, StructureID::SID_COMMERCIAL});
+	mDefaultUndergroundStructures.push_back({constants::RedLightDistrict, 76, StructureID::SID_RED_LIGHT_DISTRICT});
+	mDefaultUndergroundStructures.push_back({constants::University, 63, StructureID::SID_UNIVERSITY});
+}
 
 
 void StructureTracker::addUnlockedSurfaceStructure(const StructureItem& structureItem)

--- a/OPHD/States/StructureTracker.h
+++ b/OPHD/States/StructureTracker.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "../Common.h"
+
+#include <string>
+#include <vector>
+
+class StructureTracker
+{
+public:
+
+	struct StructureItem
+	{
+		const std::string name;
+		const int sheetIndex;
+		const StructureID id;
+	};
+
+	using StructureItemList = std::vector<StructureItem>;
+
+public:
+
+	const StructureItemList& defaultSurfaceStructures() const { return mDefaultSurfaceStructures; }
+	const StructureItemList& defaultUndergroundStructures() const { return mDefaultUndergroundStructures; }
+
+	const StructureItemList& unlockedSurfaceStructures() const { return mUnlockedSurfaceStructures; }
+	const StructureItemList& unlockedUndergroundStructures() const { return mUnlockedUndergroundStructures; }
+
+	void addUnlockedSurfaceStructure(const StructureItem& structureItem);
+	void addUnlockedUndergroundStructure(const StructureItem& structureItem);
+
+private:
+
+	StructureItemList mDefaultSurfaceStructures;
+	StructureItemList mDefaultUndergroundStructures;
+
+	StructureItemList mUnlockedSurfaceStructures;
+	StructureItemList mUnlockedUndergroundStructures;
+};

--- a/OPHD/States/StructureTracker.h
+++ b/OPHD/States/StructureTracker.h
@@ -20,6 +20,8 @@ public:
 
 public:
 
+	StructureTracker();
+
 	const StructureItemList& defaultSurfaceStructures() const { return mDefaultSurfaceStructures; }
 	const StructureItemList& defaultUndergroundStructures() const { return mDefaultUndergroundStructures; }
 

--- a/OPHD/States/StructuresTracker.h
+++ b/OPHD/States/StructuresTracker.h
@@ -1,8 +1,0 @@
-#pragma once
-
-
-
-class StructureTracker
-{
-
-};

--- a/OPHD/States/StructuresTracker.h
+++ b/OPHD/States/StructuresTracker.h
@@ -1,0 +1,8 @@
+#pragma once
+
+
+
+class StructureTracker
+{
+
+};

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -260,6 +260,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="States\Planet.cpp" />
     <ClCompile Include="States\PlanetSelectState.cpp" />
     <ClCompile Include="States\SplashState.cpp" />
+    <ClCompile Include="States\StructureTracker.cpp" />
     <ClCompile Include="StructureCatalogue.cpp" />
     <ClCompile Include="StructureManager.cpp" />
     <ClCompile Include="Technology\ResearchTracker.cpp" />
@@ -337,6 +338,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClInclude Include="RandomNumberGenerator.h" />
     <ClInclude Include="States\CrimeExecution.h" />
     <ClInclude Include="States\CrimeRateUpdate.h" />
+    <ClInclude Include="States\StructuresTracker.h" />
     <ClInclude Include="StorableResources.h" />
     <ClInclude Include="PopulationPool.h" />
     <ClInclude Include="Population\Morale.h" />

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -338,7 +338,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClInclude Include="RandomNumberGenerator.h" />
     <ClInclude Include="States\CrimeExecution.h" />
     <ClInclude Include="States\CrimeRateUpdate.h" />
-    <ClInclude Include="States\StructuresTracker.h" />
+    <ClInclude Include="States\StructureTracker.h" />
     <ClInclude Include="StorableResources.h" />
     <ClInclude Include="PopulationPool.h" />
     <ClInclude Include="Population\Morale.h" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -360,6 +360,9 @@
     <ClCompile Include="Technology\ResearchTracker.cpp">
       <Filter>Source Files\Technology</Filter>
     </ClCompile>
+    <ClCompile Include="States\StructureTracker.cpp">
+      <Filter>Source Files\States</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
@@ -781,6 +784,9 @@
     </ClInclude>
     <ClInclude Include="Technology\ResearchTracker.h">
       <Filter>Header Files\Technology</Filter>
+    </ClInclude>
+    <ClInclude Include="States\StructuresTracker.h">
+      <Filter>Header Files\States</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -785,7 +785,7 @@
     <ClInclude Include="Technology\ResearchTracker.h">
       <Filter>Header Files\Technology</Filter>
     </ClInclude>
-    <ClInclude Include="States\StructuresTracker.h">
+    <ClInclude Include="States\StructureTracker.h">
       <Filter>Header Files\States</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Checks for unlocked structure technologies and simplifies `IconGrid` population. This doesn't close any issues but does add structure unlocks through research.

There are a few changes that could make this even cleaner, specifically with the `IconGrid::addItem()` function -- can use a basic struct like `StructureTracker::StructureItemList`, then remove the struct from `StructureTracker` and change `IconGrid::addItem()` to use the struct. Beyond the scope of this change set.

Something that occurred to me while I was working on this is structures superseding older designs and how to handle that. This can be done in a few ways but for me I think the simplest is to add a 'supersedes' parameter to the unlock type. Would mean modifying the tech editor (it needs some fixes anyway) and accepting that as an optional attribute in the reader function.