### PR TITLE
Refactor `Rectangle` uses

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -163,7 +163,7 @@ void TileMap::buildTerrainMap(const std::string& path)
 	 */
 	for (int depth = 0; depth <= mMaxDepth; depth++)
 	{
-		for (const auto point : PointInRectangleRange{Rectangle<int>::Create({0, 0}, mSizeInTiles)})
+		for (const auto point : PointInRectangleRange{Rectangle{{0, 0}, mSizeInTiles}})
 		{
 			auto color = heightmap.pixelColor(point);
 			auto& tile = getTile({point, depth});
@@ -199,7 +199,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 	// underground and excavated or surface and bulldozed.
 	for (int depth = 0; depth <= maxDepth(); ++depth)
 	{
-		for (const auto point : PointInRectangleRange{Rectangle<int>::Create({0, 0}, mSizeInTiles)})
+		for (const auto point : PointInRectangleRange{Rectangle{{0, 0}, mSizeInTiles}})
 		{
 			auto& tile = getTile({point, depth});
 			if (

--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -261,7 +261,7 @@ NAS2D::State* MainMenuState::update()
 	if (!mFileIoDialog.visible())
 	{
 		const auto padding = NAS2D::Vector{5, 5};
-		const auto menuRect = NAS2D::Rectangle<int>::Create(buttons.front().rect().startPoint() - padding, buttons.back().rect().endPoint() + padding);
+		const auto menuRect = NAS2D::Rectangle<int>::Create(buttons.front().rect().position - padding, buttons.back().rect().endPoint() + padding);
 		renderer.drawBoxFilled(menuRect, NAS2D::Color{0, 0, 0, 150});
 		renderer.drawBox(menuRect, NAS2D::Color{0, 185, 0, 255});
 

--- a/OPHD/States/MainReportsUiState.cpp
+++ b/OPHD/States/MainReportsUiState.cpp
@@ -92,7 +92,7 @@ static void setPanelRects(int width)
 	for (std::size_t i = 0; i < NavigationPanel::PANEL_EXIT; ++i)
 	{
 		auto& panel = Panels[i];
-		panel.Rect = NAS2D::Rectangle<int>::Create(panelPosition, panelSize);
+		panel.Rect = NAS2D::Rectangle{panelPosition, panelSize};
 		panel.TextPosition = panelPosition + (panelSize - BIG_FONT->size(panel.Name)) / 2 + NAS2D::Vector{20, 0};
 		panel.IconPosition = {panel.TextPosition.x - 40, 8};
 		panelPosition.x += panelSize.x;

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -63,8 +63,8 @@ namespace
 	{
 		const auto endPoint = rect.endPoint();
 		return {
-			std::clamp(point.x, rect.startPoint().x, endPoint.x),
-			std::clamp(point.y, rect.startPoint().y, endPoint.y),
+			std::clamp(point.x, rect.position.x, endPoint.x),
+			std::clamp(point.y, rect.position.y, endPoint.y),
 		};
 	}
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -307,7 +307,7 @@ void MapViewState::difficulty(Difficulty difficulty)
 NAS2D::State* MapViewState::update()
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto windowClientRect = NAS2D::Rectangle<int>::Create({0, 0}, renderer.size());
+	const auto windowClientRect = NAS2D::Rectangle{{0, 0}, renderer.size()};
 
 	// Game's over, don't bother drawing anything else
 	if (mGameOverDialog.visible())

--- a/OPHD/States/MapViewStateDraw.cpp
+++ b/OPHD/States/MapViewStateDraw.cpp
@@ -36,7 +36,7 @@ void MapViewState::drawSystemButton() const
 	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
 	renderer.drawText(font, std::to_string(mTurnCount), position + textOffset, NAS2D::Color::White);
 
-	position = mTooltipSystemButton.rect().startPoint() + NAS2D::Vector{constants::MarginTight, constants::MarginTight};
+	position = mTooltipSystemButton.rect().position + NAS2D::Vector{constants::MarginTight, constants::MarginTight};
 	bool isMouseInMenu = mTooltipSystemButton.rect().contains(MOUSE_COORDS);
 	int menuGearHighlightOffsetX = isMouseInMenu ? 144 : 128;
 	const auto menuImageRect = NAS2D::Rectangle<int>{{menuGearHighlightOffsetX, 32}, {constants::ResourceIconSize, constants::ResourceIconSize}};

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -114,7 +114,7 @@ void MapViewState::initUi()
 
 	// BUTTONS
 	mBtnTurns.image("ui/icons/turns.png");
-	mBtnTurns.position(NAS2D::Point{mMiniMapRect.startPoint().x - constants::MainButtonSize - constants::MarginTight, size.y - constants::Margin - constants::MainButtonSize});
+	mBtnTurns.position(NAS2D::Point{mMiniMapRect.position.x - constants::MainButtonSize - constants::MarginTight, size.y - constants::Margin - constants::MainButtonSize});
 	mBtnTurns.size(constants::MainButtonSize);
 	mBtnTurns.click().connect({this, &MapViewState::onTurns});
 	mBtnTurns.enabled(false);
@@ -145,16 +145,16 @@ void MapViewState::initUi()
 	mBtnTogglePoliceOverlay.click().connect({this, &MapViewState::onTogglePoliceOverlay});
 
 	// Menus
-	mRobots.position({mBtnTurns.positionX() - constants::MarginTight - 52, mBottomUiRect.startPoint().y + constants::Margin});
+	mRobots.position({mBtnTurns.positionX() - constants::MarginTight - 52, mBottomUiRect.position.y + constants::Margin});
 	mRobots.size({52, constants::BottomUiHeight - constants::Margin * 2});
 	mRobots.showTooltip(true);
 	mRobots.selectionChanged().connect({this, &MapViewState::onRobotsSelectionChange});
 
-	mConnections.position({mRobots.positionX() - constants::MarginTight - 52, mBottomUiRect.startPoint().y + constants::Margin});
+	mConnections.position({mRobots.positionX() - constants::MarginTight - 52, mBottomUiRect.position.y + constants::Margin});
 	mConnections.size({52, constants::BottomUiHeight - constants::Margin * 2});
 	mConnections.selectionChanged().connect({this, &MapViewState::onConnectionsSelectionChange});
 
-	mStructures.position(NAS2D::Point{constants::Margin, mBottomUiRect.startPoint().y + constants::Margin});
+	mStructures.position(NAS2D::Point{constants::Margin, mBottomUiRect.position.y + constants::Margin});
 	mStructures.size({mConnections.positionX() - constants::Margin - constants::MarginTight, constants::BottomUiHeight - constants::Margin * 2});
 	mStructures.showTooltip(true);
 	mStructures.selectionChanged().connect({this, &MapViewState::onStructuresSelectionChange});
@@ -192,10 +192,10 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mRobotDeploymentSummary.area({{8, size.y - constants::BottomUiHeight - 8 - 100}, {200, 100}});
 
 	// Mini Map
-	mMiniMapRect = {{size.x - 300 - constants::Margin, mBottomUiRect.startPoint().y + constants::Margin}, {300, 150}};
+	mMiniMapRect = {{size.x - 300 - constants::Margin, mBottomUiRect.position.y + constants::Margin}, {300, 150}};
 	mMiniMap->area(mMiniMapRect);
 
-	const auto navControlEndPoint = NAS2D::Point{size.x, mBottomUiRect.startPoint().y};
+	const auto navControlEndPoint = NAS2D::Point{size.x, mBottomUiRect.position.y};
 	const auto navControlSize = NAS2D::Vector{(32 + constants::MarginTight) * 3, 99};
 	mNavControl->area(NAS2D::Rectangle<int>::Create(navControlEndPoint - navControlSize, navControlSize));
 
@@ -205,17 +205,17 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 	mNotificationArea.position({renderer.size().x - mNotificationArea.size().x, 22});
 
 	// Position UI Buttons
-	mBtnTurns.position(NAS2D::Point{mMiniMapRect.startPoint().x - constants::MainButtonSize - constants::MarginTight, size.y - constants::Margin - constants::MainButtonSize});
-	mBtnToggleHeightmap.position({mBtnTurns.positionX(), mMiniMapRect.startPoint().y});
-	mBtnToggleConnectedness.position({mBtnTurns.positionX(), mMiniMapRect.startPoint().y + constants::MainButtonSize});
-	mBtnToggleCommRangeOverlay.position({mBtnTurns.positionX(), mMiniMapRect.startPoint().y + (constants::MainButtonSize * 2)});
-	mBtnToggleRouteOverlay.position({mBtnTurns.positionX(), mMiniMapRect.startPoint().y + (constants::MainButtonSize * 3)});
-	mBtnTogglePoliceOverlay.position({mBtnTurns.positionX() - constants::MainButtonSize, mMiniMapRect.startPoint().y});
+	mBtnTurns.position(NAS2D::Point{mMiniMapRect.position.x - constants::MainButtonSize - constants::MarginTight, size.y - constants::Margin - constants::MainButtonSize});
+	mBtnToggleHeightmap.position({mBtnTurns.positionX(), mMiniMapRect.position.y});
+	mBtnToggleConnectedness.position({mBtnTurns.positionX(), mMiniMapRect.position.y + constants::MainButtonSize});
+	mBtnToggleCommRangeOverlay.position({mBtnTurns.positionX(), mMiniMapRect.position.y + (constants::MainButtonSize * 2)});
+	mBtnToggleRouteOverlay.position({mBtnTurns.positionX(), mMiniMapRect.position.y + (constants::MainButtonSize * 3)});
+	mBtnTogglePoliceOverlay.position({mBtnTurns.positionX() - constants::MainButtonSize, mMiniMapRect.position.y});
 
 	// UI Panels
-	mRobots.position({mBtnTogglePoliceOverlay.positionX() - constants::MarginTight - 52, mBottomUiRect.startPoint().y + constants::Margin});
-	mConnections.position({mRobots.positionX() - constants::MarginTight - 52, mBottomUiRect.startPoint().y + constants::Margin});
-	mStructures.position(NAS2D::Point{constants::Margin, mBottomUiRect.startPoint().y + constants::Margin});
+	mRobots.position({mBtnTogglePoliceOverlay.positionX() - constants::MarginTight - 52, mBottomUiRect.position.y + constants::Margin});
+	mConnections.position({mRobots.positionX() - constants::MarginTight - 52, mBottomUiRect.position.y + constants::Margin});
+	mStructures.position(NAS2D::Point{constants::Margin, mBottomUiRect.position.y + constants::Margin});
 
 	mStructures.size({mConnections.positionX() - constants::Margin - constants::MarginTight, constants::BottomUiHeight - constants::Margin * 2});
 
@@ -373,7 +373,7 @@ void MapViewState::drawUI()
 	// Bottom UI
 	renderer.drawBoxFilled(mBottomUiRect, NAS2D::Color{39, 39, 39});
 	renderer.drawBox(mBottomUiRect, NAS2D::Color{21, 21, 21});
-	renderer.drawLine(NAS2D::Point{mBottomUiRect.startPoint().x + 1, mBottomUiRect.startPoint().y}, NAS2D::Point{mBottomUiRect.startPoint().x + mBottomUiRect.size.x - 2, mBottomUiRect.startPoint().y}, NAS2D::Color{56, 56, 56});
+	renderer.drawLine(NAS2D::Point{mBottomUiRect.position.x + 1, mBottomUiRect.position.y}, NAS2D::Point{mBottomUiRect.position.x + mBottomUiRect.size.x - 2, mBottomUiRect.position.y}, NAS2D::Color{56, 56, 56});
 
 	mMiniMap->draw();
 	mNavControl->draw();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -197,7 +197,7 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 
 	const auto navControlEndPoint = NAS2D::Point{size.x, mBottomUiRect.position.y};
 	const auto navControlSize = NAS2D::Vector{(32 + constants::MarginTight) * 3, 99};
-	mNavControl->area(NAS2D::Rectangle<int>::Create(navControlEndPoint - navControlSize, navControlSize));
+	mNavControl->area(NAS2D::Rectangle{navControlEndPoint - navControlSize, navControlSize});
 
 	// Notification Area
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();

--- a/OPHD/States/Planet.cpp
+++ b/OPHD/States/Planet.cpp
@@ -66,7 +66,7 @@ void Planet::update()
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto spriteFrameOffset = NAS2D::Point{mTick % 16 * PlanetSize.x, ((mTick % 256) / 16) * PlanetSize.y};
-	renderer.drawSubImage(mImage, mPosition, NAS2D::Rectangle<int>::Create(spriteFrameOffset, PlanetSize));
+	renderer.drawSubImage(mImage, mPosition, NAS2D::Rectangle{spriteFrameOffset, PlanetSize});
 }
 
 namespace

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -91,7 +91,7 @@ NAS2D::State* PlanetSelectState::update()
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const auto size = renderer.size();
-	renderer.drawImageStretched(mBg, NAS2D::Rectangle<int>::Create({0, 0}, size));
+	renderer.drawImageStretched(mBg, NAS2D::Rectangle{{0, 0}, size});
 
 	float rotation = static_cast<float>(mTimer.tick()) / 1200.0f;
 	renderer.drawImageRotated(mCloud1, {-256, -256}, rotation, NAS2D::Color{100, 255, 0, 135});

--- a/OPHD/States/SplashState.cpp
+++ b/OPHD/States/SplashState.cpp
@@ -104,7 +104,7 @@ NAS2D::State* SplashState::update()
 
 	const auto size = renderer.size();
 	const auto backgroundColor = (currentState == LogoState::OutpostHD) ? NAS2D::Color::Black : NAS2D::Color::White;
-	renderer.drawBoxFilled(NAS2D::Rectangle<int>::Create({0, 0}, size), backgroundColor);
+	renderer.drawBoxFilled(NAS2D::Rectangle{{0, 0}, size}, backgroundColor);
 
 
 	if (currentState == LogoState::Lairworks)

--- a/OPHD/UI/Core/ComboBox.cpp
+++ b/OPHD/UI/Core/ComboBox.cpp
@@ -54,7 +54,7 @@ void ComboBox::onResize()
 	lstItems.width(mRect.size.x);
 	lstItems.position(rect().crossYPoint());
 
-	mBarRect = NAS2D::Rectangle<int>::Create(position(), NAS2D::Vector{mRect.size.x, btnDown.size().y});
+	mBarRect = NAS2D::Rectangle{position(), {mRect.size.x, btnDown.size().y}};
 }
 
 
@@ -69,7 +69,7 @@ void ComboBox::onMove(NAS2D::Vector<int> displacement)
 	btnDown.position(txtField.rect().crossXPoint());
 	lstItems.position(rect().crossYPoint());
 
-	mBarRect = NAS2D::Rectangle<int>::Create(position(), NAS2D::Vector{mRect.size.x, btnDown.size().y});
+	mBarRect = NAS2D::Rectangle{position(), {mRect.size.x, btnDown.size().y}};
 }
 
 

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -3,7 +3,7 @@
 
 void Control::area(const NAS2D::Rectangle<int>& newRect)
 {
-	const auto displacement = newRect.startPoint() - mRect.startPoint();
+	const auto displacement = newRect.position - mRect.position;
 	mRect = newRect;
 	onMove(displacement);
 	onResize();
@@ -17,7 +17,7 @@ void Control::area(const NAS2D::Rectangle<int>& newRect)
  */
 void Control::position(NAS2D::Point<int> pos)
 {
-	const auto displacement = pos - mRect.startPoint();
+	const auto displacement = pos - mRect.position;
 	mRect.startPoint(pos);
 	onMove(displacement);
 }
@@ -28,7 +28,7 @@ void Control::position(NAS2D::Point<int> pos)
  */
 int Control::positionX() const
 {
-	return mRect.startPoint().x;
+	return mRect.position.x;
 }
 
 
@@ -37,7 +37,7 @@ int Control::positionX() const
  */
 int Control::positionY() const
 {
-	return mRect.startPoint().y;
+	return mRect.position.y;
 }
 
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -26,7 +26,7 @@ public:
 	const NAS2D::Rectangle<int>& area() const { return mRect; }
 	void area(const NAS2D::Rectangle<int>& area);
 
-	NAS2D::Point<int> position() const { return mRect.startPoint(); }
+	NAS2D::Point<int> position() const { return mRect.position; }
 	void position(NAS2D::Point<int> pos);
 
 	int positionX() const;

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -41,7 +41,7 @@ void Label::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const auto textPosition = mRect.startPoint() + NAS2D::Vector{mPadding, mPadding};
+	const auto textPosition = mRect.position + NAS2D::Vector{mPadding, mPadding};
 	renderer.drawText(*mFont, text(), textPosition, mTextColor);
 }
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -24,7 +24,7 @@ void ListBoxItemText::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> draw
 	}
 
 	// Draw item contents
-	const auto textPosition = drawRect.startPoint() + NAS2D::Vector{constants::MarginTight, 0};
+	const auto textPosition = drawRect.position + NAS2D::Vector{constants::MarginTight, 0};
 	const auto textColor = isHighlighted ? context.textColorMouseHover : context.textColorNormal;
 	renderer.drawTextShadow(context.font, text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 }

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -184,7 +184,7 @@ public:
 		}
 
 		// Paint remaining section of scroll area not covered by items
-		itemDrawRect.size.y = mClientRect.endPoint().y - itemDrawRect.startPoint().y;
+		itemDrawRect.size.y = mClientRect.endPoint().y - itemDrawRect.position.y;
 		renderer.drawBoxFilled(itemDrawRect, mContext.backgroundColorNormal);
 
 		renderer.clipRectClear();
@@ -211,7 +211,7 @@ protected:
 			return;
 		}
 
-		const auto dy = position.y - mClientRect.startPoint().y;
+		const auto dy = position.y - mClientRect.position.y;
 		mHighlightIndex = (static_cast<std::size_t>(dy) + mScrollOffsetInPixels) / static_cast<std::size_t>(mContext.itemHeight());
 		if (mHighlightIndex >= mItems.size())
 		{
@@ -250,7 +250,7 @@ private:
 		const auto neededDisplaySize = mContext.itemHeight() * mItems.size();
 		if (neededDisplaySize > static_cast<std::size_t>(mRect.size.y))
 		{
-			mScrollBar.position({rect().startPoint().x + mRect.size.x - 14, mRect.startPoint().y});
+			mScrollBar.position({rect().position.x + mRect.size.x - 14, mRect.position.y});
 			mScrollBar.size({14, mRect.size.y});
 			mScrollBar.max(static_cast<ScrollBar::ValueType>(static_cast<int>(neededDisplaySize) - mRect.size.y));
 			mScrollOffsetInPixels = static_cast<std::size_t>(mScrollBar.value());

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -71,7 +71,7 @@ void ListBoxBase::updateScrollLayout()
 
 	if ((mItemHeight * static_cast<int>(mItems.size())) > mRect.size.y)
 	{
-		mScrollBar.position({rect().startPoint().x + mRect.size.x - 14, mRect.startPoint().y});
+		mScrollBar.position({rect().position.x + mRect.size.x - 14, mRect.position.y});
 		mScrollBar.size({14, mRect.size.y});
 		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemHeight * static_cast<int>(mItems.size()) - mRect.size.y));
 		mScrollOffsetInPixels = static_cast<unsigned int>(mScrollBar.value());
@@ -262,7 +262,7 @@ void ListBoxBase::draw() const
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// CONTROL EXTENTS
-	const auto backgroundRect = NAS2D::Rectangle<int>{{mRect.startPoint().x, mRect.startPoint().y}, {mItemWidth, mRect.size.y}};
+	const auto backgroundRect = NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y}, {mItemWidth, mRect.size.y}};
 	renderer.drawBoxFilled(backgroundRect, NAS2D::Color::Black);
 	renderer.drawBox(backgroundRect, (hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75}));
 

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -20,7 +20,7 @@ RadioButtonGroup::RadioButtonGroup(std::vector<ButtonInfo> buttonInfos)
 
 		auto &button = mRadioButtons.emplace_back(*this, buttonInfo.name, buttonInfo.delegate);
 		button.visible(visible());
