### PR TITLE
Remove mine veins

### DIFF
--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Common.h"
+#include "StorableResources.h"
 
 #include <NAS2D/Math/Point.h>
 
@@ -29,9 +30,6 @@ public:
 		RareMetals,
 		RareMinerals,
 	};
-
-	using MineVein = StorableResources;
-	using MineVeins = std::vector<MineVein>;
 
 public:
 	Mine();
@@ -65,7 +63,8 @@ private:
 	Mine& operator=(const Mine&) = delete;
 
 private:
-	MineVeins mVeins;
+	StorableResources mTappedReserves;
+	int mCurrentDepth{1};
 	MineProductionRate mProductionRate = MineProductionRate::Low;
 
 	/**

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -65,8 +65,8 @@ private:
 	Mine& operator=(const Mine&) = delete;
 
 private:
-	MineVeins mVeins; /**< Ore veins */
-	MineProductionRate mProductionRate = MineProductionRate::Low; /**< Mine's production rate. */
+	MineVeins mVeins;
+	MineProductionRate mProductionRate = MineProductionRate::Low;
 
 	/**
 	 * Flags indicating several states for the mine:


### PR DESCRIPTION
Remove the private internal detail of mine veins. Instead, there is a single pool of tapped reserves, which gets added to when the mine depth is extended.

Keep the iteration code for mine veins when loading saved games, so as to maintain compatibility with old saved games. Instead of storing a `std::vector` of results, they are simply added to the tapped reserves.

When writing saved game files, all tapped reserves are written to a single vein record. This is a sort of minimal change that makes it easy to stay compatible with the loading code.
