### PR TITLE
Feature/expand structure icon tool tip

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -18,6 +18,8 @@
 #include "../Map/TileMap.h"
 #include "../Map/MapView.h"
 
+#include "../MapObjects/StructureType.h"
+
 #include "../UI/MessageBox.h"
 #include "../UI/DetailMap.h"
 #include "../UI/NavControl.h"
@@ -155,6 +157,26 @@ namespace
 		fade.update();
 		fade.draw(renderer);
 	}
+
+
+	void fillResourceCosts(IconGrid& grid, const std::vector<IconGrid::Item>& itemList)
+	{
+		for (const auto& item : itemList)
+		{
+			const auto& structureType = StructureCatalogue::getType(static_cast<StructureID>(item.meta));
+			std::vector<std::tuple<std::string, int>> resourceCosts;
+			const auto& resourcesToBuild = structureType.buildCost.resources;
+			const auto& populationRequirements = structureType.populationRequirements;
+			for (std::vector<int>::size_type index = 0; index < resourcesToBuild.size(); ++index)
+			{
+				resourceCosts.push_back(std::make_tuple(ResourceNamesRefined[index], resourcesToBuild[index]));
+			}
+
+			resourceCosts.push_back(std::make_tuple("Workers", populationRequirements.workers));
+			resourceCosts.push_back(std::make_tuple("Scientists", populationRequirements.scientists));
+			grid.addResourceCosts(item.name, resourceCosts);
+		}
+	}
 }
 
 
@@ -282,6 +304,8 @@ void MapViewState::initialize()
 
 	delete mPathSolver;
 	mPathSolver = new micropather::MicroPather(mTileMap, 250, 6, false);
+	fillResourceCosts(mStructures, mStructureTracker.availableSurfaceStructures());
+	fillResourceCosts(mStructures, mStructureTracker.availableUndergroundStructures());
 }
 
 

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -151,6 +151,12 @@ void IconGrid::addItem(const Item& item)
 }
 
 
+void IconGrid::addResourceCosts(std::string name, std::vector<std::tuple<std::string, int>>& resourceCost)
+{
+	mResourceCosts[name] = resourceCost;
+}
+
+
 /**
  * Set item availability
  */

--- a/OPHD/UI/IconGrid.cpp
+++ b/OPHD/UI/IconGrid.cpp
@@ -378,10 +378,40 @@ void IconGrid::update()
 		if (mShowTooltip)
 		{
 			const auto& highlightedName = mIconItemList[mHighlightIndex].name;
-			const auto tooltipRect = NAS2D::Rectangle<int>{{position.x, position.y - 15}, {mFont.width(highlightedName) + 4, mFont.height()}};
-			renderer.drawBoxFilled(tooltipRect, NAS2D::Color{245, 245, 245});
+
+			int toolTipBoxWidth = mFont.width(highlightedName);
+			int toolTipBoxHeight = mFont.height();
+
+			auto resourceCostIterator = mResourceCosts.find(mIconItemList[mHighlightIndex].name);
+			if (resourceCostIterator != mResourceCosts.end())
+			{
+				for(auto& resourceCost: resourceCostIterator->second)
+				{
+					toolTipBoxWidth = std::max(toolTipBoxWidth, mFont.width(std::get<0>(resourceCost) + ": " + std::to_string(std::get<1>(resourceCost))));
+				}
+				toolTipBoxHeight = mFont.height() * static_cast<int>(resourceCostIterator->second.size() + 1);
+			}
+
+			const auto tooltipRect = NAS2D::Rectangle<int>{{position.x, position.y - toolTipBoxHeight}, {toolTipBoxWidth + 4, toolTipBoxHeight}};
+			renderer.drawBoxFilled(tooltipRect, NAS2D::Color{225, 225, 225});
+
+			const auto toolTipHighlightRect = NAS2D::Rectangle<int>{{position.x, position.y - mFont.height()}, {toolTipBoxWidth + 4, mFont.height()}};
+			renderer.drawBoxFilled(toolTipHighlightRect, NAS2D::Color{245, 245, 245});
 			renderer.drawBox(tooltipRect, NAS2D::Color{175, 175, 175});
 			renderer.drawText(mFont, highlightedName, position + NAS2D::Vector{2, -15}, NAS2D::Color::Black);
+
+
+			if (resourceCostIterator != mResourceCosts.end())
+			{
+				const int numberOfLines = static_cast<int>(resourceCostIterator->second.size());
+				const int startOffset = static_cast<int>(-mFont.height() * numberOfLines);
+				int currentLine = 0;
+				for(auto& resourceCost: resourceCostIterator->second)
+				{
+					renderer.drawText(mFont, std::get<0>(resourceCost) + ": " + std::to_string(std::get<1>(resourceCost)), position + NAS2D::Vector{2, startOffset + (-15 + mFont.height() * currentLine)}, NAS2D::Color::Black);
+					currentLine++;
+				}
+			}
 		}
 	}
 }

--- a/OPHD/UI/IconGrid.h
+++ b/OPHD/UI/IconGrid.h
@@ -48,6 +48,7 @@ public:
 	bool empty() const { return mIconItemList.empty(); }
 
 	void addItem(const Item&);
+	void addResourceCosts(std::string name, std::vector<std::tuple<std::string, int>>& resourceCost);
 
 	void removeItem(const std::string& item);
 	bool itemExists(const std::string& item);
@@ -108,6 +109,7 @@ private:
 	NAS2D::Vector<int> mGridSize; /**< Dimensions of the grid that can be contained in the IconGrid with the current Icon Size and Icon Margin. */
 
 	IconItemList mIconItemList; /**< List of items. */
+	std::map<std::string, std::vector<std::tuple<std::string, int>>> mResourceCosts; /**< List of resources required to build the item. */
 
 	Signal mSignal; /**< Signal whenever a selection is made. */
 };


### PR DESCRIPTION
Expanded the Structure icon tool tip to now include the cost to build it and the workers and scientist needed to operate it.

I don't know if this is a too ad hoc solution but I made a temporary Structure Object to gain access to the population requirements.
`const auto& tempStructure = Structure::Structure(Structure::StructureClass::Undefined, (StructureID)mIconItemList[mHighlightIndex].meta);`
`const auto& popNeeds = tempStructure.populationRequirements();`

I would also like to direct your attention to the HEADS UP comment. Again this feels ad hoc.