-		button.position(mRect.startPoint() + offset);
+		button.position(mRect.position + offset);
 	}
 }
 

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -250,7 +250,7 @@ void ScrollBar::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<
 	{
 		const auto [clickPosition, thumbPosition, viewSize] =
 			(mScrollBarType == ScrollBarType::Vertical) ?
-				std::tuple{position.y, mThumbRect.startPoint().y, mRect.size.y} : std::tuple{position.x, mThumbRect.startPoint().x, mRect.size.x};
+				std::tuple{position.y, mThumbRect.position.y, mRect.size.y} : std::tuple{position.x, mThumbRect.position.x, mRect.size.x};
 		const auto changeAmount = (clickPosition < thumbPosition) ?
 			-viewSize : viewSize;
 		changeValue(changeAmount);
@@ -266,8 +266,8 @@ void ScrollBar::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rel
 	{
 		value(
 			(mScrollBarType == ScrollBarType::Vertical) ?
-				mMax * (position.y - mTrackRect.startPoint().y - mThumbRect.size.y / 2) / (mTrackRect.size.y - mThumbRect.size.y) :
-				mMax * (position.x - mTrackRect.startPoint().x - mThumbRect.size.x / 2) / (mTrackRect.size.x - mThumbRect.size.x)
+				mMax * (position.y - mTrackRect.position.y - mThumbRect.size.y / 2) / (mTrackRect.size.y - mThumbRect.size.y) :
+				mMax * (position.x - mTrackRect.position.x - mThumbRect.size.x / 2) / (mTrackRect.size.x - mThumbRect.size.x)
 		);
 	}
 }
