### PR TITLE
Improve `StructureManager` `const`-correctness

### DIFF
--- a/OPHD/MapObjects/Structure.cpp
+++ b/OPHD/MapObjects/Structure.cpp
@@ -107,6 +107,16 @@ std::string StructureName(StructureID id)
 }
 
 
+std::vector<Structure::StructureClass> allStructureClasses()
+{
+	std::vector<Structure::StructureClass> result;
+	for (const auto& entry : STRUCTURE_CLASS_TRANSLATION)
+	{
+		result.push_back(entry.first);
+	}
+	return result;
+}
+
 
 Structure::Structure(StructureClass structureClass, StructureID id) :
 	MapObject(StructureName(id), StructureCatalogue::getType(id).spritePath, constants::StructureStateConstruction),

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -219,3 +219,4 @@ private:
 using StructureList = std::vector<Structure*>;
 
 std::string StructureName(StructureID id);
+std::vector<Structure::StructureClass> allStructureClasses();

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -200,7 +200,7 @@ const StructureList& StructureManager::structureList(Structure::StructureClass s
 }
 
 
-StructureList StructureManager::allStructures()
+StructureList StructureManager::allStructures() const
 {
 	StructureList structuresOut;
 
@@ -214,7 +214,7 @@ StructureList StructureManager::allStructures()
 }
 
 
-Tile& StructureManager::tileFromStructure(Structure* structure)
+Tile& StructureManager::tileFromStructure(Structure* structure) const
 {
 	auto it = mStructureTileTable.find(structure);
 	if (it == mStructureTileTable.end())
@@ -264,7 +264,7 @@ int StructureManager::count() const
 }
 
 
