### PR TITLE
Use `Fade` control

### DIFF
--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -66,6 +66,7 @@ void GameState::initialize()
 
 	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect(MakeDelegate(this, &GameState::onMusicComplete));
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeComplete().connect(this, &GameState::onFadeComplete);
+	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(std::chrono::milliseconds{0});
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeIn(constants::FadeSpeed);
 }
 

--- a/OPHD/States/GameState.h
+++ b/OPHD/States/GameState.h
@@ -3,6 +3,7 @@
 #include <NAS2D/State.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
+#include <NAS2D/Renderer/Fade.h>
 
 #include <memory>
 
@@ -11,9 +12,6 @@ class MainReportsUiState;
 class MapViewState;
 class Structure;
 class Wrapper;
-
-
-extern NAS2D::Point<int> MOUSE_COORDS;
 
 
 class GameState : public NAS2D::State
@@ -46,4 +44,5 @@ private:
 	std::unique_ptr<MapViewState> mMapView;
 	Wrapper* mActiveState = nullptr;
 	std::unique_ptr<MainReportsUiState> mMainReportsState;
+	NAS2D::Fade mFade;
 };

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -67,10 +67,10 @@ void MainMenuState::initialize()
 	disableButtons();
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	renderer.showSystemPointer(true);
 	renderer.fadeComplete().connect(this, &MainMenuState::onFadeComplete);
 	renderer.fadeOut(std::chrono::milliseconds{0});
 	renderer.fadeIn(constants::FadeSpeed);
-	renderer.showSystemPointer(true);
 
 	NAS2D::Mixer& mixer = NAS2D::Utility<NAS2D::Mixer>::get();
 	if (!mixer.musicPlaying()) { mixer.playMusic(*trackMars); }

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -254,9 +254,6 @@ NAS2D::State* MainMenuState::update()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	// Disable renderer fade from previous or next screens, as we use Fade control here
-	renderer.fadeIn(std::chrono::milliseconds{0});
-
 	renderer.clearScreen();
 
 	renderer.drawImage(mBgImage, renderer.center() - mBgImage.size() / 2);

--- a/OPHD/States/MainMenuState.h
+++ b/OPHD/States/MainMenuState.h
@@ -5,6 +5,7 @@
 #include <NAS2D/State.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Resource/Image.h>
+#include <NAS2D/Renderer/Fade.h>
 
 #include <array>
 
@@ -48,4 +49,5 @@ private:
 
 	Label lblVersion;
 	NAS2D::State* mReturnState = this;
+	NAS2D::Fade mFade;
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -243,6 +243,7 @@ void MapViewState::initialize()
 	setupUiPositions(renderer.size());
 	resetPoliceOverlays();
 
+	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(std::chrono::milliseconds{0});
 	NAS2D::Utility<NAS2D::Renderer>::get().fadeIn(constants::FadeSpeed);
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -243,8 +243,7 @@ void MapViewState::initialize()
 	setupUiPositions(renderer.size());
 	resetPoliceOverlays();
 
-	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(std::chrono::milliseconds{0});
-	NAS2D::Utility<NAS2D::Renderer>::get().fadeIn(constants::FadeSpeed);
+	mFade.fadeIn(constants::FadeSpeed);
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 
@@ -329,6 +328,9 @@ NAS2D::State* MapViewState::update()
 	}
 
 	drawUI();
+
+	mFade.update();
+	mFade.draw(renderer);
 
 	return this;
 }
@@ -1401,4 +1403,10 @@ void MapViewState::scrubRobotList()
 	{
 		it.second->removeThing();
 	}
+}
+
+
+bool MapViewState::hasGameEnded()
+{
+	return mFade.isFaded();
 }

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -51,6 +51,7 @@
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Renderer/Fade.h>
 
 #include <string>
 #include <memory>
@@ -127,6 +128,8 @@ public:
 
 	Difficulty difficulty() { return mDifficulty; }
 	void difficulty(Difficulty difficulty);
+
+	bool hasGameEnded();
 
 protected:
 	void initialize() override;
@@ -393,4 +396,6 @@ private:
 	std::unique_ptr<MiniMap> mMiniMap;
 	std::unique_ptr<DetailMap> mDetailMap;
 	std::unique_ptr<NavControl> mNavControl;
+
+	NAS2D::Fade mFade;
 };

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -647,7 +647,7 @@ void MapViewState::onReturnToGame()
  */
 void MapViewState::onGameOver()
 {
-	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(constants::FadeSpeed);
+	mFade.fadeOut(constants::FadeSpeed);
 	mQuitSignal();
 }
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -97,9 +97,9 @@ NAS2D::State* PlanetSelectState::update()
 	renderer.drawImageRotated(mCloud1, {-256, -256}, rotation, NAS2D::Color{100, 255, 0, 135});
 	renderer.drawImageRotated(mCloud1, NAS2D::Point{size.x - 800, -256}, -rotation, NAS2D::Color{180, 0, 255, 150});
 