@@ -289,20 +289,20 @@ void ScrollBar::onLayoutChange()
 {
 	if (mScrollBarType == ScrollBarType::Vertical)
 	{
-		mButtonDecreaseRect = {{mRect.startPoint().x, mRect.startPoint().y}, {mRect.size.x, mRect.size.x}};
-		mButtonIncreaseRect = {{mRect.startPoint().x, mRect.startPoint().y + mRect.size.y - mRect.size.x}, {mRect.size.x, mRect.size.x}};
-		mTrackRect = {{mRect.startPoint().x, mRect.startPoint().y + mRect.size.x}, {mRect.size.x, mRect.size.y - 2 * mRect.size.x}};
+		mButtonDecreaseRect = {{mRect.position.x, mRect.position.y}, {mRect.size.x, mRect.size.x}};
+		mButtonIncreaseRect = {{mRect.position.x, mRect.position.y + mRect.size.y - mRect.size.x}, {mRect.size.x, mRect.size.x}};
+		mTrackRect = {{mRect.position.x, mRect.position.y + mRect.size.x}, {mRect.size.x, mRect.size.y - 2 * mRect.size.x}};
 		const auto newSize = std::min(mTrackRect.size.y * mRect.size.y / std::max(mMax + mRect.size.y, 1), mTrackRect.size.y);
 		const auto drawOffset = (mTrackRect.size.y - newSize) * mValue / std::max(mMax, 1);
-		mThumbRect = {{mTrackRect.startPoint().x, mTrackRect.startPoint().y + drawOffset}, {mTrackRect.size.x, newSize}};
+		mThumbRect = {{mTrackRect.position.x, mTrackRect.position.y + drawOffset}, {mTrackRect.size.x, newSize}};
 	}
 	else
 	{
-		mButtonDecreaseRect = {{mRect.startPoint().x, mRect.startPoint().y}, {mRect.size.y, mRect.size.y}};
-		mButtonIncreaseRect = {{mRect.startPoint().x + mRect.size.x - mRect.size.y, mRect.startPoint().y}, {mRect.size.y, mRect.size.y}};
-		mTrackRect = {{mRect.startPoint().x + mRect.size.y, mRect.startPoint().y}, {mRect.size.x - 2 * mRect.size.y, mRect.size.y}};
+		mButtonDecreaseRect = {{mRect.position.x, mRect.position.y}, {mRect.size.y, mRect.size.y}};
+		mButtonIncreaseRect = {{mRect.position.x + mRect.size.x - mRect.size.y, mRect.position.y}, {mRect.size.y, mRect.size.y}};
+		mTrackRect = {{mRect.position.x + mRect.size.y, mRect.position.y}, {mRect.size.x - 2 * mRect.size.y, mRect.size.y}};
 		const auto newSize = std::min(mTrackRect.size.x * mRect.size.x / std::max(mMax + mRect.size.x, 1), mTrackRect.size.x);
 		const auto drawOffset = (mTrackRect.size.x - newSize) * mValue / std::max(mMax, 1);
-		mThumbRect = {{mTrackRect.startPoint().x + drawOffset, mTrackRect.startPoint().y}, {newSize, mTrackRect.size.y}};
+		mThumbRect = {{mTrackRect.position.x + drawOffset, mTrackRect.position.y}, {newSize, mTrackRect.size.y}};
 	}
 }

