### PR TITLE
Refactor `Control` fonts

### DIFF
--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -105,7 +105,7 @@ bool Button::isPressed() const
 
 void Button::fontSize(unsigned int pointSize)
 {
-	mFont = &fontCache.load(constants::FONT_PRIMARY, pointSize);
+	mFont = &getDefaultFontOfSize(pointSize);
 }
 
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -52,7 +52,7 @@ Button::Button(std::string newText) :
 	eventHandler.mouseButtonUp().connect({this, &Button::onMouseUp});
 	eventHandler.mouseMotion().connect({this, &Button::onMouseMove});
 
-	mFont = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	mFont = &getDefaultFont();
 }
 
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -1,7 +1,6 @@
 #include "Button.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -15,7 +15,6 @@
 #include "CheckBox.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/CheckBox.cpp
+++ b/OPHD/UI/Core/CheckBox.cpp
@@ -25,7 +25,7 @@
 
 
 CheckBox::CheckBox(std::string newText) :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{getDefaultFont()},
 	mSkin{imageCache.load("ui/skin/checkbox.png")}
 {
 	text(newText);

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -1,5 +1,26 @@
 #include "Control.h"
 
+#include "../../Cache.h"
+#include "../../Constants/UiConstants.h"
+
+
+const NAS2D::Font& Control::getDefaultFont()
+{
+	return fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+}
+
+
+const NAS2D::Font& Control::getDefaultFontBold()
+{
+	return fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+}
+
+
+const NAS2D::Font& Control::getDefaultFontOfSize(unsigned int pointSize)
+{
+	return fontCache.load(constants::FONT_PRIMARY, pointSize);
+}
+
 
 void Control::area(const NAS2D::Rectangle<int>& newRect)
 {

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -6,6 +6,12 @@
 #include <NAS2D/Math/Rectangle.h>
 
 
+namespace NAS2D
+{
+	class Font;
+}
+
+
 /**
  * Implements a base for all GUI Controls to derive from.
  * 
@@ -17,6 +23,11 @@ class Control
 public:
 	using ResizeSignal = NAS2D::Signal<Control*>;
 	using OnMoveSignal = NAS2D::Signal<NAS2D::Vector<int>>;
+
+	static const NAS2D::Font& getDefaultFont();
+	static const NAS2D::Font& getDefaultFontBold();
+	static const NAS2D::Font& getDefaultFontOfSize(unsigned int pointSize);
+
 
 	Control() = default;
 	Control(Control&) = default;

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -10,7 +10,7 @@
 
 
 Label::Label(std::string newText) :
-	mFont(&fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal))
+	mFont(&getDefaultFont())
 {
 	text(newText);
 	autosize();

--- a/OPHD/UI/Core/Label.cpp
+++ b/OPHD/UI/Core/Label.cpp
@@ -1,7 +1,6 @@
 #include "Label.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -66,7 +66,7 @@ public:
 
 
 	ListBox() :
-		mContext{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)}
+		mContext{getDefaultFont()}
 	{
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &ListBox::onMouseDown});
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &ListBox::onMouseMove});

--- a/OPHD/UI/Core/ListBox.h
+++ b/OPHD/UI/Core/ListBox.h
@@ -3,7 +3,6 @@
 #include "Control.h"
 #include "ScrollBar.h"
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Signal/Signal.h>

--- a/OPHD/UI/Core/ListBoxBase.cpp
+++ b/OPHD/UI/Core/ListBoxBase.cpp
@@ -1,6 +1,5 @@
 #include "ListBoxBase.h"
 
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -4,7 +4,7 @@
 
 
 RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup& parentContainer, std::string newText, NAS2D::Delegate<void()> delegate) :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{getDefaultFont()},
 	mSkin{imageCache.load("ui/skin/radio.png")},
 	mLabel{newText},
 	mParentContainer{parentContainer}

--- a/OPHD/UI/Core/RadioButton.cpp
+++ b/OPHD/UI/Core/RadioButton.cpp
@@ -1,6 +1,5 @@
 #include "RadioButtonGroup.h"
 
-#include "../../Constants/UiConstants.h"
 
 
 RadioButtonGroup::RadioButton::RadioButton(RadioButtonGroup& parentContainer, std::string newText, NAS2D::Delegate<void()> delegate) :

--- a/OPHD/UI/Core/RadioButtonGroup.cpp
+++ b/OPHD/UI/Core/RadioButtonGroup.cpp
@@ -1,7 +1,6 @@
 #include "RadioButtonGroup.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -8,7 +8,6 @@
 #include "TextField.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/TextField.cpp
+++ b/OPHD/UI/Core/TextField.cpp
@@ -25,7 +25,7 @@ namespace
 
 
 TextField::TextField() :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{getDefaultFont()},
 	mSkinNormal{
 		imageCache.load("ui/skin/textbox_top_left.png"),
 		imageCache.load("ui/skin/textbox_top_middle.png"),

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -9,7 +9,7 @@
 
 
 ToolTip::ToolTip():
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)}
+	mFont{getDefaultFont()}
 {
 	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &ToolTip::onMouseMove});
 }

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -1,7 +1,6 @@
 #include "Window.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -8,7 +8,7 @@
 
 
 Window::Window(std::string newTitle) :
-	mTitleFont{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
+	mTitleFont{getDefaultFontBold()},
 	mTitleBarLeft{imageCache.load("ui/skin/window_title_left.png")},
 	mTitleBarCenter{imageCache.load("ui/skin/window_title_middle.png")},
 	mTitleBarRight{imageCache.load("ui/skin/window_title_right.png")},


### PR DESCRIPTION
Partial work for:
- #903

By having a central place in the `Control` base class where derived classes can access the default Fonts, we reduce the number of places where controls need access to code outside of the `Control` classes. To split this code into it's own project, we'll need to remove all such outside references.
