### PR TITLE
Multi `CommandCenter` graph walk

### DIFF
--- a/OPHD/GraphWalker.cpp
+++ b/OPHD/GraphWalker.cpp
@@ -81,10 +81,13 @@ static bool validConnection(Structure* src, Structure* dst, Direction direction)
 }
 
 
-std::vector<Tile*> walkGraph(const MapCoordinate& position, TileMap& tileMap)
+std::vector<Tile*> walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap)
 {
 	std::vector<Tile*> tileList;
-	walkGraph(position, tileMap, tileList);
+	for (const auto& position : positions)
+	{
+		walkGraph(position, tileMap, tileList);
+	}
 	return tileList;
 }
 

--- a/OPHD/GraphWalker.h
+++ b/OPHD/GraphWalker.h
@@ -8,5 +8,5 @@ class Tile;
 class TileMap;
 
 
-std::vector<Tile*> walkGraph(const MapCoordinate& position, TileMap& tileMap);
+std::vector<Tile*> walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap);
 void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile*>& tileList);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1357,7 +1357,7 @@ void MapViewState::updateConnectedness()
 	}
 
 	// Start graph walking at the CC location.
-	mConnectednessOverlay = walkGraph({ccLocation(), 0}, *mTileMap);
+	mConnectednessOverlay = walkGraph({{ccLocation(), 0}}, *mTileMap);
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1337,27 +1337,9 @@ void MapViewState::setStructureID(StructureID type, InsertMode mode)
  */
 void MapViewState::updateConnectedness()
 {
-	if (ccLocation() == CcNotPlaced)
-	{
-		return;
-	}
-
-	// Assumes that the 'thing' at mCCLocation is in fact a Structure.
-	auto& tile = mTileMap->getTile({ccLocation(), 0});
-	Structure* cc = tile.structure();
-
-	if (!cc)
-	{
-		throw std::runtime_error("CC coordinates do not actually point to a Command Center.");
-	}
-
-	if (cc->state() == StructureState::UnderConstruction)
-	{
-		return;
-	}
-
-	// Start graph walking at the CC location.
-	mConnectednessOverlay = walkGraph({{ccLocation(), 0}}, *mTileMap);
+	auto& structureManager = NAS2D::Utility<StructureManager>::get();
+	const auto ccLocations = structureManager.operationalCommandCenterPositions();
+	mConnectednessOverlay = walkGraph(ccLocations, *mTileMap);
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -227,6 +227,20 @@ Tile& StructureManager::tileFromStructure(const Structure* structure) const
 }
 
 
+std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions() const
+{
+	std::vector<MapCoordinate> positions;
+	for (const auto* commandCenter : structureList(Structure::StructureClass::Command))
+	{
+		if (commandCenter->operational())
+		{
+			positions.push_back(tileFromStructure(commandCenter).xyz());
+		}
+	}
+	return positions;
+}
+
+
 /**
  * Resets the 'connected' flag on all structures in the primary structure list.
  */

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -4,6 +4,7 @@
 #include "MapObjects/Structures.h"
 
 #include <map>
+#include <vector>
 
 
 namespace NAS2D
@@ -17,6 +18,7 @@ namespace NAS2D
 class Tile;
 class PopulationPool;
 struct StorableResources;
+struct MapCoordinate;
 
 
 template <typename T> constexpr bool dependent_false = false;
@@ -105,6 +107,8 @@ public:
 	StructureList allStructures() const;
 
 	Tile& tileFromStructure(const Structure* structure) const;
+
+	std::vector<MapCoordinate> operationalCommandCenterPositions() const;
 
 	void disconnectAll();
 	void dropAllStructures();

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -57,17 +57,16 @@ void MiniMap::draw() const
 
 	renderer.drawImage((mIsHeightMapVisible ? mBackgroundHeightMap : mBackgroundSatellite), miniMapFloatRect.startPoint());
 
+	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	const auto miniMapOffset = mRect.startPoint() - NAS2D::Point{0, 0};
-	const auto ccPosition = ccLocation();
-	if (ccPosition != CcNotPlaced)
+	for (const auto& ccPosition : structureManager.operationalCommandCenterPositions())
 	{
-		const auto ccOffsetPosition = ccPosition + miniMapOffset;
+		const auto ccOffsetPosition = ccPosition.xy + miniMapOffset;
 		const auto ccCommRangeImageRect = NAS2D::Rectangle{166, 226, 30, 30};
 		renderer.drawSubImage(mUiIcons, ccOffsetPosition - ccCommRangeImageRect.size() / 2, ccCommRangeImageRect);
 		renderer.drawBoxFilled(NAS2D::Rectangle<int>::Create(ccOffsetPosition - NAS2D::Vector{1, 1}, NAS2D::Vector{3, 3}), NAS2D::Color::White);
 	}
 
-	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	for (auto commTower : structureManager.getStructures<CommTower>())
 	{
 		if (commTower->operational())


### PR DESCRIPTION
Add partial support for multiple Command Centers. Oddly, it's sometimes easier to iterate over all Command Centers (which may be 0 of them), than to error check for 1 specific Command Center.

Partial support added is for `walkGraph` starting points, and highlights on the `MiniMap`.

Depends on recent changes in PR #1370.
