### PR TITLE
Add packed parameter event overloads

### DIFF
--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -100,9 +100,15 @@ MainReportsUiState& GameState::getMainReportsState()
 /**
  * Mouse motion event handler.
  */
-void GameState::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
+void GameState::onMouseMove(int x, int y, int relX, int relY)
 {
-	MOUSE_COORDS = {x, y};
+	onMouseMove({x, y}, {relX, relY});
+}
+
+
+void GameState::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
+	MOUSE_COORDS = position;
 }
 
 

--- a/OPHD/States/GameState.h
+++ b/OPHD/States/GameState.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <NAS2D/State.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <memory>
 
@@ -25,6 +27,7 @@ public:
 
 private:
 	void onMouseMove(int x, int y, int relX, int relY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void onFadeComplete();
 	void onMusicComplete();

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -243,9 +243,15 @@ void MainReportsUiState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::Even
  */
 void MainReportsUiState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void MainReportsUiState::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!active()) { return; }
 
-	if (!NAS2D::Rectangle{0, 0, NAS2D::Utility<NAS2D::Renderer>::get().size().x, 40}.contains(NAS2D::Point{x, y})) { return; } // ignore clicks in the UI area.
+	if (!NAS2D::Rectangle{0, 0, NAS2D::Utility<NAS2D::Renderer>::get().size().x, 40}.contains(position)) { return; } // ignore clicks in the UI area.
 
 	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{

--- a/OPHD/States/MainReportsUiState.h
+++ b/OPHD/States/MainReportsUiState.h
@@ -4,6 +4,7 @@
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
 
 #include <vector>
 
@@ -41,6 +42,7 @@ private:
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void deselectAllPanels();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -489,6 +489,12 @@ void MapViewState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
  */
 void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!active()) { return; }
 
 	if (modalUiElementDisplayed()) { return; }
@@ -532,7 +538,7 @@ void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, i
 		}
 
 		// MiniMap Check
-		mMiniMap->onMouseDown(button, x, y);
+		mMiniMap->onMouseDown(button, position);
 
 		// Click was within the bounds of the TileMap.
 		if (mDetailMap->isMouseOverTile())
@@ -543,7 +549,13 @@ void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, i
 }
 
 
-void MapViewState::onMouseDoubleClick(NAS2D::EventHandler::MouseButton button, int /*x*/, int /*y*/)
+void MapViewState::onMouseDoubleClick(NAS2D::EventHandler::MouseButton button, int x, int y)
+{
+	onMouseDoubleClick(button, {x, y});
+}
+
+
+void MapViewState::onMouseDoubleClick(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> /*position*/)
 {
 	if (!active()) { return; }
 
@@ -588,9 +600,15 @@ void MapViewState::onMouseDoubleClick(NAS2D::EventHandler::MouseButton button, i
 */
 void MapViewState::onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y)
 {
+	onMouseUp(button, {x, y});
+}
+
+
+void MapViewState::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{
-		mMiniMap->onMouseUp(button, x, y);
+		mMiniMap->onMouseUp(button, position);
 	}
 }
 
@@ -600,8 +618,14 @@ void MapViewState::onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int
 */
 void MapViewState::onMouseMove(int x, int y, int rX, int rY)
 {
+	onMouseMove({x, y}, {rX, rY});
+}
+
+
+void MapViewState::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative)
+{
 	if (!active()) { return; }
-	mMiniMap->onMouseMove(x, y, rX, rY);
+	mMiniMap->onMouseMove(position, relative);
 	mMouseTilePosition = mDetailMap->mouseTilePosition();
 }
 
@@ -609,11 +633,17 @@ void MapViewState::onMouseMove(int x, int y, int rX, int rY)
 /**
  * Mouse wheel event handler.
  */
