### PR TITLE
Fix PgUp/PgDown not changing structure palette

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -458,11 +458,11 @@ void MapViewState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEUP:
-			changeViewDepth(0, MapOffsetUp);
+			moveView( MapOffsetUp);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEDOWN:
-			changeViewDepth(0, MapOffsetDown);
+			moveView(MapOffsetDown);
 			break;
 
 
@@ -723,29 +723,44 @@ void MapViewState::onSystemMenu()
 	resetUi();
 }
 
-
 /**
- * Changes the current view depth. If a value is given for the 2nd parameter, the first will be ignored.
- */
-void MapViewState::changeViewDepth(int depth, std::optional<MapOffset> direction)
-{
+* Handle side effects of changing depth view
+*/
+void MapViewState::onChangeDepth(int oldDepth, int newDepth) {
 	if (mBtnTogglePoliceOverlay.isPressed())
 	{
-		changePoliceOverlayDepth(mMapView->currentDepth(), depth);
-	}
-
-	if (direction.has_value())
-	{
-		mMapView->moveView(direction.value());
-	}
-	else
-	{
-		mMapView->currentDepth(depth);
+		changePoliceOverlayDepth(oldDepth, newDepth);
 	}
 
 	if (mInsertMode != InsertMode::Robot) { clearMode(); }
 
 	populateStructureMenu();
+}
+
+void MapViewState::moveView(MapOffset offset) {
+	int oldZLevel = mMapView->currentDepth();
+	
+	mMapView->moveView(offset);
+
+	int newZLevel = mMapView->currentDepth();
+	if (oldZLevel != newZLevel) {
+		onChangeDepth(oldZLevel, newZLevel);
+	}
+}
+
+/**
+ * Changes the current view depth.
+ */
+void MapViewState::changeViewDepth(int depth)
+{
+	int oldZLevel = mMapView->currentDepth();
+
+	mMapView->currentDepth(depth);
+
+	int newZLevel = mMapView->currentDepth();
+	if (oldZLevel != newZLevel) {
+		onChangeDepth(oldZLevel, newZLevel);
+	}
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -458,11 +458,11 @@ void MapViewState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEUP:
-			mMapView->moveView(MapOffsetUp);
+			changeViewDepth(0, MapOffsetUp);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEDOWN:
-			mMapView->moveView(MapOffsetDown);
+			changeViewDepth(0, MapOffsetDown);
 			break;
 
 
@@ -725,18 +725,26 @@ void MapViewState::onSystemMenu()
 
 
 /**
- * Changes the current view depth.
+ * Changes the current view depth. If a value is given for the 2nd parameter, the first will be ignored.
  */
-void MapViewState::changeViewDepth(int depth)
+void MapViewState::changeViewDepth(int depth, std::optional<MapOffset> direction)
 {
 	if (mBtnTogglePoliceOverlay.isPressed())
 	{
 		changePoliceOverlayDepth(mMapView->currentDepth(), depth);
 	}
 
-	mMapView->currentDepth(depth);
+	if (direction.has_value())
+	{
+		mMapView->moveView(direction.value());
+	}
+	else
+	{
+		mMapView->currentDepth(depth);
+	}
 
 	if (mInsertMode != InsertMode::Robot) { clearMode(); }
+
 	populateStructureMenu();
 }
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -458,7 +458,7 @@ void MapViewState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEUP:
-			moveView( MapOffsetUp);
+			moveView(MapOffsetUp);
 			break;
 
 		case NAS2D::EventHandler::KeyCode::KEY_PAGEDOWN:
@@ -550,7 +550,7 @@ void MapViewState::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::P
 		mNavControl->onClick(MOUSE_COORDS);
 		if (oldDepth != mMapView->currentDepth())
 		{
-			changeViewDepth(mMapView->currentDepth());
+			onChangeDepth(oldDepth, mMapView->currentDepth());
 		}
 
 		// MiniMap Check

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -192,7 +192,9 @@ private:
 	void updatePoliceOverlay();
 	void resetPoliceOverlays();
 	void updateConnectedness();
-	void changeViewDepth(int, std::optional<MapOffset> = std::nullopt);
+	void changeViewDepth(int);
+	void moveView(MapOffset offset);
+	void onChangeDepth(int oldDepth, int newDepth);
 
 	void pullRobotFromFactory(ProductType pt, Factory& factory);
 	void onFactoryProductionComplete(Factory& factory);

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -192,7 +192,7 @@ private:
 	void updatePoliceOverlay();
 	void resetPoliceOverlays();
 	void updateConnectedness();
-	void changeViewDepth(int);
+	void changeViewDepth(int, std::optional<MapOffset> = std::nullopt);
 
 	void pullRobotFromFactory(ProductType pt, Factory& factory);
 	void onFactoryProductionComplete(Factory& factory);


### PR DESCRIPTION
The number keys called a local function that handled changing the structure picker. This change adds a 2nd parameter (defaulting to null) to that local function, allowing the event handlers for PageUp/Down to call the same function, rather than call directly to the mMapView object. If the 2nd parameter have a value, then the 1st parameter is ignored and the 2nd is used to change the mMapView z level.

----

Edit:
Closes #1364