### PR TITLE
Fix implicit `int`/`float` conversion

### DIFF
--- a/OPHD/Population/Population.cpp
+++ b/OPHD/Population/Population.cpp
@@ -156,7 +156,7 @@ int Population::consumeFood(int food)
 	const int populationFed = food * PopulationPerFood;
 	const int populationUnfed = mPopulation.size() - populationFed;
 	const int minKill = std::clamp(populationUnfed, 0, 1);
-	const int populationToKill = std::clamp(static_cast<int>(populationUnfed * mStarveRate), minKill, mPopulation.size());
+	const int populationToKill = std::clamp(static_cast<int>(static_cast<float>(populationUnfed) * mStarveRate), minKill, mPopulation.size());
 	mDeathCount += populationToKill;
 
 	for (int i = populationToKill; i > 0; mStarveRoleIndex = (mStarveRoleIndex + 1) % 5)

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -32,7 +32,7 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 		// Crime Rate of 0% means no crime
 		// Crime Rate of 100% means crime occurs 10% of the time on medium difficulty
 		// chanceCrimeOccurs multiplier increases or decreases chance based on difficulty
-		if (structure->crimeRate() * chanceCrimeOccurs[mDifficulty] + randomNumber.generate<int>(0, 1000) > 1000)
+		if (static_cast<int>(static_cast<float>(structure->crimeRate()) * chanceCrimeOccurs[mDifficulty]) + randomNumber.generate<int>(0, 1000) > 1000)
 		{
 			mStructuresCommittingCrimes.push_back(structure);
 		}
@@ -40,7 +40,7 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 		accumulatedCrime += structure->crimeRate();
 	}
 
-	mMeanCrimeRate = static_cast<int>(accumulatedCrime / structuresWithCrime.size());
+	mMeanCrimeRate = static_cast<int>(accumulatedCrime / static_cast<double>(structuresWithCrime.size()));
 
 	updateMoraleChanges();
 }

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -91,7 +91,7 @@ NAS2D::State* PlanetSelectState::update()
 	const auto size = renderer.size();
 	renderer.drawImageStretched(mBg, NAS2D::Rectangle<int>::Create({0, 0}, size));
 
-	float rotation = mTimer.tick() / 1200.0f;
+	float rotation = static_cast<float>(mTimer.tick()) / 1200.0f;
 	renderer.drawImageRotated(mCloud1, {-256, -256}, rotation, NAS2D::Color{100, 255, 0, 135});
 	renderer.drawImageRotated(mCloud1, NAS2D::Point{size.x - 800, -256}, -rotation, NAS2D::Color{180, 0, 255, 150});
 

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -118,13 +118,13 @@ NAS2D::State* SplashState::update()
 		const unsigned int tick = bylineTimer.accumulator();
 		const auto logoPosition = renderer.center() - mLogoOutpostHd.size() / 2 - NAS2D::Vector{100, 0};
 
-		renderer.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, bylineTimer.tick() / 600.0f);
+		renderer.drawImageRotated(mFlare, logoPosition + NAS2D::Vector{302 - 512, 241 - 512}, static_cast<float>(bylineTimer.tick()) / 600.0f);
 		renderer.drawImage(mLogoOutpostHd, logoPosition);
 
 		const float bylineScaleStep = 0.000025f;
 		const float bylineAlphaFadeStep = 0.30f;
-		const float bylineScale = 0.50f + tick * bylineScaleStep;
-		const float bylineAlpha = -800.0f + tick * bylineAlphaFadeStep;
+		const float bylineScale = 0.50f + static_cast<float>(tick) * bylineScaleStep;
+		const float bylineAlpha = -800.0f + static_cast<float>(tick) * bylineAlphaFadeStep;
 		const auto clampedBylineAlpha = static_cast<uint8_t>(std::clamp(bylineAlpha, 0.0f, 255.0f));
 
 		if (clampedBylineAlpha > 0)

--- a/OPHD/Things/Structures/ResearchFacility.h
+++ b/OPHD/Things/Structures/ResearchFacility.h
@@ -32,14 +32,14 @@ public:
 	int regularResearchProduced() const
 	{
 		return static_cast<int>(
-			std::floor(mActualScientstsEmployed * mRegularPointsPerScientist));
+			std::floor(static_cast<float>(mActualScientstsEmployed) * mRegularPointsPerScientist));
 	}
 
 
 	int hotResearchProduced() const
 	{
 		return static_cast<int>(
-			std::floor(mActualScientstsEmployed * mHotPointsPerScientist));
+			std::floor(static_cast<float>(mActualScientstsEmployed) * mHotPointsPerScientist));
 	}
 
 

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -45,7 +45,7 @@ static void drawItem(Renderer& renderer, FactoryListBox::FactoryListBoxItem& ite
 	renderer.drawText(*MAIN_FONT, productDescription(f->productType()), NAS2D::Point{x + w - 112, ((y + 19) - MAIN_FONT_BOLD->height() / 2) - offset}, structureTextColor);
 
 	// PROGRESS BAR
-	float percentage = (f->productType() == ProductType::PRODUCT_NONE) ? 0.0f : (f->productionTurnsCompleted() / f->productionTurnsToComplete());
+	float percentage = (f->productType() == ProductType::PRODUCT_NONE) ? 0.0f : (static_cast<float>(f->productionTurnsCompleted()) / static_cast<float>(f->productionTurnsToComplete()));
 	drawBasicProgressBar(x + w - 112, y + 30 - offset, 105, 11, percentage, 2);
 }
 


### PR DESCRIPTION
Reference: #307

Use an explicit `static_cast` where implicit `int`/`float` conversions were being done. These were found with the Clang warning flag `-Wimplicit-int-float-conversion`.

----

The warning flag has not been enabled since the NAS2D submodule still has code that generates a warning with that flag in the `Renderer` code.

> NAS2D/Renderer/Renderer.cpp:156:50: error: implicit conversion from 'int' to 'float' may lose precision [-Werror,-Wimplicit-int-float-conversion]
                float fade = (fadeTimer.delta() * mFadeStep) * static_cast<int>(mCurrentFadeType);
                                                             ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
NAS2D/Renderer/Renderer.cpp:156:27: error: implicit conversion from 'unsigned int' to 'float' may lose precision [-Werror,-Wimplicit-int-float-conversion]
                float fade = (fadeTimer.delta() * mFadeStep) * static_cast<int>(mCurrentFadeType);
                              ~~~~~~~~~~^~~~~~~ ~
2 errors generated.
make[1]: *** [makefile:62: .build/debug/intermediate/Renderer/Renderer.o] Error 1
NAS2D/Renderer/RendererOpenGL.cpp:822:25: error: implicit conversion from 'int' to 'float' may lose precision [-Werror,-Wimplicit-int-float-conversion]
                float f = lineWidth - static_cast<int>(lineWidth);
                                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~
