### PR TITLE
Remove `#pragma` warning suppression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     docker:
       - image: outpostuniverse/nas2d-clang:1.3
     environment:
-      WARN_EXTRA: -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wcovered-switch-default -Wshadow-field -Wextra-semi -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wdocumentation-unknown-command -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
+      WARN_EXTRA: -Wunknown-pragmas -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wcovered-switch-default -Wshadow-field -Wextra-semi -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wdocumentation-unknown-command -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -29,9 +29,6 @@
 #include <sstream>
 #include <vector>
 
-// Disable some warnings that can be safely ignored.
-#pragma warning(disable : 4244) // possible loss of data (floats to int and vice versa)
-
 
 extern NAS2D::Point<int> MOUSE_COORDS;
 


### PR DESCRIPTION
Reference: #307

Add Clang warning flag `-Wunknown-pragmas`. It seems we had a `#pragma` to suppress MSVC warnings that was no longer relevant.
