### PR TITLE
Make CC ageless

### DIFF
--- a/OPHD/Things/Structures/CommandCenter.h
+++ b/OPHD/Things/Structures/CommandCenter.h
@@ -17,8 +17,9 @@ public:
 		StructureClass::Command,
 		StructureID::SID_COMMAND_CENTER)
 	{
-		maxAge(500);
+		maxAge(0);
 		turnsToBuild(4);
+		integrityDecayRate(0);
 
 		requiresCHAP(false);
 		selfSustained(true);

--- a/OPHD/Things/Structures/Structure.cpp
+++ b/OPHD/Things/Structures/Structure.cpp
@@ -261,6 +261,14 @@ void Structure::incrementAge()
 	{
 		activate();
 	}
+	else if (maxAge() == 0)
+	{
+		/**
+		 * Structures defined with a max age of '0' are 'ageless'
+		 * and should continue to operate regardless of how old
+		 * they are (for example, the Command Center).
+		 */
+	}
 	else if (age() == maxAge())
 	{
 		destroy();


### PR DESCRIPTION
Makes the Command Center 'ageless' -- no integrity decay and doesn't age