--- a/OPHD/UI/Core/ScrollBar.cpp
+++ b/OPHD/UI/Core/ScrollBar.cpp
@@ -289,7 +289,7 @@ void ScrollBar::onLayoutChange()
 {
 	if (mScrollBarType == ScrollBarType::Vertical)
 	{
-		mButtonDecreaseRect = {{mRect.position.x, mRect.position.y}, {mRect.size.x, mRect.size.x}};
+		mButtonDecreaseRect = {mRect.position, {mRect.size.x, mRect.size.x}};
 		mButtonIncreaseRect = {{mRect.position.x, mRect.position.y + mRect.size.y - mRect.size.x}, {mRect.size.x, mRect.size.x}};
 		mTrackRect = {{mRect.position.x, mRect.position.y + mRect.size.x}, {mRect.size.x, mRect.size.y - 2 * mRect.size.x}};
 		const auto newSize = std::min(mTrackRect.size.y * mRect.size.y / std::max(mMax + mRect.size.y, 1), mTrackRect.size.y);
@@ -298,7 +298,7 @@ void ScrollBar::onLayoutChange()
 	}
 	else
 	{
-		mButtonDecreaseRect = {{mRect.position.x, mRect.position.y}, {mRect.size.y, mRect.size.y}};
+		mButtonDecreaseRect = {mRect.position, {mRect.size.y, mRect.size.y}};
 		mButtonIncreaseRect = {{mRect.position.x + mRect.size.x - mRect.size.y, mRect.position.y}, {mRect.size.y, mRect.size.y}};
 		mTrackRect = {{mRect.position.x + mRect.size.y, mRect.position.y}, {mRect.size.x - 2 * mRect.size.y, mRect.size.y}};
 		const auto newSize = std::min(mTrackRect.size.x * mRect.size.x / std::max(mMax + mRect.size.x, 1), mTrackRect.size.x);

--- a/OPHD/UI/Core/TextArea.cpp
+++ b/OPHD/UI/Core/TextArea.cpp
@@ -91,7 +91,7 @@ void TextArea::draw() const
 
 	if (!mFont) { return; }
 
-	auto textPosition = mRect.startPoint();
+	auto textPosition = mRect.position;
 	for (std::size_t i = 0; i < mFormattedList.size() && i < mNumLines; ++i)
 	{
 		renderer.drawText(*mFont, mFormattedList[i], textPosition, mTextColor);

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -222,7 +222,7 @@ void TextField::onMouseDown(NAS2D::EventHandler::MouseButton /*button*/, NAS2D::
 
 	if (!enabled() || !visible()) { return; }
 
-	int relativePosition = position.x - mRect.startPoint().x;
+	int relativePosition = position.x - mRect.position.x;
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
@@ -261,8 +261,8 @@ void TextField::drawCursor() const
 		if (mShowCursor)
 		{
 			auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-			const auto startPosition = NAS2D::Point{mCursorX, mRect.startPoint().y + fieldPadding};
-			const auto endPosition = NAS2D::Point{mCursorX, mRect.startPoint().y + mRect.size.y - fieldPadding - 1};
+			const auto startPosition = NAS2D::Point{mCursorX, mRect.position.y + fieldPadding};
+			const auto endPosition = NAS2D::Point{mCursorX, mRect.position.y + mRect.size.y - fieldPadding - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);
 			renderer.drawLine(startPosition, endPosition, NAS2D::Color::White);
 		}
@@ -291,7 +291,7 @@ void TextField::updateScrollPosition()
 		mScrollOffset = 0;
 	}
 
-	mCursorX = mRect.startPoint().x + fieldPadding + cursorX - mScrollOffset;
+	mCursorX = mRect.position.x + fieldPadding + cursorX - mScrollOffset;
 }
 
 

--- a/OPHD/UI/Core/UIContainer.cpp
+++ b/OPHD/UI/Core/UIContainer.cpp
@@ -36,7 +36,7 @@ void UIContainer::add(Control& control, NAS2D::Vector<int> offset)
 	if (mControls.size() > 0) { mControls.back()->hasFocus(false); }
 	mControls.push_back(&control);
 
-	control.position(mRect.startPoint() + offset);
+	control.position(mRect.position + offset);
 	control.visible(visible());
 	control.hasFocus(true);
 }

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -47,7 +47,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<i
 
 	UIContainer::onMouseDown(button, position);
 
-	const auto titleBarBounds = NAS2D::Rectangle<int>{{mRect.startPoint().x, mRect.startPoint().y}, {mRect.size.x, sWindowTitleBarHeight}};
+	const auto titleBarBounds = NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y}, {mRect.size.x, sWindowTitleBarHeight}};
 	mMouseDrag = (button == NAS2D::EventHandler::MouseButton::Left && titleBarBounds.contains(position));
 }
 
@@ -94,13 +94,13 @@ void Window::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	renderer.drawImage(mTitleBarLeft, mRect.startPoint());
-	renderer.drawImageRepeated(mTitleBarCenter, NAS2D::Rectangle<int>{{mRect.startPoint().x + 4, mRect.startPoint().y}, {mRect.size.x - 8, sWindowTitleBarHeight}});
-	renderer.drawImage(mTitleBarRight, NAS2D::Point{mRect.startPoint().x + mRect.size.x - 4, mRect.startPoint().y});
+	renderer.drawImage(mTitleBarLeft, mRect.position);
+	renderer.drawImageRepeated(mTitleBarCenter, NAS2D::Rectangle<int>{{mRect.position.x + 4, mRect.position.y}, {mRect.size.x - 8, sWindowTitleBarHeight}});
+	renderer.drawImage(mTitleBarRight, NAS2D::Point{mRect.position.x + mRect.size.x - 4, mRect.position.y});
 
-	mBody.draw(renderer, NAS2D::Rectangle<int>{{mRect.startPoint().x, mRect.startPoint().y + 20}, {mRect.size.x, mRect.size.y - 20}});
+	mBody.draw(renderer, NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y + 20}, {mRect.size.x, mRect.size.y - 20}});
 
-	renderer.drawText(mTitleFont, title(), NAS2D::Point{mRect.startPoint().x + 5, mRect.startPoint().y + 2}, NAS2D::Color::White);
+	renderer.drawText(mTitleFont, title(), NAS2D::Point{mRect.position.x + 5, mRect.position.y + 2}, NAS2D::Color::White);
 }
 
 

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -47,7 +47,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<i
 
 	UIContainer::onMouseDown(button, position);
 
-	const auto titleBarBounds = NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y}, {mRect.size.x, sWindowTitleBarHeight}};
+	const auto titleBarBounds = NAS2D::Rectangle{mRect.position, {mRect.size.x, sWindowTitleBarHeight}};
 	mMouseDrag = (button == NAS2D::EventHandler::MouseButton::Left && titleBarBounds.contains(position));
 }
 

