### PR TITLE
Enquote path value to all open command to properly handle paths with spaces

### DIFF
--- a/OPHD/ShellOpenPath.cpp
+++ b/OPHD/ShellOpenPath.cpp
@@ -26,6 +26,6 @@ void shellOpenPath(const std::string& path)
 		std::ignore = ShellExecuteA(NULL, "explore", path.c_str(), NULL, NULL, SW_NORMAL);
 	#else
 		// Explicitly ignore implementation defined return value
-		std::ignore = std::system((std::string{ShellOpenCommand} + " " + path).c_str());
+		std::ignore = std::system((std::string{ShellOpenCommand} + " " + "\"" + path + "\"").c_str());
 	#endif
 }


### PR DESCRIPTION
This fixes finder windows not opening with the 'open' shell command. I have not tested this on linux so I'd want your input @DanRStevens before merging this change.