### PR TITLE
Allow manual builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   windows:


### PR DESCRIPTION
Allow manual running of the GitHub Actions workflow to build the project.

This should add a button to the following page (once merged):
https://github.com/OutpostUniverse/OPHD/actions/workflows/build.yml
