### PR TITLE
Consolidate Structure/ProductCatalog init calls

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -228,17 +228,13 @@ void MapViewState::initialize()
 
 	mPopulationPool.population(&mPopulation);
 
+	StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
+	ProductCatalogue::init("factory_products.xml");
+
 	if (mLoadingExisting)
 	{
 		load(mExistingToLoad);
 	}
-	else
-	{
-		// StructureCatalogue is initialized in load routine if saved game present to load existing structures
-		StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
-	}
-
-	ProductCatalogue::init("factory_products.xml");
 
 	setupUiPositions(renderer.size());
 	resetPoliceOverlays();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -285,8 +285,6 @@ void MapViewState::load(const std::string& filePath)
 
 	difficulty(stringToEnum(difficultyTable, dictionary.get("difficulty", std::string{"Medium"})));
 
-	StructureCatalogue::init(mPlanetAttributes.meanSolarDistance);
-	ProductCatalogue::init("factory_products.xml");
 	mTileMap = new TileMap(mPlanetAttributes.mapImagePath, mPlanetAttributes.maxDepth);
 	mTileMap->deserialize(root);
 	mMapView = std::make_unique<MapView>(*mTileMap);


### PR DESCRIPTION
Noticed some inefficiencies in how the `ProductCatalogue::init()` and `StructureCatalogue::init()` functions were being called so I consolidated those calls and simplified the conditional check in `MapViewState::initialize()`.