### PR TITLE
Be explicit about `Point` objects when calling `Rectangle::contains`

### DIFF
--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -194,7 +194,7 @@ public:
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, int x, int y) {
-		if (!visible() || mHighlightIndex == constants::NoSelection || mHighlightIndex >= mItems.size() || !mScrollArea.contains({x, y}))
+		if (!visible() || mHighlightIndex == constants::NoSelection || mHighlightIndex >= mItems.size() || !mScrollArea.contains(NAS2D::Point{x, y}))
 		{
 			return;
 		}
@@ -203,7 +203,7 @@ protected:
 	}
 
 	virtual void onMouseMove(int x, int y, int /*relX*/, int /*relY*/) {
-		if (!visible() || !mScrollArea.contains({x, y}))
+		if (!visible() || !mScrollArea.contains(NAS2D::Point{x, y}))
 		{
 			mHighlightIndex = constants::NoSelection;
 			return;

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -267,7 +267,7 @@ void ScrollBar::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (mThumbPressed && mTrack.contains({x, y}))
+	if (mThumbPressed && mTrack.contains(NAS2D::Point{x, y}))
 	{
 		value(
 			(mScrollBarType == ScrollBarType::Vertical) ?

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -70,11 +70,12 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 
 void ToolTip::onMouseMove(int x, int y, int dX, int dY)
 {
+	const auto position = NAS2D::Point{x, y};
 	if (dX != 0 || dY != 0)
 	{
 		if (mFocusedControl)
 		{
-			if (mFocusedControl->first->rect().contains({x, y})) { return; }
+			if (mFocusedControl->first->rect().contains(position)) { return; }
 			else { mFocusedControl = nullptr; }
 		}
 
@@ -84,7 +85,7 @@ void ToolTip::onMouseMove(int x, int y, int dX, int dY)
 	for (auto& item : mControls)
 	{
 		if (mFocusedControl) { break; }
-		if (item.first->rect().contains({x, y}))
+		if (item.first->rect().contains(position))
 		{
 			mFocusedControl = &item;
 			buildDrawParams(item, x);

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -124,8 +124,9 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 
 void NotificationArea::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
 {
-	if (!rect().contains({x, y})) { return; }
-	mNotificationIndex = notificationIndex({x, y});
+	const auto position = NAS2D::Point{x, y};
+	if (!rect().contains(position)) { return; }
+	mNotificationIndex = notificationIndex(position);
 }
 
 


### PR DESCRIPTION
It would be helpful to have an overload of `contains` that can check for `Rectangle` containment in addition to `Point` containment. However, both `Point` and `Rectangle` are constructable from 2 values (with `Rectangle` using a default of `0` for unspecified width and height). This creates ambiguity over which overload to call, which results in a compiler error. By being explicit about what type of object is being passed to `contains`, we can add an overload without creating such ambiguity.