### PR TITLE
Delay recycle value table init

### DIFF
--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -99,7 +99,7 @@ namespace
 	 */
 	StorableResources recycleValue(StructureID type, int percent)
 	{
-		return findOrDefault(StructureCostTable, type) * percent / 100;
+		return StructureCatalogue::costToBuild(type) * percent / 100;
 	}
 
 

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -112,7 +112,8 @@ namespace
 
 		for (std::size_t i = 0; i < StructureID::SID_COUNT; ++i)
 		{
-			structureRecycleValueTable[static_cast<StructureID>(i)] = recycleValue(static_cast<StructureID>(i), recoveryPercent);
+			const auto structureId = static_cast<StructureID>(i);
+			structureRecycleValueTable[structureId] = recycleValue(structureId, recoveryPercent);
 		}
 
 		// Set recycling values for landers and automatically built structures.

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -46,6 +46,10 @@ namespace
 		{SID_WAREHOUSE, {5, 5, 0, 0}},
 	}};
 
+	/**	Default recycle value. Currently set at 90% but this should probably be
+	 *	lowered for actual gameplay with modifiers to improve efficiency. */
+	const int DEFAULT_RECYCLE_VALUE = 90;
+
 	const std::map<StructureID, StorableResources> StructureRecycleValueTable = buildRecycleValueTable();
 
 	const std::map<StructureID, PopulationRequirements> PopulationRequirementsTable = {
@@ -74,10 +78,6 @@ namespace
 		{SID_UNIVERSITY, {1, 3}},
 		{SID_WAREHOUSE, {1, 0}},
 	};
-
-	/**	Default recycle value. Currently set at 90% but this should probably be
-	 *	lowered for actual gameplay with modifiers to improve efficiency. */
-	const int DEFAULT_RECYCLE_VALUE = 90;
 
 
 	template <typename Value>

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -93,17 +93,6 @@ namespace
 
 
 	/**
-	 * Calculates the base recycling value of a given structure.
-	 *
-	 * \param	type	A valid StructureID value.
-	 */
-	StorableResources recycleValue(StructureID type, int percent)
-	{
-		return StructureCatalogue::costToBuild(type) * percent / 100;
-	}
-
-
-	/**
 	 * Fills out the recycle value for all structures.
 	 */
 	std::map<StructureID, StorableResources> buildRecycleValueTable(int recoveryPercent)
@@ -113,7 +102,7 @@ namespace
 		for (std::size_t i = 0; i < StructureID::SID_COUNT; ++i)
 		{
 			const auto structureId = static_cast<StructureID>(i);
-			structureRecycleValueTable[structureId] = recycleValue(structureId, recoveryPercent);
+			structureRecycleValueTable[structureId] = StructureCatalogue::costToBuild(structureId) * recoveryPercent / 100;
 		}
 
 		// Set recycling values for landers and automatically built structures.

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -50,7 +50,7 @@ namespace
 	 *	lowered for actual gameplay with modifiers to improve efficiency. */
 	const int DefaultRecyclePercent = 90;
 
-	const std::map<StructureID, StorableResources> StructureRecycleValueTable = buildRecycleValueTable(DefaultRecyclePercent);
+	std::map<StructureID, StorableResources> StructureRecycleValueTable;
 
 	const std::map<StructureID, PopulationRequirements> PopulationRequirementsTable = {
 		{SID_NONE, {}},
@@ -125,6 +125,7 @@ namespace
  */
 void StructureCatalogue::init()
 {
+	StructureRecycleValueTable = buildRecycleValueTable(DefaultRecyclePercent);
 }
 
 

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -9,7 +9,7 @@
 
 namespace
 {
-	std::map<StructureID, StorableResources> buildRecycleValueTable();
+	std::map<StructureID, StorableResources> buildRecycleValueTable(int recoveryPercent);
 
 
 	// RESOURCES: CommonMetals | CommonMinerals | RareMetals | RareMinerals
@@ -50,7 +50,7 @@ namespace
 	 *	lowered for actual gameplay with modifiers to improve efficiency. */
 	const int DEFAULT_RECYCLE_VALUE = 90;
 
-	const std::map<StructureID, StorableResources> StructureRecycleValueTable = buildRecycleValueTable();
+	const std::map<StructureID, StorableResources> StructureRecycleValueTable = buildRecycleValueTable(DEFAULT_RECYCLE_VALUE);
 
 	const std::map<StructureID, PopulationRequirements> PopulationRequirementsTable = {
 		{SID_NONE, {}},
@@ -106,13 +106,13 @@ namespace
 	/**
 	 * Fills out the recycle value for all structures.
 	 */
-	std::map<StructureID, StorableResources> buildRecycleValueTable()
+	std::map<StructureID, StorableResources> buildRecycleValueTable(int recoveryPercent)
 	{
 		std::map<StructureID, StorableResources> structureRecycleValueTable;
 
 		for (std::size_t i = 0; i < StructureID::SID_COUNT; ++i)
 		{
-			structureRecycleValueTable[static_cast<StructureID>(i)] = recycleValue(static_cast<StructureID>(i), DEFAULT_RECYCLE_VALUE);
+			structureRecycleValueTable[static_cast<StructureID>(i)] = recycleValue(static_cast<StructureID>(i), recoveryPercent);
 		}
 
 		// Set recycling values for landers and automatically built structures.

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -46,11 +46,11 @@ namespace
 		{SID_WAREHOUSE, {5, 5, 0, 0}},
 	}};
 
-	/**	Default recycle value. Currently set at 90% but this should probably be
+	/**	Currently set at 90% but this should probably be
 	 *	lowered for actual gameplay with modifiers to improve efficiency. */
-	const int DEFAULT_RECYCLE_VALUE = 90;
+	const int DefaultRecyclePercent = 90;
 
-	const std::map<StructureID, StorableResources> StructureRecycleValueTable = buildRecycleValueTable(DEFAULT_RECYCLE_VALUE);
+	const std::map<StructureID, StorableResources> StructureRecycleValueTable = buildRecycleValueTable(DefaultRecyclePercent);
 
 	const std::map<StructureID, PopulationRequirements> PopulationRequirementsTable = {
 		{SID_NONE, {}},


### PR DESCRIPTION
A bit of pre-work to support work on #1329.

By delaying the construction of the structure recycle value table, we have a chance to load external data from `StructureTypes.xml`, and base the recycle values off the costs loaded for each `StructureType`.
