### PR TITLE
Use win32 API ShellExecute for opening explorer window

### DIFF
--- a/OPHD/ShellOpenPath.cpp
+++ b/OPHD/ShellOpenPath.cpp
@@ -8,7 +8,7 @@
 namespace
 {
 	#if defined(_WIN32)
-		#include <Windows.h>
+		#include <windows.h>
 		#include <shellapi.h>
 	#elif defined(__APPLE__)
 		constexpr const std::string_view ShellOpenCommand{"open"};

--- a/OPHD/ShellOpenPath.cpp
+++ b/OPHD/ShellOpenPath.cpp
@@ -23,7 +23,7 @@ namespace
 void shellOpenPath(const std::string& path)
 {
 	#if defined(_WIN32)
-		std::ignore = ShellExecute(NULL, L"explore", std::wstring(path.begin(), path.end()).c_str(), NULL, NULL, SW_NORMAL);
+		std::ignore = ShellExecuteA(NULL, "explore", path.c_str(), NULL, NULL, SW_NORMAL);
 	#else
 		// Explicitly ignore implementation defined return value
 		std::ignore = std::system((std::string{ShellOpenCommand} + " " + path).c_str());

--- a/OPHD/ShellOpenPath.cpp
+++ b/OPHD/ShellOpenPath.cpp
@@ -8,7 +8,8 @@
 namespace
 {
 	#if defined(_WIN32)
-		constexpr const std::string_view ShellOpenCommand{"start"};
+		#include <Windows.h>
+		#include <shellapi.h>
 	#elif defined(__APPLE__)
 		constexpr const std::string_view ShellOpenCommand{"open"};
 	#elif defined(__linux__) || defined(__FreeBSD__)
@@ -21,6 +22,10 @@ namespace
 
 void shellOpenPath(const std::string& path)
 {
-	// Explicitly ignore implementation defined return value
-	std::ignore = std::system((std::string{ShellOpenCommand} + " " + path).c_str());
+	#if defined(_WIN32)
+		std::ignore = ShellExecute(NULL, L"explore", std::wstring(path.begin(), path.end()).c_str(), NULL, NULL, SW_NORMAL);
+	#else
+		// Explicitly ignore implementation defined return value
+		std::ignore = std::system((std::string{ShellOpenCommand} + " " + path).c_str());
+	#endif
 }


### PR DESCRIPTION
The original method of win32 shell execute used `"open"` which didn't work well (or at all in the case of path's with spaces in the name), with a terminal window opening to execute the command and then closing.

This change set replaces the Windows code with win32 `shellapi` calls according to API documentation provided by Microsoft ([see documentation here](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutea)). Ensures that the correct behavior is achieved and that it's seamless for the user.