--- a/OPHD/UI/DetailMap.cpp
+++ b/OPHD/UI/DetailMap.cpp
@@ -124,7 +124,7 @@ void DetailMap::draw() const
 
 		if (tile.excavated())
 		{
-			const auto offset = tilePosition - mMapView.viewTileRect().startPoint();
+			const auto offset = tilePosition - mMapView.viewTileRect().position;
 			const auto position = mOriginPixelPosition - TileDrawOffset + NAS2D::Vector{(offset.x - offset.y) * TileSize.x / 2, (offset.x + offset.y) * TileSize.y / 2};
 			const auto subImageRect = NAS2D::Rectangle{{static_cast<int>(tile.index()) * TileDrawSize.x, tsetOffset}, TileDrawSize};
 			const bool isTileHighlighted = tilePosition == mMouseTilePosition;
@@ -171,5 +171,5 @@ void DetailMap::onMouseMove(NAS2D::Point<int> position)
 {
 	const auto pixelOffset = position - mOriginPixelPosition;
 	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);
-	mMouseTilePosition = mMapView.viewTileRect().startPoint() + tileOffset;
+	mMouseTilePosition = mMapView.viewTileRect().position + tileOffset;
 }

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -49,7 +49,7 @@ static void drawItem(Renderer& renderer, FactoryListBox::FactoryListBoxItem& ite
 		drawProgressBar(
 			f->productionTurnsCompleted(),
 			f->productionTurnsToComplete(),
-			NAS2D::Rectangle<int>::Create(rect.crossXPoint() + NAS2D::Vector{-112, 30}, NAS2D::Vector{105, 11}),
+			NAS2D::Rectangle{rect.crossXPoint() + NAS2D::Vector{-112, 30}, {105, 11}},
 			2
 		);
 	}

