### PR TITLE
Mark `getStructures` as `const`

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -287,7 +287,7 @@ int getTruckAvailability()
 {
 	int trucksAvailable = 0;
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
+	const auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouseList)
 	{
 		trucksAvailable += warehouse->products().count(ProductType::PRODUCT_TRUCK);
@@ -303,7 +303,7 @@ int pullTruckFromInventory()
 
 	if (trucksAvailable == 0) { return 0; }
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
+	const auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouseList)
 	{
 		if (warehouse->products().pull(ProductType::PRODUCT_TRUCK, 1) > 0)
@@ -320,7 +320,7 @@ int pushTruckIntoInventory()
 {
 	const int storageNeededForTruck = storageRequiredPerUnit(ProductType::PRODUCT_TRUCK);
 
-	auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
+	const auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (auto warehouse : warehouseList)
 	{
 		if (warehouse->products().availableStorage() >= storageNeededForTruck)

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -356,8 +356,8 @@ NAS2D::State* MapViewState::update()
 
 void MapViewState::updatePlayerResources()
 {
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
-	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
+	const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), command.begin(), command.end());

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -363,8 +363,8 @@ StorableResources addRefinedResources(StorableResources resourcesToAdd)
 	 * structure list and that it's always the first structure in the list.
 	 */
 
-	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
+	const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), command.begin(), command.end());
@@ -398,8 +398,8 @@ void removeRefinedResources(StorableResources& resourcesToRemove)
 {
 	// Command Center is backup storage, we want to pull from it last
 
-	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
-	auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
+	const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
 
 	std::vector<Structure*> storage;
 	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -538,7 +538,7 @@ void MapViewState::transferFoodToCommandCenter()
  */
 void MapViewState::updateRoads()
 {
-	const auto roads = NAS2D::Utility<StructureManager>::get().getStructures<Road>();
+	const auto& roads = NAS2D::Utility<StructureManager>::get().getStructures<Road>();
 
 	for (auto road : roads)
 	{

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -111,7 +111,7 @@ void MapViewState::updatePopulation()
 	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::Operational);
 
 	auto foodProducers = structureManager.getStructures<FoodProduction>();
-	auto& commandCenters = structureManager.getStructures<CommandCenter>();
+	const auto& commandCenters = structureManager.getStructures<CommandCenter>();
 	foodProducers.insert(foodProducers.end(), commandCenters.begin(), commandCenters.end());
 
 	int amountToConsume = mPopulation.update(mCurrentMorale, mFood, residences, universities, nurseries, hospitals);
@@ -196,7 +196,7 @@ void MapViewState::updateMorale()
 	const int residentialOverCapacityHit = mPopulation.getPopulations().size() > mResidentialCapacity ? 2 : 0;
 	const int foodProductionHit = foodProducingStructures > 0 ? 0 : 5;
 
-	auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
+	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
 	int bioWasteAccumulation = 0;
 	for (auto residence : residences)
 	{
@@ -268,7 +268,7 @@ void MapViewState::updateMorale()
 
 void MapViewState::findMineRoutes()
 {
-	auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<OreRefining>();
+	const auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<OreRefining>();
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();
 	mTruckRouteOverlay.clear();
 
@@ -343,7 +343,7 @@ void MapViewState::transportOreFromMines()
 
 void MapViewState::transportResourcesToStorage()
 {
-	auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<OreRefining>();
+	const auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<OreRefining>();
 	for (auto smelter : smelterList)
 	{
 		if (!smelter->operational() && !smelter->isIdle()) { continue; }
@@ -460,8 +460,8 @@ void MapViewState::updateResidentialCapacity()
 
 void MapViewState::updateBiowasteRecycling()
 {
-	auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
-	auto& recyclingFacilities = NAS2D::Utility<StructureManager>::get().getStructures<Recycling>();
+	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
+	const auto& recyclingFacilities = NAS2D::Utility<StructureManager>::get().getStructures<Recycling>();
 
 	if (residences.empty() || recyclingFacilities.empty()) { return; }
 
@@ -490,7 +490,7 @@ void MapViewState::updateFood()
 	mFood = 0;
 
 	auto foodProducers = NAS2D::Utility<StructureManager>::get().getStructures<FoodProduction>();
-	auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
@@ -506,8 +506,8 @@ void MapViewState::updateFood()
 
 void MapViewState::transferFoodToCommandCenter()
 {
-	auto& foodProducers = NAS2D::Utility<StructureManager>::get().getStructures<FoodProduction>();
-	auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	const auto& foodProducers = NAS2D::Utility<StructureManager>::get().getStructures<FoodProduction>();
+	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	auto foodProducerIterator = foodProducers.begin();
 	for (auto commandCenter : commandCenters)
@@ -538,7 +538,7 @@ void MapViewState::transferFoodToCommandCenter()
  */
 void MapViewState::updateRoads()
 {
-	auto roads = NAS2D::Utility<StructureManager>::get().getStructures<Road>();
+	const auto roads = NAS2D::Utility<StructureManager>::get().getStructures<Road>();
 
 	for (auto road : roads)
 	{
@@ -624,7 +624,7 @@ void MapViewState::updateMaintenance()
 	auto structures = structureManager.allStructures();
 	std::sort(structures.begin(), structures.end(), sortLambda);
 
-	auto& maintenanceFacilities = structureManager.getStructures<MaintenanceFacility>();
+	const auto& maintenanceFacilities = structureManager.getStructures<MaintenanceFacility>();
 	for (auto maintenanceFacility : maintenanceFacilities)
 	{
 		maintenanceFacility->repairStructures(structures);
@@ -731,7 +731,7 @@ void MapViewState::nextTurn()
 
 	updateOverlays();
 
-	auto& factories = NAS2D::Utility<StructureManager>::get().getStructures<Factory>();
+	const auto& factories = NAS2D::Utility<StructureManager>::get().getStructures<Factory>();
 	for (auto factory : factories)
 	{
 		factory->updateProduction();

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -707,7 +707,7 @@ void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
 		case CheatMenu::CheatCode::AddFood:
 		{
 			auto foodProducers = NAS2D::Utility<StructureManager>::get().getStructures<FoodProduction>();
-			auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+			const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 			foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
 			for (auto fp : foodProducers)

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -86,7 +86,7 @@ public:
 	void removeStructure(Structure& structure);
 
 	template <typename StructureType>
-	const std::vector<StructureType*> getStructures()
+	const std::vector<StructureType*> getStructures() const
 	{
 		// Get list of structures with same function
 		const auto& sameClassStructures = structureList(structureTypeToClass<StructureType>());

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -57,7 +57,7 @@ void MiniMap::draw() const
 
 	renderer.drawImage((mIsHeightMapVisible ? mBackgroundHeightMap : mBackgroundSatellite), miniMapFloatRect.position);
 
-	auto& structureManager = NAS2D::Utility<StructureManager>::get();
+	const auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	const auto miniMapOffset = mRect.position - NAS2D::Point{0, 0};
 	for (const auto& ccPosition : structureManager.operationalCommandCenterPositions())
 	{


### PR DESCRIPTION
Also mark the result of most calls to `getStructures` as `const`.

----

Not addressed: The result is often iterated over, and the iterated items can mostly also be marked as `const`.

----

Part of:
- Issue #1446 