### PR TITLE
Update NAS2D for key modifier method changes

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -530,7 +530,7 @@ void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::P
 		const auto tilePosition = mDetailMap->mouseTilePosition();
 		if (!mTileMap->isValidPosition(tilePosition)) { return; }
 
-		const bool inspectModifier = NAS2D::Utility<NAS2D::EventHandler>::get().query_shift() ||
+		const bool inspectModifier = NAS2D::Utility<NAS2D::EventHandler>::get().shift() ||
 			button == NAS2D::EventHandler::MouseButton::Middle;
 
 		onInspect(tilePosition, inspectModifier);

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -148,7 +148,7 @@ void TextField::onTextInput(const std::string& newTextInput)
 }
 
 
-void TextField::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
+void TextField::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool /*repeat*/)
 {
 	if (!hasFocus() || !editable() || !visible()) { return; }
 
@@ -193,12 +193,12 @@ void TextField::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler:
 
 		// KEYPAD ARROWS
 		case NAS2D::EventHandler::KeyCode::KEY_KP4:
-			if ((mCursorPosition > 0) && !NAS2D::Utility<NAS2D::EventHandler>::get().numlock())
+			if ((mCursorPosition > 0) && !NAS2D::EventHandler::numlock(mod))
 				--mCursorPosition;
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_KP6:
-			if ((mCursorPosition < text().length()) && !NAS2D::Utility<NAS2D::EventHandler>::get().numlock())
+			if ((mCursorPosition < text().length()) && !NAS2D::EventHandler::numlock(mod))
 				++mCursorPosition;
 			break;
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -193,12 +193,12 @@ void TextField::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler:
 
 		// KEYPAD ARROWS
 		case NAS2D::EventHandler::KeyCode::KEY_KP4:
-			if ((mCursorPosition > 0) && !NAS2D::Utility<NAS2D::EventHandler>::get().query_numlock())
+			if ((mCursorPosition > 0) && !NAS2D::Utility<NAS2D::EventHandler>::get().numlock())
 				--mCursorPosition;
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_KP6:
-			if ((mCursorPosition < text().length()) && !NAS2D::Utility<NAS2D::EventHandler>::get().query_numlock())
+			if ((mCursorPosition < text().length()) && !NAS2D::Utility<NAS2D::EventHandler>::get().numlock())
 				++mCursorPosition;
 			break;
 


### PR DESCRIPTION
Update NAS2D submodule for renamed `KeyModifier` query methods. Allows use of `static` methods to check key modifier state.

Upstream change:
https://github.com/lairworks/nas2d-core/pull/1152

----

Draft: The upstream PR has not yet been merged to `main`. The submodule reference update here should be updated once the upstream PR is merged.
