### PR TITLE
Remove `using namespace NAS2D;` from UI/Core

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -9,9 +9,6 @@
 #include <NAS2D/Math/MathUtils.h>
 
 
-using namespace NAS2D;
-
-
 Button::Button(std::string newText) :
 	mButtonSkin{
 		{
@@ -51,7 +48,7 @@ Button::Button(std::string newText) :
 {
 	text(newText);
 
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &Button::onMouseDown});
 	eventHandler.mouseButtonUp().connect({this, &Button::onMouseUp});
 	eventHandler.mouseMotion().connect({this, &Button::onMouseMove});
@@ -75,7 +72,7 @@ Button::Button(const ButtonSkin& buttonSkin, ClickSignal::DelegateType clickHand
 
 Button::~Button()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect({this, &Button::onMouseDown});
 	eventHandler.mouseButtonUp().disconnect({this, &Button::onMouseUp});
 	eventHandler.mouseMotion().disconnect({this, &Button::onMouseMove});
@@ -118,11 +115,11 @@ bool Button::hasImage() const
 }
 
 
-void Button::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void Button::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left)
+	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{
 		if (mRect.contains(position))
 		{
@@ -140,11 +137,11 @@ void Button::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> pos
 }
 
 
-void Button::onMouseUp(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void Button::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left)
+	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{
 		if (mType == Type::Push)
 		{
@@ -178,7 +175,7 @@ void Button::draw() const
 {
 	if (!visible()) { return; }
 
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const auto& skin = (mIsPressed) ? mButtonSkin.pressed :
 		(enabled() && mMouseHover) ? mButtonSkin.hover : mButtonSkin.normal;

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -24,15 +24,12 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 CheckBox::CheckBox(std::string newText) :
 	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
 	mSkin{imageCache.load("ui/skin/checkbox.png")}
 {
 	text(newText);
-	Utility<EventHandler>::get().mouseButtonDown().connect({this, &CheckBox::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &CheckBox::onMouseDown});
 }
 
 
@@ -44,7 +41,7 @@ CheckBox::CheckBox(std::string newText, ClickSignal::DelegateType clickHandler) 
 
 CheckBox::~CheckBox()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &CheckBox::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &CheckBox::onMouseDown});
 }
 
 
@@ -72,11 +69,11 @@ CheckBox::ClickSignal::Source& CheckBox::click()
 }
 
 
-void CheckBox::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void CheckBox::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left && mRect.contains(position))
+	if (button == NAS2D::EventHandler::MouseButton::Left && mRect.contains(position))
 	{
 		mChecked = !mChecked;
 		mSignal();
@@ -109,7 +106,7 @@ void CheckBox::update()
 
 void CheckBox::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const auto uncheckedIconRect = NAS2D::Rectangle{0, 0, 13, 13};
 	const auto checkedIconRect = NAS2D::Rectangle{13, 0, 13, 13};

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -10,13 +10,10 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 ComboBox::ComboBox() :
 	UIContainer{{&btnDown, &txtField, &lstItems}}
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().connect({this, &ComboBox::onMouseWheel});
 
 	btnDown.image("ui/icons/down.png");
@@ -33,7 +30,7 @@ ComboBox::ComboBox() :
 ComboBox::~ComboBox()
 {
 	lstItems.selectionChanged().disconnect({this, &ComboBox::onListSelectionChange});
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().disconnect({this, &ComboBox::onMouseWheel});
 }
 
@@ -57,7 +54,7 @@ void ComboBox::onResize()
 	lstItems.width(mRect.width);
 	lstItems.position(rect().crossYPoint());
 
-	mBaseArea = Rectangle<int>::Create(position(), NAS2D::Vector{mRect.width, btnDown.size().y});
+	mBaseArea = NAS2D::Rectangle<int>::Create(position(), NAS2D::Vector{mRect.width, btnDown.size().y});
 }
 
 
@@ -72,17 +69,17 @@ void ComboBox::onMove(NAS2D::Vector<int> displacement)
 	btnDown.position(txtField.rect().crossXPoint());
 	lstItems.position(rect().crossYPoint());
 
-	mBaseArea = Rectangle<int>::Create(position(), NAS2D::Vector{mRect.width, btnDown.size().y});
+	mBaseArea = NAS2D::Rectangle<int>::Create(position(), NAS2D::Vector{mRect.width, btnDown.size().y});
 }
 
 
