### PR TITLE
Preconstruct `DelegateX` before calling `connect`/`disconnect`

### DIFF
--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -28,19 +28,19 @@ GameState::~GameState()
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseMotion().disconnect(this, &GameState::onMouseMove);
+	eventHandler.mouseMotion().disconnect({this, &GameState::onMouseMove});
 
-	mMainReportsState->hideReports().disconnect(this, &GameState::onHideReports);
-	mMapView->quit().disconnect(this, &GameState::onQuit);
-	mMapView->showReporstUi().disconnect(this, &GameState::onShowReports);
-	mMapView->mapChanged().disconnect(this, &GameState::onMapChange);
+	mMainReportsState->hideReports().disconnect({this, &GameState::onHideReports});
+	mMapView->quit().disconnect({this, &GameState::onQuit});
+	mMapView->showReporstUi().disconnect({this, &GameState::onShowReports});
+	mMapView->mapChanged().disconnect({this, &GameState::onMapChange});
 
 	for (auto takeMeThere : mMainReportsState->takeMeThere())
 	{
-		takeMeThere->disconnect(this, &GameState::onTakeMeThere);
+		takeMeThere->disconnect({this, &GameState::onTakeMeThere});
 	}
 
-	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().disconnect(MakeDelegate(this, &GameState::onMusicComplete));
+	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().disconnect({MakeDelegate(this, &GameState::onMusicComplete)});
 	NAS2D::Utility<NAS2D::Mixer>::get().stopAllAudio();
 }
 
@@ -51,18 +51,18 @@ GameState::~GameState()
 void GameState::initialize()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseMotion().connect(this, &GameState::onMouseMove);
+	eventHandler.mouseMotion().connect({this, &GameState::onMouseMove});
 
 	mMainReportsState = std::make_unique<MainReportsUiState>();
 	mMainReportsState->_initialize();
-	mMainReportsState->hideReports().connect(this, &GameState::onHideReports);
+	mMainReportsState->hideReports().connect({this, &GameState::onHideReports});
 
 	for (auto takeMeThere : mMainReportsState->takeMeThere())
 	{
-		takeMeThere->connect(this, &GameState::onTakeMeThere);
+		takeMeThere->connect({this, &GameState::onTakeMeThere});
 	}
 
-	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect(MakeDelegate(this, &GameState::onMusicComplete));
+	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect({MakeDelegate(this, &GameState::onMusicComplete)});
 	mFade.fadeIn(constants::FadeSpeed);
 }
 
@@ -82,9 +82,9 @@ void GameState::mapviewstate(MapViewState* state)
 	mMapView.reset(state);
 	mActiveState = mMapView.get();
 
-	mMapView->quit().connect(this, &GameState::onQuit);
-	mMapView->showReporstUi().connect(this, &GameState::onShowReports);
-	mMapView->mapChanged().connect(this, &GameState::onMapChange);
+	mMapView->quit().connect({this, &GameState::onQuit});
+	mMapView->showReporstUi().connect({this, &GameState::onShowReports});
+	mMapView->mapChanged().connect({this, &GameState::onMapChange});
 }
 
 

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -31,11 +31,11 @@ MainMenuState::MainMenuState() :
 MainMenuState::~MainMenuState()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.windowResized().disconnect(this, &MainMenuState::onWindowResized);
-	eventHandler.keyDown().disconnect(this, &MainMenuState::onKeyDown);
+	eventHandler.windowResized().disconnect({this, &MainMenuState::onWindowResized});
+	eventHandler.keyDown().disconnect({this, &MainMenuState::onKeyDown});
 
 	NAS2D::Utility<NAS2D::Mixer>::get().stopAllAudio();
-	mFade.fadeComplete().disconnect(this, &MainMenuState::onFadeComplete);
+	mFade.fadeComplete().disconnect({this, &MainMenuState::onFadeComplete});
 }
 
 
@@ -45,8 +45,8 @@ MainMenuState::~MainMenuState()
 void MainMenuState::initialize()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.windowResized().connect(this, &MainMenuState::onWindowResized);
-	eventHandler.keyDown().connect(this, &MainMenuState::onKeyDown);
+	eventHandler.windowResized().connect({this, &MainMenuState::onWindowResized});
+	eventHandler.keyDown().connect({this, &MainMenuState::onKeyDown});
 
 	for (auto& button : buttons)
 	{
@@ -55,7 +55,7 @@ void MainMenuState::initialize()
 	}
 
 	mFileIoDialog.setMode(FileIo::FileOperation::Load);
-	mFileIoDialog.fileOperation().connect(this, &MainMenuState::onFileIoAction);
+	mFileIoDialog.fileOperation().connect({this, &MainMenuState::onFileIoAction});
 	mFileIoDialog.anchored(false);
 	mFileIoDialog.hide();
 
@@ -68,7 +68,7 @@ void MainMenuState::initialize()
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.showSystemPointer(true);
-	mFade.fadeComplete().connect(this, &MainMenuState::onFadeComplete);
+	mFade.fadeComplete().connect({this, &MainMenuState::onFadeComplete});
 	mFade.fadeIn(constants::FadeSpeed);
 
 	NAS2D::Mixer& mixer = NAS2D::Utility<NAS2D::Mixer>::get();

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -126,18 +126,18 @@ static void drawPanel(NAS2D::Renderer& renderer, Panel& panel)
 MainReportsUiState::MainReportsUiState()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.windowResized().connect(this, &MainReportsUiState::onWindowResized);
-	eventHandler.keyDown().connect(this, &MainReportsUiState::onKeyDown);
-	eventHandler.mouseButtonDown().connect(this, &MainReportsUiState::onMouseDown);
+	eventHandler.windowResized().connect({this, &MainReportsUiState::onWindowResized});
+	eventHandler.keyDown().connect({this, &MainReportsUiState::onKeyDown});
+	eventHandler.mouseButtonDown().connect({this, &MainReportsUiState::onMouseDown});
 }
 
 
 MainReportsUiState::~MainReportsUiState()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.windowResized().disconnect(this, &MainReportsUiState::onWindowResized);
