### PR TITLE
Fix windows warning C26478 - Don't use `std::move` on constant variables

### DIFF
--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -248,7 +248,8 @@ void ScrollBar::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<
 	{
 		const auto& [clickPosition, thumbPosition, viewSize] =
 			(mScrollBarType == ScrollBarType::Vertical) ?
-				std::tuple{position.y, mThumbRect.position.y, mRect.size.y} : std::tuple{position.x, mThumbRect.position.x, mRect.size.x};
+				std::tuple{position.y, mThumbRect.position.y, mRect.size.y} :
+				std::tuple{position.x, mThumbRect.position.x, mRect.size.x};
 		const auto changeAmount = (clickPosition < thumbPosition) ?
 			-viewSize : viewSize;
 		changeValue(changeAmount);

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -246,7 +246,7 @@ void ScrollBar::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<
 
 	if (mTrackRect.contains(position) && !mThumbRect.contains(position))
 	{
-		const auto [clickPosition, thumbPosition, viewSize] =
+		const auto& [clickPosition, thumbPosition, viewSize] =
 			(mScrollBarType == ScrollBarType::Vertical) ?
 				std::tuple{position.y, mThumbRect.position.y, mRect.size.y} : std::tuple{position.x, mThumbRect.position.x, mRect.size.x};
 		const auto changeAmount = (clickPosition < thumbPosition) ?


### PR DESCRIPTION
Use a reference to work around buggy MSVC warning:
> OPHD\libControls\ScrollBar.cpp(250): error C26478: Don't use std::move on constant variables.

Example problem run:
https://github.com/OutpostUniverse/OPHD/actions/runs/7684040546

----

The original code perhaps makes slightly more sense, but has been generating a warning with recent MSVC compiler releases. A fix has supposedly been released, but doesn't seem to be present on GitHub Action runners.

References:
- https://stackoverflow.com/questions/77051369/msvc-gives-warning-c26478-using-stdmove-on-constant-variables
- https://developercommunity.visualstudio.com/t/Wrong-C26478-warning-when-using-structur/10417562

----

Related to Issue #307
