### PR TITLE
Fix global `selfSustained` function

### DIFF
--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -14,6 +14,7 @@
 #include "../StructureManager.h"
 #include "../DirectionOffset.h"
 #include "../Map/TileMap.h"
+#include "../MapObjects/StructureType.h"
 #include "../MapObjects/Structures/Warehouse.h"
 
 #include "../UI/MessageBox.h"
@@ -192,15 +193,7 @@ bool structureIsLander(StructureID id)
  */
 bool selfSustained(StructureID id)
 {
-	switch (id)
-	{
-	case StructureID::SID_COMM_TOWER:
-	case StructureID::SID_ROAD:
-		return true;
-
-	default:
-		return false;
-	}
+	return StructureCatalogue::getType(id).isSelfSustained;
 }
 
 


### PR DESCRIPTION
Before, this method could not query the `Structure` class, since it's used when placing a `Structure`, before the class is instantiated. That meant maintaining a separate function that needed to be kept in sync with the `Structure` data. No surprise, it wasn't, and so the result of this function did not necessarily match how some structures behaved.

Now that the info has been moved to `StructureType`, we can query the same info as `Structure`, even before the `Structure` class has been instantiated.