-void MapViewState::onMouseWheel(int /*x*/, int y)
+void MapViewState::onMouseWheel(int x, int y)
+{
+	onMouseWheel({x, y});
+}
+
+
+void MapViewState::onMouseWheel(NAS2D::Vector<int> changeAmount)
 {
 	if (mInsertMode != InsertMode::Tube) { return; }
 
-	y > 0 ? mConnections.decrementSelection() : mConnections.incrementSelection();
+	changeAmount.y > 0 ? mConnections.decrementSelection() : mConnections.incrementSelection();
 }
 
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -137,10 +137,15 @@ private:
 	void onActivate(bool newActiveValue);
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDoubleClick(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDoubleClick(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(int x, int y, int rX, int rY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(int x, int y);
+	void onMouseWheel(NAS2D::Vector<int> changeAmount);
 	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void onInspect(const MapCoordinate& tilePosition, bool inspectModifier);

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -44,9 +44,15 @@ bool Planet::pointInCircle(NAS2D::Point<int> point)
 }
 
 
-void Planet::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
+void Planet::onMouseMove(int x, int y, int rX, int rY)
 {
-	bool inArea = pointInCircle({x, y});
+	onMouseMove({x, y}, {rX, rY});
+}
+
+
+void Planet::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
+	bool inArea = pointInCircle(position);
 	if (inArea != mMouseInArea)
 	{
 		mMouseInArea = inArea;

--- a/OPHD/States/Planet.h
+++ b/OPHD/States/Planet.h
@@ -3,6 +3,7 @@
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Timer.h>
 #include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Resource/Image.h>
 
 #include <string>
@@ -66,6 +67,7 @@ public:
 protected:
 	bool pointInCircle(NAS2D::Point<int> point);
 	void onMouseMove(int x, int y, int rX, int rY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 private:
 	Planet() = delete;

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -131,7 +131,13 @@ NAS2D::State* PlanetSelectState::update()
 }
 
 
-void PlanetSelectState::onMouseDown(NAS2D::EventHandler::MouseButton, int, int)
+void PlanetSelectState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
+{
+	onMouseDown(button, {x, y});
+}
+
+
+void PlanetSelectState::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
 {
 	for (std::size_t i = 0; i < mPlanets.size(); ++i)
 	{

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -30,6 +30,7 @@ protected:
 
 private:
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
+	void onMouseDown(NAS2D::EventHandler::MouseButton, NAS2D::Point<int> position);
 
 	void onMousePlanetEnter();
 	void onMousePlanetExit();

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -159,7 +159,13 @@ void SplashState::onKeyDown(NAS2D::EventHandler::KeyCode /*key*/, NAS2D::EventHa
 }
 
 
-void SplashState::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
+void SplashState::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
+{
+	onMouseDown(button, {x, y});
+}
+
+
+void SplashState::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
 {
 	skipSplash();
 }

--- a/OPHD/States/SplashState.h
+++ b/OPHD/States/SplashState.h
@@ -21,6 +21,7 @@ protected:
 private:
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 
 	void skipSplash();
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -120,11 +120,17 @@ bool Button::hasImage() const
 
 void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void Button::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left)
 	{
-		if (mRect.contains(Point<int>{x, y}))
+		if (mRect.contains(position))
 		{
 			if (mType == Type::BUTTON_NORMAL)
 			{
@@ -142,6 +148,12 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseUp(button, {x, y});
+}
+
+
+void Button::onMouseUp(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left)
@@ -150,7 +162,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 		{
 			mState = State::Normal;
 
-			if (mRect.contains(Point<int>{x, y}))
+			if (mRect.contains(position))
 			{
 				mSignal();
 			}
@@ -159,9 +171,15 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void Button::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
+void Button::onMouseMove(int x, int y, int dX, int dY)
 {
-	mMouseHover = mRect.contains(NAS2D::Point{x, y});
+	onMouseMove({x, y}, {dX, dY});
+}
+
+
+void Button::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
+	mMouseHover = mRect.contains(position);
 }
 
 

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -4,6 +4,8 @@
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
@@ -50,8 +52,11 @@ public:
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(int x, int y, int dX, int dY);
+	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 private:
 	enum class State

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -74,9 +74,15 @@ CheckBox::ClickSignal::Source& CheckBox::click()
 
 void CheckBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void CheckBox::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left && mRect.contains(Point{x, y}))
+	if (button == EventHandler::MouseButton::Left && mRect.contains(position))
 	{
 		mChecked = !mChecked;
 		mSignal();

--- a/OPHD/UI/Core/CheckBox.h
+++ b/OPHD/UI/Core/CheckBox.h
@@ -4,6 +4,7 @@
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
 
 #include <string>
 
@@ -34,6 +35,7 @@ public:
 
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 
 	void onResize() override;
 	void onTextChange() override;

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -81,13 +81,19 @@ void ComboBox::onMove(NAS2D::Vector<int> displacement)
  */
 void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	UIContainer::onMouseDown(button, x, y);
+	onMouseDown(button, {x, y});
+}
+
+
+void ComboBox::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
+	UIContainer::onMouseDown(button, position);
 
 	if (!enabled() || !visible()) { return; }
 
 	if (button != EventHandler::MouseButton::Left) { return; }
 
-	if (mBaseArea.contains(Point{x, y}))
+	if (mBaseArea.contains(position))
 	{
 		lstItems.visible(!lstItems.visible());
 		if (lstItems.visible())
@@ -99,7 +105,7 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 			mRect = mBaseArea;
 		}
 	}
-	else if (!lstItems.rect().contains(Point{x, y}))
+	else if (!lstItems.rect().contains(position))
 	{
 		lstItems.visible(false);
 		mRect = mBaseArea;
@@ -107,7 +113,13 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void ComboBox::onMouseWheel(int /*x*/, int /*y*/)
+void ComboBox::onMouseWheel(int x, int y)
+{
+	onMouseWheel({x, y});
+}
+
+
+void ComboBox::onMouseWheel(NAS2D::Vector<int> /*scrollAmount*/)
 {
 
 }

--- a/OPHD/UI/Core/ComboBox.h
+++ b/OPHD/UI/Core/ComboBox.h
@@ -7,6 +7,8 @@
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Math/Rectangle.h>
 
 #include <cstddef>
@@ -45,7 +47,9 @@ private:
 	void onListSelectionChange();
 
 	void onMouseWheel(int x, int y);
+	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) override;
 
 	Button btnDown;
 	ListBox<> lstItems;

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -8,6 +8,8 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
 
@@ -193,8 +195,12 @@ public:
 	}
 
 protected:
-	virtual void onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, int x, int y) {
-		if (!visible() || mHighlightIndex == constants::NoSelection || mHighlightIndex >= mItems.size() || !mScrollArea.contains(NAS2D::Point{x, y}))
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) {
+		onMouseDown(button, {x, y});
+	}
+
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> position) {
+		if (!visible() || mHighlightIndex == constants::NoSelection || mHighlightIndex >= mItems.size() || !mScrollArea.contains(position))
 		{
 			return;
 		}
@@ -202,24 +208,32 @@ protected:
 		setSelected(mHighlightIndex);
 	}
 
-	virtual void onMouseMove(int x, int y, int /*relX*/, int /*relY*/) {
-		if (!visible() || !mScrollArea.contains(NAS2D::Point{x, y}))
+	virtual void onMouseMove(int x, int y, int relX, int relY) {
+		onMouseMove({x, y}, {relX, relY});
+	}
+
+	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/) {
+		if (!visible() || !mScrollArea.contains(position))
 		{
 			mHighlightIndex = constants::NoSelection;
 			return;
 		}
 
-		mHighlightIndex = (static_cast<std::size_t>(y) - mScrollArea.y + mScrollOffsetInPixels) / static_cast<std::size_t>(mContext.itemHeight());
+		mHighlightIndex = (static_cast<std::size_t>(position.y) - mScrollArea.y + mScrollOffsetInPixels) / static_cast<std::size_t>(mContext.itemHeight());
 		if (mHighlightIndex >= mItems.size())
 		{
 			mHighlightIndex = constants::NoSelection;
 		}
 	}
 
-	void onMouseWheel(int /*x*/, int y) {
+	void onMouseWheel(int x, int y) {
+		onMouseWheel({x, y});
+	}
+
+	void onMouseWheel(NAS2D::Vector<int> scrollAmount) {
 		if (isEmpty() || !visible()) { return; }
 
-		mScrollBar.changeValue((y < 0 ? 16 : -16));
+		mScrollBar.changeValue((scrollAmount.y < 0 ? 16 : -16));
 	}
 
 	virtual void onSlideChange(ScrollBar::ValueType /*newPosition*/) {

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -104,21 +104,25 @@ void ListBoxBase::onResize()
  */
 void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	const auto point = NAS2D::Point{x, y};
+	onMouseDown(button, {x, y});
+}
 
+
+void ListBoxBase::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
 	if (isEmpty() || button == EventHandler::MouseButton::Middle) { return; }
 
-	if (button == EventHandler::MouseButton::Right && mRect.contains(point))
+	if (button == EventHandler::MouseButton::Right && mRect.contains(position))
 	{
 		setSelection(constants::NoSelection);
 		return;
 	}
 
 	// A few basic checks
-	if (!rect().contains(point) || mHighlightIndex == constants::NoSelection) { return; }
-	if (mScrollBar.visible() && mScrollBar.rect().contains(point)) { return; }
+	if (!rect().contains(position) || mHighlightIndex == constants::NoSelection) { return; }
+	if (mScrollBar.visible() && mScrollBar.rect().contains(position)) { return; }
 	if (mHighlightIndex >= mItems.size()) { return; }
 
 	setSelection(mHighlightIndex);
@@ -128,12 +132,17 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 /**
  * Mouse Motion event handler.
  */
-void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
+void ListBoxBase::onMouseMove(int x, int y, int relX, int relY)
+{
+	onMouseMove({x, y}, {relX, relY});
+}
+
+
+void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 {
 	if (!visible() || isEmpty()) { return; }
 
-	const auto mousePosition = NAS2D::Point{x, y};
-	mHasFocus = rect().contains(mousePosition);
+	mHasFocus = rect().contains(position);
 
 	// Ignore mouse motion events if the pointer isn't within the menu rect.
 	if (!mHasFocus)
@@ -143,13 +152,13 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 	}
 
 	// if the mouse is on the scroll bar then the scroll bar should handle that
-	if (mScrollBar.visible() && mScrollBar.rect().contains(mousePosition))
+	if (mScrollBar.visible() && mScrollBar.rect().contains(position))
 	{
 		mHighlightIndex = constants::NoSelection;
 		return;
 	}
 
-	mHighlightIndex = (static_cast<unsigned int>(y - positionY()) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemHeight);
+	mHighlightIndex = (static_cast<unsigned int>(position.y - positionY()) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemHeight);
 
 	if (mHighlightIndex >= mItems.size())
 	{
@@ -163,14 +172,20 @@ void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
  * 
  * \todo	Make the scroll step configurable. Legacy from the ListBox.
  */
-void ListBoxBase::onMouseWheel(int /*x*/, int y)
+void ListBoxBase::onMouseWheel(int x, int y)
+{
+	onMouseWheel({x, y});
+}
+
+
+void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 {
 	if (!enabled() || !visible()) { return; }
 	if (!mHasFocus) { return; }
 
 	auto change = static_cast<ScrollBar::ValueType>(mItemHeight);
 
-	mScrollBar.changeValue((y < 0 ? change : -change));
+	mScrollBar.changeValue((scrollAmount.y < 0 ? change : -change));
 }
 
 

--- a/OPHD/UI/Core/ListBoxBase.h
+++ b/OPHD/UI/Core/ListBoxBase.h
@@ -6,6 +6,8 @@
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Color.h>
 
 #include <string>
@@ -88,8 +90,11 @@ private:
 	void onSlideChange(ScrollBar::ValueType newPosition);
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(int x, int y, int relX, int relY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(int x, int y);
+	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
 	void onResize() override;
 

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -84,9 +84,15 @@ void RadioButtonGroup::RadioButton::onTextChange()
 
 void RadioButtonGroup::RadioButton::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void RadioButtonGroup::RadioButton::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left && mRect.contains(Point{x, y}))
+	if (button == EventHandler::MouseButton::Left && mRect.contains(position))
 	{
 		mParentContainer->select(*this);
 		mSignal();

--- a/OPHD/UI/Core/RadioButtonGroup.h
+++ b/OPHD/UI/Core/RadioButtonGroup.h
@@ -12,6 +12,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Math/MathUtils.h>
+#include <NAS2D/Math/Point.h>
 
 #include <algorithm>
 #include <string>
@@ -41,6 +42,7 @@ private:
 		void onResize() override;
 		void onTextChange() override;
 		void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+		void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 
 	private:
 		const NAS2D::Font& mFont;

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -219,20 +219,25 @@ void ScrollBar::onButtonClick(bool& buttonFlag, ValueType value)
 
 void ScrollBar::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void ScrollBar::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
 	if (button == EventHandler::MouseButton::Left)
 	{
-		const auto mousePosition = NAS2D::Point{x, y};
-		if (mThumb.contains(mousePosition))
+		if (mThumb.contains(position))
 		{
 			mThumbPressed = true;
 		}
-		else if (mButtonDecrease.contains(mousePosition))
+		else if (mButtonDecrease.contains(position))
 		{
 			onButtonClick(mButtonDecreaseHeld, -1);
 		}
-		else if (mButtonIncrease.contains(mousePosition))
+		else if (mButtonIncrease.contains(position))
 		{
 			onButtonClick(mButtonIncreaseHeld, 1);
 		}
@@ -242,6 +247,12 @@ void ScrollBar::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 void ScrollBar::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseUp(button, {x, y});
+}
+
+
+void ScrollBar::onMouseUp(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (button != EventHandler::MouseButton::Left) { return; }
 
 	mButtonDecreaseHeld = false;
@@ -250,12 +261,11 @@ void ScrollBar::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 	if (!enabled() || !visible()) { return; }
 
-	const auto mousePosition = NAS2D::Point{x, y};
-	if (mTrack.contains(mousePosition) && !mThumb.contains(mousePosition))
+	if (mTrack.contains(position) && !mThumb.contains(position))
 	{
 		const auto [clickPosition, thumbPosition, viewSize] =
 			(mScrollBarType == ScrollBarType::Vertical) ?
-				std::tuple{y, mThumb.y, mRect.height} : std::tuple{x, mThumb.x, mRect.width};
+				std::tuple{position.y, mThumb.y, mRect.height} : std::tuple{position.x, mThumb.x, mRect.width};
 		const auto changeAmount = (clickPosition < thumbPosition) ?
 			-viewSize : viewSize;
 		changeValue(changeAmount);
@@ -263,16 +273,22 @@ void ScrollBar::onMouseUp(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void ScrollBar::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
+void ScrollBar::onMouseMove(int x, int y, int dX, int dY)
+{
+	onMouseMove({x, y}, {dX, dY});
+}
+
+
+void ScrollBar::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (mThumbPressed && mTrack.contains(NAS2D::Point{x, y}))
+	if (mThumbPressed && mTrack.contains(position))
 	{
 		value(
 			(mScrollBarType == ScrollBarType::Vertical) ?
-				mMax * (y - mTrack.y - mThumb.height / 2) / (mTrack.height - mThumb.height) :
-				mMax * (x - mTrack.x - mThumb.width / 2) / (mTrack.width - mThumb.width)
+				mMax * (position.y - mTrack.y - mThumb.height / 2) / (mTrack.height - mThumb.height) :
+				mMax * (position.x - mTrack.x - mThumb.width / 2) / (mTrack.width - mThumb.width)
 		);
 	}
 }

--- a/OPHD/UI/Core/ScrollBar.h
+++ b/OPHD/UI/Core/ScrollBar.h
@@ -4,6 +4,8 @@
 
 #include <NAS2D/Timer.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
 
@@ -46,8 +48,11 @@ public:
 protected:
 	void onButtonClick(bool& buttonFlag, ValueType value);
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(int x, int y, int dX, int dY);
+	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void onMove(NAS2D::Vector<int> displacement) override;
 	void onResize() override;

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -222,13 +222,19 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 /**
  * Mouse down even handler.
  */
-void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
+void TextField::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	hasFocus(mRect.contains(Point{x, y})); // This is a very useful check, should probably include this in all controls.
+	onMouseDown(button, {x, y});
+}
+
+
+void TextField::onMouseDown(EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
+{
+	hasFocus(mRect.contains(position)); // This is a very useful check, should probably include this in all controls.
 
 	if (!enabled() || !visible()) { return; }
 
-	int relativePosition = x - mRect.x;
+	int relativePosition = position.x - mRect.x;
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.

--- a/OPHD/UI/Core/TextField.h
+++ b/OPHD/UI/Core/TextField.h
@@ -10,6 +10,7 @@
 #include "TextControl.h"
 
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
 #include <NAS2D/Timer.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
 
@@ -61,6 +62,7 @@ public:
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	virtual void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onTextInput(const std::string& newTextInput);
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -70,8 +70,13 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 
 void ToolTip::onMouseMove(int x, int y, int dX, int dY)
 {
-	const auto position = NAS2D::Point{x, y};
-	if (dX != 0 || dY != 0)
+	onMouseMove({x, y}, {dX, dY});
+}
+
+
+void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative)
+{
+	if (relative != Vector{0, 0})
 	{
 		if (mFocusedControl)
 		{
@@ -88,7 +93,7 @@ void ToolTip::onMouseMove(int x, int y, int dX, int dY)
 		if (item.first->rect().contains(position))
 		{
 			mFocusedControl = &item;
-			buildDrawParams(item, x);
+			buildDrawParams(item, position.x);
 			return;
 		}
 	}

--- a/OPHD/UI/Core/ToolTip.h
+++ b/OPHD/UI/Core/ToolTip.h
@@ -3,6 +3,7 @@
 #include "Control.h"
 
 #include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Timer.h>
 
@@ -23,6 +24,7 @@ public:
 
 private:
 	void onMouseMove(int, int, int, int);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void buildDrawParams(std::pair<Control*, std::string>&, int);
 

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -87,7 +87,13 @@ void UIContainer::onMove(NAS2D::Vector<int> displacement)
 }
 
 
-void UIContainer::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
+void UIContainer::onMouseDown(EventHandler::MouseButton button, int x, int y)
+{
+	onMouseDown(button, {x, y});
+}
+
+
+void UIContainer::onMouseDown(EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
 {
 	if (!visible()) { return; }
 
@@ -95,7 +101,7 @@ void UIContainer::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y
 	for (auto it = mControls.rbegin(); it != mControls.rend(); ++it)
 	{
 		control = (*it);
-		if (control->visible() && control->rect().contains(NAS2D::Point{x, y}))
+		if (control->visible() && control->rect().contains(position))
 		{
 			if (control == mControls.back()) { return; }
 			bringToFront(control);

--- a/OPHD/UI/Core/UIContainer.h
+++ b/OPHD/UI/Core/UIContainer.h
@@ -2,6 +2,7 @@
 
 #include "Control.h"
 
+#include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/EventHandler.h>
 
@@ -34,6 +35,7 @@ protected:
 	void onMove(NAS2D::Vector<int> displacement) override;
 
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 
 private:
 	std::vector<Control*> mControls;

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -46,28 +46,46 @@ Window::~Window()
 
 void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if (!enabled() || !visible()) { return; }
-
-	UIContainer::onMouseDown(button, x, y);
-
-	const auto titleBarBounds = NAS2D::Rectangle{mRect.x, mRect.y, mRect.width, sWindowTitleBarHeight};
-	mMouseDrag = (button == EventHandler::MouseButton::Left && titleBarBounds.contains(NAS2D::Point{x, y}));
+	onMouseDown(button, {x, y});
 }
 
 
-void Window::onMouseUp(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
+void Window::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
+	if (!enabled() || !visible()) { return; }
+
+	UIContainer::onMouseDown(button, position);
+
+	const auto titleBarBounds = NAS2D::Rectangle{mRect.x, mRect.y, mRect.width, sWindowTitleBarHeight};
+	mMouseDrag = (button == EventHandler::MouseButton::Left && titleBarBounds.contains(position));
+}
+
+
+void Window::onMouseUp(EventHandler::MouseButton button, int x, int y)
+{
+	onMouseUp(button, {x, y});
+}
+
+
+void Window::onMouseUp(EventHandler::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
 {
 	mMouseDrag = false;
 }
 
 
-void Window::onMouseMove(int /*x*/, int /*y*/, int dX, int dY)
+void Window::onMouseMove(int x, int y, int dX, int dY)
+{
+	onMouseMove({x, y}, {dX, dY});
+}
+
+
+void Window::onMouseMove(NAS2D::Point<int> /*position*/, NAS2D::Vector<int> relative)
 {
 	if (!enabled() || !visible()) { return; }
 
 	if (mMouseDrag && !mAnchored)
 	{
-		position(position() + NAS2D::Vector{dX, dY});
+		position(position() + relative);
 	}
 }
 

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -5,6 +5,8 @@
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <string>
 
@@ -32,8 +34,11 @@ public:
 
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) override;
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(int x, int y, int dX, int dY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	static constexpr int sWindowTitleBarHeight = 20;
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -71,11 +71,17 @@ FileIo::~FileIo()
 /**
  * Event handler for mouse double click.
  */
-void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
+void FileIo::onDoubleClick(EventHandler::MouseButton button, int x, int y)
+{
+	onDoubleClick(button, {x, y});
+}
+
+
+void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
 {
 	if (!visible()) { return; } // ignore key presses when hidden.
 
-	if (mListBox.rect().contains(NAS2D::Point{x, y}))
+	if (mListBox.rect().contains(position))
 	{
 		if (mListBox.currentHighlight() != constants::NoSelection && !txtFileName.empty())
 		{

--- a/OPHD/UI/FileIo.h
+++ b/OPHD/UI/FileIo.h
@@ -8,6 +8,7 @@
 
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
 
 
 class FileIo : public Window
@@ -33,6 +34,7 @@ public:
 
 protected:
 	void onDoubleClick(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onDoubleClick(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 
 private:

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -69,6 +69,12 @@ void IconGrid::updateGrid()
  */
 void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void IconGrid::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!enabled() || !visible()) { return; }
 
 	// Don't respond to anything unless it's the left mouse button.
@@ -80,14 +86,13 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	}
 
 	auto startPoint = mRect.startPoint();
-	auto mousePoint = NAS2D::Point{x, y};
-	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(mousePoint))
+	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(position))
 	{
 		return;
 	}
 
 	auto previousIndex = mSelectedIndex;
-	mSelectedIndex = translateCoordsToIndex(mousePoint - startPoint);
+	mSelectedIndex = translateCoordsToIndex(position - startPoint);
 
 	if (mSelectedIndex >= mIconItemList.size())
 	{
@@ -104,20 +109,25 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 /**
  * MouseMotion event handler.
  */
-void IconGrid::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
+void IconGrid::onMouseMove(int x, int y, int dX, int dY)
+{
+	onMouseMove({x, y}, {dX, dY});
+}
+
+
+void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 {
 	if (!enabled() || !visible()) { return; }
 
 	auto startPoint = mRect.startPoint();
-	auto mousePoint = NAS2D::Point{x, y};
-	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(mousePoint))
+	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(position))
 	{
 		mHighlightIndex = constants::NoSelection;
 		return;
 	}
 
 	// Assumes all coordinates are not negative.
-	mHighlightIndex = translateCoordsToIndex(mousePoint - startPoint);
+	mHighlightIndex = translateCoordsToIndex(position - startPoint);
 
 	if (mHighlightIndex >= mIconItemList.size())
 	{

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -78,7 +78,9 @@ public:
 
 protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(int x, int y, int dX, int dY);
+	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void onResize() override;
 

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -124,7 +124,13 @@ void MiniMap::onActivate()
 }
 
 
-void MiniMap::onMouseUp(NAS2D::EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
+void MiniMap::onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y)
+{
+	onMouseUp(button, {x, y});
+}
+
+
+void MiniMap::onMouseUp(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
 {
 	mLeftButtonDown = false;
 }
@@ -132,26 +138,36 @@ void MiniMap::onMouseUp(NAS2D::EventHandler::MouseButton /*button*/, int /*x*/, 
 
 void MiniMap::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void MiniMap::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{
 		mLeftButtonDown = true;
-		const auto mousePosition = NAS2D::Point{x, y};
-		if (mRect.contains(mousePosition))
+		if (mRect.contains(position))
 		{
-			onSetView(mousePosition);
+			onSetView(position);
 		}
 	}
 }
 
 
-void MiniMap::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
+void MiniMap::onMouseMove(int x, int y, int rX, int rY)
+{
+	onMouseMove({x, y}, {rX, rY});
+}
+
+
+void MiniMap::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 {
 	if (mLeftButtonDown)
 	{
-		const auto mousePosition = NAS2D::Point{x, y};
-		if (mRect.contains(mousePosition))
+		if (mRect.contains(position))
 		{
-			onSetView(mousePosition);
+			onSetView(position);
 		}
 	}
 }

--- a/OPHD/UI/MiniMap.h
+++ b/OPHD/UI/MiniMap.h
@@ -5,6 +5,8 @@
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <map>
 #include <string>
@@ -31,8 +33,11 @@ protected:
 	friend MapViewState;
 	void onActivate();
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(int x, int y, int rX, int rY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onSetView(NAS2D::Point<int> mousePixel);
 
 private:

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -102,13 +102,19 @@ std::size_t NotificationArea::notificationIndex(NAS2D::Point<int> pixelPosition)
 
 void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
+	onMouseDown(button, {x, y});
+}
+
+
+void NotificationArea::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (button != EventHandler::MouseButton::Left &&
 		button != EventHandler::MouseButton::Right)
 	{
 		return;
 	}
 
-	const auto index = notificationIndex({x, y});
+	const auto index = notificationIndex(position);
 	if (index != NoSelection)
 	{
 		if (button == EventHandler::MouseButton::Left)
@@ -117,14 +123,19 @@ void NotificationArea::onMouseDown(EventHandler::MouseButton button, int x, int 
 		}
 
 		mNotificationList.erase(mNotificationList.begin() + index);
-		onMouseMove(x, y, 0, 0);
+		onMouseMove(position, {0, 0});
 	}
 }
 
 
-void NotificationArea::onMouseMove(int x, int y, int /*dX*/, int /*dY*/)
+void NotificationArea::onMouseMove(int x, int y, int dX, int dY)
 {
-	const auto position = NAS2D::Point{x, y};
+	onMouseMove({x, y}, {dX, dY});
+}
+
+
+void NotificationArea::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
 	if (!rect().contains(position)) { return; }
 	mNotificationIndex = notificationIndex(position);
 }

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -6,6 +6,7 @@
 
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Signal/Signal.h>
 
 #include <vector>
@@ -57,7 +58,9 @@ protected:
 	std::size_t notificationIndex(NAS2D::Point<int> pixelPosition);
 
 	void onMouseDown(NAS2D::EventHandler::MouseButton, int, int);
+	void onMouseDown(NAS2D::EventHandler::MouseButton, NAS2D::Point<int> position);
 	void onMouseMove(int x, int y, int dX, int dY);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 private:
 	const NAS2D::Image& mIcons;

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -183,10 +183,16 @@ void WarehouseReport::fillListDisabled()
 
 void WarehouseReport::onDoubleClick(EventHandler::MouseButton button, int x, int y)
 {
+	onDoubleClick(button, {x, y});
+}
+
+
+void WarehouseReport::onDoubleClick(EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
 	if (!visible()) { return; }
 	if (button != EventHandler::MouseButton::Left) { return; }
 
-	if (selectedWarehouse && lstStructures.rect().contains(NAS2D::Point{x, y}))
+	if (selectedWarehouse && lstStructures.rect().contains(position))
 	{
 		takeMeThereSignal()(selectedWarehouse);
 	}

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -7,6 +7,8 @@
 
 #include "../Core/Button.h"
 
+#include <NAS2D/Math/Point.h>
+
 #include <vector>
 
 
@@ -55,6 +57,7 @@ private:
 	void fillListDisabled();
 
 	void onDoubleClick(NAS2D::EventHandler::MouseButton, int, int);
+	void onDoubleClick(NAS2D::EventHandler::MouseButton, NAS2D::Point<int> position);
 
 	void onStructureSelectionChange();
 

--- a/OPHD/UI/ResourceInfoBar.cpp
+++ b/OPHD/UI/ResourceInfoBar.cpp
@@ -187,7 +187,13 @@ void ResourceInfoBar::draw() const
 
 void ResourceInfoBar::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 {
-	UIContainer::onMouseDown(button, x, y);
+	onMouseDown(button, {x, y});
+}
+
+
+void ResourceInfoBar::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
+{
+	UIContainer::onMouseDown(button, position);
 
 	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{

--- a/OPHD/UI/ResourceInfoBar.h
+++ b/OPHD/UI/ResourceInfoBar.h
@@ -6,6 +6,7 @@
 #include "Core/ToolTip.h"
 
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
 #include <NAS2D/Resource/Image.h>
 
 
@@ -26,6 +27,7 @@ public:
 
 protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y) override;
+	void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) override;
 
 	int totalStorage(Structure::StructureClass, int) const;
 


### PR DESCRIPTION
This implements the idea from https://github.com/OutpostUniverse/OPHD/issues/217#issuecomment-633267904 to create event overloads that would be compatible with a switch to packed parameter events. From there, NAS2D can be updated to use packed event parameters, and it should just work. At that point, the unpacked parameter overloads can then be removed.
