### PR TITLE
Refactor `makefile` - Port changes from NAS2D

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ NAS2DINCLUDEDIR := $(NAS2DDIR)
 NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
-$(NAS2DLIB): nas2d
+$(NAS2DLIB): nas2d ;
 
 .PHONY: nas2d
 nas2d: $(NAS2DDIR)makefile

--- a/makefile
+++ b/makefile
@@ -59,10 +59,10 @@ CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN) -I
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(OpenGL_LIBS)
 
-DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)$*.Td
+DEPFLAGS = -MT $@ -MMD -MP -MF $(@:.o=.Td)
 
 COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
-POSTCOMPILE = @mv -f $(OBJDIR)$*.Td $(OBJDIR)$*.d && touch $@
+POSTCOMPILE = @mv -f $(@:.o=.Td) $(@:.o=.d) && touch $@
 
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)%.cpp,$(OBJDIR)%.o,$(SRCS))

--- a/makefile
+++ b/makefile
@@ -59,9 +59,11 @@ CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN) -I
 LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(OpenGL_LIBS)
 
+PROJECT_FLAGS := $(CPPFLAGS) $(CXXFLAGS)
+
 DEPFLAGS = -MT $@ -MMD -MP -MF $(@:.o=.Td)
 
-COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
+COMPILE.cpp = $(CXX) $(DEPFLAGS) $(PROJECT_FLAGS) $(TARGET_ARCH) -c
 POSTCOMPILE = @mv -f $(@:.o=.Td) $(@:.o=.d) && touch $@
 
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')

--- a/makefile
+++ b/makefile
@@ -60,6 +60,7 @@ LDFLAGS := $(LDFLAGS_EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS_EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(OpenGL_LIBS)
 
 PROJECT_FLAGS := $(CPPFLAGS) $(CXXFLAGS)
+PROJECT_LINKFLAGS := $(LDFLAGS) $(LDLIBS)
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(@:.o=.Td)
 
@@ -75,7 +76,7 @@ ophd: $(EXE)
 
 $(EXE): $(NAS2DLIB) $(OBJS)
 	@mkdir -p ${@D}
-	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
+	$(CXX) $^ $(PROJECT_LINKFLAGS) -o $@
 
 .PHONY: intermediate
 intermediate: $(OBJS)

--- a/makefile
+++ b/makefile
@@ -69,13 +69,13 @@ OBJS := $(patsubst $(SRCDIR)%.cpp,$(OBJDIR)%.o,$(SRCS))
 ophd: $(EXE)
 
 $(EXE): $(NAS2DLIB) $(OBJS)
-
-.PHONY: intermediate
-intermediate: $(OBJS)
-
 $(OBJS): $(OBJDIR)%.o : $(SRCDIR)%.cpp $(OBJDIR)%.d
 
 include $(wildcard $(patsubst %.o,%.d,$(OBJS)))
+
+
+.PHONY: intermediate
+intermediate: $(OBJS)
 
 
 ## Compile rules ##

--- a/makefile
+++ b/makefile
@@ -85,8 +85,8 @@ $(OBJS): $(OBJDIR)%.o : $(SRCDIR)%.cpp $(OBJDIR)%.d
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 	$(POSTCOMPILE)
 
-$(OBJDIR)%.d: ;
-.PRECIOUS: $(OBJDIR)%.d
+%.d: ;
+.PRECIOUS: %.d
 
 include $(wildcard $(patsubst %.o,%.d,$(OBJS)))
 

--- a/makefile
+++ b/makefile
@@ -88,7 +88,7 @@ $(OBJS): $(OBJDIR)%.o : $(SRCDIR)%.cpp $(OBJDIR)%.d
 $(OBJDIR)%.d: ;
 .PRECIOUS: $(OBJDIR)%.d
 
-include $(wildcard $(patsubst $(SRCDIR)%.cpp,$(OBJDIR)%.d,$(SRCS)))
+include $(wildcard $(patsubst %.o,%.d,$(OBJS)))
 
 
 ## Package ##

--- a/makefile
+++ b/makefile
@@ -102,6 +102,16 @@ lib%.a:
 .PRECIOUS: %.d
 
 
+## Clean ##
+
+.PHONY: clean clean-all
+clean:
+	-rm -fr $(OBJDIR)
+clean-all:
+	-rm -rf $(BUILDDIR)
+	-rm -f $(EXE)
+
+
 ## Package ##
 
 PACKAGEDIR := $(BUILDDIR)/package/
@@ -115,16 +125,6 @@ package: $(PACKAGE_NAME)
 $(PACKAGE_NAME): $(EXE)
 	@mkdir -p "$(PACKAGEDIR)"
 	tar -czf $(PACKAGE_NAME) $(EXE)
-
-
-## Clean ##
-
-.PHONY: clean clean-all
-clean:
-	-rm -fr $(OBJDIR)
-clean-all:
-	-rm -rf $(BUILDDIR)
-	-rm -f $(EXE)
 
 
 ## Dependencies ##

--- a/makefile
+++ b/makefile
@@ -69,7 +69,6 @@ POSTCOMPILE = @mv -f $(@:.o=.Td) $(@:.o=.d) && touch $@
 
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)%.cpp,$(OBJDIR)%.o,$(SRCS))
-FOLDERS := $(sort $(dir $(SRCS)))
 
 .PHONY: ophd
 ophd: $(EXE)
@@ -81,13 +80,10 @@ $(EXE): $(NAS2DLIB) $(OBJS)
 .PHONY: intermediate
 intermediate: $(OBJS)
 
-$(OBJS): $(OBJDIR)%.o : $(SRCDIR)%.cpp $(OBJDIR)%.d | build-folder
+$(OBJS): $(OBJDIR)%.o : $(SRCDIR)%.cpp $(OBJDIR)%.d
+	@mkdir -p ${@D}
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 	$(POSTCOMPILE)
-
-.PHONY: build-folder
-build-folder:
-	@mkdir -p $(patsubst $(SRCDIR)%,$(OBJDIR)%, $(FOLDERS))
 
 $(OBJDIR)%.d: ;
 .PRECIOUS: $(OBJDIR)%.d


### PR DESCRIPTION
Closes #1404

Port changes from NAS2D:
- Use automatic variables rather than project specific variables
- Collect project specific flags for compile/link into single name
- Remove rule to pre-create folders, have compile rule create output folder
- Use generic build rules
