### PR TITLE
Move Robot implementations to .cpp files

### DIFF
--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -299,9 +299,6 @@ enum class Morale
 };
 
 
-class Robot;
-using RobotList = std::vector<Robot*>;
-
 extern const std::map<TerrainType, std::string> TILE_INDEX_TRANSLATION;
 extern const std::map<MineProductionRate, std::string> MINE_YIELD_TRANSLATION;
 

--- a/OPHD/MapObjects/Robots/Robodigger.cpp
+++ b/OPHD/MapObjects/Robots/Robodigger.cpp
@@ -1,0 +1,31 @@
+#include "Robodigger.h"
+
+#include "../../Common.h"
+#include "../../Constants/Strings.h"
+
+
+Robodigger::Robodigger() :
+	Robot(constants::Robodigger, "robots/robodigger.sprite", Robot::Type::Digger),
+	mDirection(Direction::Down)
+{
+}
+
+
+void Robodigger::direction(Direction dir)
+{
+	mDirection = dir;
+}
+
+
+Direction Robodigger::direction() const
+{
+	return mDirection;
+}
+
+
+NAS2D::Dictionary Robodigger::getDataDict() const
+{
+	auto dictionary = Robot::getDataDict();
+	dictionary.set("direction", static_cast<int>(mDirection));
+	return dictionary;
+}

--- a/OPHD/MapObjects/Robots/Robodigger.h
+++ b/OPHD/MapObjects/Robots/Robodigger.h
@@ -2,28 +2,19 @@
 
 #include "../Robot.h"
 
-#include "../../Common.h"
-#include "../../Constants/Strings.h"
+
+enum class Direction;
 
 
 class Robodigger : public Robot
 {
 public:
-	Robodigger() :
-		Robot(constants::Robodigger, "robots/robodigger.sprite", Robot::Type::Digger),
-		mDirection(Direction::Down)
-	{
-	}
+	Robodigger();
 
-	void direction(Direction dir) { mDirection = dir; }
-	Direction direction() const { return mDirection; }
+	void direction(Direction dir);
+	Direction direction() const;
 
-	NAS2D::Dictionary getDataDict() const override
-	{
-		auto dictionary = Robot::getDataDict();
-		dictionary.set("direction", static_cast<int>(mDirection));
-		return dictionary;
-	}
+	NAS2D::Dictionary getDataDict() const override;
 
 private:
 	Direction mDirection;

--- a/OPHD/MapObjects/Robots/Robodozer.cpp
+++ b/OPHD/MapObjects/Robots/Robodozer.cpp
@@ -1,0 +1,25 @@
+#include "Robodozer.h"
+
+#include "../../Constants/Strings.h"
+#include "../../Map/Tile.h"
+
+
+Robodozer::Robodozer() :
+	Robot(constants::Robodozer, "robots/robodozer.sprite", Robot::Type::Dozer)
+{
+}
+
+
+void Robodozer::startTask(Tile& tile)
+{
+	Robot::startTask(tile);
+
+	mTileIndex = static_cast<std::size_t>(tile.index());
+	tile.index(TerrainType::Dozed);
+}
+
+
+void Robodozer::abortTask(Tile& tile)
+{
+	tile.index(static_cast<TerrainType>(mTileIndex));
+}

--- a/OPHD/MapObjects/Robots/Robodozer.h
+++ b/OPHD/MapObjects/Robots/Robodozer.h
@@ -2,29 +2,16 @@
 
 #include "../Robot.h"
 
-#include "../../Constants/Strings.h"
-#include "../../Map/Tile.h"
+class Tile;
 
 
 class Robodozer : public Robot
 {
 public:
-	Robodozer(): Robot(constants::Robodozer, "robots/robodozer.sprite", Robot::Type::Dozer)
-	{
-	}
+	Robodozer();
 
-	void startTask(Tile& tile) override
-	{
-		Robot::startTask(tile);
-
-		mTileIndex = static_cast<std::size_t>(tile.index());
-		tile.index(TerrainType::Dozed);
-	}
-
-	void abortTask(Tile& tile) override
-	{
-		tile.index(static_cast<TerrainType>(mTileIndex));
-	}
+	void startTask(Tile& tile) override;
+	void abortTask(Tile& tile) override;
 
 private:
 	std::size_t mTileIndex = 0;

--- a/OPHD/MapObjects/Robots/Robominer.cpp
+++ b/OPHD/MapObjects/Robots/Robominer.cpp
@@ -1,0 +1,9 @@
+#include "Robominer.h"
+
+#include "../../Constants/Strings.h"
+
+
+Robominer::Robominer() :
+	Robot(constants::Robominer, "robots/robominer.sprite", Robot::Type::Miner)
+{
+}

--- a/OPHD/MapObjects/Robots/Robominer.h
+++ b/OPHD/MapObjects/Robots/Robominer.h
@@ -1,13 +1,11 @@
 #pragma once
 
 #include "../Robot.h"
-#include "../../Constants/Strings.h"
 
 
 class Robominer : public Robot
 {
 public:
-	Robominer(): Robot(constants::Robominer, "robots/robominer.sprite", Robot::Type::Miner)
-	{
-	}
+	Robominer();
+
 };

--- a/OPHD/RobotPool.h
+++ b/OPHD/RobotPool.h
@@ -10,6 +10,7 @@
 
 class Tile;
 class RobotCommand;
+using RobotList = std::vector<Robot*>;
 
 
 class RobotPool

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -1,5 +1,6 @@
 #include "Cache.h"
 #include "Common.h"
+#include "Constants/Strings.h"
 #include "Constants/Numbers.h"
 #include "WindowEventWrapper.h"
 

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -267,6 +267,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="Technology\ResearchTracker.cpp" />
     <ClCompile Include="Technology\TechnologyCatalog.cpp" />
     <ClCompile Include="MapObjects\Robot.cpp" />
+    <ClCompile Include="MapObjects\Robots\Robodigger.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -269,6 +269,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="MapObjects\Robot.cpp" />
     <ClCompile Include="MapObjects\Robots\Robodigger.cpp" />
     <ClCompile Include="MapObjects\Robots\Robodozer.cpp" />
+    <ClCompile Include="MapObjects\Robots\Robominer.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -268,6 +268,7 @@ IF NOT "$(VcpkgInstalledDir)" == "" (
     <ClCompile Include="Technology\TechnologyCatalog.cpp" />
     <ClCompile Include="MapObjects\Robot.cpp" />
     <ClCompile Include="MapObjects\Robots\Robodigger.cpp" />
+    <ClCompile Include="MapObjects\Robots\Robodozer.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="MapObjects\Robots\Robodigger.cpp">
       <Filter>Source Files\MapObjects</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Robots\Robodozer.cpp">
+      <Filter>Source Files\MapObjects</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClCompile Include="MapObjects\Robot.cpp">
       <Filter>Source Files\MapObjects</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Robots\Robodigger.cpp">
+      <Filter>Source Files\MapObjects</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClCompile Include="MapObjects\Robots\Robodozer.cpp">
       <Filter>Source Files\MapObjects</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Robots\Robominer.cpp">
+      <Filter>Source Files\MapObjects</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>


### PR DESCRIPTION
A bit of pre-work to help support:
- Issue #650
- Issue #1191
- Issue #1335

The `Robot` code should be responsible for the effects of robots (rather than `MapViewState`). That means moving code into the `Robot` derived classes. That's easier to do and with less transitive includes when the implementation is split.
