### PR TITLE
Solar distance - check once

### DIFF
--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -11,11 +11,15 @@ const int SOLAR_PANEL_BASE_PRODUCUCTION = 50;
 class SolarPanelArray : public PowerStructure
 {
 public:
-	SolarPanelArray(float meanSolarDistance) : PowerStructure(constants::SolarPanel1,
-		"structures/solar_array1.sprite",
-		StructureClass::EnergyProduction,
-		StructureID::SID_SOLAR_PANEL1),
-		mMeanSolarDistance(meanSolarDistance)
+	SolarPanelArray(float meanSolarDistance) :
+		PowerStructure
+		{
+			constants::SolarPanel1,
+			"structures/solar_array1.sprite",
+			StructureClass::EnergyProduction,
+			StructureID::SID_SOLAR_PANEL1
+		},
+		mMeanSolarDistance{meanSolarDistance}
 	{
 		maxAge(1000);
 		turnsToBuild(4);

--- a/OPHD/Things/Structures/SolarPanelArray.h
+++ b/OPHD/Things/Structures/SolarPanelArray.h
@@ -19,7 +19,7 @@ public:
 			StructureClass::EnergyProduction,
 			StructureID::SID_SOLAR_PANEL1
 		},
-		mMeanSolarDistance{meanSolarDistance}
+		mMeanSolarDistance{meanSolarDistance != 0 ? meanSolarDistance : 1.0f} // Prevent division by 0
 	{
 		maxAge(1000);
 		turnsToBuild(4);
@@ -30,10 +30,7 @@ public:
 protected:
 	int calculateMaxEnergyProduction() override
 	{
-		// Prevent possible dividing by zero
-		float solarDistance = mMeanSolarDistance != 0 ? mMeanSolarDistance : 1;
-
-		return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / solarDistance);
+		return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / mMeanSolarDistance);
 	}
 
 private:

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -11,11 +11,15 @@ const int SOLAR_PLANT_BASE_PRODUCUCTION = 2000;
 class SolarPlant : public PowerStructure
 {
 public:
-	SolarPlant(float meanSolarDistance) : PowerStructure(constants::SolarPlant,
-		"structures/solar_plant.sprite",
-		StructureClass::EnergyProduction,
-		StructureID::SID_SOLAR_PLANT),
-		mMeanSolarDistance(meanSolarDistance)
+	SolarPlant(float meanSolarDistance) :
+		PowerStructure
+		{
+			constants::SolarPlant,
+			"structures/solar_plant.sprite",
+			StructureClass::EnergyProduction,
+			StructureID::SID_SOLAR_PLANT
+		},
+		mMeanSolarDistance{meanSolarDistance}
 	{
 		maxAge(1000);
 		turnsToBuild(4);

--- a/OPHD/Things/Structures/SolarPlant.h
+++ b/OPHD/Things/Structures/SolarPlant.h
@@ -19,7 +19,7 @@ public:
 			StructureClass::EnergyProduction,
 			StructureID::SID_SOLAR_PLANT
 		},
-		mMeanSolarDistance{meanSolarDistance}
+		mMeanSolarDistance{meanSolarDistance != 0 ? meanSolarDistance : 1.0f} // Prevent division by 0
 	{
 		maxAge(1000);
 		turnsToBuild(4);
@@ -30,10 +30,7 @@ public:
 protected:
 	int calculateMaxEnergyProduction() override
 	{
-		// Prevent possible dividing by zero
-		float solarDistance = mMeanSolarDistance != 0 ? mMeanSolarDistance : 1;
-
-		return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / solarDistance);
+		return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / mMeanSolarDistance);
 	}
 
 private:


### PR DESCRIPTION
We should check `meanSolarDistance` against `0` once during initialization, rather than every time it is used.

Perhaps even better would be to `throw` from the constructor if the passed value was ever `0`.

Would be nice if the check could be done without a floating point comparison (#307, `-Wfloat-equal`), though that get's awkward. It might be possible to use [`std::equal_to`](https://en.cppreference.com/w/cpp/utility/functional/equal_to), though that's getting a bit esoteric.

It might also make sense to set the default value to `1.0` instead of `0`. Of course, that doesn't really eliminate the need for the check, since when the value is set, it could be set to `0`.
