### PR TITLE
Fix GitHub actions warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Checkout NAS2D
       run: git submodule update --init nas2d-core/
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.3.1
+      uses: microsoft/setup-msbuild@v1.3.2
 
     - name: Setup NuGet credentials
       shell: bash
@@ -42,7 +42,7 @@ jobs:
         -source "https://nuget.pkg.github.com/OutpostUniverse/index.json"
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         path: vcpkg_installed


### PR DESCRIPTION
Update referenced actions to latest versions. This makes them depend on Node 20, rather than Node 16, which was generating a warning.

Example run with warnings:
- https://github.com/OutpostUniverse/OPHD/actions/runs/7701397910

Additional reading:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Related upstream change:
- https://github.com/lairworks/nas2d-core/pull/1153