-void ComboBox::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void ComboBox::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	UIContainer::onMouseDown(button, position);
 
 	if (!enabled() || !visible()) { return; }
 
-	if (button != EventHandler::MouseButton::Left) { return; }
+	if (button != NAS2D::EventHandler::MouseButton::Left) { return; }
 
 	if (mBaseArea.contains(position))
 	{
@@ -189,7 +186,7 @@ void ComboBox::setSelected(std::size_t index) {
 
 void ComboBox::text(const std::string& text) {
 	txtField.text(text);
-	lstItems.selectIf([target = toLowercase(txtField.text())](const auto& item){ return toLowercase(item.text) == target; });
+	lstItems.selectIf([target = NAS2D::toLowercase(txtField.text())](const auto& item){ return NAS2D::toLowercase(item.text) == target; });
 	mSelectionChanged();
 }
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -1,9 +1,6 @@
 #include "Control.h"
 
 
-using namespace NAS2D;
-
-
 void Control::area(const NAS2D::Rectangle<int>& area)
 {
 	const auto displacement = area.startPoint() - mRect.startPoint();
@@ -18,7 +15,7 @@ void Control::area(const NAS2D::Rectangle<int>& area)
  * 
  * \param pos	2D Coordinate to position the Control at.
  */
-void Control::position(Point<int> pos)
+void Control::position(NAS2D::Point<int> pos)
 {
 	const auto displacement = pos - mRect.startPoint();
 	mRect.startPoint(pos);
@@ -103,7 +100,7 @@ Control::ResizeSignal::Source& Control::resized()
  * 
  * \return	A const reference to a Rectangle<int> object.
  */
-const Rectangle<int>& Control::rect() const
+const NAS2D::Rectangle<int>& Control::rect() const
 {
 	return mRect;
 }

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -5,9 +5,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 unsigned int ListBoxItemText::Context::itemHeight() const
 {
 	return font.height() + constants::MarginTight;

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -10,12 +10,9 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 ListBoxBase::ListBoxBase()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().connect({this, &ListBoxBase::onMouseWheel});
 	eventHandler.mouseButtonDown().connect({this, &ListBoxBase::onMouseDown});
 	eventHandler.mouseMotion().connect({this, &ListBoxBase::onMouseMove});
@@ -32,7 +29,7 @@ ListBoxBase::~ListBoxBase()
 {
 	mScrollBar.change().disconnect({this, &ListBoxBase::onSlideChange});
 
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().disconnect({this, &ListBoxBase::onMouseWheel});
 	eventHandler.mouseButtonDown().disconnect({this, &ListBoxBase::onMouseDown});
 	eventHandler.mouseMotion().disconnect({this, &ListBoxBase::onMouseMove});
@@ -99,13 +96,13 @@ void ListBoxBase::onResize()
 }
 
 
-void ListBoxBase::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void ListBoxBase::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (isEmpty() || button == EventHandler::MouseButton::Middle) { return; }
+	if (isEmpty() || button == NAS2D::EventHandler::MouseButton::Middle) { return; }
 
-	if (button == EventHandler::MouseButton::Right && mRect.contains(position))
+	if (button == NAS2D::EventHandler::MouseButton::Right && mRect.contains(position))
 	{
 		setSelection(constants::NoSelection);
 		return;
@@ -262,7 +259,7 @@ void ListBoxBase::update()
 
 void ListBoxBase::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// CONTROL EXTENTS
 	const auto backgroundRect = NAS2D::Rectangle{mRect.x, mRect.y, mItemWidth, mRect.height};

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -1,9 +1,6 @@
 #include "RadioButtonGroup.h"
 
 
-using namespace NAS2D;
-
-
 RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup* parentContainer, std::string newText, NAS2D::Delegate<void()> delegate) :
 	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
 	mSkin{imageCache.load("ui/skin/radio.png")},
@@ -12,14 +9,14 @@ RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup* parentContainer, st
 {
 	text(newText);
 	mSignal.connect({delegate});
-	Utility<EventHandler>::get().mouseButtonDown().connect({this, &RadioButtonGroup::RadioButton::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &RadioButtonGroup::RadioButton::onMouseDown});
 	onTextChange();
 }
 
 
 RadioButtonGroup::RadioButton::~RadioButton()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &RadioButtonGroup::RadioButton::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &RadioButtonGroup::RadioButton::onMouseDown});
 }
 
 
@@ -56,7 +53,7 @@ const std::string& RadioButtonGroup::RadioButton::text() const
 
 void RadioButtonGroup::RadioButton::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const auto unselectedIconRect = NAS2D::Rectangle{0, 0, 13, 13};
 	const auto selectedIconRect = NAS2D::Rectangle{13, 0, 13, 13};
@@ -82,11 +79,11 @@ void RadioButtonGroup::RadioButton::onTextChange()
 }
 
 
-void RadioButtonGroup::RadioButton::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void RadioButtonGroup::RadioButton::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left && mRect.contains(position))
+	if (button == NAS2D::EventHandler::MouseButton::Left && mRect.contains(position))
 	{
 		mParentContainer->select(*this);
 		mSignal();

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -10,9 +10,6 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 RadioButtonGroup::RadioButtonGroup(std::vector<ButtonInfo> buttonInfos)
 {
 	mRadioButtons.reserve(buttonInfos.size());

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -8,9 +8,6 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	ScrollBar::Skins loadSkins(ScrollBar::ScrollBarType scrollBarType)
@@ -126,7 +123,7 @@ ScrollBar::ScrollBar(ScrollBar::Skins skins, ScrollBarType scrollBarType) :
 	mScrollBarType{scrollBarType},
 	mSkins{skins}
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &ScrollBar::onMouseDown});
 	eventHandler.mouseButtonUp().connect({this, &ScrollBar::onMouseUp});
 	eventHandler.mouseMotion().connect({this, &ScrollBar::onMouseMove});
