### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -31,7 +31,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: C:\vcpkg\installed\

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,7 +22,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Checkout NAS2D
       run: git submodule update --init nas2d-core/

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,7 +28,7 @@ jobs:
       run: git submodule update --init nas2d-core/
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache@v2


### PR DESCRIPTION
Eliminates warnings seen on the GitHub Actions Summary page, under the "Annotations" section.

Example of previous warnings:
https://github.com/OutpostUniverse/OPHD/actions/runs/4659260160