### PR TITLE
Refactor `Structure` names

### DIFF
--- a/OPHD/MapObjects/Structure.cpp
+++ b/OPHD/MapObjects/Structure.cpp
@@ -105,16 +105,16 @@ std::string StructureName(StructureID id)
 
 
 
-Structure::Structure(const std::string& name, const std::string& spritePath, StructureClass structureClass, StructureID id) :
-	MapObject(name, spritePath, constants::StructureStateConstruction),
+Structure::Structure(const std::string& spritePath, StructureClass structureClass, StructureID id) :
+	MapObject(StructureName(id), spritePath, constants::StructureStateConstruction),
 	mStructureId(id),
 	mStructureClass(structureClass)
 {
 }
 
 
-Structure::Structure(const std::string& name, const std::string& spritePath, const std::string& initialAction, StructureClass structureClass, StructureID id) :
-	MapObject(name, spritePath, initialAction),
+Structure::Structure(const std::string& spritePath, const std::string& initialAction, StructureClass structureClass, StructureID id) :
+	MapObject(StructureName(id), spritePath, initialAction),
 	mStructureId(id),
 	mStructureClass(structureClass)
 {

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -67,8 +67,8 @@ public:
 	};
 
 public:
-	Structure(const std::string& name, const std::string& spritePath, StructureClass structureClass, StructureID id);
-	Structure(const std::string& name, const std::string& spritePath, const std::string& initialAction, StructureClass structureClass, StructureID id);
+	Structure(const std::string& spritePath, StructureClass structureClass, StructureID id);
+	Structure(const std::string& spritePath, const std::string& initialAction, StructureClass structureClass, StructureID id);
 
 	~Structure() override = default;
 