@@ -135,7 +132,7 @@ ScrollBar::ScrollBar(ScrollBar::Skins skins, ScrollBarType scrollBarType) :
 
 ScrollBar::~ScrollBar()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect({this, &ScrollBar::onMouseDown});
 	eventHandler.mouseButtonUp().disconnect({this, &ScrollBar::onMouseUp});
 	eventHandler.mouseMotion().disconnect({this, &ScrollBar::onMouseMove});
@@ -198,7 +195,7 @@ void ScrollBar::update()
 
 void ScrollBar::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	mSkins.skinTrack.draw(renderer, mTrack);
 	mSkins.skinThumb.draw(renderer, mThumb);
@@ -217,11 +214,11 @@ void ScrollBar::onButtonClick(bool& buttonFlag, ValueType value)
 }
 
 
-void ScrollBar::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void ScrollBar::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (button == EventHandler::MouseButton::Left)
+	if (button == NAS2D::EventHandler::MouseButton::Left)
 	{
 		if (mThumb.contains(position))
 		{
@@ -239,9 +236,9 @@ void ScrollBar::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> 
 }
 
 
-void ScrollBar::onMouseUp(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void ScrollBar::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
-	if (button != EventHandler::MouseButton::Left) { return; }
+	if (button != NAS2D::EventHandler::MouseButton::Left) { return; }
 
 	mButtonDecreaseHeld = false;
 	mButtonIncreaseHeld = false;

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -7,9 +7,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 void TextArea::font(const std::string& filePath, unsigned int pointSize)
 {
 	mFont = &fontCache.load(filePath, pointSize);
@@ -88,7 +85,7 @@ void TextArea::update()
 
 void TextArea::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	if (highlight()) { renderer.drawBox(mRect, NAS2D::Color::White); }
 

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -17,9 +17,6 @@
 #include <locale>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	constexpr int fieldPadding = 4;
@@ -52,7 +49,7 @@ TextField::TextField() :
 		imageCache.load("ui/skin/textbox_bottom_right_highlight.png")
 	}
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &TextField::onMouseDown});
 	eventHandler.keyDown().connect({this, &TextField::onKeyDown});
 	eventHandler.textInput().connect({this, &TextField::onTextInput});
@@ -65,7 +62,7 @@ TextField::TextField() :
 
 TextField::~TextField()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect({this, &TextField::onMouseDown});
 	eventHandler.keyDown().disconnect({this, &TextField::onKeyDown});
 	eventHandler.textInput().disconnect({this, &TextField::onTextInput});
@@ -153,14 +150,14 @@ void TextField::onTextInput(const std::string& newTextInput)
 }
 
 