-	for (std::size_t i = 0; i < mPlanets.size(); ++i)
+	for (auto* planet : mPlanets)
 	{
-		mPlanets[i]->update();
+		planet->update();
 	}
 
 	renderer.drawText(mFontBold, PlanetAttributes[0].name, mPlanets[0]->position() + NAS2D::Vector{64 - (mFontBold.width(PlanetAttributes[0].name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -80,8 +80,7 @@ void PlanetSelectState::initialize()
 	mPlanetDescription.position(NAS2D::Point{viewportSize.x / 2 - 275, viewportSize.y - 225});
 
 	renderer.showSystemPointer(true);
-	renderer.fadeOut(std::chrono::milliseconds{0});
-	renderer.fadeIn(constants::FadeSpeed);
+	mFade.fadeIn(constants::FadeSpeed);
 
 	NAS2D::Utility<NAS2D::Mixer>::get().playMusic(mBgMusic);
 }
@@ -113,7 +112,10 @@ NAS2D::State* PlanetSelectState::update()
 
 	renderer.drawText(mTinyFont, constants::Version, NAS2D::Point{-5, -5} + size - mTinyFont.size(constants::Version), NAS2D::Color::White);
 
-	if (renderer.isFading())
+	mFade.update();
+	mFade.draw(renderer);
+
+	if (mFade.isFading())
 	{
 		return this;
 	}
@@ -142,7 +144,7 @@ void PlanetSelectState::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/,
 		{
 			NAS2D::Utility<NAS2D::Mixer>::get().playSound(mSelect);
 			mPlanetSelection = i;
-			NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(constants::FadeSpeed);
+			mFade.fadeOut(constants::FadeSpeed);
 			NAS2D::Utility<NAS2D::Mixer>::get().fadeOutMusic(constants::FadeSpeed);
 			return;
 		}
@@ -186,6 +188,6 @@ void PlanetSelectState::onWindowResized(NAS2D::Vector<int> newSize)
 
 void PlanetSelectState::onQuit()
 {
-	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(constants::FadeSpeed);
+	mFade.fadeOut(constants::FadeSpeed);
 	mReturnState = new MainMenuState();
 }

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -80,6 +80,7 @@ void PlanetSelectState::initialize()
 	mPlanetDescription.position(NAS2D::Point{viewportSize.x / 2 - 275, viewportSize.y - 225});
 
 	renderer.showSystemPointer(true);
+	renderer.fadeOut(std::chrono::milliseconds{0});
 	renderer.fadeIn(constants::FadeSpeed);
 
 	NAS2D::Utility<NAS2D::Mixer>::get().playMusic(mBgMusic);

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -10,10 +10,11 @@
 #include <NAS2D/State.h>
 #include <NAS2D/Timer.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Resource/Music.h>
 #include <NAS2D/Resource/Sound.h>
-#include <NAS2D/Math/Point.h>
+#include <NAS2D/Renderer/Fade.h>
 
 #include <vector>
 
@@ -60,6 +61,7 @@ private:
 	std::size_t mPlanetSelection{constants::NoSelection};
 
 	NAS2D::Timer mTimer;
+	NAS2D::Fade mFade;
 
 	NAS2D::State* mReturnState = this;
 

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -71,14 +71,16 @@ void SplashState::initialize()
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.showSystemPointer(false);
-	renderer.fadeOut(std::chrono::milliseconds{0});
 }
 
 
 void SplashState::skipSplash()
 {
 	mReturnState = new MainMenuState();
-	NAS2D::Utility<NAS2D::Renderer>::get().fadeOut(fadeLength);
+	if (!mFade.isFading())
+	{
+		mFade.fadeOut(fadeLength);
+	}
 }
 
 
@@ -91,12 +93,12 @@ NAS2D::State* SplashState::update()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	if (renderer.isFaded() && !renderer.isFading() && mTimer.accumulator() > fadePauseTime)
+	if (mFade.isFaded() && !mFade.isFading() && mTimer.accumulator() > fadePauseTime)
 	{
 		if (mReturnState != this) { return mReturnState; }
 
 		currentState = setNextState(currentState);
-		renderer.fadeIn(fadeLength);
+		mFade.fadeIn(fadeLength);
 		mTimer.reset();
 	}
 
@@ -133,7 +135,10 @@ NAS2D::State* SplashState::update()
 		}
 	}
 
-	if (renderer.isFading()) { return this; }
+	mFade.update();
+	mFade.draw(renderer);
+
+	if (mFade.isFaded()) { return this; }
 
 	if (currentState == LogoState::OutpostHD)
 	{
@@ -145,7 +150,7 @@ NAS2D::State* SplashState::update()
 	}
 	else if (mTimer.accumulator() > pauseTime)
 	{
-		renderer.fadeOut(fadeLength);
+		mFade.fadeOut(fadeLength);
 		mTimer.reset();
 	}
 

--- a/OPHD/States/SplashState.h
+++ b/OPHD/States/SplashState.h
@@ -5,6 +5,7 @@
 #include <NAS2D/Timer.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Resource/Image.h>
+#include <NAS2D/Renderer/Fade.h>
 
 
 class SplashState : public NAS2D::State
@@ -34,6 +35,7 @@ private:
 	NAS2D::Point<int> mMousePosition;
 
 	NAS2D::Timer mTimer;
+	NAS2D::Fade mFade;
 
 	NAS2D::State* mReturnState = this;
 };


### PR DESCRIPTION
Use extracted `Fade` control, rather than rely on functionality directly from `Renderer`.

Reference: https://github.com/lairworks/nas2d-core/issues/702, https://github.com/lairworks/nas2d-core/pull/779, PR #599