### PR TITLE
Refactor UI/Core - Remove outside includes

### DIFF
--- a/OPHD/States/MainMenuState.cpp
+++ b/OPHD/States/MainMenuState.cpp
@@ -50,7 +50,7 @@ void MainMenuState::initialize()
 
 	for (auto& button : buttons)
 	{
-		button.fontSize(constants::FontPrimaryMedium);
+		button.font(fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium));
 		button.size({200, 30});
 	}
 

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -106,6 +106,12 @@ void Button::fontSize(unsigned int pointSize)
 }
 
 
+void Button::font(const NAS2D::Font& font)
+{
+	mFont = &font;
+}
+
+
 void Button::image(const std::string& path)
 {
 	mImage = &getImage(path);

--- a/OPHD/UI/Core/Button.cpp
+++ b/OPHD/UI/Core/Button.cpp
@@ -100,12 +100,6 @@ bool Button::isPressed() const
 }
 
 
-void Button::fontSize(unsigned int pointSize)
-{
-	mFont = &getDefaultFontOfSize(pointSize);
-}
-
-
 void Button::font(const NAS2D::Font& font)
 {
 	mFont = &font;

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -42,7 +42,6 @@ public:
 	void toggle(bool toggle);
 	bool isPressed() const;
 
-	void fontSize(unsigned int pointSize);
 	void font(const NAS2D::Font& font);
 
 	void image(const std::string& path);

--- a/OPHD/UI/Core/Button.h
+++ b/OPHD/UI/Core/Button.h
@@ -43,6 +43,7 @@ public:
 	bool isPressed() const;
 
 	void fontSize(unsigned int pointSize);
+	void font(const NAS2D::Font& font);
 
 	void image(const std::string& path);
 	bool hasImage() const;

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -1,18 +1,46 @@
 #include "Control.h"
 
 #include "../../Cache.h"
-#include "../../Constants/UiConstants.h"
+
+
+namespace
+{
+	const NAS2D::Font* defaultFont = nullptr;
+	const NAS2D::Font* defaultFontBold = nullptr;
+}
+
+
+// Global static functions
+
+void Control::setDefaultFont(const NAS2D::Font& font)
+{
+	defaultFont = &font;
+}
+
+
+void Control::setDefaultFontBold(const NAS2D::Font& font)
+{
+	defaultFontBold = &font;
+}
 
 
 const NAS2D::Font& Control::getDefaultFont()
 {
-	return fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	if (!defaultFont)
+	{
+		throw std::runtime_error("No default font set");
+	}
+	return *defaultFont;
 }
 
 
 const NAS2D::Font& Control::getDefaultFontBold()
 {
-	return fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+	if (!defaultFontBold)
+	{
+		throw std::runtime_error("No default bold font set");
+	}
+	return *defaultFontBold;
 }
 
 
@@ -21,6 +49,8 @@ const NAS2D::Image& Control::getImage(const std::string& filename)
 	return imageCache.load(filename);
 }
 
+
+// Control member functions
 
 void Control::area(const NAS2D::Rectangle<int>& newRect)
 {

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -16,12 +16,6 @@ const NAS2D::Font& Control::getDefaultFontBold()
 }
 
 
