### PR TITLE
Use `const` list-init default available structs

### DIFF
--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -4,6 +4,37 @@
 
 namespace
 {
+	const std::vector<IconGrid::Item> DefaultAvailableSurfaceStructures = {
+		{constants::Agridome, 5, StructureID::SID_AGRIDOME},
+		{constants::Chap, 3, StructureID::SID_CHAP},
+		{constants::CommTower, 22, StructureID::SID_COMM_TOWER},
+		{constants::HotLaboratory, 18, StructureID::SID_HOT_LABORATORY},
+		{constants::MaintenanceFacility, 54, StructureID::SID_MAINTENANCE_FACILITY},
+		{constants::Recycling, 16, StructureID::SID_RECYCLING},
+		{constants::Road, 24, StructureID::SID_ROAD},
+		{constants::RobotCommand, 14, StructureID::SID_ROBOT_COMMAND},
+		{constants::Smelter, 4, StructureID::SID_SMELTER},
+		{constants::SolarPanel1, 33, StructureID::SID_SOLAR_PANEL1},
+		{constants::StorageTanks, 8, StructureID::SID_STORAGE_TANKS},
+		{constants::SurfaceFactory, 11, StructureID::SID_SURFACE_FACTORY},
+		{constants::SurfacePolice, 23, StructureID::SID_SURFACE_POLICE},
+		{constants::Warehouse, 9, StructureID::SID_WAREHOUSE},
+	};
+
+	const std::vector<IconGrid::Item> DefaultAvailableUndergroundStructures = {
+		{constants::Laboratory, 58, StructureID::SID_LABORATORY},
+		{constants::Park, 75, StructureID::SID_PARK},
+		{constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE},
+		{constants::RecreationCenter, 73, StructureID::SID_RECREATION_CENTER},
+		{constants::Residence, 55, StructureID::SID_RESIDENCE},
+		{constants::UndergroundFactory, 69, StructureID::SID_UNDERGROUND_FACTORY},
+		{constants::MedicalCenter, 62, StructureID::SID_MEDICAL_CENTER},
+		{constants::Nursery, 77, StructureID::SID_NURSERY},
+		{constants::Commercial, 66, StructureID::SID_COMMERCIAL},
+		{constants::RedLightDistrict, 76, StructureID::SID_RED_LIGHT_DISTRICT},
+		{constants::University, 63, StructureID::SID_UNIVERSITY},
+	};
+
 	void addItemToList(const IconGrid::Item& structureItem, std::vector<IconGrid::Item>& list)
 	{
 		for (const auto& item : list)
@@ -39,32 +70,6 @@ void StructureTracker::addUnlockedUndergroundStructure(const IconGrid::Item& str
 
 void StructureTracker::reset()
 {
-	mAvailableSurfaceStructures.clear();
-	mAvailableSurfaceStructures.push_back({constants::Agridome, 5, StructureID::SID_AGRIDOME});
-	mAvailableSurfaceStructures.push_back({constants::Chap, 3, StructureID::SID_CHAP});
-	mAvailableSurfaceStructures.push_back({constants::CommTower, 22, StructureID::SID_COMM_TOWER});
-	mAvailableSurfaceStructures.push_back({constants::HotLaboratory, 18, StructureID::SID_HOT_LABORATORY});
-	mAvailableSurfaceStructures.push_back({constants::MaintenanceFacility, 54, StructureID::SID_MAINTENANCE_FACILITY});
-	mAvailableSurfaceStructures.push_back({constants::Recycling, 16, StructureID::SID_RECYCLING});
-	mAvailableSurfaceStructures.push_back({constants::Road, 24, StructureID::SID_ROAD});
-	mAvailableSurfaceStructures.push_back({constants::RobotCommand, 14, StructureID::SID_ROBOT_COMMAND});
-	mAvailableSurfaceStructures.push_back({constants::Smelter, 4, StructureID::SID_SMELTER});
-	mAvailableSurfaceStructures.push_back({constants::SolarPanel1, 33, StructureID::SID_SOLAR_PANEL1});
-	mAvailableSurfaceStructures.push_back({constants::StorageTanks, 8, StructureID::SID_STORAGE_TANKS});
-	mAvailableSurfaceStructures.push_back({constants::SurfaceFactory, 11, StructureID::SID_SURFACE_FACTORY});
-	mAvailableSurfaceStructures.push_back({constants::SurfacePolice, 23, StructureID::SID_SURFACE_POLICE});
-	mAvailableSurfaceStructures.push_back({constants::Warehouse, 9, StructureID::SID_WAREHOUSE});
-
-	mAvailableUndergroundStructures.clear();
-	mAvailableUndergroundStructures.push_back({constants::Laboratory, 58, StructureID::SID_LABORATORY});
-	mAvailableUndergroundStructures.push_back({constants::Park, 75, StructureID::SID_PARK});
-	mAvailableUndergroundStructures.push_back({constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE});
-	mAvailableUndergroundStructures.push_back({constants::RecreationCenter, 73, StructureID::SID_RECREATION_CENTER});
-	mAvailableUndergroundStructures.push_back({constants::Residence, 55, StructureID::SID_RESIDENCE});
-	mAvailableUndergroundStructures.push_back({constants::UndergroundFactory, 69, StructureID::SID_UNDERGROUND_FACTORY});
-	mAvailableUndergroundStructures.push_back({constants::MedicalCenter, 62, StructureID::SID_MEDICAL_CENTER});
-	mAvailableUndergroundStructures.push_back({constants::Nursery, 77, StructureID::SID_NURSERY});
-	mAvailableUndergroundStructures.push_back({constants::Commercial, 66, StructureID::SID_COMMERCIAL});
-	mAvailableUndergroundStructures.push_back({constants::RedLightDistrict, 76, StructureID::SID_RED_LIGHT_DISTRICT});
-	mAvailableUndergroundStructures.push_back({constants::University, 63, StructureID::SID_UNIVERSITY});
+	mAvailableSurfaceStructures = DefaultAvailableSurfaceStructures;
+	mAvailableUndergroundStructures = DefaultAvailableUndergroundStructures;
 }


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/pull/1201#discussion_r869874118

Use `std::vector` list initialization rather than repeated `push_back`, and mark the list as `const` data.

This change used to crash MSVC. For example:
https://github.com/OutpostUniverse/OPHD/actions/runs/2898105709/jobs/4610071913
> D:\a\OPHD\OPHD\OPHD\States\StructureTracker.cpp(7): fatal error C1001: Internal compiler error. [D:\a\OPHD\OPHD\OPHD\ophd.vcxproj]
         LINK : fatal error LNK1000: Internal error during IMAGE::BuildImage [D:\a\OPHD\OPHD\OPHD\ophd.vcxproj]

It seems the updated version of MSVC is now able to handle this code. We may want to delay or avoid merging this change in case we still have developers using older versions of MSVC, or want to support older versions of MSVC.