-	eventHandler.keyDown().disconnect(this, &MainReportsUiState::onKeyDown);
-	eventHandler.mouseButtonDown().disconnect(this, &MainReportsUiState::onMouseDown);
+	eventHandler.windowResized().disconnect({this, &MainReportsUiState::onWindowResized});
+	eventHandler.keyDown().disconnect({this, &MainReportsUiState::onKeyDown});
+	eventHandler.mouseButtonDown().disconnect({this, &MainReportsUiState::onMouseDown});
 
 	for (Panel& panel : Panels)
 	{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -160,7 +160,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 	mRobotDeploymentSummary{mRobotPool}
 {
 	ccLocation() = CcNotPlaced;
-	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);
+	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
 }
 
 
@@ -179,7 +179,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 {
 	difficulty(selectedDifficulty);
 	ccLocation() = CcNotPlaced;
-	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect(this, &MapViewState::onWindowResized);
+	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
 }
 
 
@@ -193,14 +193,14 @@ MapViewState::~MapViewState()
 	NAS2D::Utility<NAS2D::Renderer>::get().setCursor(PointerType::POINTER_NORMAL);
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.activate().disconnect(this, &MapViewState::onActivate);
-	eventHandler.keyDown().disconnect(this, &MapViewState::onKeyDown);
-	eventHandler.mouseButtonDown().disconnect(this, &MapViewState::onMouseDown);
-	eventHandler.mouseButtonUp().disconnect(this, &MapViewState::onMouseUp);
-	eventHandler.mouseDoubleClick().disconnect(this, &MapViewState::onMouseDoubleClick);
-	eventHandler.mouseMotion().disconnect(this, &MapViewState::onMouseMove);
-	eventHandler.mouseWheel().disconnect(this, &MapViewState::onMouseWheel);
-	eventHandler.windowResized().disconnect(this, &MapViewState::onWindowResized);
+	eventHandler.activate().disconnect({this, &MapViewState::onActivate});
+	eventHandler.keyDown().disconnect({this, &MapViewState::onKeyDown});
+	eventHandler.mouseButtonDown().disconnect({this, &MapViewState::onMouseDown});
+	eventHandler.mouseButtonUp().disconnect({this, &MapViewState::onMouseUp});
+	eventHandler.mouseDoubleClick().disconnect({this, &MapViewState::onMouseDoubleClick});
+	eventHandler.mouseMotion().disconnect({this, &MapViewState::onMouseMove});
+	eventHandler.mouseWheel().disconnect({this, &MapViewState::onMouseWheel});
+	eventHandler.windowResized().disconnect({this, &MapViewState::onWindowResized});
 
 	eventHandler.textInputMode(false);
 
@@ -247,13 +247,13 @@ void MapViewState::initialize()
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 
-	eventHandler.activate().connect(this, &MapViewState::onActivate);
-	eventHandler.keyDown().connect(this, &MapViewState::onKeyDown);
-	eventHandler.mouseButtonDown().connect(this, &MapViewState::onMouseDown);
-	eventHandler.mouseButtonUp().connect(this, &MapViewState::onMouseUp);
-	eventHandler.mouseDoubleClick().connect(this, &MapViewState::onMouseDoubleClick);
-	eventHandler.mouseMotion().connect(this, &MapViewState::onMouseMove);
-	eventHandler.mouseWheel().connect(this, &MapViewState::onMouseWheel);
+	eventHandler.activate().connect({this, &MapViewState::onActivate});
+	eventHandler.keyDown().connect({this, &MapViewState::onKeyDown});
+	eventHandler.mouseButtonDown().connect({this, &MapViewState::onMouseDown});
+	eventHandler.mouseButtonUp().connect({this, &MapViewState::onMouseUp});
+	eventHandler.mouseDoubleClick().connect({this, &MapViewState::onMouseDoubleClick});
+	eventHandler.mouseMotion().connect({this, &MapViewState::onMouseMove});
+	eventHandler.mouseWheel().connect({this, &MapViewState::onMouseWheel});
 
 	eventHandler.textInputMode(true);
 
@@ -825,7 +825,7 @@ void MapViewState::placeStructure(Tile& tile)
 		if (!validLanderSite(tile)) { return; }
 
 		auto& s = *new ColonistLander(&tile);
-		s.deploySignal().connect(this, &MapViewState::onDeployColonistLander);
+		s.deploySignal().connect({this, &MapViewState::onDeployColonistLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
 
 		--mLandersColonist;
@@ -841,7 +841,7 @@ void MapViewState::placeStructure(Tile& tile)
 		if (!validLanderSite(tile)) { return; }
 
 		auto& cargoLander = *new CargoLander(&tile);
-		cargoLander.deploySignal().connect(this, &MapViewState::onDeployCargoLander);
+		cargoLander.deploySignal().connect({this, &MapViewState::onDeployCargoLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(cargoLander, tile);
 
 		--mLandersCargo;
@@ -873,7 +873,7 @@ void MapViewState::placeStructure(Tile& tile)
 		if (structure.isFactory())
 		{
 			auto& factory = static_cast<Factory&>(structure);
-			factory.productionComplete().connect(this, &MapViewState::onFactoryProductionComplete);
+			factory.productionComplete().connect({this, &MapViewState::onFactoryProductionComplete});
 			factory.resourcePool(&mResourcesCount);
 		}
 
@@ -1172,7 +1172,7 @@ Robot& MapViewState::addRobot(Robot::Type type)
 	}
 
 	auto& robot = mRobotPool.addRobot(type);
-	robot.taskComplete().connect(this, RobotTypeToHandler.at(type));
+	robot.taskComplete().connect({this, RobotTypeToHandler.at(type)});
 	return robot;
 }
 
@@ -1213,7 +1213,7 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 		}
 
 		auto& s = *new SeedLander(point);
-		s.deploySignal().connect(this, &MapViewState::onDeploySeedLander);
+		s.deploySignal().connect({this, &MapViewState::onDeploySeedLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(s, mTileMap->getTile({point, 0})); // Can only ever be placed on depth level 0
 
 		clearMode();

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -142,7 +142,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	// BOTTOM ROW
 	auto& sf = *static_cast<SeedFactory*>(StructureCatalogue::get(StructureID::SID_SEED_FACTORY));
 	sf.resourcePool(&mResourcesCount);
-	sf.productionComplete().connect(this, &MapViewState::onFactoryProductionComplete);
+	sf.productionComplete().connect({this, &MapViewState::onFactoryProductionComplete});
 	sf.sprite().setFrame(7);
 	structureManager.addStructure(sf, mTileMap->getTile({point + DirectionSouthWest, 0}));
 
@@ -156,9 +156,9 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	mRobots.addItem({constants::Robominer, constants::RobominerSheetId, static_cast<int>(Robot::Type::Miner)});
 	mRobots.sort();
 
-	mRobotPool.addRobot(Robot::Type::Dozer).taskComplete().connect(this, &MapViewState::onDozerTaskComplete);
-	mRobotPool.addRobot(Robot::Type::Digger).taskComplete().connect(this, &MapViewState::onDiggerTaskComplete);
-	mRobotPool.addRobot(Robot::Type::Miner).taskComplete().connect(this, &MapViewState::onMinerTaskComplete);
+	mRobotPool.addRobot(Robot::Type::Dozer).taskComplete().connect({this, &MapViewState::onDozerTaskComplete});
+	mRobotPool.addRobot(Robot::Type::Digger).taskComplete().connect({this, &MapViewState::onDiggerTaskComplete});
+	mRobotPool.addRobot(Robot::Type::Miner).taskComplete().connect({this, &MapViewState::onMinerTaskComplete});
 }
 
 
@@ -240,7 +240,7 @@ void MapViewState::onMinerTaskComplete(Robot* robot)
 	auto& mineFacility = *new MineFacility(robotTile.mine());
 	mineFacility.maxDepth(mTileMap->maxDepth());
 	NAS2D::Utility<StructureManager>::get().addStructure(mineFacility, robotTile);
-	mineFacility.extensionComplete().connect(this, &MapViewState::onMineFacilityExtend);
+	mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});
 
 	// Tile immediately underneath facility.
 	auto& tileBelow = mTileMap->getTile({robotTile.xy(), robotTile.depth() + 1});

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -351,7 +351,7 @@ void MapViewState::load(const std::string& filePath)
 			SeedLander* seedLander = list[0];
 			if (!seedLander) { throw std::runtime_error("MapViewState::load(): Structure in list is not a SeedLander."); }
 