-int StructureManager::getCountInState(Structure::StructureClass structureClass, StructureState state)
+int StructureManager::getCountInState(Structure::StructureClass structureClass, StructureState state) const
 {
 	int count = 0;
 	for (const auto* structure : structureList(structureClass))
@@ -281,7 +281,7 @@ int StructureManager::getCountInState(Structure::StructureClass structureClass, 
 /**
  * Gets a count of the number of disabled buildings.
  */
-int StructureManager::disabled()
+int StructureManager::disabled() const
 {
 	int count = 0;
 	for (auto& pair : mStructureLists)
@@ -296,7 +296,7 @@ int StructureManager::disabled()
 /**
  * Gets a count of the number of destroyed buildings.
  */
-int StructureManager::destroyed()
+int StructureManager::destroyed() const
 {
 	int count = 0;
 	for (auto& pair : mStructureLists)
@@ -308,7 +308,7 @@ int StructureManager::destroyed()
 }
 
 
-bool StructureManager::CHAPAvailable()
+bool StructureManager::CHAPAvailable() const
 {
 	for (const auto* chap : structureList(Structure::StructureClass::LifeSupport))
 	{
@@ -444,7 +444,7 @@ void StructureManager::update(const StorableResources& resources, PopulationPool
 }
 
 
-NAS2D::Xml::XmlElement* StructureManager::serialize()
+NAS2D::Xml::XmlElement* StructureManager::serialize() const
 {
 	auto* structures = new NAS2D::Xml::XmlElement("structures");
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -310,7 +310,7 @@ int StructureManager::destroyed()
 
 bool StructureManager::CHAPAvailable()
 {
-	for (auto chap : mStructureLists[Structure::StructureClass::LifeSupport])
+	for (const auto* chap : structureList(Structure::StructureClass::LifeSupport))
 	{
 		if (chap->operational()) { return true; }
 	}

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -19,6 +19,17 @@
 
 namespace
 {
+	auto populateKeys()
+	{
+		std::map<Structure::StructureClass, StructureList> result;
+		for (const auto structureClass : allStructureClasses())
+		{
+			result[structureClass]; // Generate blank array value for given key
+		}
+		return result;
+	}
+
+
 	/**
 	 * Fills population requirements fields in a Structure.
 	 */
@@ -119,6 +130,12 @@ namespace
 
 		return structureElement;
 	}
+}
+
+
+StructureManager::StructureManager() :
+	mStructureLists{populateKeys()}
+{
 }
 
 
@@ -228,7 +245,7 @@ void StructureManager::dropAllStructures()
 	}
 
 	mStructureTileTable.clear();
-	mStructureLists.clear();
+	mStructureLists = populateKeys();
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -214,14 +214,16 @@ StructureList StructureManager::allStructures() const
 }
 
 
-Tile& StructureManager::tileFromStructure(Structure* structure) const
+Tile& StructureManager::tileFromStructure(const Structure* structure) const
 {
-	auto it = mStructureTileTable.find(structure);
-	if (it == mStructureTileTable.end())
+	for (const auto [keyStructure, valueTile] : mStructureTileTable)
 	{
-		throw std::runtime_error("Could not find tile for structure");
+		if (keyStructure == structure)
+		{
+			return *valueTile;
+		}
 	}
-	return *it->second;
+	throw std::runtime_error("Could not find tile for structure");
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -194,9 +194,9 @@ void StructureManager::removeStructure(Structure& structure)
 }
 
 
-const StructureList& StructureManager::structureList(Structure::StructureClass structureClass)
+const StructureList& StructureManager::structureList(Structure::StructureClass structureClass) const
 {
-	return mStructureLists[structureClass];
+	return mStructureLists.at(structureClass);
 }
 
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -77,6 +77,8 @@ constexpr Structure::StructureClass structureTypeToClass() {
 class StructureManager
 {
 public:
+	StructureManager();
+
 	void addStructure(Structure& structure, Tile& tile);
 	void removeStructure(Structure& structure);
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -101,7 +101,7 @@ public:
 		return output;
 	}
 
-	const StructureList& structureList(Structure::StructureClass structureClass);
+	const StructureList& structureList(Structure::StructureClass structureClass) const;
 	StructureList allStructures();
 
 	Tile& tileFromStructure(Structure* structure);

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -102,25 +102,25 @@ public:
 	}
 
 	const StructureList& structureList(Structure::StructureClass structureClass) const;
-	StructureList allStructures();
+	StructureList allStructures() const;
 
-	Tile& tileFromStructure(Structure* structure);
+	Tile& tileFromStructure(Structure* structure) const;
 
 	void disconnectAll();
 	void dropAllStructures();
 
 	int count() const;
 
-	int getCountInState(Structure::StructureClass structureClass, StructureState state);
+	int getCountInState(Structure::StructureClass structureClass, StructureState state) const;
 
 	const StructureList& agingStructures() const { return mAgingStructures; }
 	const StructureList& newlyBuiltStructures() const { return mNewlyBuiltStructures; }
 	const StructureList& structuresWithCrime() const { return mStructuresWithCrime; }
 
-	int disabled();
-	int destroyed();
+	int disabled() const;
+	int destroyed() const;
 
-	bool CHAPAvailable();
+	bool CHAPAvailable() const;
 
 	void updateEnergyProduction();
 	void updateEnergyConsumed();
@@ -133,7 +133,7 @@ public:
 
 	void update(const StorableResources&, PopulationPool&);
 
-	NAS2D::Xml::XmlElement* serialize();
+	NAS2D::Xml::XmlElement* serialize() const;
 
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -104,7 +104,7 @@ public:
 	const StructureList& structureList(Structure::StructureClass structureClass) const;
 	StructureList allStructures() const;
 
-	Tile& tileFromStructure(Structure* structure) const;
+	Tile& tileFromStructure(const Structure* structure) const;
 
 	void disconnectAll();
 	void dropAllStructures();


### PR DESCRIPTION
Related to: PR #1369 

Mark methods as `const`, so they can be called on const objects and references. Mark parameters as `const`, so they can accept `const` objects.

Pre-populate `std::map` of `StructureClass` so key lookup never fails for a valid `StructureClass`. This allows a `const` lookup method to be used, as we no longer end up modifying the `std::map` to insert blank `std::vector` values when a new key is used.
