### PR TITLE
Remove `mine()` check from `walkGraph`

### DIFF
--- a/OPHD/GraphWalker.cpp
+++ b/OPHD/GraphWalker.cpp
@@ -113,7 +113,7 @@ void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile
 		if (!tileMap.isValidPosition(nextPosition)) { continue; }
 
 		auto& tile = tileMap.getTile(nextPosition);
-		if (!tile.thingIsStructure() || tile.structure()->connected() || tile.mine()) { continue; }
+		if (!tile.thingIsStructure() || tile.structure()->connected()) { continue; }
 
 		if (validConnection(thisTile.structure(), tile.structure(), direction))
 		{


### PR DESCRIPTION
Remove the `mine()` check from `walkGraph` that prohibited connections through any `Tile` with a `Mine` on it.

The `MiningFacility` doesn't need a Command Center connection, but should be allowed to transmit a connection, if it's adjacent to another `Structure`.

Technically this change isn't specific to the `MiningFacility`, but rather to any structure on the same `Tile` as a `Mine`. Normally we would only expect a `MiningFacility` on such a `Tile`.

Related to:
- PR #1377