-			seedLander->deploySignal().connect(this, &MapViewState::onDeploySeedLander);
+			seedLander->deploySignal().connect({this, &MapViewState::onDeploySeedLander});
 
 			mStructures.clear();
 			mConnections.clear();
@@ -475,7 +475,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element, const std::ma
 			auto& mineFacility = *static_cast<MineFacility*>(&structure);
 			mineFacility.mine(mine);
 			mineFacility.maxDepth(mTileMap->maxDepth());
-			mineFacility.extensionComplete().connect(this, &MapViewState::onMineFacilityExtend);
+			mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});
 
 			auto trucks = structureElement->firstChildElement("trucks");
 			if (trucks)
@@ -561,7 +561,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element, const std::ma
 			factory.productType(static_cast<ProductType>(production_type));
 			factory.productionTurnsCompleted(production_completed);
 			factory.resourcePool(&mResourcesCount);
-			factory.productionComplete().connect(this, &MapViewState::onFactoryProductionComplete);
+			factory.productionComplete().connect({this, &MapViewState::onFactoryProductionComplete});
 		}
 
 		if (structure.isRobotCommand())

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -51,10 +51,10 @@ void MapViewState::initUi()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	mCheatMenu.cheatCodeEntered().connect(this, &MapViewState::onCheatCodeEntry);
+	mCheatMenu.cheatCodeEntered().connect({this, &MapViewState::onCheatCodeEntry});
 	mCheatMenu.hide();
 
-	mDiggerDirection.directionSelected().connect(this, &MapViewState::onDiggerSelectionDialog);
+	mDiggerDirection.directionSelected().connect({this, &MapViewState::onDiggerSelectionDialog});
 	mDiggerDirection.hide();
 
 	mTileInspector.position(renderer.center() - NAS2D::Vector{mTileInspector.size().x / 2.0f, 175.0f});
@@ -70,7 +70,7 @@ void MapViewState::initUi()
 	mFactoryProduction.hide();
 
 	mFileIoDialog.setMode(FileIo::FileOperation::Save);
-	mFileIoDialog.fileOperation().connect(this, &MapViewState::onFileIoAction);
+	mFileIoDialog.fileOperation().connect({this, &MapViewState::onFileIoAction});
 	mFileIoDialog.anchored(true);
 	mFileIoDialog.hide();
 
@@ -80,13 +80,13 @@ void MapViewState::initUi()
 	mResourceBreakdownPanel.position({0, 22});
 	mResourceBreakdownPanel.playerResources(&mResourcesCount);
 
-	mGameOverDialog.returnToMainMenu().connect(this, &MapViewState::onGameOver);
+	mGameOverDialog.returnToMainMenu().connect({this, &MapViewState::onGameOver});
 	mGameOverDialog.hide();
 
-	mGameOptionsDialog.SaveGame().connect(this, &MapViewState::onSaveGame);
-	mGameOptionsDialog.LoadGame().connect(this, &MapViewState::onLoadGame);
-	mGameOptionsDialog.returnToGame().connect(this, &MapViewState::onReturnToGame);
-	mGameOptionsDialog.returnToMainMenu().connect(this, &MapViewState::onGameOver);
+	mGameOptionsDialog.SaveGame().connect({this, &MapViewState::onSaveGame});
+	mGameOptionsDialog.LoadGame().connect({this, &MapViewState::onLoadGame});
+	mGameOptionsDialog.returnToGame().connect({this, &MapViewState::onReturnToGame});
+	mGameOptionsDialog.returnToMainMenu().connect({this, &MapViewState::onGameOver});
 	mGameOptionsDialog.hide();
 
 	mAnnouncement.hide();
@@ -104,9 +104,9 @@ void MapViewState::initUi()
 	mWindowStack.addWindow(&mNotificationWindow);
 	mWindowStack.addWindow(&mCheatMenu);
 
-	mNotificationArea.notificationClicked().connect(this, &MapViewState::onNotificationClicked);
+	mNotificationArea.notificationClicked().connect({this, &MapViewState::onNotificationClicked});
 
-	mNotificationWindow.takeMeThere().connect(this, &MapViewState::onTakeMeThere);
+	mNotificationWindow.takeMeThere().connect({this, &MapViewState::onTakeMeThere});
 	mNotificationWindow.hide();
 
 	const auto size = renderer.size().to<int>();
@@ -116,48 +116,48 @@ void MapViewState::initUi()
 	mBtnTurns.image("ui/icons/turns.png");
 	mBtnTurns.position(NAS2D::Point{mMiniMapBoundingBox.x - constants::MainButtonSize - constants::MarginTight, size.y - constants::Margin - constants::MainButtonSize});
 	mBtnTurns.size(constants::MainButtonSize);
