### PR TITLE
Allow zero-max progress bars to draw as empty bars

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -284,18 +284,16 @@ float getMeanSolarDistance()
 
 void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding)
 {
-	if (max == 0)
-	{
-		throw std::runtime_error("Progress bar must have non-zero max value: " + std::to_string(max));
-	}
-
 	const auto clippedValue = std::clamp(value, 0, max);
-	auto innerRect = rect.inset(padding);
-	innerRect.width = innerRect.width * clippedValue / max;
-
 	auto& renderer = Utility<Renderer>::get();
 	renderer.drawBox(rect, NAS2D::Color{0, 185, 0});
-	renderer.drawBoxFilled(innerRect, NAS2D::Color{0, 100, 0});
+
+	if (max > 0)
+	{
+		auto innerRect = rect.inset(padding);
+		innerRect.width = innerRect.width * clippedValue / max;
+		renderer.drawBoxFilled(innerRect, NAS2D::Color{0, 100, 0});
+	}
 }
 
 


### PR DESCRIPTION
This allows progress bars with a zero-value 'max' component to draw as just an empty bar. Fixes an exception in the Warehouse Report.

@DanRStevens, want your opinion on this one. Another option is to just not draw the bar at all in the case that a zero-value for max is found which would require some logic elsewhere in the code to be modified. If that's the option we choose to go with this PR can be deleted.