-void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
+void TextField::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	if (!hasFocus() || !editable() || !visible()) { return; }
 
 	switch(key)
 	{
 		// COMMAND KEYS
-		case EventHandler::KeyCode::KEY_BACKSPACE:
+		case NAS2D::EventHandler::KeyCode::KEY_BACKSPACE:
 			if (!text().empty() && mCursorPosition > 0)
 			{
 				mCursorPosition--;
@@ -169,15 +166,15 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			}
 			break;
 
-		case EventHandler::KeyCode::KEY_HOME:
+		case NAS2D::EventHandler::KeyCode::KEY_HOME:
 			mCursorPosition = 0;
 			break;
 
-		case EventHandler::KeyCode::KEY_END:
+		case NAS2D::EventHandler::KeyCode::KEY_END:
 			mCursorPosition = text().length();
 			break;
 
-		case EventHandler::KeyCode::KEY_DELETE:
+		case NAS2D::EventHandler::KeyCode::KEY_DELETE:
 			if (text().length() > 0)
 			{
 				mText = mText.erase(mCursorPosition, 1);
@@ -186,30 +183,30 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		// ARROW KEYS
-		case EventHandler::KeyCode::KEY_LEFT:
+		case NAS2D::EventHandler::KeyCode::KEY_LEFT:
 			if (mCursorPosition > 0)
 				--mCursorPosition;
 			break;
 
-		case EventHandler::KeyCode::KEY_RIGHT:
+		case NAS2D::EventHandler::KeyCode::KEY_RIGHT:
 			if (mCursorPosition < text().length())
 				++mCursorPosition;
 			break;
 
 		// KEYPAD ARROWS
-		case EventHandler::KeyCode::KEY_KP4:
-			if ((mCursorPosition > 0) && !Utility<EventHandler>::get().query_numlock())
+		case NAS2D::EventHandler::KeyCode::KEY_KP4:
+			if ((mCursorPosition > 0) && !NAS2D::Utility<NAS2D::EventHandler>::get().query_numlock())
 				--mCursorPosition;
 			break;
 
-		case EventHandler::KeyCode::KEY_KP6:
-			if ((mCursorPosition < text().length()) && !Utility<EventHandler>::get().query_numlock())
+		case NAS2D::EventHandler::KeyCode::KEY_KP6:
+			if ((mCursorPosition < text().length()) && !NAS2D::Utility<NAS2D::EventHandler>::get().query_numlock())
 				++mCursorPosition;
 			break;
 
 		// IGNORE ENTER/RETURN KEY
-		case EventHandler::KeyCode::KEY_ENTER:
-		case EventHandler::KeyCode::KEY_KP_ENTER:
+		case NAS2D::EventHandler::KeyCode::KEY_ENTER:
+		case NAS2D::EventHandler::KeyCode::KEY_KP_ENTER:
 			break;
 
 		// REGULAR KEYS
@@ -219,7 +216,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 }
 
 
-void TextField::onMouseDown(EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
+void TextField::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
 {
 	hasFocus(mRect.contains(position)); // This is a very useful check, should probably include this in all controls.
 
@@ -263,7 +260,7 @@ void TextField::drawCursor() const
 	{
 		if (mShowCursor)
 		{
-			auto& renderer = Utility<Renderer>::get();
+			auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 			const auto startPosition = NAS2D::Point{mCursorX, mRect.y + fieldPadding};
 			const auto endPosition = NAS2D::Point{mCursorX, mRect.y + mRect.height - fieldPadding - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);
@@ -317,7 +314,7 @@ void TextField::update()
 
 void TextField::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const auto showFocused = hasFocus() && editable();
 	const auto& skin = showFocused ? mSkinFocus : mSkinNormal;

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -8,19 +8,16 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 ToolTip::ToolTip():
 	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)}
 {
-	Utility<EventHandler>::get().mouseMotion().connect({this, &ToolTip::onMouseMove});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &ToolTip::onMouseMove});
 }
 
 
 ToolTip::~ToolTip()
 {
-	Utility<EventHandler>::get().mouseMotion().disconnect({this, &ToolTip::onMouseMove});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect({this, &ToolTip::onMouseMove});
 }
 
 
@@ -49,7 +46,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	auto tooltipPosition = item.first->position();
 	tooltipPosition.x = mouseX;
 
-	auto offset = Vector{0, -tooltipHeight - constants::Margin};
+	auto offset = NAS2D::Vector{0, -tooltipHeight - constants::Margin};
 
 	if (tooltipPosition.y + offset.y < 0)
 	{
@@ -57,7 +54,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	}
 
 
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	if (tooltipPosition.x + tooltipWidth > renderer.size().x)
 	{
 		offset.x -= (tooltipPosition.x + tooltipWidth) - (renderer.size().x - constants::Margin);
@@ -70,7 +67,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 
 void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative)
 {
-	if (relative != Vector{0, 0})
+	if (relative != NAS2D::Vector{0, 0})
 	{
 		if (mFocusedControl)
 		{
@@ -110,9 +107,9 @@ void ToolTip::draw() const
 {
 	if (mFocusedControl)
 	{
-		auto& renderer = Utility<Renderer>::get();
-		renderer.drawBoxFilled(rect(), Color::DarkGray);
-		renderer.drawBox(rect(), Color::Black);
-		renderer.drawText(mFont, mFocusedControl->second, Point{positionX() + constants::MarginTight, positionY() + constants::MarginTight});
+		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+		renderer.drawBoxFilled(rect(), NAS2D::Color::DarkGray);
+		renderer.drawBox(rect(), NAS2D::Color::Black);
+		renderer.drawText(mFont, mFocusedControl->second, NAS2D::Point{positionX() + constants::MarginTight, positionY() + constants::MarginTight});
 	}
 }

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -8,9 +8,6 @@
 #include <stdexcept>
 
 
-using namespace NAS2D;
-
-
 UIContainer::UIContainer() : UIContainer{{}}
 {
 }
@@ -19,13 +16,13 @@ UIContainer::UIContainer() : UIContainer{{}}
 UIContainer::UIContainer(std::vector<Control*> controls) :
 	mControls{std::move(controls)}
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect({this, &UIContainer::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &UIContainer::onMouseDown});
 }
 
 
 UIContainer::~UIContainer()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &UIContainer::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &UIContainer::onMouseDown});
 }
 
 