-	mBtnTurns.click().connect(this, &MapViewState::onTurns);
+	mBtnTurns.click().connect({this, &MapViewState::onTurns});
 	mBtnTurns.enabled(false);
 
 	mBtnToggleHeightmap.image("ui/icons/height.png");
 	mBtnToggleHeightmap.size(constants::MainButtonSize);
 	mBtnToggleHeightmap.type(Button::Type::Toggle);
-	mBtnToggleHeightmap.click().connect(this, &MapViewState::onToggleHeightmap);
+	mBtnToggleHeightmap.click().connect({this, &MapViewState::onToggleHeightmap});
 
 	mBtnToggleConnectedness.image("ui/icons/connection.png");
 	mBtnToggleConnectedness.size(constants::MainButtonSize);
 	mBtnToggleConnectedness.type(Button::Type::Toggle);
-	mBtnToggleConnectedness.click().connect(this, &MapViewState::onToggleConnectedness);
+	mBtnToggleConnectedness.click().connect({this, &MapViewState::onToggleConnectedness});
 
 	mBtnToggleCommRangeOverlay.image("ui/icons/comm_overlay.png");
 	mBtnToggleCommRangeOverlay.size(constants::MainButtonSize);
 	mBtnToggleCommRangeOverlay.type(Button::Type::Toggle);
-	mBtnToggleCommRangeOverlay.click().connect(this, &MapViewState::onToggleCommRangeOverlay);
+	mBtnToggleCommRangeOverlay.click().connect({this, &MapViewState::onToggleCommRangeOverlay});
 
 	mBtnToggleRouteOverlay.image("ui/icons/route.png");
 	mBtnToggleRouteOverlay.size(constants::MainButtonSize);
 	mBtnToggleRouteOverlay.type(Button::Type::Toggle);
-	mBtnToggleRouteOverlay.click().connect(this, &MapViewState::onToggleRouteOverlay);
+	mBtnToggleRouteOverlay.click().connect({this, &MapViewState::onToggleRouteOverlay});
 
 	mBtnTogglePoliceOverlay.image("ui/icons/police.png");
 	mBtnTogglePoliceOverlay.size(constants::MainButtonSize);
 	mBtnTogglePoliceOverlay.type(Button::Type::Toggle);
-	mBtnTogglePoliceOverlay.click().connect(this, &MapViewState::onTogglePoliceOverlay);
+	mBtnTogglePoliceOverlay.click().connect({this, &MapViewState::onTogglePoliceOverlay});
 
 	// Menus
 	mRobots.position({mBtnTurns.positionX() - constants::MarginTight - 52, mBottomUiRect.y + constants::Margin});
 	mRobots.size({52, constants::BottomUiHeight - constants::Margin * 2});
 	mRobots.showTooltip(true);
-	mRobots.selectionChanged().connect(this, &MapViewState::onRobotsSelectionChange);
+	mRobots.selectionChanged().connect({this, &MapViewState::onRobotsSelectionChange});
 
 	mConnections.position({mRobots.positionX() - constants::MarginTight - 52, mBottomUiRect.y + constants::Margin});
 	mConnections.size({52, constants::BottomUiHeight - constants::Margin * 2});
-	mConnections.selectionChanged().connect(this, &MapViewState::onConnectionsSelectionChange);
+	mConnections.selectionChanged().connect({this, &MapViewState::onConnectionsSelectionChange});
 
 	mStructures.position(NAS2D::Point{constants::Margin, mBottomUiRect.y + constants::Margin});
 	mStructures.size({mConnections.positionX() - constants::Margin - constants::MarginTight, constants::BottomUiHeight - constants::Margin * 2});
 	mStructures.showTooltip(true);
-	mStructures.selectionChanged().connect(this, &MapViewState::onStructuresSelectionChange);
+	mStructures.selectionChanged().connect({this, &MapViewState::onStructuresSelectionChange});
 
 	// Initial Structures
 	mStructures.addItem({constants::SeedLander, 0, StructureID::SID_SEED_LANDER});

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -26,13 +26,13 @@ Planet::Planet(const Attributes& attributes) :
 	mAttributes(attributes),
 	mImage(NAS2D::Image(attributes.imagePath))
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect(this, &Planet::onMouseMove);
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &Planet::onMouseMove});
 }
 
 
 Planet::~Planet()
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect(this, &Planet::onMouseMove);
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect({this, &Planet::onMouseMove});
 }
 
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -35,8 +35,8 @@ PlanetSelectState::PlanetSelectState() :
 PlanetSelectState::~PlanetSelectState()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseButtonDown().disconnect(this, &PlanetSelectState::onMouseDown);
-	eventHandler.windowResized().disconnect(this, &PlanetSelectState::onWindowResized);
+	eventHandler.mouseButtonDown().disconnect({this, &PlanetSelectState::onMouseDown});
+	eventHandler.windowResized().disconnect({this, &PlanetSelectState::onWindowResized});
 
 	for (auto planet : mPlanets) { delete planet; }
 
@@ -47,8 +47,8 @@ PlanetSelectState::~PlanetSelectState()
 void PlanetSelectState::initialize()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseButtonDown().connect(this, &PlanetSelectState::onMouseDown);
-	eventHandler.windowResized().connect(this, &PlanetSelectState::onWindowResized);
+	eventHandler.mouseButtonDown().connect({this, &PlanetSelectState::onMouseDown});
+	eventHandler.windowResized().connect({this, &PlanetSelectState::onWindowResized});
 
 	for (const auto& planetAttribute : PlanetAttributes)
 	{
@@ -60,16 +60,16 @@ void PlanetSelectState::initialize()
 	const auto centralPlanetPosition = NAS2D::Point{-64, -64} + viewportSize / 2;
 	const auto sidePlanetOffset = NAS2D::Vector{viewportSize.x / 4, 0};
 	mPlanets[0]->position(centralPlanetPosition - sidePlanetOffset);
-	mPlanets[0]->mouseEnter().connect(this, &PlanetSelectState::onMousePlanetEnter);
-	mPlanets[0]->mouseExit().connect(this, &PlanetSelectState::onMousePlanetExit);
+	mPlanets[0]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
+	mPlanets[0]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 
 	mPlanets[1]->position(centralPlanetPosition);
-	mPlanets[1]->mouseEnter().connect(this, &PlanetSelectState::onMousePlanetEnter);
-	mPlanets[1]->mouseExit().connect(this, &PlanetSelectState::onMousePlanetExit);
+	mPlanets[1]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
+	mPlanets[1]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 
 	mPlanets[2]->position(centralPlanetPosition + sidePlanetOffset);
-	mPlanets[2]->mouseEnter().connect(this, &PlanetSelectState::onMousePlanetEnter);
-	mPlanets[2]->mouseExit().connect(this, &PlanetSelectState::onMousePlanetExit);
+	mPlanets[2]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
+	mPlanets[2]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 
 	mQuit.size({100, 20});
 	mQuit.position({renderer.size().x - 105, 30});

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -58,16 +58,16 @@ SplashState::SplashState() :
 SplashState::~SplashState()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.keyDown().disconnect(this, &SplashState::onKeyDown);
-	eventHandler.mouseButtonDown().disconnect(this, &SplashState::onMouseDown);
+	eventHandler.keyDown().disconnect({this, &SplashState::onKeyDown});
+	eventHandler.mouseButtonDown().disconnect({this, &SplashState::onMouseDown});
 }
 
 
 void SplashState::initialize()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.keyDown().connect(this, &SplashState::onKeyDown);
