### PR TITLE
Move connectedness check to `StructureManager`

### DIFF
--- a/OPHD/GraphWalker.cpp
+++ b/OPHD/GraphWalker.cpp
@@ -71,22 +71,19 @@ static bool validConnection(Structure* src, Structure* dst, Direction direction)
 }
 
 
-std::vector<Tile*> walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap)
+void walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap)
 {
-	std::vector<Tile*> tileList;
 	for (const auto& position : positions)
 	{
-		walkGraph(position, tileMap, tileList);
+		walkGraph(position, tileMap);
 	}
-	return tileList;
 }
 
 
-void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile*>& tileList)
+void walkGraph(const MapCoordinate& position, TileMap& tileMap)
 {
 	Tile& thisTile = tileMap.getTile(position);
 	thisTile.structure()->connected(true);
-	tileList.push_back(&thisTile);
 
 	const auto directions = std::array{
 		Direction::Up,
@@ -107,7 +104,7 @@ void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile
 
 		if (validConnection(thisTile.structure(), tile.structure(), direction))
 		{
-			walkGraph(nextPosition, tileMap, tileList);
+			walkGraph(nextPosition, tileMap);
 		}
 	}
 }

--- a/OPHD/GraphWalker.h
+++ b/OPHD/GraphWalker.h
@@ -8,5 +8,5 @@ class Tile;
 class TileMap;
 
 
-std::vector<Tile*> walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap);
-void walkGraph(const MapCoordinate& position, TileMap& tileMap, std::vector<Tile*>& tileList);
+void walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap);
+void walkGraph(const MapCoordinate& position, TileMap& tileMap);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -10,7 +10,6 @@
 
 #include "../DirectionOffset.h"
 #include "../Cache.h"
-#include "../GraphWalker.h"
 #include "../ProductCatalogue.h"
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"
@@ -1335,9 +1334,7 @@ void MapViewState::setStructureID(StructureID type, InsertMode mode)
 void MapViewState::updateConnectedness()
 {
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	structureManager.disconnectAll();
-	const auto ccLocations = structureManager.operationalCommandCenterPositions();
-	mConnectednessOverlay = walkGraph(ccLocations, *mTileMap);
+	mConnectednessOverlay = structureManager.updateConnectedness(*mTileMap);
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1334,7 +1334,8 @@ void MapViewState::setStructureID(StructureID type, InsertMode mode)
 void MapViewState::updateConnectedness()
 {
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	mConnectednessOverlay = structureManager.updateConnectedness(*mTileMap);
+	structureManager.updateConnectedness(*mTileMap);
+	mConnectednessOverlay = structureManager.getConnectednessOverlay();
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -242,10 +242,25 @@ std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions()
 }
 
 
-std::vector<Tile*> StructureManager::updateConnectedness(TileMap& tileMap)
+void StructureManager::updateConnectedness(TileMap& tileMap)
 {
 	disconnectAll();
-	return walkGraph(operationalCommandCenterPositions(), tileMap);
+	walkGraph(operationalCommandCenterPositions(), tileMap);
+}
+
+
+std::vector<Tile*> StructureManager::getConnectednessOverlay() const
+{
+	std::vector<Tile*> result;
+	result.reserve(mStructureTileTable.size());
+	for (const auto [structure, tile] : mStructureTileTable)
+	{
+		if (structure->connected())
+		{
+			result.push_back(tile);
+		}
+	}
+	return result;
 }
 
 

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -6,6 +6,7 @@
 #include "PopulationPool.h"
 #include "Map/Tile.h"
 #include "MapObjects/Robot.h"
+#include "GraphWalker.h"
 
 #include "States/MapViewStateHelper.h" // <-- For removeRefinedResources()
 
@@ -238,6 +239,13 @@ std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions()
 		}
 	}
 	return positions;
+}
+
+
+std::vector<Tile*> StructureManager::updateConnectedness(TileMap& tileMap)
+{
+	disconnectAll();
+	return walkGraph(operationalCommandCenterPositions(), tileMap);
 }
 
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -112,7 +112,7 @@ public:
 	std::vector<MapCoordinate> operationalCommandCenterPositions() const;
 
 	std::vector<Tile*> updateConnectedness(TileMap& tileMap);
-	void disconnectAll();
+
 	void dropAllStructures();
 
 	int count() const;
@@ -144,6 +144,8 @@ public:
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;
 	using StructureClassTable = std::map<Structure::StructureClass, StructureList>;
+
+	void disconnectAll();
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -16,6 +16,7 @@ namespace NAS2D
 }
 
 class Tile;
+class TileMap;
 class PopulationPool;
 struct StorableResources;
 struct MapCoordinate;
@@ -110,6 +111,7 @@ public:
 
 	std::vector<MapCoordinate> operationalCommandCenterPositions() const;
 
+	std::vector<Tile*> updateConnectedness(TileMap& tileMap);
 	void disconnectAll();
 	void dropAllStructures();
 

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -111,7 +111,8 @@ public:
 
 	std::vector<MapCoordinate> operationalCommandCenterPositions() const;
 
-	std::vector<Tile*> updateConnectedness(TileMap& tileMap);
+	void updateConnectedness(TileMap& tileMap);
+	std::vector<Tile*> getConnectednessOverlay() const;
 
 	void dropAllStructures();
 


### PR DESCRIPTION
The `StructureManager` should be responsible for checking connectedness. Additionally, the connected overlay info has been split off as separate functionality.

Related to:
- PR #1379
- PR #1378