### PR TITLE
Have `RobotPool` own robots

### DIFF
--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -22,9 +22,9 @@ RobotPool::~RobotPool()
 
 void RobotPool::clear()
 {
-	clearRobots(mDiggers);
-	clearRobots(mDozers);
-	clearRobots(mMiners);
+	mDiggers.clear();
+	mDozers.clear();
+	mMiners.clear();
 	mRobots.clear();
 
 	mRobotControlCount = 0;
@@ -39,8 +39,6 @@ void RobotPool::erase(Robot* robot)
 	eraseRobot(mDiggers, robot);
 	eraseRobot(mDozers, robot);
 	eraseRobot(mMiners, robot);
-
-	delete robot;
 }
 
 
@@ -54,16 +52,16 @@ Robot& RobotPool::addRobot(Robot::Type type)
 	switch (type)
 	{
 	case Robot::Type::Dozer:
-		mDozers.push_back(new Robodozer());
-		mRobots.push_back(mDozers.back());
+		mDozers.emplace_back();
+		mRobots.push_back(&mDozers.back());
 		break;
 	case Robot::Type::Digger:
-		mDiggers.push_back(new Robodigger());
-		mRobots.push_back(mDiggers.back());
+		mDiggers.emplace_back();
+		mRobots.push_back(&mDiggers.back());
 		break;
 	case Robot::Type::Miner:
-		mMiners.push_back(new Robominer());
-		mRobots.push_back(mMiners.back());
+		mMiners.emplace_back();
+		mRobots.push_back(&mMiners.back());
 		break;
 	default:
 		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -111,15 +111,15 @@ bool RobotPool::robotAvailable(Robot::Type type) const
 	{
 	case Robot::Type::Digger:
 	{
-		return getIdleRobotOrNull(mDiggers) != nullptr;
+		return hasIdleRobot(mDiggers);
 	}
 	case Robot::Type::Dozer:
 	{
-		return getIdleRobotOrNull(mDozers) != nullptr;
+		return hasIdleRobot(mDozers);
 	}
 	case Robot::Type::Miner:
 	{
-		return getIdleRobotOrNull(mMiners) != nullptr;
+		return hasIdleRobot(mMiners);
 	}
 	default:
 	{

--- a/OPHD/RobotPool.cpp
+++ b/OPHD/RobotPool.cpp
@@ -39,6 +39,8 @@ void RobotPool::erase(Robot* robot)
 	eraseRobot(mDiggers, robot);
 	eraseRobot(mDozers, robot);
 	eraseRobot(mMiners, robot);
+
+	delete robot;
 }
 
 

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -4,7 +4,7 @@
 #include "Things/Robots/Robots.h"
 
 #include <cstddef>
-#include <vector>
+#include <list>
 #include <map>
 
 
@@ -14,9 +14,9 @@ class Tile;
 class RobotPool
 {
 public:
-	using DiggerList = std::vector<Robodigger*>;
-	using DozerList = std::vector<Robodozer*>;
-	using MinerList = std::vector<Robominer*>;
+	using DiggerList = std::list<Robodigger>;
+	using DozerList = std::list<Robodozer>;
+	using MinerList = std::list<Robominer>;
 	using RobotTileTable = std::map<Robot*, Tile*>;
 
 public:

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -25,6 +25,17 @@ void clearRobots(T& list)
 
 
 template <class T>
+void eraseRobot(T& list, Robot* robot)
+{
+	auto it = find(list.begin(), list.end(), robot);
+	if (it != list.end())
+	{
+		list.erase(it);
+	}
+}
+
+
+template <class T>
 typename T::value_type getIdleRobotOrNull(const T& list)
 {
 	for (auto robot : list)
@@ -69,15 +80,4 @@ std::size_t robotControlCount(const T& list)
 		if (!robot->idle() && !robot->isDead()) { ++controlCounter; }
 	}
 	return controlCounter;
-}
-
-
-template <class T>
-void eraseRobot(T& list, Robot* robot)
-{
-	auto it = find(list.begin(), list.end(), robot);
-	if (it != list.end())
-	{
-		list.erase(it);
-	}
 }

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -47,25 +47,13 @@ bool hasIdleRobot(const T& list)
 
 
 template <class T>
-typename T::value_type getIdleRobotOrNull(const T& list)
+auto& getIdleRobot(T& list)
 {
-	for (const auto& robot : list)
+	for (auto& robot : list)
 	{
-		if (robot->idle()) { return robot; }
+		if (robot->idle()) { return *robot; }
 	}
-	return nullptr;
-}
-
-
-template <class T>
-auto& getIdleRobot(const T& list)
-{
-	auto* robot = getIdleRobotOrNull(list);
-	if (robot == nullptr)
-	{
-		throw std::runtime_error("Failed to get an idle robot");
-	}
-	return *robot;
+	throw std::runtime_error("Failed to get an idle robot");
 }
 
 

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -36,6 +36,17 @@ void eraseRobot(T& list, Robot* robot)
 
 
 template <class T>
+bool hasIdleRobot(const T& list)
+{
+	for (const auto& robot : list)
+	{
+		if (robot->idle()) { return true; }
+	}
+	return false;
+}
+
+
+template <class T>
 typename T::value_type getIdleRobotOrNull(const T& list)
 {
 	for (const auto& robot : list)

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -13,21 +13,21 @@
 
 
 template <class T>
-void clearRobots(T& t)
+void clearRobots(T& list)
 {
-	for (auto robot : t)
+	for (auto robot : list)
 	{
 		delete robot;
 	}
 
-	t.clear();
+	list.clear();
 }
 
 
 template <class T>
-typename T::value_type getIdleRobotOrNull(const T& t)
+typename T::value_type getIdleRobotOrNull(const T& list)
 {
-	for (auto robot : t)
+	for (auto robot : list)
 	{
 		if (robot->idle()) { return robot; }
 	}
@@ -48,10 +48,10 @@ auto& getIdleRobot(const T& list)
 
 
 template <class T>
-std::size_t getIdleCount(const T& t)
+std::size_t getIdleCount(const T& list)
 {
 	std::size_t count = 0;
-	for (auto robot : t)
+	for (auto robot : list)
 	{
 		if (robot->idle()) { ++count; }
 	}
@@ -61,10 +61,10 @@ std::size_t getIdleCount(const T& t)
 
 
 template <class T>
-std::size_t robotControlCount(const T& t)
+std::size_t robotControlCount(const T& list)
 {
 	std::size_t controlCounter{0};
-	for (auto robot : t)
+	for (auto robot : list)
 	{
 		if (!robot->idle() && !robot->isDead()) { ++controlCounter; }
 	}
@@ -73,11 +73,11 @@ std::size_t robotControlCount(const T& t)
 
 
 template <class T>
-void eraseRobot(T& t, Robot* robot)
+void eraseRobot(T& list, Robot* robot)
 {
-	auto it = find(t.begin(), t.end(), robot);
-	if (it != t.end())
+	auto it = find(list.begin(), list.end(), robot);
+	if (it != list.end())
 	{
-		t.erase(it);
+		list.erase(it);
 	}
 }

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -15,7 +15,7 @@
 template <class T>
 void clearRobots(T& list)
 {
-	for (auto robot : list)
+	for (const auto& robot : list)
 	{
 		delete robot;
 	}
@@ -38,7 +38,7 @@ void eraseRobot(T& list, Robot* robot)
 template <class T>
 typename T::value_type getIdleRobotOrNull(const T& list)
 {
-	for (auto robot : list)
+	for (const auto& robot : list)
 	{
 		if (robot->idle()) { return robot; }
 	}
@@ -62,7 +62,7 @@ template <class T>
 std::size_t getIdleCount(const T& list)
 {
 	std::size_t count = 0;
-	for (auto robot : list)
+	for (const auto& robot : list)
 	{
 		if (robot->idle()) { ++count; }
 	}
@@ -75,7 +75,7 @@ template <class T>
 std::size_t robotControlCount(const T& list)
 {
 	std::size_t controlCounter{0};
-	for (auto robot : list)
+	for (const auto& robot : list)
 	{
 		if (!robot->idle() && !robot->isDead()) { ++controlCounter; }
 	}

--- a/OPHD/RobotPoolHelper.h
+++ b/OPHD/RobotPoolHelper.h
@@ -13,24 +13,15 @@
 
 
 template <class T>
-void clearRobots(T& list)
-{
-	for (const auto& robot : list)
-	{
-		delete robot;
-	}
-
-	list.clear();
-}
-
-
-template <class T>
 void eraseRobot(T& list, Robot* robot)
 {
-	auto it = find(list.begin(), list.end(), robot);
-	if (it != list.end())
+	for (auto it = list.begin(); it != list.end(); ++it)
 	{
-		list.erase(it);
+		if (&*it == robot)
+		{
+			list.erase(it);
+			return;
+		}
 	}
 }
 
@@ -38,9 +29,9 @@ void eraseRobot(T& list, Robot* robot)
 template <class T>
 bool hasIdleRobot(const T& list)
 {
-	for (const auto& robot : list)
+	for (auto& robot : list)
 	{
-		if (robot->idle()) { return true; }
+		if (robot.idle()) { return true; }
 	}
 	return false;
 }
@@ -51,7 +42,7 @@ auto& getIdleRobot(T& list)
 {
 	for (auto& robot : list)
 	{
-		if (robot->idle()) { return *robot; }
+		if (robot.idle()) { return robot; }
 	}
 	throw std::runtime_error("Failed to get an idle robot");
 }
@@ -63,7 +54,7 @@ std::size_t getIdleCount(const T& list)
 	std::size_t count = 0;
 	for (const auto& robot : list)
 	{
-		if (robot->idle()) { ++count; }
+		if (robot.idle()) { ++count; }
 	}
 
 	return count;
@@ -76,7 +67,7 @@ std::size_t robotControlCount(const T& list)
 	std::size_t controlCounter{0};
 	for (const auto& robot : list)
 	{
-		if (!robot->idle() && !robot->isDead()) { ++controlCounter; }
+		if (!robot.idle() && !robot.isDead()) { ++controlCounter; }
 	}
 	return controlCounter;
 }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1289,7 +1289,6 @@ void MapViewState::updateRobots()
 			if (mRobotInspector.focusedRobot() == robot) { mRobotInspector.hide(); }
 
 			mRobotPool.erase(robot);
-			delete robot;
 			robot_it = mRobotList.erase(robot_it);
 		}
 		else if (robot->idle())

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -193,7 +193,6 @@ void deleteRobotsInRCC(RobotCommand* rcc, RobotPool& robotPool, RobotTileTable& 
 		}
 
 		robotPool.erase(robot);
-		delete robot;
 	}
 }
 


### PR DESCRIPTION
Have `RobotPool` own all `Robot` objects, and be in complete control of their lifetime.

Convert the internal lists from pointers to actual full objects.

Removes some uses of `new` and `delete` (#480).
