### PR TITLE
Fix copy constructor suppression

### DIFF
--- a/OPHD/Technology/ResearchTracker.h
+++ b/OPHD/Technology/ResearchTracker.h
@@ -18,10 +18,6 @@ public:
 	};
 
 
-	ResearchTracker() = default;
-	~ResearchTracker() = default;
-
-
 	const std::vector<int>& completedResearch() const
 	{
 		return mCompleted;

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -19,6 +19,8 @@ public:
 	using OnMoveSignal = NAS2D::Signal<NAS2D::Vector<int>>;
 
 	Control() = default;
+	Control(Control&) = default;
+	Control(Control&&) = default;
 	virtual ~Control() = default;
 
 	const NAS2D::Rectangle<int>& area() const { return mRect; }

--- a/OPHD/UI/Core/RadioButtonGroup.h
+++ b/OPHD/UI/Core/RadioButtonGroup.h
@@ -27,7 +27,6 @@ private:
 
 		// TODO: Best to delete these, but they need to exist for now
 		// The default methods do not properly handle global event connect/disconnect
-		RadioButton(const RadioButton&) = default;
 		RadioButton(RadioButton&&) = default;
 
 		void checked(bool toggle);


### PR DESCRIPTION
Fix copy constructor suppression warnings seen with new version of Clang.

Related: https://github.com/lairworks/nas2d-core/pull/1030 (which upgrades build images and compilers used)

----

Example of problem:
https://app.circleci.com/pipelines/github/OutpostUniverse/OPHD/2112/workflows/8f80bf83-1df7-4449-ba92-461e87e06a27/jobs/9617
> OPHD/UI/Core/Control.h:21:10: error: definition of implicit copy constructor for 'Control' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated-copy-with-dtor]
        virtual ~Control() = default;
                ^
OPHD/UI/Core/TextControl.h:10:7: note: in implicit copy constructor for 'Control' first required here
class TextControl : public Control
      ^
OPHD/UI/Core/RadioButtonGroup.h:30:3: note: in implicit copy constructor for 'TextControl' first required here
                RadioButton(const RadioButton&) = default;
                ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97:39: note: in defaulted copy constructor for 'RadioButtonGroup::RadioButton' first required here
    { return ::new((void*)__location) _Tp(std::forward<_Args>(__args)...); }
                                      ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:115:9: note: in instantiation of function template specialization 'std::construct_at<RadioButtonGroup::RadioButton, const RadioButtonGroup::RadioButton &>' requested here
          std::construct_at(__p, std::forward<_Args>(__args)...);
               ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:92:8: note: in instantiation of function template specialization 'std::_Construct<RadioButtonGroup::RadioButton, const RadioButtonGroup::RadioButton &>' requested here
                std::_Construct(std::__addressof(*__cur), *__first);
                     ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:151:2: note: in instantiation of function template specialization 'std::__uninitialized_copy<false>::__uninit_copy<const RadioButtonGroup::RadioButton *, RadioButtonGroup::RadioButton *>' requested here
        __uninit_copy(__first, __last, __result);
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:333:19: note: in instantiation of function template specialization 'std::uninitialized_copy<const RadioButtonGroup::RadioButton *, RadioButtonGroup::RadioButton *>' requested here
    { return std::uninitialized_copy(__first, __last, __result); }
                  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:1514:13: note: in instantiation of function template specialization 'std::__uninitialized_copy_a<const RadioButtonGroup::RadioButton *, RadioButtonGroup::RadioButton *, RadioButtonGroup::RadioButton>' requested here
              std::__uninitialized_copy_a(__first, __last, __result,
                   ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/vector.tcc:85:16: note: in instantiation of function template specialization 'std::vector<RadioButtonGroup::RadioButton>::_M_allocate_and_copy<const RadioButtonGroup::RadioButton *>' requested here
              __tmp = _M_allocate_and_copy(__n,
                      ^
OPHD/UI/Core/RadioButtonGroup.cpp:18:16: note: in instantiation of member function 'std::vector<RadioButtonGroup::RadioButton>::reserve' requested here
        mRadioButtons.reserve(buttonInfos.size());
                      ^