--- a/OPHD/UI/FactoryListBox.cpp
+++ b/OPHD/UI/FactoryListBox.cpp
@@ -41,8 +41,8 @@ static void drawItem(Renderer& renderer, FactoryListBox::FactoryListBoxItem& ite
 	renderer.drawBox(rect.inset(2), structureColor);
 
 	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
-	renderer.drawSubImage(*STRUCTURE_ICONS, rect.startPoint() + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
-	renderer.drawText(*MAIN_FONT_BOLD, f->name(), rect.startPoint() + NAS2D::Vector{64, 29 - MAIN_FONT_BOLD->height() / 2}, structureTextColor);
+	renderer.drawSubImage(*STRUCTURE_ICONS, rect.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
+	renderer.drawText(*MAIN_FONT_BOLD, f->name(), rect.position + NAS2D::Vector{64, 29 - MAIN_FONT_BOLD->height() / 2}, structureTextColor);
 	if (productType != ProductType::PRODUCT_NONE)
 	{
 		renderer.drawText(*MAIN_FONT, ProductCatalogue::get(productType).Name, rect.crossXPoint() + NAS2D::Vector{-112, 19 - MAIN_FONT_BOLD->height() / 2}, structureTextColor);

--- a/OPHD/UI/FactoryProduction.cpp
+++ b/OPHD/UI/FactoryProduction.cpp
@@ -156,7 +156,7 @@ void FactoryProduction::update()
 	Window::update();
 
 	StringTable stringTable(2, 5);
-	stringTable.position(mRect.startPoint() + NAS2D::Vector{constants::Margin * 2 + mProductGrid.size().x, 25});
+	stringTable.position(mRect.position + NAS2D::Vector{constants::Margin * 2 + mProductGrid.size().x, 25});
 	stringTable.setColumnJustification(1, StringTable::Justification::Right);
 
 	stringTable.setColumnText(0,

--- a/OPHD/UI/GameOptionsDialog.cpp
+++ b/OPHD/UI/GameOptionsDialog.cpp
@@ -16,7 +16,7 @@ GameOptionsDialog::GameOptionsDialog() :
 	position({0, 0});
 	
 	const auto buttons = std::array{&btnSave, &btnLoad, &btnHelp, &btnReturn, &btnClose};
-	auto position = mRect.startPoint() + NAS2D::Vector{buttonHorizontalMargin, buttonHeight};
+	auto position = mRect.position + NAS2D::Vector{buttonHorizontalMargin, buttonHeight};
 	for (auto button : buttons)
 	{
 		button->size({buttonWidth, buttonHeight});

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -76,7 +76,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> p
 		return;
 	}
 
-	auto startPoint = mRect.startPoint();
+	auto startPoint = mRect.position;
 	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(position))
 	{
 		return;
@@ -101,7 +101,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 {
 	if (!enabled() || !visible()) { return; }
 
-	auto startPoint = mRect.startPoint();
+	auto startPoint = mRect.position;
 	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(position))
 	{
 		mHighlightIndex = constants::NoSelection;
@@ -344,7 +344,7 @@ void IconGrid::update()
 	mSkin.draw(renderer, mRect);
 
 	if (mGridSize.x == 0) { return; }
-	const auto indexToGridPosition = [gridSize = mGridSize, startPoint = mRect.startPoint(), spacing = mIconSize + mIconMargin](std::size_t index) {
+	const auto indexToGridPosition = [gridSize = mGridSize, startPoint = mRect.position, spacing = mIconSize + mIconMargin](std::size_t index) {
 		const auto linearOffset = static_cast<int>(index);
 		const auto offset = NAS2D::Vector{linearOffset % gridSize.x, linearOffset / gridSize.x};
 		return startPoint + offset * spacing;

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -77,7 +77,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> p
 	}
 
 	auto startPoint = mRect.position;
-	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(position))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint, mGridSize * (mIconSize + mIconMargin)}.contains(position))
 	{
 		return;
 	}
@@ -102,7 +102,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 	if (!enabled() || !visible()) { return; }
 
 	auto startPoint = mRect.position;
-	if (mIconItemList.empty() || !NAS2D::Rectangle<int>::Create(startPoint, mGridSize * (mIconSize + mIconMargin)).contains(position))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint, mGridSize * (mIconSize + mIconMargin)}.contains(position))
 	{
 		mHighlightIndex = constants::NoSelection;
 		return;
@@ -360,13 +360,13 @@ void IconGrid::update()
 	if (mSelectedIndex != constants::NoSelection)
 	{
 		const auto position = indexToGridPosition(mSelectedIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
-		renderer.drawBox(NAS2D::Rectangle<int>::Create(position, NAS2D::Vector{mIconSize, mIconSize}), NAS2D::Color{0, 100, 255});
+		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 100, 255});
 	}
 
 	if (mHighlightIndex != constants::NoSelection)
 	{
 		const auto position = indexToGridPosition(mHighlightIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
-		renderer.drawBox(NAS2D::Rectangle<int>::Create(position, NAS2D::Vector{mIconSize, mIconSize}), NAS2D::Color{0, 180, 0});
+		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 180, 0});
 
 		// Name Tooltip
 		if (mShowTooltip)

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -181,7 +181,7 @@ void MineOperationsWindow::update()
 
 	auto& renderer = Utility<Renderer>::get();
 
-	const auto origin = mRect.startPoint();
+	const auto origin = mRect.position;
 	renderer.drawImage(mUiIcon, origin + NAS2D::Vector{10, 30});
 
 	const auto& mineYield = MINE_YIELD_TRANSLATION.at(mFacility->mine()->productionRate());

--- a/OPHD/UI/MineOperationsWindow.cpp
+++ b/OPHD/UI/MineOperationsWindow.cpp
@@ -212,7 +212,7 @@ void MineOperationsWindow::update()
 	const auto width = mRect.size.x;
 	renderer.drawText(mFontBold, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
-	mPanel.draw(renderer, NAS2D::Rectangle<int>::Create(origin + NAS2D::Vector{10, 180}, NAS2D::Vector{width - 20, 40}));
+	mPanel.draw(renderer, NAS2D::Rectangle{origin + NAS2D::Vector{10, 180}, {width - 20, 40}});
 
 	renderer.drawLine(origin + NAS2D::Vector{98, 180}, origin + NAS2D::Vector{98, 219}, NAS2D::Color{22, 22, 22});
 	renderer.drawLine(origin + NAS2D::Vector{187, 180}, origin + NAS2D::Vector{187, 219}, NAS2D::Color{22, 22, 22});

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -55,10 +55,10 @@ void MiniMap::draw() const
 	const auto miniMapFloatRect = mRect.to<float>();
 	renderer.clipRect(miniMapFloatRect);
 
-	renderer.drawImage((mIsHeightMapVisible ? mBackgroundHeightMap : mBackgroundSatellite), miniMapFloatRect.startPoint());
+	renderer.drawImage((mIsHeightMapVisible ? mBackgroundHeightMap : mBackgroundSatellite), miniMapFloatRect.position);
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	const auto miniMapOffset = mRect.startPoint() - NAS2D::Point{0, 0};
+	const auto miniMapOffset = mRect.position - NAS2D::Point{0, 0};
 	for (const auto& ccPosition : structureManager.operationalCommandCenterPositions())
 	{
 		const auto ccOffsetPosition = ccPosition.xy + miniMapOffset;
@@ -156,6 +156,6 @@ void MiniMap::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relat
 
 void MiniMap::onSetView(NAS2D::Point<int> mousePixel)
 {
-	const auto position = NAS2D::Point{0, 0} + (mousePixel - mRect.startPoint());
+	const auto position = NAS2D::Point{0, 0} + (mousePixel - mRect.position);
 	mMapView.centerOn(position);
 }

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -64,7 +64,7 @@ void MiniMap::draw() const
 		const auto ccOffsetPosition = ccPosition.xy + miniMapOffset;
 		const auto ccCommRangeImageRect = NAS2D::Rectangle<int>{{166, 226}, {30, 30}};
 		renderer.drawSubImage(mUiIcons, ccOffsetPosition - ccCommRangeImageRect.size / 2, ccCommRangeImageRect);
-		renderer.drawBoxFilled(NAS2D::Rectangle<int>::Create(ccOffsetPosition - NAS2D::Vector{1, 1}, NAS2D::Vector{3, 3}), NAS2D::Color::White);
+		renderer.drawBoxFilled(NAS2D::Rectangle{ccOffsetPosition - NAS2D::Vector{1, 1}, {3, 3}}, NAS2D::Color::White);
 	}
 
 	for (auto commTower : structureManager.getStructures<CommTower>())

--- a/OPHD/UI/NavControl.cpp
+++ b/OPHD/UI/NavControl.cpp
@@ -43,7 +43,7 @@ void NavControl::onMove(NAS2D::Vector<int> displacement)
 	Control::onMove(displacement);
 
 	// NAVIGATION BUTTONS
-	const auto position = mRect.startPoint();
+	const auto position = mRect.position;
 	const auto navIconSpacing = 32 + constants::MarginTight;
 	// Top line
 	mMoveWestIconRect = {{position.x, position.y + 8}, {32, 16}};
@@ -98,7 +98,7 @@ void NavControl::draw() const
 	{
 		bool isMouseInIcon = currentIconRect.contains(MOUSE_COORDS);
 		NAS2D::Color color = isMouseInIcon ? NAS2D::Color::Red : NAS2D::Color::White;
-		renderer.drawSubImage(mUiIcons, currentIconRect.startPoint(), subImageRect, color);
+		renderer.drawSubImage(mUiIcons, currentIconRect.position, subImageRect, color);
 	}
 
 	// Display the levels "bar"

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -86,7 +86,7 @@ void NotificationArea::clear()
 NAS2D::Rectangle<int> NotificationArea::notificationRect(std::size_t index)
 {
 	auto rectPosition = position() + NAS2D::Vector{IconPadding.x, size().y - IconPaddedSize.y * static_cast<int>(index + 1)};
-	return NAS2D::Rectangle<int>::Create(rectPosition, IconSize);
+	return NAS2D::Rectangle{rectPosition, IconSize};
 }
 
 
@@ -146,7 +146,7 @@ void NotificationArea::update()
 			const auto textPadding = Vector<int>{4, 2};
 			const auto textAreaSize = mFont.size(notification.brief) + textPadding * 2;
 			const auto briefPosition = rect.position + NAS2D::Vector{-IconPadding.x - textAreaSize.x, (rect.size.y - textAreaSize.y) / 2};
-			const auto notificationBriefRect = NAS2D::Rectangle<int>::Create(briefPosition, textAreaSize);
+			const auto notificationBriefRect = NAS2D::Rectangle{briefPosition, textAreaSize};
 			const auto textPosition = briefPosition + textPadding;
 
 			renderer.drawBoxFilled(notificationBriefRect, Color::DarkGray);

--- a/OPHD/UI/NotificationArea.cpp
+++ b/OPHD/UI/NotificationArea.cpp
@@ -139,13 +139,13 @@ void NotificationArea::update()
 	for (auto& notification : mNotificationList)
 	{
 		const auto& rect = notificationRect(count);
-		drawNotificationIcon(rect.startPoint(), notification.type, mIcons);
+		drawNotificationIcon(rect.position, notification.type, mIcons);
 
 		if (mNotificationIndex == count)
 		{
 			const auto textPadding = Vector<int>{4, 2};
 			const auto textAreaSize = mFont.size(notification.brief) + textPadding * 2;
-			const auto briefPosition = rect.startPoint() + NAS2D::Vector{-IconPadding.x - textAreaSize.x, (rect.size.y - textAreaSize.y) / 2};
+			const auto briefPosition = rect.position + NAS2D::Vector{-IconPadding.x - textAreaSize.x, (rect.size.y - textAreaSize.y) / 2};
 			const auto notificationBriefRect = NAS2D::Rectangle<int>::Create(briefPosition, textAreaSize);
 			const auto textPosition = briefPosition + textPadding;
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -171,7 +171,7 @@ void PopulationPanel::update()
 		renderer.drawText(mFont, item.first, position);
 
 		const auto text = formatDiff(item.second);
-		const NAS2D::Point<int> labelPosition = {rect().startPoint().x + rect().size.x - mFont.width(text) - 5 , position.y};
+		const NAS2D::Point<int> labelPosition = {rect().position.x + rect().size.x - mFont.width(text) - 5 , position.y};
 
 		renderer.drawText(mFont, text, labelPosition, trend[trendIndex(item.second)]);
 		position.y += fontHeight;

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -116,7 +116,7 @@ FactoryReport::FactoryReport() :
 
 	cboFilterByProduct.selectionChanged().connect({this, &FactoryReport::onProductFilterSelectionChange});
 
-	add(lstProducts, {cboFilterByProduct.rect().startPoint().x + cboFilterByProduct.rect().size.x + 20, mRect.startPoint().y + 230});
+	add(lstProducts, {cboFilterByProduct.rect().position.x + cboFilterByProduct.rect().size.x + 20, mRect.position.y + 230});
 
 	txtProductDescription.font(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
 	txtProductDescription.height(128);
@@ -257,8 +257,8 @@ void FactoryReport::onResize()
 	lstFactoryList.size({comboEndPoint.x - 10, mRect.size.y - 74});
 
 	detailPanelRect = {
-		{ comboEndPoint.x + 20, rect().startPoint().y + 10},
-		{rect().size.x - comboEndPoint.x - 30, rect().startPoint().y + mRect.size.y - 69}
+		{ comboEndPoint.x + 20, rect().position.y + 10},
+		{rect().size.x - comboEndPoint.x - 30, rect().position.y + mRect.size.y - 69}
 	};
 
 	int position_x = mRect.size.x - 150;
@@ -439,7 +439,7 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 {
 	NAS2D::Color defaultTextColor{0, 185, 0};
 
-	const auto startPoint = detailPanelRect.startPoint();
+	const auto startPoint = detailPanelRect.position;
 	renderer.drawImage(*factoryImage, startPoint + NAS2D::Vector{0, 25});
 	renderer.drawText(fontBigBold, selectedFactory->name(), startPoint + NAS2D::Vector{0, -8}, defaultTextColor);
 
@@ -481,34 +481,34 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 void FactoryReport::drawProductPane(Renderer& renderer)
 {
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	renderer.drawText(fontBigBold, "Production", NAS2D::Point{detailPanelRect.startPoint().x, detailPanelRect.startPoint().y + 180}, textColor);
+	renderer.drawText(fontBigBold, "Production", NAS2D::Point{detailPanelRect.position.x, detailPanelRect.position.y + 180}, textColor);
 
-	int position_x = detailPanelRect.startPoint().x + lstProducts.size().x + 20;
+	int position_x = detailPanelRect.position.x + lstProducts.size().x + 20;
 
 	if (selectedProductType != ProductType::PRODUCT_NONE)
 	{
-		renderer.drawText(fontBigBold, ProductCatalogue::get(selectedProductType).Name, NAS2D::Point{position_x, detailPanelRect.startPoint().y + 180}, textColor);
+		renderer.drawText(fontBigBold, ProductCatalogue::get(selectedProductType).Name, NAS2D::Point{position_x, detailPanelRect.position.y + 180}, textColor);
 		renderer.drawImage(productImage(selectedProductType), NAS2D::Point{position_x, lstProducts.positionY()});
 		txtProductDescription.update();
 	}
 
 	if (selectedFactory->productType() == ProductType::PRODUCT_NONE) { return; }
 
-	renderer.drawText(fontBigBold, "Progress", NAS2D::Point{position_x, detailPanelRect.startPoint().y + 358}, textColor);
-	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, NAS2D::Point{position_x, detailPanelRect.startPoint().y + 393}, textColor);
+	renderer.drawText(fontBigBold, "Progress", NAS2D::Point{position_x, detailPanelRect.position.y + 358}, textColor);
+	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, NAS2D::Point{position_x, detailPanelRect.position.y + 393}, textColor);
 
 	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
 	{
 		drawProgressBar(
 			selectedFactory->productionTurnsCompleted(),
 			selectedFactory->productionTurnsToComplete(),
-			{{position_x, detailPanelRect.startPoint().y + 413}, {mRect.size.x - position_x - 10, 30}}
+			{{position_x, detailPanelRect.position.y + 413}, {mRect.size.x - position_x - 10, 30}}
 		);
 	}
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
-	renderer.drawText(fontMediumBold, "Turns", NAS2D::Point{position_x, detailPanelRect.startPoint().y + 449}, textColor);
-	renderer.drawText(fontMedium, text, NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, detailPanelRect.startPoint().y + 449}, textColor);
+	renderer.drawText(fontMediumBold, "Turns", NAS2D::Point{position_x, detailPanelRect.position.y + 449}, textColor);
+	renderer.drawText(fontMedium, text, NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, detailPanelRect.position.y + 449}, textColor);
 }
 
 
@@ -518,9 +518,9 @@ void FactoryReport::update()
 	auto& renderer = Utility<Renderer>::get();
 
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	const auto positionX = cboFilterByProduct.rect().startPoint().x + cboFilterByProduct.rect().size.x;
-	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.startPoint().y + 10}, NAS2D::Point{positionX + 10, mRect.startPoint().y + mRect.size.y - 10}, textColor);
-	renderer.drawText(font, "Filter by Product", NAS2D::Point{positionX - font.width("Filter by Product"), mRect.startPoint().y + 10}, textColor);
+	const auto positionX = cboFilterByProduct.rect().position.x + cboFilterByProduct.rect().size.x;
+	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.position.y + 10}, NAS2D::Point{positionX + 10, mRect.position.y + mRect.size.y - 10}, textColor);
+	renderer.drawText(font, "Filter by Product", NAS2D::Point{positionX - font.width("Filter by Product"), mRect.position.y + 10}, textColor);
 
 	if (selectedFactory)
 	{

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -523,7 +523,7 @@ void MineReport::update()
 	auto& r = Utility<Renderer>::get();
 
 	const auto textColor = NAS2D::Color{0, 185, 0};
-	const auto startPoint = NAS2D::Point{rect().center().x , rect().startPoint().y + 10};
+	const auto startPoint = NAS2D::Point{rect().center().x , rect().position.y + 10};
 
 	r.drawLine(startPoint, startPoint + NAS2D::Vector{0, rect().size.y - 20}, textColor);
 

--- a/OPHD/UI/Reports/ResearchReport.cpp
+++ b/OPHD/UI/Reports/ResearchReport.cpp
@@ -78,7 +78,7 @@ ResearchReport::ResearchReport() :
 		button->toggle(false);
 	}
 
