### PR TITLE
Population height fix

### DIFF
--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -66,8 +66,7 @@ PopulationPanel::PopulationPanel() :
 {
 	constexpr int linesOfText = 14;
 	constexpr int edgeBuffer = constants::Margin * 2;
-	constexpr int dividerHeight = constants::Margin * 3;
-	const int windowHeight = mFontBold.height() + (mFont.height() * linesOfText) + edgeBuffer + dividerHeight;
+	const int windowHeight = mFontBold.height() + (mFont.height() * linesOfText) + (edgeBuffer * 2 /* Times two to account for both the edge and the divider line. */);
 
 	int largestStringLength = mFontBold.width(constants::MoraleBreakdown);
 	for (int i = 0; i < moraleStringTableCount(); ++i)

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -66,8 +66,8 @@ PopulationPanel::PopulationPanel() :
 {
 	constexpr int linesOfText = 14;
 	constexpr int edgeBuffer = constants::Margin * 2;
-
-	const int windowHeight = mFontBold.height() + (mFont.height() * linesOfText) + edgeBuffer;
+	constexpr int dividerHeight = constants::Margin * 3;
+	const int windowHeight = mFontBold.height() + (mFont.height() * linesOfText) + edgeBuffer + dividerHeight;
 
 	int largestStringLength = mFontBold.width(constants::MoraleBreakdown);
 	for (int i = 0; i < moraleStringTableCount(); ++i)


### PR DESCRIPTION
I fixed the height of the population window to accommodate fourteen lines of text as well as the dividing line. This fixes #1097 

![image](https://user-images.githubusercontent.com/2125926/181363470-26e27d44-bd2f-4ba3-824d-96f2e809888d.png)