--- a/OPHD/MapObjects/Structures/Agridome.h
+++ b/OPHD/MapObjects/Structures/Agridome.h
@@ -13,7 +13,7 @@ const int AGRIDOME_BASE_PRODUCUCTION = 10;
 class Agridome : public FoodProduction
 {
 public:
-	Agridome() : FoodProduction(constants::Agridome, "structures/agridome.sprite", StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
+	Agridome() : FoodProduction("structures/agridome.sprite", StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
 	{
 		maxAge(600);
 		turnsToBuild(3);

--- a/OPHD/MapObjects/Structures/AirShaft.h
+++ b/OPHD/MapObjects/Structures/AirShaft.h
@@ -9,7 +9,7 @@
 class AirShaft : public Structure
 {
 public:
-	AirShaft() : Structure(constants::AirShaft, "structures/air_shaft.sprite",
+	AirShaft() : Structure("structures/air_shaft.sprite",
 		constants::StructureStateOperational,
 		StructureClass::Tube,
 		StructureID::SID_AIR_SHAFT)

--- a/OPHD/MapObjects/Structures/AirShaft.h
+++ b/OPHD/MapObjects/Structures/AirShaft.h
@@ -9,7 +9,8 @@
 class AirShaft : public Structure
 {
 public:
-	AirShaft() : Structure("structures/air_shaft.sprite",
+	AirShaft() : Structure(
+		"structures/air_shaft.sprite",
 		constants::StructureStateOperational,
 		StructureClass::Tube,
 		StructureID::SID_AIR_SHAFT)

--- a/OPHD/MapObjects/Structures/CHAP.h
+++ b/OPHD/MapObjects/Structures/CHAP.h
@@ -8,7 +8,7 @@
 class CHAP : public Structure
 {
 public:
-	CHAP() : Structure(constants::Chap, "structures/chap.sprite", StructureClass::LifeSupport, StructureID::SID_CHAP)
+	CHAP() : Structure("structures/chap.sprite", StructureClass::LifeSupport, StructureID::SID_CHAP)
 	{
 		maxAge(600);
 		turnsToBuild(5);

--- a/OPHD/MapObjects/Structures/CargoLander.h
+++ b/OPHD/MapObjects/Structures/CargoLander.h
@@ -12,7 +12,7 @@ public:
 
 	using Signal = NAS2D::Signal<>;
 
-	CargoLander(Tile* tile) : Structure(constants::CargoLander,
+	CargoLander(Tile* tile) : Structure(
 		"structures/lander_0.sprite",
 		StructureClass::Lander,
 		StructureID::SID_CARGO_LANDER),

--- a/OPHD/MapObjects/Structures/ColonistLander.h
+++ b/OPHD/MapObjects/Structures/ColonistLander.h
@@ -13,7 +13,7 @@ public:
 
 public:
 
-	ColonistLander(Tile* tile) : Structure(constants::ColonistLander,
+	ColonistLander(Tile* tile) : Structure(
 		"structures/lander_1.sprite",
 		StructureClass::Lander,
 		StructureID::SID_COLONIST_LANDER),

--- a/OPHD/MapObjects/Structures/CommTower.h
+++ b/OPHD/MapObjects/Structures/CommTower.h
@@ -12,7 +12,7 @@ private:
 	const int BaseRange = 10;
 
 public:
-	CommTower() : Structure(constants::CommTower,
+	CommTower() : Structure(
 		"structures/communications_tower.sprite",
 		StructureClass::Communication,
 		StructureID::SID_COMM_TOWER)

--- a/OPHD/MapObjects/Structures/CommandCenter.h
+++ b/OPHD/MapObjects/Structures/CommandCenter.h
@@ -12,7 +12,7 @@
 class CommandCenter : public FoodProduction
 {
 public:
-	CommandCenter() : FoodProduction(constants::CommandCenter,
+	CommandCenter() : FoodProduction(
 		"structures/command_center.sprite",
 		StructureClass::Command,
 		StructureID::SID_COMMAND_CENTER)

--- a/OPHD/MapObjects/Structures/Commercial.h
+++ b/OPHD/MapObjects/Structures/Commercial.h
@@ -8,7 +8,7 @@
 class Commercial : public Structure
 {
 public:
-	Commercial() : Structure(constants::Commercial,
+	Commercial() : Structure(
 		"structures/commercial.sprite",
 		StructureClass::Commercial,
 		StructureID::SID_COMMERCIAL)

--- a/OPHD/MapObjects/Structures/Factory.cpp
+++ b/OPHD/MapObjects/Structures/Factory.cpp
@@ -36,8 +36,8 @@ const ProductionCost& productCost(ProductType productType)
 }
 
 
-Factory::Factory(const std::string& name, const std::string& spritePath, StructureID id) :
-	Structure(name, spritePath, StructureClass::Factory, id)
+Factory::Factory(const std::string& spritePath, StructureID id) :
+	Structure(spritePath, StructureClass::Factory, id)
 {}
 
 

--- a/OPHD/MapObjects/Structures/Factory.h
+++ b/OPHD/MapObjects/Structures/Factory.h
@@ -31,7 +31,7 @@ public:
 	using ProductionTypeList = std::vector<ProductType>;
 
 public:
-	Factory(const std::string& name, const std::string& spritePath, StructureID id);
+	Factory(const std::string& spritePath, StructureID id);
 
 	virtual void updateProduction();
 

--- a/OPHD/MapObjects/Structures/FoodProduction.h
+++ b/OPHD/MapObjects/Structures/FoodProduction.h
@@ -10,8 +10,8 @@
 class FoodProduction : public Structure
 {
 public:
-	FoodProduction(const std::string& name, const std::string& spritePath, StructureClass structureClass, StructureID id) :
-		Structure(name, spritePath, structureClass, id) {}
+	FoodProduction(const std::string& spritePath, StructureClass structureClass, StructureID id) :
+		Structure(spritePath, structureClass, id) {}
 
 	StringTable createInspectorViewTable() override
 	{

--- a/OPHD/MapObjects/Structures/FusionReactor.h
+++ b/OPHD/MapObjects/Structures/FusionReactor.h
@@ -13,7 +13,7 @@ const int FUSION_REACTOR_BASE_PRODUCUCTION = 1000;
 class FusionReactor : public PowerStructure
 {
 public:
-	FusionReactor() : PowerStructure(constants::FusionReactor,
+	FusionReactor() : PowerStructure(
 		"structures/fusion_reactor.sprite",
 		StructureClass::EnergyProduction,
 		StructureID::SID_FUSION_REACTOR)

--- a/OPHD/MapObjects/Structures/HotLaboratory.h
+++ b/OPHD/MapObjects/Structures/HotLaboratory.h
@@ -9,7 +9,7 @@ class HotLaboratory : public ResearchFacility
 {
 public:
 	HotLaboratory() :
-		ResearchFacility(constants::HotLaboratory,
+		ResearchFacility(
 		"structures/labo_surface.sprite",
 		StructureClass::Laboratory,
 		StructureID::SID_HOT_LABORATORY)

--- a/OPHD/MapObjects/Structures/HotLaboratory.h
+++ b/OPHD/MapObjects/Structures/HotLaboratory.h
@@ -8,8 +8,7 @@
 class HotLaboratory : public ResearchFacility
 {
 public:
-	HotLaboratory() :
-		ResearchFacility(
+	HotLaboratory() : ResearchFacility(
 		"structures/labo_surface.sprite",
 		StructureClass::Laboratory,
 		StructureID::SID_HOT_LABORATORY)

--- a/OPHD/MapObjects/Structures/Laboratory.h
+++ b/OPHD/MapObjects/Structures/Laboratory.h
@@ -9,7 +9,7 @@ class Laboratory : public ResearchFacility
 {
 public:
 	Laboratory() :
-		ResearchFacility(constants::Laboratory,
+		ResearchFacility(
 		"structures/laboratory_underground.sprite",
 		StructureClass::Laboratory,
 		StructureID::SID_LABORATORY)

--- a/OPHD/MapObjects/Structures/Laboratory.h
+++ b/OPHD/MapObjects/Structures/Laboratory.h
@@ -8,8 +8,7 @@
 class Laboratory : public ResearchFacility
 {
 public:
-	Laboratory() :
-		ResearchFacility(
+	Laboratory() : ResearchFacility(
 		"structures/laboratory_underground.sprite",
 		StructureClass::Laboratory,
 		StructureID::SID_LABORATORY)

--- a/OPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/OPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -18,7 +18,7 @@ public:
 	static constexpr int MinimumPersonnel{1};
 
 public:
-	MaintenanceFacility() : Structure(constants::MaintenanceFacility,
+	MaintenanceFacility() : Structure(
 		"structures/maintenance.sprite",
 		StructureClass::Maintenance,
 		StructureID::SID_MAINTENANCE_FACILITY)

--- a/OPHD/MapObjects/Structures/MedicalCenter.h
+++ b/OPHD/MapObjects/Structures/MedicalCenter.h
@@ -8,7 +8,7 @@
 class MedicalCenter : public Structure
 {
 public:
-	MedicalCenter() : Structure(constants::MedicalCenter,
+	MedicalCenter() : Structure(
 		"structures/medical.sprite",
 		StructureClass::MedicalCenter,
 		StructureID::SID_MEDICAL_CENTER)

--- a/OPHD/MapObjects/Structures/MineFacility.cpp
+++ b/OPHD/MapObjects/Structures/MineFacility.cpp
@@ -20,7 +20,6 @@ namespace
 
 MineFacility::MineFacility(Mine* mine) :
 	Structure(
-		constants::MineFacility,
 		"structures/mine_facility.sprite",
 		StructureClass::Mine,
 		StructureID::SID_MINE_FACILITY

--- a/OPHD/MapObjects/Structures/MineShaft.h
+++ b/OPHD/MapObjects/Structures/MineShaft.h
@@ -8,7 +8,7 @@
 class MineShaft : public Structure
 {
 public:
-	MineShaft() : Structure(constants::MineShaft,
+	MineShaft() : Structure(
 		"structures/mine_shaft.sprite",
 		StructureClass::Undefined,
 		StructureID::SID_MINE_SHAFT)

--- a/OPHD/MapObjects/Structures/Nursery.h
+++ b/OPHD/MapObjects/Structures/Nursery.h
@@ -8,7 +8,7 @@
 class Nursery : public Structure
 {
 public:
-	Nursery() : Structure(constants::Nursery,
+	Nursery() : Structure(
 		"structures/nursery_01.sprite",
 		StructureClass::Nursery,
 		StructureID::SID_NURSERY)

--- a/OPHD/MapObjects/Structures/OreRefining.h
+++ b/OPHD/MapObjects/Structures/OreRefining.h
@@ -12,8 +12,8 @@
 class OreRefining : public Structure
 {
 public:
-	OreRefining(const std::string& name, const std::string& spritePath, StructureClass structureClass, StructureID id) :
-		Structure(name, spritePath, structureClass, id) {}
+	OreRefining(const std::string& spritePath, StructureClass structureClass, StructureID id) :
+		Structure(spritePath, structureClass, id) {}
 
 	StringTable createInspectorViewTable() override
 	{

--- a/OPHD/MapObjects/Structures/Park.h
+++ b/OPHD/MapObjects/Structures/Park.h
@@ -8,7 +8,7 @@
 class Park : public Structure
 {
 public:
-	Park() : Structure(constants::Park,
+	Park() : Structure(
 		"structures/park.sprite",
 		StructureClass::Park,
 		StructureID::SID_PARK)

--- a/OPHD/MapObjects/Structures/PowerStructure.h
+++ b/OPHD/MapObjects/Structures/PowerStructure.h
@@ -15,8 +15,8 @@
 class PowerStructure : public Structure
 {
 public:
-	PowerStructure(const std::string& name, const std::string& spritePath, StructureClass structureClass, StructureID id) :
-		Structure(name, spritePath, structureClass, id) {}
+	PowerStructure(const std::string& spritePath, StructureClass structureClass, StructureID id) :
+		Structure(spritePath, structureClass, id) {}
 
 	StringTable createInspectorViewTable() override
 	{

--- a/OPHD/MapObjects/Structures/RecreationCenter.h
+++ b/OPHD/MapObjects/Structures/RecreationCenter.h
@@ -8,7 +8,7 @@
 class RecreationCenter : public Structure
 {
 public:
-	RecreationCenter() : Structure(constants::RecreationCenter,
+	RecreationCenter() : Structure(
 		"structures/recreation_center.sprite",
 		StructureClass::RecreationCenter,
 		StructureID::SID_RECREATION_CENTER)

--- a/OPHD/MapObjects/Structures/Recycling.h
+++ b/OPHD/MapObjects/Structures/Recycling.h
@@ -15,7 +15,7 @@ private:
 	const int ResidentialSupportCount = 10;
 
 public:
-	Recycling() : Structure(constants::Recycling,
+	Recycling() : Structure(
 		"structures/recycling.sprite",
 		StructureClass::Recycling,
 		StructureID::SID_RECYCLING)

--- a/OPHD/MapObjects/Structures/RedLightDistrict.h
+++ b/OPHD/MapObjects/Structures/RedLightDistrict.h
@@ -8,7 +8,7 @@
 class RedLightDistrict : public Structure
 {
 public:
-	RedLightDistrict() : Structure(constants::RedLightDistrict,
+	RedLightDistrict() : Structure(
 		"structures/red_light_district.sprite",
 		StructureClass::Residence,
 		StructureID::SID_RED_LIGHT_DISTRICT)

--- a/OPHD/MapObjects/Structures/ResearchFacility.h
+++ b/OPHD/MapObjects/Structures/ResearchFacility.h
@@ -9,8 +9,8 @@
 class ResearchFacility : public Structure
 {
 public:
-	ResearchFacility(const std::string& name, const std::string& spritePath, StructureClass structureClass, StructureID id) :
-		Structure(name, spritePath, structureClass, id)
+	ResearchFacility(const std::string& spritePath, StructureClass structureClass, StructureID id) :
+		Structure(spritePath, structureClass, id)
 	{}
 
 

--- a/OPHD/MapObjects/Structures/Residence.h
+++ b/OPHD/MapObjects/Structures/Residence.h
@@ -20,7 +20,7 @@ const int ResidentialColonistCapacityBase = 25;
 class Residence : public Structure
 {
 public:
-	Residence() : Structure(constants::Residence,
+	Residence() : Structure(
 		"structures/residential_1.sprite",
 		StructureClass::Residence,
 		StructureID::SID_RESIDENCE)

--- a/OPHD/MapObjects/Structures/Road.h
+++ b/OPHD/MapObjects/Structures/Road.h
@@ -8,7 +8,7 @@
 class Road : public Structure
 {
 public:
-	Road() : Structure(constants::Road,
+	Road() : Structure(
 		"structures/roads.sprite",
 		StructureClass::Road,
 		StructureID::SID_ROAD)

--- a/OPHD/MapObjects/Structures/RobotCommand.h
+++ b/OPHD/MapObjects/Structures/RobotCommand.h
@@ -16,7 +16,7 @@ class Robot;
 class RobotCommand : public Structure
 {
 public:
-	RobotCommand() : Structure(constants::RobotCommand,
+	RobotCommand() : Structure(
 		"structures/robot_control.sprite",
 		StructureClass::RobotCommand,
 		StructureID::SID_ROBOT_COMMAND)

--- a/OPHD/MapObjects/Structures/SeedFactory.h
+++ b/OPHD/MapObjects/Structures/SeedFactory.h
@@ -8,7 +8,7 @@
 class SeedFactory : public Factory
 {
 public:
-	SeedFactory() : Factory(constants::SeedFactory,
+	SeedFactory() : Factory(
 		"structures/seed_1.sprite",
 		StructureID::SID_SEED_FACTORY)
 	{

--- a/OPHD/MapObjects/Structures/SeedLander.h
+++ b/OPHD/MapObjects/Structures/SeedLander.h
@@ -16,9 +16,10 @@ public:
 	SeedLander() = delete;
 	SeedLander(NAS2D::Point<int> position) :
 		Structure{
-		"structures/seed_0.sprite",
-		StructureClass::Lander,
-		StructureID::SID_SEED_LANDER},
+			"structures/seed_0.sprite",
+			StructureClass::Lander,
+			StructureID::SID_SEED_LANDER
+		},
 		mPosition{position}
 	{
 		maxAge(50);

--- a/OPHD/MapObjects/Structures/SeedLander.h
+++ b/OPHD/MapObjects/Structures/SeedLander.h
@@ -15,7 +15,7 @@ public:
 public:
 	SeedLander() = delete;
 	SeedLander(NAS2D::Point<int> position) :
-		Structure{constants::SeedLander,
+		Structure{
 		"structures/seed_0.sprite",
 		StructureClass::Lander,
 		StructureID::SID_SEED_LANDER},

--- a/OPHD/MapObjects/Structures/SeedPower.h
+++ b/OPHD/MapObjects/Structures/SeedPower.h
@@ -12,7 +12,7 @@ const int SEED_POWER_PRODUCTION = 50;
 class SeedPower : public PowerStructure
 {
 public:
-	SeedPower() : PowerStructure(constants::SeedPower,
+	SeedPower() : PowerStructure(
 		"structures/seed_1.sprite",
 		StructureClass::EnergyProduction,
 		StructureID::SID_SEED_POWER)

--- a/OPHD/MapObjects/Structures/SeedSmelter.h
+++ b/OPHD/MapObjects/Structures/SeedSmelter.h
@@ -10,7 +10,7 @@ class SeedSmelter : public OreRefining
 	const int StorageCapacity = 500;
 
 public:
-	SeedSmelter() : OreRefining(constants::SeedSmelter,
+	SeedSmelter() : OreRefining(
 		"structures/seed_1.sprite",
 		StructureClass::Smelter,
 		StructureID::SID_SEED_SMELTER)

--- a/OPHD/MapObjects/Structures/Smelter.h
+++ b/OPHD/MapObjects/Structures/Smelter.h
@@ -10,7 +10,7 @@ class Smelter : public OreRefining
 	const int StorageCapacity = 800;
 
 public:
-	Smelter() : OreRefining(constants::Smelter,
+	Smelter() : OreRefining(
 		"structures/smelter.sprite",
 		StructureClass::Smelter,
 		StructureID::SID_SMELTER)

--- a/OPHD/MapObjects/Structures/SolarPanelArray.h
+++ b/OPHD/MapObjects/Structures/SolarPanelArray.h
@@ -15,7 +15,6 @@ public:
 	SolarPanelArray() :
 		PowerStructure
 		{
-			constants::SolarPanel1,
 			"structures/solar_array1.sprite",
 			StructureClass::EnergyProduction,
 			StructureID::SID_SOLAR_PANEL1

--- a/OPHD/MapObjects/Structures/SolarPlant.h
+++ b/OPHD/MapObjects/Structures/SolarPlant.h
@@ -15,7 +15,6 @@ public:
 	SolarPlant() :
 		PowerStructure
 		{
-			constants::SolarPlant,
 			"structures/solar_plant.sprite",
 			StructureClass::EnergyProduction,
 			StructureID::SID_SOLAR_PLANT

--- a/OPHD/MapObjects/Structures/StorageTanks.h
+++ b/OPHD/MapObjects/Structures/StorageTanks.h
@@ -11,7 +11,7 @@ const int StorageTanksCapacity = 1000;
 class StorageTanks : public Structure
 {
 public:
-	StorageTanks() : Structure(constants::StorageTanks,
+	StorageTanks() : Structure(
 		"structures/storage_tanks.sprite",
 		StructureClass::Storage,
 		StructureID::SID_STORAGE_TANKS)

--- a/OPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/OPHD/MapObjects/Structures/SurfaceFactory.h
@@ -8,7 +8,7 @@
 class SurfaceFactory : public Factory
 {
 public:
-	SurfaceFactory() : Factory(constants::SurfaceFactory,
+	SurfaceFactory() : Factory(
 		"structures/factory_surface.sprite",
 		StructureID::SID_SURFACE_FACTORY)
 	{

--- a/OPHD/MapObjects/Structures/SurfacePolice.h
+++ b/OPHD/MapObjects/Structures/SurfacePolice.h
@@ -8,7 +8,7 @@
 class SurfacePolice : public Structure
 {
 public:
-	SurfacePolice() : Structure(constants::SurfacePolice,
+	SurfacePolice() : Structure(
 		"structures/police_surface.sprite",
 		StructureClass::SurfacePolice,
 		StructureID::SID_SURFACE_POLICE)

--- a/OPHD/MapObjects/Structures/Tube.h
+++ b/OPHD/MapObjects/Structures/Tube.h
@@ -14,7 +14,7 @@ class Tube : public Structure
 {
 public:
 	Tube(ConnectorDir dir, bool underground) :
-		Structure(constants::Tube, "structures/tubes.sprite",
+		Structure("structures/tubes.sprite",
 			getAnimationName(dir, underground),
 			StructureClass::Tube,
 			StructureID::SID_TUBE)

--- a/OPHD/MapObjects/Structures/Tube.h
+++ b/OPHD/MapObjects/Structures/Tube.h
@@ -14,7 +14,8 @@ class Tube : public Structure
 {
 public:
 	Tube(ConnectorDir dir, bool underground) :
-		Structure("structures/tubes.sprite",
+		Structure(
+			"structures/tubes.sprite",
 			getAnimationName(dir, underground),
 			StructureClass::Tube,
 			StructureID::SID_TUBE)

--- a/OPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/OPHD/MapObjects/Structures/UndergroundFactory.h
@@ -8,7 +8,7 @@
 class UndergroundFactory : public Factory
 {
 public:
-	UndergroundFactory() : Factory(constants::UndergroundFactory,
+	UndergroundFactory() : Factory(
 		"structures/factory_underground.sprite",
 		StructureID::SID_UNDERGROUND_FACTORY)
 	{

--- a/OPHD/MapObjects/Structures/UndergroundPolice.h
+++ b/OPHD/MapObjects/Structures/UndergroundPolice.h
@@ -8,7 +8,7 @@
 class UndergroundPolice : public Structure
 {
 public:
-	UndergroundPolice() : Structure(constants::UndergroundPolice,
+	UndergroundPolice() : Structure(
 		"structures/police_underground.sprite",
 		StructureClass::UndergroundPolice,
 		StructureID::SID_UNDERGROUND_POLICE)

--- a/OPHD/MapObjects/Structures/University.h
+++ b/OPHD/MapObjects/Structures/University.h
@@ -8,7 +8,7 @@
 class University : public Structure
 {
 public:
-	University() : Structure(constants::University,
+	University() : Structure(
 		"structures/university.sprite",
 		StructureClass::University,
 		StructureID::SID_UNIVERSITY)

--- a/OPHD/MapObjects/Structures/Warehouse.h
+++ b/OPHD/MapObjects/Structures/Warehouse.h
@@ -9,7 +9,7 @@
 class Warehouse : public Structure
 {
 public:
-	Warehouse() : Structure(constants::Warehouse,
+	Warehouse() : Structure(
 		"structures/warehouse.sprite",
 		StructureClass::Warehouse,
 		StructureID::SID_WAREHOUSE)


### PR DESCRIPTION
Noticed this redundancy while working on #1329. Hopefully the simplification will help with that work.

Rather than specify the names, we can just lookup the names using the ID, and the already available functions.
