### PR TITLE
Warehouse notification

### DIFF
--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -130,6 +130,11 @@ int ProductPool::availableStorage() const
 	return mCapacity - mCurrentStorageCount;
 }
 
+int ProductPool::availableStoragePercent() const 
+{
+	return (100 - (mCurrentStorageCount * 100 / mCapacity))
+}
+
 
 int ProductPool::productStorageRequirement(ProductType type) const
 {

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -36,6 +36,7 @@ public:
 	int count(ProductType type);
 
 	int availableStorage() const;
+	int availableStoragePercent() const;
 
 	NAS2D::Dictionary serialize();
 	void deserialize(const NAS2D::Dictionary& dictionary);

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -68,7 +68,17 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
 		{
 			Warehouse* warehouse = getAvailableWarehouse(productType, 1);
 			if (warehouse) { warehouse->products().store(productType, 1); factory.pullProduct(); }
-			else { factory.idle(IdleReason::FactoryInsufficientWarehouseSpace); }
+			else 
+			{
+				factory.idle(IdleReason::FactoryInsufficientWarehouseSpace); 
+				auto& structureManager = NAS2D::Utility<StructureManager>::get();
+				Tile& factoryPos = structureManager.tileFromStructure(factory);
+				mNotificationArea.push({
+				"Warehouse full",
+				"A factory has shut down due to lack of available warehouse space.",
+				factoryPos,
+				NotificationArea::NotificationType::Warning});
+			}
 			break;
 		}
 


### PR DESCRIPTION
Factories will now notify you when they go idle because warehouses are full. (Fixes #1059)

Because I am very bad at this game, I am unable to test this fix. Can someone else test this for me?

I also have created a method that tells you what percentage of a given warehouse is available for storage, only to realize there's really nowhere to put it. If this should be commented out or deleted for being unused, please let me know.