### PR TITLE
Cleanup on exit

### DIFF
--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -13,6 +13,7 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
+#include <NAS2D/EventHandler.h>
 #include <NAS2D/StateManager.h>
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Resource/Music.h>
@@ -168,6 +169,11 @@ int main(int argc, char *argv[])
 	}
 
 	imageCache.clear();
+	Utility<Renderer>::clear();
+	Utility<EventHandler>::clear();
+	Utility<Mixer>::clear();
+	Utility<Configuration>::clear();
+	Utility<Filesystem>::clear();
 
 	#ifdef NDEBUG
 	// Reset to stdout again (prevents crashes on exit)


### PR DESCRIPTION
It seems the `Utility` wrapped globals weren't being automatically destructed on app exit. The `Game` class in NAS2D does manual cleanup of these game components. We should replicate there in OPHD, as it doesn't use `Game`.

Switching to `inline` header variables for the globals would probably make this manual cleanup unnecessary.

Reference: https://github.com/lairworks/nas2d-core/pull/1067, https://github.com/lairworks/nas2d-core/issues/810