### PR TITLE
Update NAS2D submodule - (Remove PhysFS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - build
   build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc:1.3
+      - image: outpostuniverse/nas2d-gcc:1.4
     environment:
       WARN_EXTRA: -Wsuggest-override
     steps:
@@ -36,7 +36,7 @@ jobs:
       - build
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.2
+      - image: outpostuniverse/nas2d-clang:1.3
     environment:
       WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
@@ -45,7 +45,7 @@ jobs:
       - build
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.7
+      - image: outpostuniverse/nas2d-mingw:1.8
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		auto& filesystem = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
+		auto& filesystem = Utility<Filesystem>::init<Filesystem>("OutpostHD", "LairWorks");
 		// Prioritize data from working directory, fallback on data from executable path
 		filesystem.mountSoftFail("data");
 		filesystem.mountSoftFail(filesystem.basePath() + "data");

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MacOS X applications are generally distributed as App Bundles which include all 
 
 In the mean time, for users of MacOS 10.14 (Mojave) and above, you can install all of OPHD's dependencies using Homebrew (https://brew.sh -- follow instructions for installation) and then run the following command in terminal:
 
-    brew install physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
+    brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
 
 It will take a few minutes but all dependencies will be installed. From here you can clone the OPHD git repository and run `make` in terminal to build OutpostHD. When built, you can launch OutpostHD by entering `./ophd.exe` from the terminal.
 

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN) -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
-LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs $(OpenGL_LIBS)
+LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(OpenGL_LIBS)
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)$*.Td
 


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/1030, PR #1237, https://github.com/lairworks/nas2d-core/issues/1028

Uses the newer NAS2D defined build environments, with PhysFS removed. The updated build environments for Ubuntu are now based on Ubuntu 22.04, with newer compilers.