-	eventHandler.mouseButtonDown().connect(this, &SplashState::onMouseDown);
+	eventHandler.keyDown().connect({this, &SplashState::onKeyDown});
+	eventHandler.mouseButtonDown().connect({this, &SplashState::onMouseDown});
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.showSystemPointer(false);

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -52,9 +52,9 @@ Button::Button(std::string newText) :
 	text(newText);
 
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().connect(this, &Button::onMouseDown);
-	eventHandler.mouseButtonUp().connect(this, &Button::onMouseUp);
-	eventHandler.mouseMotion().connect(this, &Button::onMouseMove);
+	eventHandler.mouseButtonDown().connect({this, &Button::onMouseDown});
+	eventHandler.mouseButtonUp().connect({this, &Button::onMouseUp});
+	eventHandler.mouseMotion().connect({this, &Button::onMouseMove});
 
 	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
 }
@@ -62,23 +62,23 @@ Button::Button(std::string newText) :
 
 Button::Button(std::string newText, ClickSignal::DelegateType clickHandler) : Button(newText)
 {
-	mSignal.connect(clickHandler);
+	mSignal.connect({clickHandler});
 }
 
 
 Button::Button(const ButtonSkin& buttonSkin, ClickSignal::DelegateType clickHandler) :
 	mButtonSkin{buttonSkin}
 {
-	mSignal.connect(clickHandler);
+	mSignal.connect({clickHandler});
 }
 
 
 Button::~Button()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().disconnect(this, &Button::onMouseDown);
-	eventHandler.mouseButtonUp().disconnect(this, &Button::onMouseUp);
-	eventHandler.mouseMotion().disconnect(this, &Button::onMouseMove);
+	eventHandler.mouseButtonDown().disconnect({this, &Button::onMouseDown});
+	eventHandler.mouseButtonUp().disconnect({this, &Button::onMouseUp});
+	eventHandler.mouseMotion().disconnect({this, &Button::onMouseMove});
 }
 
 

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -32,19 +32,19 @@ CheckBox::CheckBox(std::string newText) :
 	mSkin{imageCache.load("ui/skin/checkbox.png")}
 {
 	text(newText);
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &CheckBox::onMouseDown);
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &CheckBox::onMouseDown});
 }
 
 
 CheckBox::CheckBox(std::string newText, ClickSignal::DelegateType clickHandler) : CheckBox(newText)
 {
-	mSignal.connect(clickHandler);
+	mSignal.connect({clickHandler});
 }
 
 
 CheckBox::~CheckBox()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &CheckBox::onMouseDown);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &CheckBox::onMouseDown});
 }
 
 

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -17,7 +17,7 @@ ComboBox::ComboBox() :
 	UIContainer{{&btnDown, &txtField, &lstItems}}
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseWheel().connect(this, &ComboBox::onMouseWheel);
+	eventHandler.mouseWheel().connect({this, &ComboBox::onMouseWheel});
 
 	btnDown.image("ui/icons/down.png");
 	btnDown.size({20, 20});
@@ -26,15 +26,15 @@ ComboBox::ComboBox() :
 	lstItems.visible(false);
 	lstItems.height(300);
 
-	lstItems.selectionChanged().connect(this, &ComboBox::onListSelectionChange);
+	lstItems.selectionChanged().connect({this, &ComboBox::onListSelectionChange});
 }
 
 
 ComboBox::~ComboBox()
 {
-	lstItems.selectionChanged().disconnect(this, &ComboBox::onListSelectionChange);
+	lstItems.selectionChanged().disconnect({this, &ComboBox::onListSelectionChange});
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseWheel().disconnect(this, &ComboBox::onMouseWheel);
+	eventHandler.mouseWheel().disconnect({this, &ComboBox::onMouseWheel});
 }
 
 

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -64,22 +64,22 @@ public:
 	ListBox() :
 		mContext{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)}
 	{
-		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
-		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
-		NAS2D::Utility<NAS2D::EventHandler>::get().mouseWheel().connect(this, &ListBox::onMouseWheel);
+		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &ListBox::onMouseDown});
+		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &ListBox::onMouseMove});
+		NAS2D::Utility<NAS2D::EventHandler>::get().mouseWheel().connect({this, &ListBox::onMouseWheel});
 
 		mScrollBar.max(0);
 		mScrollBar.value(0);
-		mScrollBar.change().connect(this, &ListBox::onSlideChange);
+		mScrollBar.change().connect({this, &ListBox::onSlideChange});
 		updateScrollLayout();
 	}
 
 	~ListBox() override {
-		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect(this, &ListBox::onMouseDown);
-		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect(this, &ListBox::onMouseMove);
-		NAS2D::Utility<NAS2D::EventHandler>::get().mouseWheel().disconnect(this, &ListBox::onMouseWheel);
+		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &ListBox::onMouseDown});
+		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect({this, &ListBox::onMouseMove});
+		NAS2D::Utility<NAS2D::EventHandler>::get().mouseWheel().disconnect({this, &ListBox::onMouseWheel});
 
