### PR TITLE
Refactor `connected` checks

### DIFF
--- a/OPHD/GraphWalker.cpp
+++ b/OPHD/GraphWalker.cpp
@@ -113,7 +113,7 @@ void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile
 		if (!tileMap.isValidPosition(nextPosition)) { continue; }
 
 		auto& tile = tileMap.getTile(nextPosition);
-		if (!tile.thingIsStructure() || tile.connected() || tile.mine() || !tile.excavated()) { continue; }
+		if (!tile.thingIsStructure() || tile.connected() || tile.mine()) { continue; }
 
 		if (validConnection(thisTile.structure(), tile.structure(), direction))
 		{

--- a/OPHD/GraphWalker.cpp
+++ b/OPHD/GraphWalker.cpp
@@ -113,7 +113,7 @@ void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile
 		if (!tileMap.isValidPosition(nextPosition)) { continue; }
 
 		auto& tile = tileMap.getTile(nextPosition);
-		if (tile.connected() || tile.mine() || !tile.excavated() || !tile.thingIsStructure()) { continue; }
+		if (!tile.thingIsStructure() || tile.connected() || tile.mine() || !tile.excavated()) { continue; }
 
 		if (validConnection(thisTile.structure(), tile.structure(), direction))
 		{

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1026,7 +1026,6 @@ void MapViewState::placeRobodozer(Tile& tile)
 		updatePlayerResources();
 		updateStructuresAvailability();
 
-		tile.connected(false);
 		NAS2D::Utility<StructureManager>::get().removeStructure(*structure);
 		tile.deleteMapObject();
 		NAS2D::Utility<StructureManager>::get().disconnectAll();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -581,7 +581,6 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 		NAS2D::Utility<StructureManager>::get().removeStructure(*tile.structure());
 		NAS2D::Utility<StructureManager>::get().disconnectAll();
 		tile.deleteMapObject();
-		tile.connected(false);
 		updateConnectedness();
 	}
 


### PR DESCRIPTION
Also questionable if we want to skip over tiles with mines. This means a `MiningFacility` can never be `connected`. They don't need to be, but it also means they can't transmit a connection through them to other structures.

