### PR TITLE
Wrap `dumpGraphicsInfo` in unnamed namespace

### DIFF
--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -31,6 +31,7 @@
 using namespace NAS2D;
 
 
+namespace {
 void dumpGraphicsInfo(RendererOpenGL& renderer)
 {
 	std::vector<std::string> info{
@@ -45,6 +46,7 @@ void dumpGraphicsInfo(RendererOpenGL& renderer)
 	{
 		std::cout << "\t" << str << std::endl;
 	}
+}
 }
 
 

--- a/OPHD/main.cpp
+++ b/OPHD/main.cpp
@@ -32,21 +32,21 @@ using namespace NAS2D;
 
 
 namespace {
-void dumpGraphicsInfo(RendererOpenGL& renderer)
-{
-	std::vector<std::string> info{
-		"- OpenGL System Info -",
-		"Vendor: " + renderer.getVendor(),
-		"Renderer: " + renderer.getRenderer(),
-		"Driver Version: " + renderer.getDriverVersion(),
-		"GLSL Version: " + renderer.getShaderVersion(),
-	};
-
-	for (const auto& str : info)
+	void dumpGraphicsInfo(RendererOpenGL& renderer)
 	{
-		std::cout << "\t" << str << std::endl;
+		std::vector<std::string> info{
+			"- OpenGL System Info -",
+			"Vendor: " + renderer.getVendor(),
+			"Renderer: " + renderer.getRenderer(),
+			"Driver Version: " + renderer.getDriverVersion(),
+			"GLSL Version: " + renderer.getShaderVersion(),
+		};
+
+		for (const auto& str : info)
+		{
+			std::cout << "\t" << str << std::endl;
+		}
 	}
-}
 }
 
 


### PR DESCRIPTION
Fix Clang warning `-Wmissing-prototypes`.

Part of:
- Issue #307

----

~Build failure appears to be unrelated. It should perhaps be looked into before merging.~
Edit: Rebased after pushing fix in PR #1436.
