### PR TITLE
Inline and remove type alias `StructureItemList`

### DIFF
--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -31,7 +31,7 @@ extern NAS2D::Point<int> MOUSE_COORDS;
 
 namespace
 {
-	void fillList(IconGrid& grid, const StructureTracker::StructureItemList& itemList)
+	void fillList(IconGrid& grid, const std::vector<IconGrid::Item>& itemList)
 	{
 		for (const auto& item : itemList)
 		{

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -4,7 +4,7 @@
 
 namespace
 {
-	void addItemToList(const IconGrid::Item& structureItem, StructureTracker::StructureItemList& list)
+	void addItemToList(const IconGrid::Item& structureItem, std::vector<IconGrid::Item>& list)
 	{
 		for (const auto& item : list)
 		{

--- a/OPHD/States/StructureTracker.h
+++ b/OPHD/States/StructureTracker.h
@@ -10,14 +10,11 @@
 class StructureTracker
 {
 public:
-	using StructureItemList = std::vector<IconGrid::Item>;
-
-public:
 
 	StructureTracker();
 
-	const StructureItemList& availableSurfaceStructures() const { return mAvailableSurfaceStructures; }
-	const StructureItemList& availableUndergroundStructures() const { return mAvailableUndergroundStructures; }
+	const std::vector<IconGrid::Item>& availableSurfaceStructures() const { return mAvailableSurfaceStructures; }
+	const std::vector<IconGrid::Item>& availableUndergroundStructures() const { return mAvailableUndergroundStructures; }
 
 	void addUnlockedSurfaceStructure(const IconGrid::Item& structureItem);
 	void addUnlockedUndergroundStructure(const IconGrid::Item& structureItem);
@@ -26,6 +23,6 @@ public:
 
 private:
 
-	StructureItemList mAvailableSurfaceStructures;
-	StructureItemList mAvailableUndergroundStructures;
+	std::vector<IconGrid::Item> mAvailableSurfaceStructures;
+	std::vector<IconGrid::Item> mAvailableUndergroundStructures;
 };


### PR DESCRIPTION
Cherry-picked from the `useConstDefaultAvailableStructs` branch. That branch can't be merged since MSVC crashes when trying to compile changes that use `std::vector` initializer lists instead of repeated `push_back`.

Related: #1209, #1201