-	const Point<int> buttonStartPosition{rect().startPoint().x + MarginSize * 3 + CategoryIconSize, rect().startPoint().y + MarginSize * 2 + fontBigBold.height()};
+	const Point<int> buttonStartPosition{rect().position.x + MarginSize * 3 + CategoryIconSize, rect().position.y + MarginSize * 2 + fontBigBold.height()};
 	const int buttonSpacing = btnAllTopics.size().x + MarginSize;
 
 	for (size_t i = 0; i < buttons.size(); ++i)
@@ -112,7 +112,7 @@ void ResearchReport::refresh()
 	
 	for (size_t i = 0; i < CategoryPanels.size(); ++i)
 	{
-		const NAS2D::Point<int> point{rect().startPoint().x + 10, rect().startPoint().y + 10 + static_cast<int>(i) * CategoryIconSize + static_cast<int>(i) * padding};
+		const NAS2D::Point<int> point{rect().position.x + 10, rect().position.y + 10 + static_cast<int>(i) * CategoryIconSize + static_cast<int>(i) * padding};
 		CategoryPanels[i].rect = {point, {CategoryIconSize, CategoryIconSize}};
 	}
 	
@@ -122,8 +122,8 @@ void ResearchReport::refresh()
 	onAllTopicsClicked();
 
 	IconArea = {
-		{rect().startPoint().x + MarginSize * 3 + CategoryIconSize,
-		rect().startPoint().y + fontBigBold.height() + btnAllTopics.size().y + MarginSize * 3},
+		{rect().position.x + MarginSize * 3 + CategoryIconSize,
+		rect().position.y + fontBigBold.height() + btnAllTopics.size().y + MarginSize * 3},
 		{((rect().size.x / 3) * 2) - (MarginSize * 4) - CategoryIconSize,
 		rect().size.y - MarginSize * 4 - fontBigBold.height() - btnAllTopics.size().y}};
 }
@@ -253,7 +253,7 @@ void ResearchReport::drawCategories() const
 	for (const auto& panel : CategoryPanels)
 	{
 		const auto panelRect = Rectangle<int>::Create(
-			panel.rect.startPoint() - CategorySelectorPadding,
+			panel.rect.position - CategorySelectorPadding,
 			panel.rect.endPoint() + CategorySelectorPadding);
 
 		if (panel.selected)
@@ -265,7 +265,7 @@ void ResearchReport::drawCategories() const
 			renderer.drawBoxFilled(panelRect, ColorPanelHighlight);
 		}
 
-		renderer.drawSubImage(imageCategoryIcons, panel.rect.startPoint(), panel.imageSlice);
+		renderer.drawSubImage(imageCategoryIcons, panel.rect.position, panel.imageSlice);
 	}
 }
 
@@ -276,7 +276,7 @@ void ResearchReport::drawTopicHeader() const
 	renderer.drawText(
 		fontBigBold,
 		SelectedCategory->name,
-		rect().startPoint() + Vector<int>{SectionPadding.x * 3 + CategoryIconSize, SectionPadding.y},
+		rect().position + Vector<int>{SectionPadding.x * 3 + CategoryIconSize, SectionPadding.y},
 		ColorText);
 }
 
@@ -285,8 +285,8 @@ void ResearchReport::drawVerticalSectionSpacer(const int startX) const
 {
 	auto& renderer = Utility<Renderer>::get();
 	renderer.drawLine(
-		Point<int>{startX, rect().startPoint().y + SectionPadding.y},
-		Point<int>{startX, rect().startPoint().y + rect().size.y - SectionPadding.y},
+		Point<int>{startX, rect().position.y + SectionPadding.y},
+		Point<int>{startX, rect().position.y + rect().size.y - SectionPadding.y},
 		ColorText);
 }
 
