### PR TITLE
Disable Brew caching for MacOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,7 @@ commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
     steps:
-      - restore_cache:
-          name: Restoring brew dependencies
-          key: deps-OPHD-{{ arch }}-v2-{{ checksum "nas2d-core/BrewDeps.txt" }}
       - run: make --directory nas2d-core/ install-dependencies
-      - save_cache:
-          name: Caching brew dependencies
-          key: deps-OPHD-{{ arch }}-v2-{{ checksum "nas2d-core/BrewDeps.txt" }}
-          paths:
-            - /usr/local/Cellar
   build:
     steps:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d


### PR DESCRIPTION
Recently there have been permission errors attempting to restore the cache used for Brew dependencies. This is causing the failed cache restore to take longer than just re-installing dependencies would take. Better to disable the cache for now until the problem can be resolved.