@@ -87,7 +84,7 @@ void UIContainer::onMove(NAS2D::Vector<int> displacement)
 }
 
 
-void UIContainer::onMouseDown(EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
+void UIContainer::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> position)
 {
 	if (!visible()) { return; }
 
@@ -121,7 +118,7 @@ void UIContainer::update()
 		/*
 		if (control->hasFocus())
 		{
-			Utility<Renderer>::get().drawBox(control->rect(), 255, 0, 255);
+			NAS2D::Utility<NAS2D::Renderer>::get().drawBox(control->rect(), 255, 0, 255);
 		}
 		*/
 	}

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -30,7 +30,7 @@ Window::Window(std::string newTitle) :
 {
 	title(newTitle);
 
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonUp().connect({this, &Window::onMouseUp});
 	eventHandler.mouseMotion().connect({this, &Window::onMouseMove});
 }
@@ -38,24 +38,24 @@ Window::Window(std::string newTitle) :
 
 Window::~Window()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonUp().disconnect({this, &Window::onMouseUp});
 	eventHandler.mouseMotion().disconnect({this, &Window::onMouseMove});
 }
 
 
-void Window::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position)
+void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible()) { return; }
 
 	UIContainer::onMouseDown(button, position);
 
 	const auto titleBarBounds = NAS2D::Rectangle{mRect.x, mRect.y, mRect.width, sWindowTitleBarHeight};
-	mMouseDrag = (button == EventHandler::MouseButton::Left && titleBarBounds.contains(position));
+	mMouseDrag = (button == NAS2D::EventHandler::MouseButton::Left && titleBarBounds.contains(position));
 }
 
 
-void Window::onMouseUp(EventHandler::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
+void Window::onMouseUp(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
 {
 	mMouseDrag = false;
 }
@@ -95,7 +95,7 @@ void Window::update()
 
 void Window::draw() const
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	renderer.drawImage(mTitleBarLeft, mRect.startPoint());
 	renderer.drawImageRepeated(mTitleBarCenter, NAS2D::Rectangle{mRect.x + 4, mRect.y, mRect.width - 8, sWindowTitleBarHeight});

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -8,9 +8,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 Window::Window(std::string newTitle) :
 	mTitleFont{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
 	mTitleBarLeft{imageCache.load("ui/skin/window_title_left.png")},


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/issues/701

If we extract a `Window` class from the `Renderer` code in NAS2D, and simply import the full NAS2D namespace, that name will conflict with the `Window` class in OPHD. By being explicit about namespaces, we avoid ambiguity.

Might as well make the rest of UI/Core consistent too.