@@ -302,7 +302,7 @@ void ResearchReport::drawResearchPointsPanel() const
 {
 	auto& renderer = Utility<Renderer>::get();
 
-	const auto startPoint = rect().startPoint() + Vector<int>{SectionPadding.x * 5 + CategoryIconSize + IconArea.size.x, SectionPadding.y};
+	const auto startPoint = rect().position + Vector<int>{SectionPadding.x * 5 + CategoryIconSize + IconArea.size.x, SectionPadding.y};
 
 	renderer.drawText(fontBigBold, "Research Generated Per Turn", startPoint, ColorText);
 
@@ -318,7 +318,7 @@ void ResearchReport::drawResearchPointsPanel() const
 	renderer.drawText(fontMedium, "0", standardLabTextOffset, ColorText);
 	renderer.drawText(fontMedium, "0", hotLabTextOffset, ColorText);
 
-	const Point<int> lineStartPoint{startPoint.x, rect().startPoint().y + fontBigBold.height() + LabTypeIconSize + SectionPadding.y * 3};
+	const Point<int> lineStartPoint{startPoint.x, rect().position.y + fontBigBold.height() + LabTypeIconSize + SectionPadding.y * 3};
 	renderer.drawLine(lineStartPoint, lineStartPoint + Vector<int>{rect().size.x - startPoint.x - SectionPadding.x, 0}, ColorText);
 }
 

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -65,7 +65,7 @@ void ResourceBreakdownPanel::update()
 		const auto valueString = std::to_string(value);
 		renderer.drawText(mFont, valueString, position + NAS2D::Vector{195 - mFont.width(valueString), 0}, NAS2D::Color::White);
 		const auto& [textColor, iconStartPoint] = trend[trendIndex(value, oldValue)];
-		const auto changeIconImageRect = NAS2D::Rectangle<int>::Create(iconStartPoint, NAS2D::Vector{8, 8});
+		const auto changeIconImageRect = NAS2D::Rectangle{iconStartPoint, {8, 8}};
 		renderer.drawSubImage(mIcons, position + NAS2D::Vector{215, 3}, changeIconImageRect);
 		renderer.drawText(mFont, formatDiff(value - oldValue), position + NAS2D::Vector{235, 0}, textColor);
 		position.y += 18;

--- a/OPHD/UI/ResourceBreakdownPanel.cpp
+++ b/OPHD/UI/ResourceBreakdownPanel.cpp
@@ -57,7 +57,7 @@ void ResourceBreakdownPanel::update()
 		std::tuple{ResourceImageRectsRefined[3], ResourceNamesRefined[3], mPlayerResources->resources[3], mPreviousResources.resources[3]},
 	};
 
-	auto position = mRect.startPoint() + NAS2D::Vector{5, 5};
+	auto position = mRect.position + NAS2D::Vector{5, 5};
 	for (const auto& [imageRect, text, value, oldValue] : resources)
 	{
 		renderer.drawSubImage(mIcons, position, imageRect);

--- a/OPHD/UI/RobotDeploymentSummary.cpp
+++ b/OPHD/UI/RobotDeploymentSummary.cpp
@@ -24,7 +24,7 @@ void RobotDeploymentSummary::draw() const
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	auto position = mRect.startPoint();
+	auto position = mRect.position;
 	constexpr auto textOffset = NAS2D::Vector{30, 7};
 
 	const auto minerImageRect = NAS2D::Rectangle<int>{{231, 18}, {25, 25}};

--- a/OPHD/UI/RobotInspector.cpp
+++ b/OPHD/UI/RobotInspector.cpp
@@ -51,7 +51,7 @@ RobotInspector::RobotInspector() :
 		mainFont.height() + constants::Margin}
 	};
 
-	auto buttonPosition = Vector{imageWidth,  mContentRect.startPoint().y + mContentRect.size.y + constants::Margin};
+	auto buttonPosition = Vector{imageWidth,  mContentRect.position.y + mContentRect.size.y + constants::Margin};
 
 	btnCancelOrders.size(buttonSize);
 	add(btnCancelOrders, buttonPosition);
@@ -105,6 +105,6 @@ void RobotInspector::update()
 	auto& renderer = Utility<Renderer>::get();
 	renderer.drawImage(robotImage(mRobot->type()), position() + Vector{constants::Margin, constants::Margin + sWindowTitleBarHeight});
 
-	const auto labelPosition = rect().startPoint() + Vector{mContentRect.startPoint().x, mContentRect.startPoint().y};
+	const auto labelPosition = rect().position + Vector{mContentRect.position.x, mContentRect.position.y};
 	drawLabelAndValueRightJustify(labelPosition, mContentRect.size.x, "Age", std::to_string(mRobot->fuelCellAge()));
 }

--- a/OPHD/UI/StringTable.cpp
+++ b/OPHD/UI/StringTable.cpp
@@ -46,7 +46,7 @@ void StringTable::position(NAS2D::Point<int> position)
 
 NAS2D::Point<int> StringTable::position() const
 {
-	return mScreenRect.startPoint();
+	return mScreenRect.position;
 }
 
 const NAS2D::Rectangle<int>& StringTable::screenRect() const

--- a/OPHD/UI/StructureInspector.cpp
+++ b/OPHD/UI/StructureInspector.cpp
@@ -50,7 +50,7 @@ void StructureInspector::onClose()
 StringTable StructureInspector::buildStringTable() const
 {
 	StringTable stringTable(4, 6);
-	stringTable.position(mRect.startPoint() + NAS2D::Vector{5, 25});
+	stringTable.position(mRect.position + NAS2D::Vector{5, 25});
 	stringTable.setVerticalPadding(5);
 	stringTable.setColumnFont(2, stringTable.GetDefaultTitleFont());
 

--- a/OPHD/UI/StructureListBox.cpp
+++ b/OPHD/UI/StructureListBox.cpp
@@ -29,7 +29,7 @@ static void drawItem(Renderer& renderer, StructureListBox::StructureListBoxItem&
 	renderer.drawBox(rect.inset(2), structureColor);
 
 	const auto yOffset = 15 - MAIN_FONT_BOLD->height() / 2;
-	renderer.drawText(*MAIN_FONT_BOLD, item.text, rect.startPoint() + NAS2D::Vector{5, yOffset}, structureTextColor);
+	renderer.drawText(*MAIN_FONT_BOLD, item.text, rect.position + NAS2D::Vector{5, yOffset}, structureTextColor);
 	renderer.drawText(*MAIN_FONT, item.structureState, rect.crossXPoint() + NAS2D::Vector{-MAIN_FONT->width(item.structureState) - 5, yOffset}, structureTextColor);
 }
 

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -34,7 +34,7 @@ void TileInspector::update()
 
 	const auto* mine = mTile->mine();
 
-	auto position = mRect.startPoint() + NAS2D::Vector{5, 25};
+	auto position = mRect.position + NAS2D::Vector{5, 25};
 	drawLabelAndValue(position, "Has Mine: ", (mine ? "Yes" : "No"));
 
 	if (mine)
@@ -46,7 +46,7 @@ void TileInspector::update()
 		drawLabelAndValue(position, "Production Rate: ", MINE_YIELD_TRANSLATION.at(mTile->mine()->productionRate()));
 	}
 
-	position = mRect.startPoint() + NAS2D::Vector{5, 62};
+	position = mRect.position + NAS2D::Vector{5, 62};
 	const auto tilePosition = mTile->xy();
 	drawLabelAndValue(position, "Location: ", std::to_string(tilePosition.x) + ", " + std::to_string(tilePosition.y));
 

--- a/OPHD/UI/WarehouseInspector.cpp
+++ b/OPHD/UI/WarehouseInspector.cpp
@@ -52,7 +52,7 @@ void WarehouseInspector::update()
 
 	const int labelWidth = 100;
 
-	auto position = mRect.startPoint() + NAS2D::Vector{constants::Margin, 25};
+	auto position = mRect.position + NAS2D::Vector{constants::Margin, 25};
 	drawLabelAndValueLeftJustify(position, labelWidth, "Storage:", std::to_string(pool.availableStorage()) + " / " + std::to_string(pool.capacity()));
 
 	position.y += 25;


### PR DESCRIPTION
Simplify some code now that we can directly access a `Rectangle` `position`, and can construct a `Rectangle` from a `Point` and a `Vector`.

Related:
- PR #1398 
- https://github.com/lairworks/nas2d-core/issues/704
