### PR TITLE
Refactor `ToolTip` positioning

### DIFF
--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -59,7 +59,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	if (tooltipPosition.x + toolTipSize.x > renderer.size().x)
 	{
-		offset.x -= (tooltipPosition.x + toolTipSize.x) - (renderer.size().x);
+		offset.x = renderer.size().x - (tooltipPosition.x + toolTipSize.x);
 	}
 
 	position(tooltipPosition + offset);

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -48,13 +48,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	auto tooltipPosition = item.first->position();
 	tooltipPosition.x = mouseX;
 
-	auto offset = NAS2D::Vector{0, -toolTipSize.y};
-
-	if (tooltipPosition.y + offset.y < 0)
-	{
-		offset.y = toolTipSize.y;
-	}
-
+	tooltipPosition.y += (tooltipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
@@ -63,7 +57,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 		tooltipPosition.x = maxX;
 	}
 
-	position(tooltipPosition + offset);
+	position(tooltipPosition);
 	size(toolTipSize);
 }
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -109,6 +109,6 @@ void ToolTip::draw() const
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 		renderer.drawBoxFilled(rect(), NAS2D::Color::DarkGray);
 		renderer.drawBox(rect(), NAS2D::Color::Black);
-		renderer.drawText(mFont, mFocusedControl->second, NAS2D::Point{positionX() + constants::MarginTight, positionY() + constants::MarginTight});
+		renderer.drawText(mFont, mFocusedControl->second, position() + NAS2D::Vector{constants::MarginTight, constants::MarginTight});
 	}
 }

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -48,18 +48,18 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	auto tooltipPosition = item.first->position();
 	tooltipPosition.x = mouseX;
 
-	auto offset = NAS2D::Vector{0, -toolTipSize.y - paddingSize.y};
+	auto offset = NAS2D::Vector{0, -toolTipSize.y};
 
 	if (tooltipPosition.y + offset.y < 0)
 	{
-		offset.y = toolTipSize.y + paddingSize.y;
+		offset.y = toolTipSize.y;
 	}
 
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	if (tooltipPosition.x + toolTipSize.x > renderer.size().x)
 	{
-		offset.x -= (tooltipPosition.x + toolTipSize.x) - (renderer.size().x - paddingSize.x);
+		offset.x -= (tooltipPosition.x + toolTipSize.x) - (renderer.size().x);
 	}
 
 	position(tooltipPosition + offset);

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -43,30 +43,27 @@ void ToolTip::add(Control& c, const std::string& str)
 
 void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX)
 {
-	constexpr int padding = constants::MarginTight * 2;
-
-	const int tooltipWidth = mFont.width(item.second) + padding;
-	const int tooltipHeight = mFont.height() + padding;
+	const auto toolTipSize = mFont.size(item.second) + paddingSize * 2;
 
 	auto tooltipPosition = item.first->position();
 	tooltipPosition.x = mouseX;
 
-	auto offset = NAS2D::Vector{0, -tooltipHeight - constants::Margin};
+	auto offset = NAS2D::Vector{0, -toolTipSize.y - constants::Margin};
 
 	if (tooltipPosition.y + offset.y < 0)
 	{
-		offset.y = tooltipHeight + constants::Margin;
+		offset.y = toolTipSize.y + constants::Margin;
 	}
 
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	if (tooltipPosition.x + tooltipWidth > renderer.size().x)
+	if (tooltipPosition.x + toolTipSize.x > renderer.size().x)
 	{
-		offset.x -= (tooltipPosition.x + tooltipWidth) - (renderer.size().x - constants::Margin);
+		offset.x -= (tooltipPosition.x + toolTipSize.x) - (renderer.size().x - constants::Margin);
 	}
 
 	position(tooltipPosition + offset);
-	size({tooltipWidth, tooltipHeight});
+	size(toolTipSize);
 }
 
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -57,9 +57,10 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	if (tooltipPosition.x + toolTipSize.x > renderer.size().x)
+	const auto maxX = renderer.size().x - toolTipSize.x;
+	if (tooltipPosition.x > maxX)
 	{
-		offset.x = renderer.size().x - (tooltipPosition.x + toolTipSize.x);
+		offset.x = maxX - tooltipPosition.x;
 	}
 
 	position(tooltipPosition + offset);

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -48,18 +48,18 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	auto tooltipPosition = item.first->position();
 	tooltipPosition.x = mouseX;
 
-	auto offset = NAS2D::Vector{0, -toolTipSize.y - constants::Margin};
+	auto offset = NAS2D::Vector{0, -toolTipSize.y - paddingSize.y};
 
 	if (tooltipPosition.y + offset.y < 0)
 	{
-		offset.y = toolTipSize.y + constants::Margin;
+		offset.y = toolTipSize.y + paddingSize.y;
 	}
 
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	if (tooltipPosition.x + toolTipSize.x > renderer.size().x)
 	{
-		offset.x -= (tooltipPosition.x + toolTipSize.x) - (renderer.size().x - constants::Margin);
+		offset.x -= (tooltipPosition.x + toolTipSize.x) - (renderer.size().x - paddingSize.x);
 	}
 
 	position(tooltipPosition + offset);

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -60,7 +60,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	const auto maxX = renderer.size().x - toolTipSize.x;
 	if (tooltipPosition.x > maxX)
 	{
-		offset.x = maxX - tooltipPosition.x;
+		tooltipPosition.x = maxX;
 	}
 
 	position(tooltipPosition + offset);

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -46,16 +46,12 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	const auto toolTipSize = mFont.size(item.second) + paddingSize * 2;
 
 	auto tooltipPosition = item.first->position();
-	tooltipPosition.x = mouseX;
-
-	tooltipPosition.y += (tooltipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
-	if (tooltipPosition.x > maxX)
-	{
-		tooltipPosition.x = maxX;
-	}
+	tooltipPosition.x = (mouseX > maxX) ? maxX : mouseX;
+
+	tooltipPosition.y += (tooltipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
 
 	position(tooltipPosition);
 	size(toolTipSize);

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -7,6 +7,12 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
+namespace
+{
+	constexpr auto paddingSize = NAS2D::Vector{constants::MarginTight, constants::MarginTight};
+}
+
+
 ToolTip::ToolTip():
 	mFont{getDefaultFont()}
 {
@@ -109,6 +115,6 @@ void ToolTip::draw() const
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 		renderer.drawBoxFilled(rect(), NAS2D::Color::DarkGray);
 		renderer.drawBox(rect(), NAS2D::Color::Black);
-		renderer.drawText(mFont, mFocusedControl->second, position() + NAS2D::Vector{constants::MarginTight, constants::MarginTight});
+		renderer.drawText(mFont, mFocusedControl->second, position() + paddingSize);
 	}
 }


### PR DESCRIPTION
Prep work for:
- #903

This reduces references to external code, namely `constants::MarginTight`, which will be needed to isolate UI/Core to a separate library.
