### PR TITLE
Refactor to make some `Structure` fields read-only

### DIFF
--- a/OPHD/MapObjects/Structure.cpp
+++ b/OPHD/MapObjects/Structure.cpp
@@ -287,14 +287,12 @@ void Structure::activate()
 }
 
 
-void Structure::rebuild(size_t turnsToRebuild)
+void Structure::rebuild()
 {
 	sprite().play(constants::StructureStateConstruction);
 	state(StructureState::UnderConstruction);
 
-	age(0);
-
-	turnsToBuild(static_cast<int>(turnsToRebuild));
+	age(1);
 }
 
 

--- a/OPHD/MapObjects/Structure.cpp
+++ b/OPHD/MapObjects/Structure.cpp
@@ -449,7 +449,7 @@ NAS2D::Dictionary Structure::getDataDict() const
 		{"pop1", mPopulationAvailable.scientists},
 	}};
 
-	if (mHasCrime)
+	if (hasCrime())
 	{
 		dictionary.set("crime_rate", mCrimeRate);
 	}

--- a/OPHD/MapObjects/Structure.cpp
+++ b/OPHD/MapObjects/Structure.cpp
@@ -266,7 +266,7 @@ bool Structure::selfSustained() const
 
 bool Structure::repairable() const
 {
-	return mRepairable;
+	return mRepairable && (mStructureState != StructureState::Destroyed);
 }
 
 /**
@@ -368,9 +368,6 @@ void Structure::destroy()
 {
 	sprite().play(constants::StructureStateDestroyed);
 	state(StructureState::Destroyed);
-
-	// Destroyed buildings just need to be rebuilt right?
-	repairable(false);
 }
 
 

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -154,7 +154,7 @@ public:
 
 	virtual void forced_state_change(StructureState, DisabledReason, IdleReason);
 
-	void rebuild(size_t turnsToRebuild);
+	void rebuild();
 
 	void update() override;
 	virtual void think() {}

--- a/OPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/OPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -189,7 +189,7 @@ protected:
 
 			if (structure->structureId() == StructureID::SID_ROAD)
 			{
-				structure->rebuild(1);
+				structure->rebuild();
 			}
 		}
 	}


### PR DESCRIPTION
Some pre-work for Issue #1329.

When some fields move out of `Structure` and into `StructureType`, they will effectively be read-only. To prepare for this, some features are re-implemented to not require mutating these future read-only fields.

Note: There is a slight behaviour change for rebuilding `Roads`, in that `age` is reset to `1` instead of `0`, which allows for faster rebuild, though also means 1 less turn of useful life before hitting `maxAge`.

Also, it helps to reference some fields indirectly, for properties whose fields will be moved to `StructureType`, such as by using `hasCrime()` instead of `mHasCrime`.
