### PR TITLE
Calculate task time within the `Robot` class

### DIFF
--- a/OPHD/MapObjects/Robot.cpp
+++ b/OPHD/MapObjects/Robot.cpp
@@ -1,5 +1,24 @@
 #include "Robot.h"
 
+#include "../Constants/Numbers.h"
+#include "../Map/Tile.h"
+
+
+namespace
+{
+	const std::map<Robot::Type, int> basicTaskTime{
+		{Robot::Type::Dozer, 0},
+		{Robot::Type::Digger, constants::DiggerTaskTime},
+		{Robot::Type::Miner, constants::MinerTaskTime},
+	};
+
+	int getTaskTime(Robot::Type type, Tile& tile)
+	{
+		return std::max(1, basicTaskTime.at(type) + static_cast<int>(tile.index()));
+	}
+}
+
+
 Robot::Robot(const std::string& name, const std::string& spritePath, Type type) :
 	MapObject(name, spritePath, "running"),
 	mType{type}
@@ -10,6 +29,12 @@ Robot::Robot(const std::string& name, const std::string& spritePath, const std::
 	MapObject(name, spritePath, initialAction),
 	mType{type}
 {}
+
+
+void Robot::startTask(Tile& tile)
+{
+	startTask(getTaskTime(mType, tile));
+}
 
 
 void Robot::startTask(int turns)

--- a/OPHD/MapObjects/Robot.h
+++ b/OPHD/MapObjects/Robot.h
@@ -5,6 +5,9 @@
 #include <NAS2D/Dictionary.h>
 
 
+class Tile;
+
+
 class Robot : public MapObject
 {
 public:
@@ -25,6 +28,7 @@ public:
 
 	void update() override;
 
+	void startTask(Tile& tile);
 	void startTask(int turns);
 
 	void fuelCellAge(int age) { mFuelCellAge = age; }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1037,8 +1037,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 	}
 
 	auto& robot = mRobotPool.getDozer();
-	int taskTime = tile.index() == TerrainType::Dozed ? 1 : static_cast<int>(tile.index());
-	robot.startTask(taskTime);
+	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 	robot.tileIndex(static_cast<std::size_t>(tile.index()));
 	tile.index(TerrainType::Dozed);
@@ -1150,7 +1149,7 @@ void MapViewState::placeRobominer(Tile& tile)
 	}
 
 	auto& robot = mRobotPool.getMiner();
-	robot.startTask(constants::MinerTaskTime);
+	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 	tile.index(TerrainType::Dozed);
 

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -587,7 +587,7 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 
 	// Assumes a digger is available.
 	Robodigger& robot = mRobotPool.getDigger();
-	robot.startTask(static_cast<int>(tile.index()) + constants::DiggerTaskTime);
+	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
 	robot.direction(direction);


### PR DESCRIPTION
The `Robot` should know how long a task will take, given the terrain parameters, and which robot type and task is being performed. It should not be dictated by an external actor how long an action must take.

Note that when mines are placed, the terrain is bulldozed, so `RoboMiner` task times don't actually vary by terrain type. (Terrain type effectively contributes 0 turns to the task time).

Loosely related to #1335.