-		mScrollBar.change().disconnect(this, &ListBox::onSlideChange);
+		mScrollBar.change().disconnect({this, &ListBox::onSlideChange});
 	}
 
 	bool isEmpty() const {

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -16,13 +16,13 @@ using namespace NAS2D;
 ListBoxBase::ListBoxBase()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseWheel().connect(this, &ListBoxBase::onMouseWheel);
-	eventHandler.mouseButtonDown().connect(this, &ListBoxBase::onMouseDown);
-	eventHandler.mouseMotion().connect(this, &ListBoxBase::onMouseMove);
+	eventHandler.mouseWheel().connect({this, &ListBoxBase::onMouseWheel});
+	eventHandler.mouseButtonDown().connect({this, &ListBoxBase::onMouseDown});
+	eventHandler.mouseMotion().connect({this, &ListBoxBase::onMouseMove});
 
 	mScrollBar.max(0);
 	mScrollBar.value(0);
-	mScrollBar.change().connect(this, &ListBoxBase::onSlideChange);
+	mScrollBar.change().connect({this, &ListBoxBase::onSlideChange});
 
 	updateScrollLayout();
 }
@@ -30,12 +30,12 @@ ListBoxBase::ListBoxBase()
 
 ListBoxBase::~ListBoxBase()
 {
-	mScrollBar.change().disconnect(this, &ListBoxBase::onSlideChange);
+	mScrollBar.change().disconnect({this, &ListBoxBase::onSlideChange});
 
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseWheel().disconnect(this, &ListBoxBase::onMouseWheel);
-	eventHandler.mouseButtonDown().disconnect(this, &ListBoxBase::onMouseDown);
-	eventHandler.mouseMotion().disconnect(this, &ListBoxBase::onMouseMove);
+	eventHandler.mouseWheel().disconnect({this, &ListBoxBase::onMouseWheel});
+	eventHandler.mouseButtonDown().disconnect({this, &ListBoxBase::onMouseDown});
+	eventHandler.mouseMotion().disconnect({this, &ListBoxBase::onMouseMove});
 
 	for (auto item : mItems) { delete item; }
 }

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -11,15 +11,15 @@ RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup* parentContainer, st
 	mParentContainer{parentContainer}
 {
 	text(newText);
-	mSignal.connect(delegate);
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &RadioButtonGroup::RadioButton::onMouseDown);
+	mSignal.connect({delegate});
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &RadioButtonGroup::RadioButton::onMouseDown});
 	onTextChange();
 }
 
 
 RadioButtonGroup::RadioButton::~RadioButton()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &RadioButtonGroup::RadioButton::onMouseDown);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &RadioButtonGroup::RadioButton::onMouseDown});
 }
 
 

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -127,18 +127,18 @@ ScrollBar::ScrollBar(ScrollBar::Skins skins, ScrollBarType scrollBarType) :
 	mSkins{skins}
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().connect(this, &ScrollBar::onMouseDown);
-	eventHandler.mouseButtonUp().connect(this, &ScrollBar::onMouseUp);
-	eventHandler.mouseMotion().connect(this, &ScrollBar::onMouseMove);
+	eventHandler.mouseButtonDown().connect({this, &ScrollBar::onMouseDown});
+	eventHandler.mouseButtonUp().connect({this, &ScrollBar::onMouseUp});
+	eventHandler.mouseMotion().connect({this, &ScrollBar::onMouseMove});
 }
 
 
 ScrollBar::~ScrollBar()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().disconnect(this, &ScrollBar::onMouseDown);
-	eventHandler.mouseButtonUp().disconnect(this, &ScrollBar::onMouseUp);
-	eventHandler.mouseMotion().disconnect(this, &ScrollBar::onMouseMove);
+	eventHandler.mouseButtonDown().disconnect({this, &ScrollBar::onMouseDown});
+	eventHandler.mouseButtonUp().disconnect({this, &ScrollBar::onMouseUp});
+	eventHandler.mouseMotion().disconnect({this, &ScrollBar::onMouseMove});
 }
 
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -53,9 +53,9 @@ TextField::TextField() :
 	}
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().connect(this, &TextField::onMouseDown);
-	eventHandler.keyDown().connect(this, &TextField::onKeyDown);
-	eventHandler.textInput().connect(this, &TextField::onTextInput);
+	eventHandler.mouseButtonDown().connect({this, &TextField::onMouseDown});
+	eventHandler.keyDown().connect({this, &TextField::onKeyDown});
+	eventHandler.textInput().connect({this, &TextField::onTextInput});
 
 	eventHandler.textInputMode(true);
 
@@ -66,9 +66,9 @@ TextField::TextField() :
 TextField::~TextField()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().disconnect(this, &TextField::onMouseDown);
-	eventHandler.keyDown().disconnect(this, &TextField::onKeyDown);
-	eventHandler.textInput().disconnect(this, &TextField::onTextInput);
+	eventHandler.mouseButtonDown().disconnect({this, &TextField::onMouseDown});
+	eventHandler.keyDown().disconnect({this, &TextField::onKeyDown});
+	eventHandler.textInput().disconnect({this, &TextField::onTextInput});
 }
 
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -14,13 +14,13 @@ using namespace NAS2D;
 ToolTip::ToolTip():
 	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)}
 {
-	Utility<EventHandler>::get().mouseMotion().connect(this, &ToolTip::onMouseMove);
+	Utility<EventHandler>::get().mouseMotion().connect({this, &ToolTip::onMouseMove});
 }
 
 
 ToolTip::~ToolTip()
 {
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &ToolTip::onMouseMove);
+	Utility<EventHandler>::get().mouseMotion().disconnect({this, &ToolTip::onMouseMove});
 }
 
 

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -19,13 +19,13 @@ UIContainer::UIContainer() : UIContainer{{}}
 UIContainer::UIContainer(std::vector<Control*> controls) :
 	mControls{std::move(controls)}
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &UIContainer::onMouseDown);
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &UIContainer::onMouseDown});
 }
 
 
 UIContainer::~UIContainer()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &UIContainer::onMouseDown);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &UIContainer::onMouseDown});
 }
 
 

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -31,16 +31,16 @@ Window::Window(std::string newTitle) :
 	title(newTitle);
 
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonUp().connect(this, &Window::onMouseUp);
-	eventHandler.mouseMotion().connect(this, &Window::onMouseMove);
+	eventHandler.mouseButtonUp().connect({this, &Window::onMouseUp});
+	eventHandler.mouseMotion().connect({this, &Window::onMouseMove});
 }
 
 
 Window::~Window()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonUp().disconnect(this, &Window::onMouseUp);
-	eventHandler.mouseMotion().disconnect(this, &Window::onMouseMove);
+	eventHandler.mouseButtonUp().disconnect({this, &Window::onMouseUp});
+	eventHandler.mouseMotion().disconnect({this, &Window::onMouseMove});
 }
 
 

