### PR TITLE
Disable help button with the others

### DIFF
--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -43,6 +43,7 @@ void GameOptionsDialog::onEnableChange()
 {
 	btnSave.enabled(enabled());
 	btnLoad.enabled(enabled());
+	btnHelp.enabled(enabled());
 	btnReturn.enabled(enabled());
 	btnClose.enabled(enabled());
 }

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -34,6 +34,7 @@ GameOptionsDialog::~GameOptionsDialog()
 {
 	btnSave.click().disconnect({this, &GameOptionsDialog::onSave});
 	btnLoad.click().disconnect({this, &GameOptionsDialog::onLoad});
+	btnHelp.click().disconnect({this, &GameOptionsDialog::onHelp});
 	btnReturn.click().disconnect({this, &GameOptionsDialog::onReturn});
 	btnClose.click().disconnect({this, &GameOptionsDialog::onClose});
 }


### PR DESCRIPTION
Should solve #1235, I also saw the help button was not disconnected in the GameOptionsDialog.cpp destructor, so I also added that, but that was perhaps not necessary? I put them in different commits.