### PR TITLE
Update progress bar drawing code

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -284,11 +284,6 @@ float getMeanSolarDistance()
 
 void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding)
 {
-	if (value <= 0)
-	{
-		return;
-	}
-
 	if (max == 0)
 	{
 		throw std::runtime_error("Progress bar must have non-zero max value: " + std::to_string(max));

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -11,6 +11,7 @@
 #include <NAS2D/Xml/XmlElement.h>
 
 #include <stdexcept>
+#include <algorithm>
 
 
 using namespace NAS2D;
@@ -291,6 +292,28 @@ void drawBasicProgressBar(NAS2D::Rectangle<int> rect, float percent, int padding
 		int bar_width = static_cast<int>(static_cast<float>(rect.width - (padding + padding)) * percent);
 		renderer.drawBoxFilled(NAS2D::Rectangle{rect.x + padding, rect.y + padding + 1, bar_width - 1, rect.height - (padding + padding) - 1}, NAS2D::Color{0, 100, 0});
 	}
+}
+
+
+void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding)
+{
+	if (value <= 0)
+	{
+		return;
+	}
+
+	if (max == 0)
+	{
+		throw std::runtime_error("Progress bar must have non-zero max value: " + std::to_string(max));
+	}
+
+	const auto clippedValue = std::clamp(value, 0, max);
+	auto innerRect = rect.inset(padding);
+	innerRect.width = innerRect.width * clippedValue / max;
+
+	auto& renderer = Utility<Renderer>::get();
+	renderer.drawBox(rect, NAS2D::Color{0, 185, 0});
+	renderer.drawBoxFilled(innerRect, NAS2D::Color{0, 100, 0});
 }
 
 

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -282,19 +282,6 @@ float getMeanSolarDistance()
 }
 
 
-void drawBasicProgressBar(NAS2D::Rectangle<int> rect, float percent, int padding)
-{
-	auto& renderer = Utility<Renderer>::get();
-	renderer.drawBox(rect, NAS2D::Color{0, 185, 0});
-
-	if (percent > 0.0f)
-	{
-		int bar_width = static_cast<int>(static_cast<float>(rect.width - (padding + padding)) * percent);
-		renderer.drawBoxFilled(NAS2D::Rectangle{rect.x + padding, rect.y + padding + 1, bar_width - 1, rect.height - (padding + padding) - 1}, NAS2D::Color{0, 100, 0});
-	}
-}
-
-
 void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding)
 {
 	if (value <= 0)

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -339,6 +339,8 @@ int moraleStringTableCount();
  */
 void drawBasicProgressBar(NAS2D::Rectangle<int> rect, float percent, int padding = 4);
 
+void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding = 4);
+
 NAS2D::Color structureColorFromIndex(StructureState structureState);
 NAS2D::Color structureTextColorFromIndex(StructureState structureState);
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -334,11 +334,6 @@ const std::string& moraleString(int index);
 const std::string& moraleString(Morale morale);
 int moraleStringTableCount();
 
-/**
- * Super basic progress bar.
- */
-void drawBasicProgressBar(NAS2D::Rectangle<int> rect, float percent, int padding = 4);
-
 void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding = 4);
 
 NAS2D::Color structureColorFromIndex(StructureState structureState);

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -46,9 +46,12 @@ static void drawItem(Renderer& renderer, FactoryListBox::FactoryListBoxItem& ite
 	if (productType != ProductType::PRODUCT_NONE)
 	{
 		renderer.drawText(*MAIN_FONT, ProductCatalogue::get(productType).Name, rect.crossXPoint() + NAS2D::Vector{-112, 19 - MAIN_FONT_BOLD->height() / 2}, structureTextColor);
-		// PROGRESS BAR
-		float percentage = static_cast<float>(f->productionTurnsCompleted()) / static_cast<float>(f->productionTurnsToComplete());
-		drawBasicProgressBar(NAS2D::Rectangle<int>::Create(rect.crossXPoint() + NAS2D::Vector{-112, 30}, NAS2D::Vector{105, 11}), percentage, 2);
+		drawProgressBar(
+			f->productionTurnsCompleted(),
+			f->productionTurnsToComplete(),
+			NAS2D::Rectangle<int>::Create(rect.crossXPoint() + NAS2D::Vector{-112, 30}, NAS2D::Vector{105, 11}),
+			2
+		);
 	}
 }
 

--- a/OPHD/UI/ProductListBox.cpp
+++ b/OPHD/UI/ProductListBox.cpp
@@ -39,7 +39,8 @@ void ProductListBox::productPool(ProductPool& pool)
 			ProductListBoxItem* item = new ProductListBoxItem();
 			item->text = ProductCatalogue::get(productType).Name;
 			item->count = productCount;
-			item->usage = static_cast<float>(productCount * pool.productStorageRequirement(productType)) / static_cast<float>(pool.capacity());
+			item->capacityUsed = productCount * pool.productStorageRequirement(productType);
+			item->capacityTotal = pool.capacity();
 			mItems.push_back(item);
 		}
 	}
@@ -86,7 +87,12 @@ void ProductListBox::update()
 		// Draw item column contents
 		renderer.drawText(mFontBold, item.text, NAS2D::Point{x + 5, ((y + 15) - mFontBold.height() / 2) - offset}, itemColor);
 		renderer.drawText(mFont, "Quantity: " + std::to_string(item.count), NAS2D::Point{x + firstStop + 5, ((y + 15) - mFontBold.height() / 2)}, itemColor);