--- a/OPHD/UI/DiggerDirection.cpp
+++ b/OPHD/UI/DiggerDirection.cpp
@@ -13,31 +13,31 @@ DiggerDirection::DiggerDirection() :
 	add(btnDown, {5, 25});
 	btnDown.image("ui/icons/arrow-down.png");
 	btnDown.size({64, 34});
-	btnDown.click().connect(this, &DiggerDirection::onDiggerDown);
+	btnDown.click().connect({this, &DiggerDirection::onDiggerDown});
 
 	add(btnWest, {5, 68});
 	btnWest.image("ui/icons/arrow-west.png");
 	btnWest.size({32, 32});
-	btnWest.click().connect(this, &DiggerDirection::onDiggerWest);
+	btnWest.click().connect({this, &DiggerDirection::onDiggerWest});
 
 	add(btnNorth, {38, 68});
 	btnNorth.image("ui/icons/arrow-north.png");
 	btnNorth.size({32, 32});
-	btnNorth.click().connect(this, &DiggerDirection::onDiggerNorth);
+	btnNorth.click().connect({this, &DiggerDirection::onDiggerNorth});
 
 	add(btnSouth, {5, 101});
 	btnSouth.image("ui/icons/arrow-south.png");
 	btnSouth.size({32, 32});
-	btnSouth.click().connect(this, &DiggerDirection::onDiggerSouth);
+	btnSouth.click().connect({this, &DiggerDirection::onDiggerSouth});
 
 	add(btnEast, {38, 101});
 	btnEast.image("ui/icons/arrow-east.png");
 	btnEast.size({32, 32});
-	btnEast.click().connect(this, &DiggerDirection::onDiggerEast);
+	btnEast.click().connect({this, &DiggerDirection::onDiggerEast});
 
 	add(btnCancel, {5, 140});
 	btnCancel.size({64, 25});
-	btnCancel.click().connect(this, &DiggerDirection::onCancel);
+	btnCancel.click().connect({this, &DiggerDirection::onCancel});
 }
 
 

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -23,7 +23,7 @@ FactoryProduction::FactoryProduction() :
 	mProductGrid.size({140, 110});
 	mProductGrid.showTooltip(true);
 	mProductGrid.hide();
-	mProductGrid.selectionChanged().connect(this, &FactoryProduction::onProductSelectionChange);
+	mProductGrid.selectionChanged().connect({this, &FactoryProduction::onProductSelectionChange});
 
 	add(btnOkay, {233, 138});
 	btnOkay.size({40, 20});
@@ -39,7 +39,7 @@ FactoryProduction::FactoryProduction() :
 
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 	chkIdle.size({50, 20});
-	chkIdle.click().connect(this, &FactoryProduction::onCheckBoxIdleChange);
+	chkIdle.click().connect({this, &FactoryProduction::onCheckBoxIdleChange});
 }
 
 

--- a/OPHD/UI/FileIo.cpp
+++ b/OPHD/UI/FileIo.cpp
@@ -27,8 +27,8 @@ FileIo::FileIo() :
 	btnFileDelete{"Delete", {this, &FileIo::onFileDelete}}
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseDoubleClick().connect(this, &FileIo::onDoubleClick);
-	eventHandler.keyDown().connect(this, &FileIo::onKeyDown);
+	eventHandler.mouseDoubleClick().connect({this, &FileIo::onDoubleClick});
+	eventHandler.keyDown().connect({this, &FileIo::onKeyDown});
 
 	size({700, 350});
 
@@ -51,20 +51,20 @@ FileIo::FileIo() :
 	add(txtFileName, {5, 302});
 	txtFileName.size({690, 18});
 	txtFileName.maxCharacters(50);
-	txtFileName.textChanged().connect(this, &FileIo::onFileNameChange);
+	txtFileName.textChanged().connect({this, &FileIo::onFileNameChange});
 
 	add(mListBox, {5, 45});
 	mListBox.size({690, 253});
 	mListBox.visible(true);
-	mListBox.selectionChanged().connect(this, &FileIo::onFileSelect);
+	mListBox.selectionChanged().connect({this, &FileIo::onFileSelect});
 }
 
 
 FileIo::~FileIo()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseDoubleClick().disconnect(this, &FileIo::onDoubleClick);
-	eventHandler.keyDown().disconnect(this, &FileIo::onKeyDown);
+	eventHandler.mouseDoubleClick().disconnect({this, &FileIo::onDoubleClick});
+	eventHandler.keyDown().disconnect({this, &FileIo::onKeyDown});
 }
 
 

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -32,10 +32,10 @@ GameOptionsDialog::GameOptionsDialog() :
 
 GameOptionsDialog::~GameOptionsDialog()
 {
-	btnSave.click().disconnect(this, &GameOptionsDialog::onSave);
-	btnLoad.click().disconnect(this, &GameOptionsDialog::onLoad);
-	btnReturn.click().disconnect(this, &GameOptionsDialog::onReturn);
-	btnClose.click().disconnect(this, &GameOptionsDialog::onClose);
+	btnSave.click().disconnect({this, &GameOptionsDialog::onSave});
+	btnLoad.click().disconnect({this, &GameOptionsDialog::onLoad});
+	btnReturn.click().disconnect({this, &GameOptionsDialog::onReturn});
+	btnClose.click().disconnect({this, &GameOptionsDialog::onClose});
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -42,16 +42,16 @@ IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
 	}
 
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().connect(this, &IconGrid::onMouseDown);
-	eventHandler.mouseMotion().connect(this, &IconGrid::onMouseMove);
+	eventHandler.mouseButtonDown().connect({this, &IconGrid::onMouseDown});
+	eventHandler.mouseMotion().connect({this, &IconGrid::onMouseMove});
 }
 
 
 IconGrid::~IconGrid()
 {
 	auto& eventHandler = Utility<EventHandler>::get();
-	eventHandler.mouseButtonDown().disconnect(this, &IconGrid::onMouseDown);
-	eventHandler.mouseMotion().disconnect(this, &IconGrid::onMouseMove);
+	eventHandler.mouseButtonDown().disconnect({this, &IconGrid::onMouseDown});
+	eventHandler.mouseMotion().disconnect({this, &IconGrid::onMouseMove});
 }
 
 

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -55,8 +55,8 @@ NotificationArea::NotificationArea() :
 {
 	auto& eventhandler = Utility<EventHandler>::get();
 
-	eventhandler.mouseButtonDown().connect(this, &NotificationArea::onMouseDown);
-	eventhandler.mouseMotion().connect(this, &NotificationArea::onMouseMove);
+	eventhandler.mouseButtonDown().connect({this, &NotificationArea::onMouseDown});
+	eventhandler.mouseMotion().connect({this, &NotificationArea::onMouseMove});
 
 	width(IconPaddedSize.x);
 }
