### PR TITLE
Add a `show-warnings` target to the `makefile`

### DIFF
--- a/makefile
+++ b/makefile
@@ -105,6 +105,10 @@ install-dependencies:
 	$(MAKE) -C nas2d-core install-dependencies
 
 
+.PHONY: show-warnings
+show-warnings:
+	$(MAKE) -j1 clean all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+
 .PHONY: lint
 lint: cppcheck cppclean cppinclude
 


### PR DESCRIPTION
This automates running the build using Clang with `-Weverything`, and then grepping the stderr output for warning flag messages, and processing them to be sorted, with duplicates removed.

The `-j1` is needed since otherwise output from multiple processes can get interleaved, which would confuse the regex that pulls out the warning flags.

Run a `clean` before building `all` to ensure nothing is skipped during a rebuild, which would prevent warning messages from being displayed for those compilation units.

Order of output redirection is important. First stderr must be directed to where stdout is currently pointing, then stdout is redirected to be ignored. We want to process the stderr output only.

----

References:
- #307
- https://github.com/lairworks/nas2d-core/pull/1096