-		drawBasicProgressBar({x + secondStop + 5, y + 10, firstStop - 10, 10}, item.usage, 2);
+		drawProgressBar(
+			item.capacityUsed,
+			item.capacityTotal,
+			{x + secondStop + 5, y + 10, firstStop - 10, 10},
+			2
+		);
 	}
 
 	renderer.clipRectClear();

--- a/OPHD/UI/ProductListBox.h
+++ b/OPHD/UI/ProductListBox.h
@@ -20,7 +20,8 @@ public:
 	struct ProductListBoxItem : public ListBoxItem
 	{
 		int count = 0; /**< Count of the product. */
-		float usage = 0.0f; /**< Usage of available capacity. */
+		int capacityUsed = 0;
+		int capacityTotal = 0;
 	};
 
 	ProductListBox();

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -499,14 +499,14 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	renderer.drawText(fontBigBold, "Progress", NAS2D::Point{position_x, detailPanelRect.y + 358}, textColor);
 	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, NAS2D::Point{position_x, detailPanelRect.y + 393}, textColor);
 
-	float percent = 0.0f;
 	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
 	{
-		percent = static_cast<float>(selectedFactory->productionTurnsCompleted()) /
-			static_cast<float>(selectedFactory->productionTurnsToComplete());
+		drawProgressBar(
+			selectedFactory->productionTurnsCompleted(),
+			selectedFactory->productionTurnsToComplete(),
+			{position_x, detailPanelRect.y + 413, mRect.width - position_x - 10, 30}
+		);
 	}
-
-	drawBasicProgressBar({position_x, detailPanelRect.y + 413, mRect.width - position_x - 10, 30}, percent, 4);
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
 	renderer.drawText(fontMediumBold, "Turns", NAS2D::Point{position_x, detailPanelRect.y + 449}, textColor);

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -368,9 +368,12 @@ void MineReport::drawMineFacilityPane(const NAS2D::Point<int>& origin)
 	{
 		r.drawText(font, ResourceNamesOre[i], resourceTextOrigin, textColor);
 
-		const float percent = static_cast<float>(oreAvailable.resources[i]) / static_cast<float>(oreTotalYield.resources[i]);
-
-		drawBasicProgressBar({barOrigin, resourceTextOrigin.y, barWidth, 12}, percent, 2);
+		drawProgressBar(
+			oreAvailable.resources[i],
+			oreTotalYield.resources[i],
+			{barOrigin, resourceTextOrigin.y, barWidth, 12},
+			2
+		);
 		resourceTextOrigin.y += 20;
 	}
 }
@@ -395,8 +398,11 @@ void MineReport::drawOreProductionPane(const NAS2D::Point<int>& origin)
 		renderer.drawSubImage(uiIcons, origin + NAS2D::Vector{0, 30 + offsetY}, ResourceImageRectsOre[i]);
 		renderer.drawText(fontBold, ResourceNamesOre[i], origin + NAS2D::Vector{20, 30 + offsetY}, textColor);
 
-		const auto percent = static_cast<float>(oreAvailable.resources[i]) / static_cast<float>(oreTotalYield.resources[i]);
-		drawBasicProgressBar({origin.x, origin.y + 50 + offsetY, barWidth, 25}, percent);
+		drawProgressBar(
+			oreAvailable.resources[i],
+			oreTotalYield.resources[i],
+			{origin.x, origin.y + 50 + offsetY, barWidth, 25}
+		);
 
 		const std::string str = std::to_string(oreAvailable.resources[i]) + " of " + std::to_string(oreTotalYield.resources[i]) + " Remaining";
 		const int strOffsetX = (barWidth / 2) - (fontBold.width(str) / 2);

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -99,11 +99,9 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 		}
 	}
 
-	int capacityUsed = capacityTotal - capacityAvailable;
-
 	warehouseCount = warehouses.size();
 	warehouseCapacityTotal = capacityTotal;
-	warehouseCapacityPercent = static_cast<float>(capacityUsed) / static_cast<float>(capacityTotal);
+	warehouseCapacityUsed = capacityTotal - capacityAvailable;
 }
 
 
@@ -316,7 +314,11 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer)
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
 	const auto capacityBarWidth = mRect.width / 2 - 30 - capacityUsedTextWidth;
 	const auto capacityBarPositionX = 20 + capacityUsedTextWidth;
-	drawBasicProgressBar({capacityBarPositionX, positionY() + 84, capacityBarWidth, 20}, warehouseCapacityPercent);
+	drawProgressBar(
+		warehouseCapacityUsed,
+		warehouseCapacityTotal,
+		{capacityBarPositionX, positionY() + 84, capacityBarWidth, 20}
+	);
 }
 
 

--- a/OPHD/UI/Reports/WarehouseReport.h
+++ b/OPHD/UI/Reports/WarehouseReport.h
@@ -85,5 +85,5 @@ private:
 
 	std::size_t warehouseCount;
 	int warehouseCapacityTotal;
-	float warehouseCapacityPercent = 0.0f;
+	int warehouseCapacityUsed;
 };


### PR DESCRIPTION
Pass integers for `value` and `max` instead of a float for `percent` (which wasn't technically a percent, since there was no scale factor of 100). This eliminates the need to cast to and from `float` values, both at the call site, and internally within the function.

Add internal check to prevent division by 0. This no longer needs to be done at the call site.

Add internal clipping to prevent ever drawing a progress bar outside of the surrounding border.

Eliminate strange offsets to the inner rect position.