@@ -66,8 +66,8 @@ NotificationArea::~NotificationArea()
 {
 	auto& eventhandler = Utility<EventHandler>::get();
 
-	eventhandler.mouseButtonDown().disconnect(this, &NotificationArea::onMouseDown);
-	eventhandler.mouseMotion().disconnect(this, &NotificationArea::onMouseMove);
+	eventhandler.mouseButtonDown().disconnect({this, &NotificationArea::onMouseDown});
+	eventhandler.mouseMotion().disconnect({this, &NotificationArea::onMouseMove});
 }
 
 

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -60,7 +60,7 @@ FactoryReport::FactoryReport() :
 	btnApply{"Apply", {this, &FactoryReport::onApply}}
 {
 	add(lstFactoryList, {10, 63});
-	lstFactoryList.selectionChanged().connect(this, &FactoryReport::onListSelectionChange);
+	lstFactoryList.selectionChanged().connect({this, &FactoryReport::onListSelectionChange});
 
 	add(btnShowAll, {10, 10});
 	btnShowAll.size({75, 20});
@@ -114,7 +114,7 @@ FactoryReport::FactoryReport() :
 	cboFilterByProduct.addItem(constants::Robominer, ProductType::PRODUCT_MINER);
 	cboFilterByProduct.addItem(constants::Truck, ProductType::PRODUCT_TRUCK);
 
-	cboFilterByProduct.selectionChanged().connect(this, &FactoryReport::onProductFilterSelectionChange);
+	cboFilterByProduct.selectionChanged().connect({this, &FactoryReport::onProductFilterSelectionChange});
 
 	add(lstProducts, {cboFilterByProduct.rect().x + cboFilterByProduct.rect().width + 20, mRect.y + 230});
 
@@ -271,7 +271,7 @@ void FactoryReport::onResize()
 	btnApply.position({position_x, mRect.height + 8});
 
 	lstProducts.size({detailPanelRect.width / 3, detailPanelRect.height - 219});
-	lstProducts.selectionChanged().connect(this, &FactoryReport::onProductSelectionChange);
+	lstProducts.selectionChanged().connect({this, &FactoryReport::onProductSelectionChange});
 
 	txtProductDescription.position(lstProducts.rect().crossXPoint() + NAS2D::Vector{158, 0});
 	txtProductDescription.width(mRect.width - txtProductDescription.positionX() - 30);

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -63,7 +63,7 @@ MineReport::MineReport() :
 
 	btnShowAll.toggle(true);
 
-	lstMineFacilities.selectionChanged().connect(this, &MineReport::onMineFacilitySelectionChange);
+	lstMineFacilities.selectionChanged().connect({this, &MineReport::onMineFacilitySelectionChange});
 	add(lstMineFacilities, {10, 40});
 
 	// DETAIL PANE

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -58,9 +58,9 @@ WarehouseReport::WarehouseReport() :
 
 	btnTakeMeThere.size({140, 30});
 
-	lstStructures.selectionChanged().connect(this, &WarehouseReport::onStructureSelectionChange);
+	lstStructures.selectionChanged().connect({this, &WarehouseReport::onStructureSelectionChange});
 
-	Utility<EventHandler>::get().mouseDoubleClick().connect(this, &WarehouseReport::onDoubleClick);
+	Utility<EventHandler>::get().mouseDoubleClick().connect({this, &WarehouseReport::onDoubleClick});
 
 	fillLists();
 
@@ -79,7 +79,7 @@ WarehouseReport::WarehouseReport() :
 
 WarehouseReport::~WarehouseReport()
 {
-	Utility<EventHandler>::get().mouseDoubleClick().disconnect(this, &WarehouseReport::onDoubleClick);
+	Utility<EventHandler>::get().mouseDoubleClick().disconnect({this, &WarehouseReport::onDoubleClick});
 }
 
 

--- a/OPHD/WindowEventWrapper.h
+++ b/OPHD/WindowEventWrapper.h
@@ -21,16 +21,16 @@ class WindowEventWrapper
 public:
 	WindowEventWrapper()
 	{
-		NAS2D::Utility<NAS2D::EventHandler>::get().windowMaximized().connect(this, &WindowEventWrapper::onWindowMaximized);
-		NAS2D::Utility<NAS2D::EventHandler>::get().windowRestored().connect(this, &WindowEventWrapper::onWindowRestored);
-		NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect(this, &WindowEventWrapper::onWindowResized);
+		NAS2D::Utility<NAS2D::EventHandler>::get().windowMaximized().connect({this, &WindowEventWrapper::onWindowMaximized});
+		NAS2D::Utility<NAS2D::EventHandler>::get().windowRestored().connect({this, &WindowEventWrapper::onWindowRestored});
+		NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &WindowEventWrapper::onWindowResized});
 	}
 
 	~WindowEventWrapper()
 	{
-		NAS2D::Utility<NAS2D::EventHandler>::get().windowMaximized().disconnect(this, &WindowEventWrapper::onWindowMaximized);
-		NAS2D::Utility<NAS2D::EventHandler>::get().windowRestored().disconnect(this, &WindowEventWrapper::onWindowRestored);
-		NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().disconnect(this, &WindowEventWrapper::onWindowResized);
+		NAS2D::Utility<NAS2D::EventHandler>::get().windowMaximized().disconnect({this, &WindowEventWrapper::onWindowMaximized});
+		NAS2D::Utility<NAS2D::EventHandler>::get().windowRestored().disconnect({this, &WindowEventWrapper::onWindowRestored});
+		NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().disconnect({this, &WindowEventWrapper::onWindowResized});
 	}
 
 private:


### PR DESCRIPTION
This means fewer overloaded methods will be needed on the `SignalSource` object. It also more tightly associates `this` pointers with member function pointers by composing them into an obvious compound object.

One reason to want to reduce `connect` overloads, is to add debugging capabilities to the `connect` method. This is easier when only a single overload needs to be updated.

Reference: Issue #1269
