### PR TITLE
Fix save game load button bug

### DIFF
--- a/OPHD/States/GameState.cpp
+++ b/OPHD/States/GameState.cpp
@@ -40,7 +40,7 @@ GameState::~GameState()
 		takeMeThere->disconnect({this, &GameState::onTakeMeThere});
 	}
 
-	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().disconnect({MakeDelegate(this, &GameState::onMusicComplete)});
+	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().disconnect({this, &GameState::onMusicComplete});
 	NAS2D::Utility<NAS2D::Mixer>::get().stopAllAudio();
 }
 
@@ -62,7 +62,7 @@ void GameState::initialize()
 		takeMeThere->connect({this, &GameState::onTakeMeThere});
 	}
 
-	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect({MakeDelegate(this, &GameState::onMusicComplete)});
+	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect({this, &GameState::onMusicComplete});
 	mFade.fadeIn(constants::FadeSpeed);
 }
 


### PR DESCRIPTION
Update NAS2D submodule to bring in a fix for a `Signal` memory bug that could result in memory corruption and crashes.

Closes #1269 

Reference: https://github.com/lairworks/nas2d-core/pull/1057
