### PR TITLE
Update Truck movement cost algorithm for Mines and Smelters

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -279,7 +279,7 @@ void TileMap::AdjacentCost(void* state, std::vector<micropather::StateCost>* adj
 		}
 		else if (!adjacentTile.empty())
 		{
-			if (&adjacentTile == mPathStartEndPair.first || &adjacentTile == mPathStartEndPair.second)
+			if (adjacentTile.thingIsStructure() && (adjacentTile.structure()->isMineFacility() || adjacentTile.structure()->isSmelter()))
 			{
 				cost *= static_cast<float>(adjacentTile.index()) + 1.0f;
 			}


### PR DESCRIPTION
Instead of checking for path start/end points (which will always be a mine and smelter), instead check for tiles with Mines or Smelters. This makes the cost at each tile depend only on tile info. It does change the algorithm slightly, as a route from a mine can now pass through another mine. Previously only other roads were passable, aside from the start and end points.

(Note: No paths passing through another smelter would be a shortest path to a smelter.)