-const NAS2D::Font& Control::getDefaultFontOfSize(unsigned int pointSize)
-{
-	return fontCache.load(constants::FONT_PRIMARY, pointSize);
-}
-
-
 const NAS2D::Image& Control::getImage(const std::string& filename)
 {
 	return imageCache.load(filename);

--- a/OPHD/UI/Core/Control.cpp
+++ b/OPHD/UI/Core/Control.cpp
@@ -1,12 +1,13 @@
 #include "Control.h"
 
-#include "../../Cache.h"
+#include <NAS2D/Resource/Image.h>
 
 
 namespace
 {
 	const NAS2D::Font* defaultFont = nullptr;
 	const NAS2D::Font* defaultFontBold = nullptr;
+	Control::ControlImageCache* defaultImageCache = nullptr;
 }
 
 
@@ -21,6 +22,12 @@ void Control::setDefaultFont(const NAS2D::Font& font)
 void Control::setDefaultFontBold(const NAS2D::Font& font)
 {
 	defaultFontBold = &font;
+}
+
+
+void Control::setImageCache(ControlImageCache& controlImageCache)
+{
+	defaultImageCache = &controlImageCache;
 }
 
 
@@ -46,7 +53,11 @@ const NAS2D::Font& Control::getDefaultFontBold()
 
 const NAS2D::Image& Control::getImage(const std::string& filename)
 {
-	return imageCache.load(filename);
+	if (!defaultImageCache)
+	{
+		throw std::runtime_error("No default image cache set");
+	}
+	return defaultImageCache->load(filename);
 }
 
 

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -25,6 +25,9 @@ public:
 	using ResizeSignal = NAS2D::Signal<Control*>;
 	using OnMoveSignal = NAS2D::Signal<NAS2D::Vector<int>>;
 
+	static void setDefaultFont(const NAS2D::Font& font);
+	static void setDefaultFontBold(const NAS2D::Font& font);
+
 	static const NAS2D::Font& getDefaultFont();
 	static const NAS2D::Font& getDefaultFontBold();
 	static const NAS2D::Image& getImage(const std::string& filename);

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -4,6 +4,7 @@
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Resource/ResourceCache.h>
 
 
 namespace NAS2D
@@ -25,8 +26,11 @@ public:
 	using ResizeSignal = NAS2D::Signal<Control*>;
 	using OnMoveSignal = NAS2D::Signal<NAS2D::Vector<int>>;
 
+	using ControlImageCache = NAS2D::ResourceCache<NAS2D::Image, std::string>;
+
 	static void setDefaultFont(const NAS2D::Font& font);
 	static void setDefaultFontBold(const NAS2D::Font& font);
+	static void setImageCache(ControlImageCache& controlImageCache);
 
 	static const NAS2D::Font& getDefaultFont();
 	static const NAS2D::Font& getDefaultFontBold();

--- a/OPHD/UI/Core/Control.h
+++ b/OPHD/UI/Core/Control.h
@@ -27,7 +27,6 @@ public:
 
 	static const NAS2D::Font& getDefaultFont();
 	static const NAS2D::Font& getDefaultFontBold();
-	static const NAS2D::Font& getDefaultFontOfSize(unsigned int pointSize);
 	static const NAS2D::Image& getImage(const std::string& filename);
 
 

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -5,9 +5,15 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
+namespace
+{
+	constexpr int MarginTight{constants::MarginTight};
+}
+
+
 unsigned int ListBoxItemText::Context::itemHeight() const
 {
-	return static_cast<unsigned int>(font.height() + constants::MarginTight);
+	return static_cast<unsigned int>(font.height() + MarginTight);
 }
 
 
@@ -24,7 +30,7 @@ void ListBoxItemText::draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> draw
 	}
 
 	// Draw item contents
-	const auto textPosition = drawRect.position + NAS2D::Vector{constants::MarginTight, 0};
+	const auto textPosition = drawRect.position + NAS2D::Vector{MarginTight, 0};
 	const auto textColor = isHighlighted ? context.textColorMouseHover : context.textColorNormal;
 	renderer.drawTextShadow(context.font, text, textPosition, {1, 1}, textColor, NAS2D::Color::Black);
 }

--- a/OPHD/UI/Core/ListBox.cpp
+++ b/OPHD/UI/Core/ListBox.cpp
@@ -1,13 +1,11 @@
 #include "ListBox.h"
 
