### PR TITLE
Fix mine digging bug

### DIFF
--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -64,7 +64,7 @@ private:
 
 private:
 	StorableResources mTappedReserves;
-	int mCurrentDepth{1};
+	int mCurrentDepth{0};
 	MineProductionRate mProductionRate = MineProductionRate::Low;
 
 	/**


### PR DESCRIPTION
When the `MiningFacility` is complete and activated, it will increase depth by 1. Hence, we should set an initial value of 0, so when the mine completes it will then have a depth of 1.

This means as we dig deeper, the new shaft is placed at the right depth, fixing the reported bug.

Additionally, this corrects the display for the total yield in the mine reports view. The actual amount of ore available in the mine was always correct, but the reported total was yield was incorrect, as it showed as if there was an extra level to the mine.

Closes #1349
