### PR TITLE
Add success notification

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1283,6 +1283,11 @@ void MapViewState::updateRobots()
 			if (tile->thing() == robot)
 			{
 				tile->removeThing();
+
+				mNotificationArea.push({"Robot Task Completed",
+										robot->name() + " completed its task at" + std::to_string(tile->xy().x) + ", " + std::to_string(tile->xy().y) + ").",
+										tile->xyz(),
+										NotificationArea::NotificationType::Success});
 			}
 			robot_it = mRobotList.erase(robot_it);
 
@@ -1291,6 +1296,11 @@ void MapViewState::updateRobots()
 				resetTileIndexFromDozer(robot, tile);
 				populateRobotMenu();
 				robot->reset();
+
+				mNotificationArea.push({"Robot Task Canceled",
+						robot->name() + " canceled its task at" + std::to_string(tile->xy().x) + ", " + std::to_string(tile->xy().y) + ").",
+						tile->xyz(),
+						NotificationArea::NotificationType::Information});
 			}
 		}
 		else

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -567,7 +567,7 @@ void MapViewState::checkNewlyBuiltStructures()
 			"Construction Finished",
 			structure->name() + " completed construction.",
 			structureTile.xyz(),
-			NotificationArea::NotificationType::Information});
+			NotificationArea::NotificationType::Success});
 	}
 }
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -28,11 +28,13 @@ namespace
 		NAS2D::Color color;
 	};
 
+
 	const std::map<NotificationArea::NotificationType, IconDrawParameters> NotificationIconDrawParameters
 	{
 		{NotificationArea::NotificationType::Critical, {{64, 64, 32, 32}, Color::Red}},
-		{NotificationArea::NotificationType::Information, {{32, 64, 32, 32}, Color::Green}},
-		{NotificationArea::NotificationType::Warning, {{96, 64, 32, 32}, Color::Yellow}}
+		{NotificationArea::NotificationType::Information, {{128, 64, 32, 32}, Color::Blue}},
+		{NotificationArea::NotificationType::Success, {{32, 64, 32, 32}, Color::Green}},
+		{NotificationArea::NotificationType::Warning, {{96, 64, 32, 32}, {255, 165, 0}}}
 	};
 }
 
@@ -41,7 +43,7 @@ void drawNotificationIcon(NAS2D::Point<int> position, NotificationArea::Notifica
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto& iconDrawParameters = NotificationIconDrawParameters.at(type);
-	renderer.drawSubImage(icons, position, {128, 64, 32, 32}, iconDrawParameters.color);
+	renderer.drawSubImage(icons, position, {160, 64, 32, 32}, iconDrawParameters.color);
 	renderer.drawSubImage(icons, position, iconDrawParameters.iconRect, Color::Normal);
 }
 

--- a/OPHD/UI/NotificationArea.h
+++ b/OPHD/UI/NotificationArea.h
@@ -28,6 +28,7 @@ public:
 	{
 		Critical,
 		Information,
+		Success,
 		Warning
 	};
 


### PR DESCRIPTION
Adds a success notification type.

Also adjusts colors used for notification types so it's a bit easier to distinguish between them. UI Icons were modified a bit to provide a better visual distinction between notification types.