-#include "../../Constants/UiConstants.h"
-
 #include <NAS2D/Renderer/Renderer.h>
 
 
 namespace
 {
-	constexpr int MarginTight{constants::MarginTight};
+	constexpr int MarginTight{2};
 }
 
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -9,7 +9,8 @@
 
 namespace
 {
-	constexpr auto PaddingSize = NAS2D::Vector{constants::MarginTight, constants::MarginTight};
+	constexpr int MarginTight{constants::MarginTight};
+	constexpr auto PaddingSize = NAS2D::Vector{MarginTight, MarginTight};
 }
 
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -1,7 +1,5 @@
 #include "ToolTip.h"
 
-#include "../../Constants/UiConstants.h"
-
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -9,7 +7,7 @@
 
 namespace
 {
-	constexpr int MarginTight{constants::MarginTight};
+	constexpr int MarginTight{2};
 	constexpr auto PaddingSize = NAS2D::Vector{MarginTight, MarginTight};
 }
 

--- a/OPHD/UI/Core/ToolTip.cpp
+++ b/OPHD/UI/Core/ToolTip.cpp
@@ -9,7 +9,7 @@
 
 namespace
 {
-	constexpr auto paddingSize = NAS2D::Vector{constants::MarginTight, constants::MarginTight};
+	constexpr auto PaddingSize = NAS2D::Vector{constants::MarginTight, constants::MarginTight};
 }
 
 
@@ -43,7 +43,7 @@ void ToolTip::add(Control& c, const std::string& str)
 
 void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX)
 {
-	const auto toolTipSize = mFont.size(item.second) + paddingSize * 2;
+	const auto toolTipSize = mFont.size(item.second) + PaddingSize * 2;
 
 	auto tooltipPosition = item.first->position();
 
@@ -103,6 +103,6 @@ void ToolTip::draw() const
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 		renderer.drawBoxFilled(rect(), NAS2D::Color::DarkGray);
 		renderer.drawBox(rect(), NAS2D::Color::Black);
-		renderer.drawText(mFont, mFocusedControl->second, position() + paddingSize);
+		renderer.drawText(mFont, mFocusedControl->second, position() + PaddingSize);
 	}
 }

--- a/OPHD/UI/Core/Window.cpp
+++ b/OPHD/UI/Core/Window.cpp
@@ -4,8 +4,8 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-Window::Window(std::string newTitle) :
-	mTitleFont{getDefaultFontBold()},
+Window::Window(std::string newTitle, const NAS2D::Font& titleFont) :
+	mTitleFont{titleFont},
 	mTitleBarLeft{getImage("ui/skin/window_title_left.png")},
 	mTitleBarCenter{getImage("ui/skin/window_title_middle.png")},
 	mTitleBarRight{getImage("ui/skin/window_title_right.png")},

--- a/OPHD/UI/Core/Window.h
+++ b/OPHD/UI/Core/Window.h
@@ -14,7 +14,7 @@
 class Window : public UIContainer
 {
 public:
-	Window(std::string newTitle = "");
+	Window(std::string newTitle = "", const NAS2D::Font& titleFont = getDefaultFontBold());
 	~Window() override;
 
 	void anchored(bool isAnchored);

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -137,6 +137,9 @@ int main(int argc, char *argv[])
 		renderer.addCursor(constants::MousePointerPlaceTile, PointerType::POINTER_PLACE_TILE, 16, 16);
 		renderer.setCursor(PointerType::POINTER_NORMAL);
 
+		Control::setDefaultFont(fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal));
+		Control::setDefaultFontBold(fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal));
+
 		const auto& options = cf["options"];
 		if (options.get<bool>("maximized"))
 		{

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -139,6 +139,7 @@ int main(int argc, char *argv[])
 
 		Control::setDefaultFont(fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal));
 		Control::setDefaultFontBold(fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal));
+		Control::setImageCache(imageCache);
 
 		const auto& options = cf["options"];
 		if (options.get<bool>("maximized"))


### PR DESCRIPTION
Prep work for:
- #903

This removes the last include from UI/Core to code outside of UI/Core, which should enable that code to be split off into it's own library.

This also has the nice effect of setting a default global font in a single place, which can allow for easy runtime updates to the default font size.
