### PR TITLE
Move `makefile` outputs

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
-CONFIG := debug
-debug_CXX_FLAGS := -Og -g
-release_CXX_FLAGS := -O3
+CONFIG := Debug
+Debug_CXX_FLAGS := -Og -g
+Release_CXX_FLAGS := -O3
 CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 
 SRCDIR := OPHD/

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 
 SRCDIR := OPHD/
 BUILDDIR := .build/
-OBJDIR := $(BUILDDIR)obj/
+OBJDIR := $(BUILDDIR)$(CONFIG)_Linux_OPHD/Intermediate/
 EXE := ophd.exe
 NAS2DDIR := nas2d-core/
 NAS2DINCLUDEDIR := $(NAS2DDIR)


### PR DESCRIPTION
This is the Linux `makefile` equivalent of #1389.

Corresponding NAS2D changes:
- https://github.com/lairworks/nas2d-core/pull/1104
- https://github.com/lairworks/nas2d-core/pull/1105