### PR TITLE
Use on-demand check for `Mine::exhausted()`

### DIFF
--- a/OPHD/Mine.cpp
+++ b/OPHD/Mine.cpp
@@ -34,8 +34,8 @@ namespace
 	};
 
 
-	// [Exhausted, Active, 4x miningEnabled]
-	const std::bitset<6> DefaultFlags{"001111"};
+	// [Active, 4x miningEnabled]
+	const std::bitset<5> DefaultFlags{"01111"};
 }
 
 
@@ -116,22 +116,7 @@ StorableResources Mine::totalYield() const
  */
 bool Mine::exhausted() const
 {
-	return mFlags[5];
-}
-
-
-/**
- * Checks if the mine is exhausted and if it is sets the exhausted flag.
- * 
- * \note	This function is provided so that this computation is only
- *			done once per turn instead of being done every frame. The
- *			issue came up after updating the minimap code to indicate
- *			exhausted mines.
- */
-void Mine::checkExhausted()
-{
-	if (!active()) { return; }
-	mFlags[5] = mTappedReserves.isEmpty();
+	return mTappedReserves.isEmpty();
 }
 
 
@@ -192,7 +177,7 @@ void Mine::deserialize(NAS2D::Xml::XmlElement* element)
 	mCurrentDepth = dictionary.get<int>("depth");
 	mProductionRate = static_cast<MineProductionRate>(dictionary.get<int>("yield"));
 	const auto active = dictionary.get<bool>("active");
-	mFlags = std::bitset<6>(dictionary.get("flags"));
+	mFlags = std::bitset<5>(dictionary.get("flags"));
 
 	this->active(active);
 

--- a/OPHD/Mine.h
+++ b/OPHD/Mine.h
@@ -39,7 +39,6 @@ public:
 	void active(bool newActive);
 
 	bool exhausted() const;
-	void checkExhausted();
 
 	MineProductionRate productionRate() const { return mProductionRate; }
 
@@ -75,7 +74,6 @@ private:
 	 * [2] : Mine Rare Metal Ore
 	 * [3] : Mine Rare Mineral Ore
 	 * [4] : Mine is active
-	 * [5] : Mine is exhausted
 	 */
-	std::bitset<6> mFlags; /**< Set of flags. */
+	std::bitset<5> mFlags; /**< Set of flags. */
 };

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -274,8 +274,6 @@ void MapViewState::findMineRoutes()
 
 	for (auto mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
-		mine->mine()->checkExhausted();
-
 		if (!mine->operational() && !mine->isIdle()) { continue; } // consider a different control path.
 
 		auto routeIt = routeTable.find(mine);


### PR DESCRIPTION
Rather than maintaining separate state to know if a mine is exhausted, just check if it has any resources left. This is now a simpler cheaper check since mine veins were removed. It also eliminates the potential for mismatch between resource counts and the exhausted flag, in case they are not both updated when they need to be.

Effectively, we want to use the actual resource counts as the single source of truth, rather than maintain separate state that must be kept in sync.

Closes #1333