### PR TITLE
Fix MSVC Code Analysis warnings

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1011,8 +1011,8 @@ void MapViewState::placeRobodozer(Tile& tile)
 			updatePoliceOverlay();
 		}
 
-		const auto recycledResources = StructureCatalogue::recyclingValue(structure->structureId());
-		const auto wastedResources = addRefinedResources(recycledResources);
+		const auto& recycledResources = StructureCatalogue::recyclingValue(structure->structureId());
+		const auto& wastedResources = addRefinedResources(recycledResources);
 
 		if (!wastedResources.isEmpty())
 		{
@@ -1240,7 +1240,7 @@ void MapViewState::updateRobots()
 
 		robot->update();
 
-		const auto position = tile->xyz();
+		const auto& position = tile->xyz();
 
 		pushAgingRobotMessage(robot, position, mNotificationArea);
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -178,7 +178,7 @@ void MapViewState::onDiggerTaskComplete(Robot* robot)
 	}
 
 	auto& tile = *mRobotList[robot];
-	const auto position = tile.xyz();
+	const auto& position = tile.xyz();
 
 	if (position.z > mTileMap->maxDepth())
 	{

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -44,7 +44,7 @@ namespace
 
 	NAS2D::Xml::XmlElement* serializeStructure(Structure& structure, Tile& tile)
 	{
-		const auto position = tile.xyz();
+		const auto& position = tile.xyz();
 		NAS2D::Dictionary dictionary =
 		{{
 			{"x", position.xy.x},


### PR DESCRIPTION
Fixes MSVC Code Analysis warnings:
> error C26820: This is a potentially expensive copy operation. Consider using a reference unless a copy is required.

Fixes for Issue:
- #320
