### PR TITLE
Add `vcpkg` binary package caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
       BUILD_CONFIGURATION: Release
       SOLUTION_FILE_PATH: .
+      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
     steps:
     - uses: actions/checkout@v3
@@ -22,6 +23,21 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3.1
+
+    - name: Setup NuGet credentials
+      shell: bash
+      run: |
+        $(vcpkg fetch nuget | tail -n1) \
+        sources add \
+        -source "https://nuget.pkg.github.com/OutpostUniverse/index.json" \
+        -storepasswordincleartext \
+        -name "GitHub" \
+        -username "OutpostUniverse" \
+        -password "${{ secrets.GITHUB_TOKEN }}"
+
+        $(vcpkg fetch nuget | tail -n1) \
+        setApiKey "${{ secrets.GITHUB_TOKEN }}" \
+        -source "https://nuget.pkg.github.com/OutpostUniverse/index.json"
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache@v3


### PR DESCRIPTION
The GitHub hosted NuGet package repo can be used for binary package caching of `vcpkg` built dependencies. This allows for faster rebuilds of the `vcpkg` cache when some but not all packages need to be rebuilt.

Related upstream change:
- https://github.com/lairworks/nas2d-core/pull/1112
