### PR TITLE
Fix Clang warning about copy in range-for

### DIFF
--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -217,7 +217,7 @@ StructureList StructureManager::allStructures() const
 
 Tile& StructureManager::tileFromStructure(const Structure* structure) const
 {
-	for (const auto [keyStructure, valueTile] : mStructureTileTable)
+	for (const auto& [keyStructure, valueTile] : mStructureTileTable)
 	{
 		if (keyStructure == structure)
 		{
@@ -253,7 +253,7 @@ std::vector<Tile*> StructureManager::getConnectednessOverlay() const
 {
 	std::vector<Tile*> result;
 	result.reserve(mStructureTileTable.size());
-	for (const auto [structure, tile] : mStructureTileTable)
+	for (const auto& [structure, tile] : mStructureTileTable)
 	{
 		if (structure->connected())
 		{


### PR DESCRIPTION
Fixes warning [`-Wrange-loop-construct`].
> error: loop variable '[keyStructure, valueTile]' creates a copy from type 'std::pair<Structure *const, Tile *> const' [-Werror,-Wrange-loop-construct]

The warning is maybe a little silly in this case, since the members are pointers, which are cheap to copy.

Reference:
- Issue #307
