### PR TITLE
Reduce includes

### DIFF
--- a/OPHD/Map/TileMap.cpp
+++ b/OPHD/Map/TileMap.cpp
@@ -1,7 +1,5 @@
 #include "TileMap.h"
 
-#include "../Constants/Numbers.h"
-#include "../Constants/UiConstants.h"
 #include "../DirectionOffset.h"
 #include "../Mine.h"
 #include "../MapObjects/Structure.h"

--- a/OPHD/ProductPool.cpp
+++ b/OPHD/ProductPool.cpp
@@ -1,5 +1,6 @@
 #include "ProductPool.h"
 
+#include "Constants/Numbers.h"
 #include "Constants/Strings.h"
 
 #include <NAS2D/ParserHelper.h>
@@ -116,6 +117,12 @@ namespace
 int storageRequiredPerUnit(ProductType type)
 {
 	return ProductStorageSpace.at(type);
+}
+
+
+ProductPool::ProductPool() :
+	mCapacity{constants::BaseProductCapacity}
+{
 }
 
 

--- a/OPHD/ProductPool.h
+++ b/OPHD/ProductPool.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Common.h"
-#include "Constants/Numbers.h"
 
 #include <NAS2D/Dictionary.h>
 
@@ -16,7 +15,7 @@ public:
 	using ProductTypeCount = std::array<int, ProductType::PRODUCT_COUNT>;
 
 
-	ProductPool() = default;
+	ProductPool();
 	~ProductPool() = default;
 
 	ProductPool(const ProductPool&) = default;
@@ -46,6 +45,6 @@ public:
 private:
 	ProductTypeCount mProducts{};
 
-	int mCapacity{constants::BaseProductCapacity};
+	int mCapacity;
 	int mCurrentStorageCount{0};
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -164,6 +164,9 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 	mLoadingExisting(true),
 	mExistingToLoad(savegame),
 	mMainReportsState(mainReportsState),
+	mStructures{"ui/structures.png", 46, constants::MarginTight},
+	mRobots{"ui/robots.png", 46, constants::MarginTight},
+	mConnections{"ui/structures.png", 46, constants::MarginTight},
 	mResourceInfoBar{mResourcesCount, mPopulation, mCurrentMorale, mPreviousMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool}
 {
@@ -181,6 +184,9 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mPreviousMorale{constants::DefaultStartingMorale},
 	mMainReportsState(mainReportsState),
 	mMapView{std::make_unique<MapView>(*mTileMap)},
+	mStructures{"ui/structures.png", 46, constants::MarginTight},
+	mRobots{"ui/robots.png", 46, constants::MarginTight},
+	mConnections{"ui/structures.png", 46, constants::MarginTight},
 	mResourceInfoBar{mResourcesCount, mPopulation, mCurrentMorale, mPreviousMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, mTileMap, mRobotList, planetAttributes.mapImagePath)},

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -159,6 +159,8 @@ namespace
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
 	mCrimeExecution(mNotificationArea),
 	mTechnologyReader("tech0-1.xml"),
+	mCurrentMorale{constants::DefaultStartingMorale},
+	mPreviousMorale{constants::DefaultStartingMorale},
 	mLoadingExisting(true),
 	mExistingToLoad(savegame),
 	mMainReportsState(mainReportsState),
@@ -175,6 +177,8 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mCrimeExecution(mNotificationArea),
 	mTechnologyReader("tech0-1.xml"),
 	mPlanetAttributes(planetAttributes),
+	mCurrentMorale{constants::DefaultStartingMorale},
+	mPreviousMorale{constants::DefaultStartingMorale},
 	mMainReportsState(mainReportsState),
 	mMapView{std::make_unique<MapView>(*mTileMap)},
 	mResourceInfoBar{mResourcesCount, mPopulation, mCurrentMorale, mPreviousMorale, mFood},

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -7,8 +7,6 @@
 
 #include "Planet.h"
 
-#include "../Constants/UiConstants.h"
-
 #include "../Common.h"
 #include "../StorableResources.h"
 #include "../RobotPool.h"
@@ -355,9 +353,9 @@ private:
 
 	ToolTip mToolTip;
 
-	IconGrid mStructures{"ui/structures.png", 46, constants::MarginTight};
-	IconGrid mRobots{"ui/robots.png", 46, constants::MarginTight};
-	IconGrid mConnections{"ui/structures.png", 46, constants::MarginTight};
+	IconGrid mStructures;
+	IconGrid mRobots;
+	IconGrid mConnections;
 
 	CheatMenu mCheatMenu;
 	DiggerDirection mDiggerDirection;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -7,7 +7,6 @@
 
 #include "Planet.h"
 
-#include "../Constants/Numbers.h"
 #include "../Constants/UiConstants.h"
 
 #include "../Common.h"
@@ -306,8 +305,8 @@ private:
 	// MISCELLANEOUS
 	int mTurnCount = 0;
 
-	int mCurrentMorale = constants::DefaultStartingMorale;
-	int mPreviousMorale = constants::DefaultStartingMorale;
+	int mCurrentMorale;
+	int mPreviousMorale;
 
 	int mLandersColonist = 0;
 	int mLandersCargo = 0;

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -29,6 +29,7 @@ PlanetSelectState::PlanetSelectState() :
 	mHover{"sfx/menu4.ogg"},
 	mQuit{"Main Menu", {this, &PlanetSelectState::onQuit}},
 	mPlanetDescription{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
+	mPlanetSelection{constants::NoSelection},
 	mReturnState{this},
 	PlanetAttributes(parsePlanetAttributes())
 {}

--- a/OPHD/States/PlanetSelectState.h
+++ b/OPHD/States/PlanetSelectState.h
@@ -2,8 +2,6 @@
 
 #include "Planet.h"
 
-#include "../Constants/UiConstants.h"
-
 #include <libControls/Button.h>
 #include <libControls/TextArea.h>
 
@@ -58,7 +56,7 @@ private:
 
 	TextArea mPlanetDescription;
 
-	std::size_t mPlanetSelection{constants::NoSelection};
+	std::size_t mPlanetSelection;
 
 	NAS2D::Timer mTimer;
 	NAS2D::Fade mFade;


### PR DESCRIPTION
Remove unnecessary includes, and convert header includes to source file includes by moving initialization to constructors.

Unfortunately, this does add a bit of repetition when there are multiple constructors on a class, such as for `MapViewState`. Though we can potentially remove that duplication in the future by using delegating constructors. In particular, if a constructor can initialize all aspects of a game, then loading a saved game can pre-parse the saved game file and pass in the parsed info to a more general constructor, while starting a new game can pass in default or empty values to a more general constructor.

Related:
- Issue #138
