### PR TITLE
Iterate over `const` structures

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -288,7 +288,7 @@ int getTruckAvailability()
 	int trucksAvailable = 0;
 
 	const auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
-	for (auto warehouse : warehouseList)
+	for (auto* warehouse : warehouseList)
 	{
 		trucksAvailable += warehouse->products().count(ProductType::PRODUCT_TRUCK);
 	}
@@ -304,7 +304,7 @@ int pullTruckFromInventory()
 	if (trucksAvailable == 0) { return 0; }
 
 	const auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
-	for (auto warehouse : warehouseList)
+	for (auto* warehouse : warehouseList)
 	{
 		if (warehouse->products().pull(ProductType::PRODUCT_TRUCK, 1) > 0)
 		{
@@ -321,7 +321,7 @@ int pushTruckIntoInventory()
 	const int storageNeededForTruck = storageRequiredPerUnit(ProductType::PRODUCT_TRUCK);
 
 	const auto& warehouseList = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
-	for (auto warehouse : warehouseList)
+	for (auto* warehouse : warehouseList)
 	{
 		if (warehouse->products().availableStorage() >= storageNeededForTruck)
 		{

--- a/OPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/OPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -104,7 +104,7 @@ public:
 			repairPriorityStructures(structures);
 		}
 
-		for (auto structure : structures)
+		for (auto* structure : structures)
 		{
 			repairStructure(structure);
 			std::rotate(structures.begin(), structures.begin() + 1, structures.end());
@@ -132,7 +132,7 @@ protected:
 
 	void repairPriorityStructures(StructureList& structures)
 	{
-		for (auto structure : mPriorityList)
+		for (auto* structure : mPriorityList)
 		{
 			if (!canMakeRepairs()) { return; }
 

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -25,7 +25,7 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 
 	double accumulatedCrime{0};
 
-	for (auto structure : structuresWithCrime)
+	for (auto* structure : structuresWithCrime)
 	{
 		int crimeRateChange = isProtectedByPolice(policeOverlays, structure) ? -1 : 1;
 		structure->increaseCrimeRate(crimeRateChange);

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -100,7 +100,7 @@ namespace
 
 
 	template <typename StructureType>
-	void fillOverlay(TileMap& tileMap, std::vector<Tile*>& overlay, const std::vector<StructureType*> structures)
+	void fillOverlay(TileMap& tileMap, std::vector<Tile*>& overlay, const std::vector<StructureType*>& structures)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 		for (const auto* structure : structures)
@@ -113,7 +113,7 @@ namespace
 
 
 	template <typename StructureType>
-	void fillOverlay(TileMap& tileMap, std::vector<std::vector<Tile*>>& overlays, const std::vector<StructureType*> structures)
+	void fillOverlay(TileMap& tileMap, std::vector<std::vector<Tile*>>& overlays, const std::vector<StructureType*>& structures)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 		for (const auto* structure : structures)

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -103,7 +103,7 @@ namespace
 	void fillOverlay(TileMap& tileMap, std::vector<Tile*>& overlay, const std::vector<StructureType*> structures)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
-		for (auto structure : structures)
+		for (auto* structure : structures)
 		{
 			if (!structure->operational()) { continue; }
 			auto& centerTile = structureManager.tileFromStructure(structure);
@@ -116,7 +116,7 @@ namespace
 	void fillOverlay(TileMap& tileMap, std::vector<std::vector<Tile*>>& overlays, const std::vector<StructureType*> structures)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
-		for (auto structure : structures)
+		for (auto* structure : structures)
 		{
 			if (!structure->operational()) { continue; }
 			auto& centerTile = structureManager.tileFromStructure(structure);
@@ -364,7 +364,7 @@ void MapViewState::updatePlayerResources()
 	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
 
 	StorableResources resources;
-	for (auto structure : storage)
+	for (auto* structure : storage)
 	{
 		resources += structure->storage();
 	}

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -103,7 +103,7 @@ namespace
 	void fillOverlay(TileMap& tileMap, std::vector<Tile*>& overlay, const std::vector<StructureType*> structures)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
-		for (auto* structure : structures)
+		for (const auto* structure : structures)
 		{
 			if (!structure->operational()) { continue; }
 			auto& centerTile = structureManager.tileFromStructure(structure);
@@ -116,7 +116,7 @@ namespace
 	void fillOverlay(TileMap& tileMap, std::vector<std::vector<Tile*>>& overlays, const std::vector<StructureType*> structures)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
-		for (auto* structure : structures)
+		for (const auto* structure : structures)
 		{
 			if (!structure->operational()) { continue; }
 			auto& centerTile = structureManager.tileFromStructure(structure);

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -205,7 +205,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
 	const auto& seedLanders = structureManager.getStructures<SeedLander>();
-	for (auto* lander : seedLanders)
+	for (const auto* lander : seedLanders)
 	{
 		if (!lander->operational()) { continue; }
 		if (isPointInRange(position, structureManager.tileFromStructure(lander).xy(), 5)) // \fixme magic number
@@ -215,7 +215,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	}
 
 	const auto& command = structureManager.getStructures<CommandCenter>();
-	for (auto* cc : command)
+	for (const auto* cc : command)
 	{
 		if (!cc->operational()) { continue; }
 
@@ -226,7 +226,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	}
 
 	const auto& commTowers = structureManager.getStructures<CommTower>();
-	for (auto* tower : commTowers)
+	for (const auto* tower : commTowers)
 	{
 		if (!tower->operational()) { continue; }
 

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -205,7 +205,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
 	const auto& seedLanders = structureManager.getStructures<SeedLander>();
-	for (auto lander : seedLanders)
+	for (auto* lander : seedLanders)
 	{
 		if (!lander->operational()) { continue; }
 		if (isPointInRange(position, structureManager.tileFromStructure(lander).xy(), 5)) // \fixme magic number
@@ -215,7 +215,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	}
 
 	const auto& command = structureManager.getStructures<CommandCenter>();
-	for (auto cc : command)
+	for (auto* cc : command)
 	{
 		if (!cc->operational()) { continue; }
 
@@ -226,7 +226,7 @@ bool inCommRange(NAS2D::Point<int> position)
 	}
 
 	const auto& commTowers = structureManager.getStructures<CommTower>();
-	for (auto tower : commTowers)
+	for (auto* tower : commTowers)
 	{
 		if (!tower->operational()) { continue; }
 
@@ -258,7 +258,7 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count)
 {
-	for (auto warehouse : NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>())
+	for (auto* warehouse : NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>())
 	{
 		if (!warehouse->operational())
 		{
@@ -287,7 +287,7 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
 {
 	ProductPool sourcePool = sourceWarehouse->products();
 	const auto& warehouses = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
-	for (auto warehouse : warehouses)
+	for (auto* warehouse : warehouses)
 	{
 		if (warehouse->operational())
 		{
@@ -318,7 +318,7 @@ bool simulateMoveProducts(Warehouse* sourceWarehouse)
 void moveProducts(Warehouse* sourceWarehouse)
 {
 	const auto& warehouses = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
-	for (auto warehouse : warehouses)
+	for (auto* warehouse : warehouses)
 	{
 		if (warehouse->operational())
 		{
@@ -370,7 +370,7 @@ StorableResources addRefinedResources(StorableResources resourcesToAdd)
 	storage.insert(storage.end(), command.begin(), command.end());
 	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
 
-	for (auto structure : storage)
+	for (auto* structure : storage)
 	{
 		if (resourcesToAdd.isEmpty()) { break; }
 
@@ -405,7 +405,7 @@ void removeRefinedResources(StorableResources& resourcesToRemove)
 	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
 	storage.insert(storage.end(), command.begin(), command.end());
 
-	for (auto structure : storage)
+	for (auto* structure : storage)
 	{
 		if (resourcesToRemove.isEmpty()) { break; }
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -58,7 +58,7 @@ namespace
 
 		RouteList routeList;
 
-		for (auto* smelter : smelters)
+		for (const auto* smelter : smelters)
 		{
 			if (!smelter->operational()) { continue; }
 
@@ -198,7 +198,7 @@ void MapViewState::updateMorale()
 
 	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
 	int bioWasteAccumulation = 0;
-	for (auto* residence : residences)
+	for (const auto* residence : residences)
 	{
 		if (residence->wasteOverflow() > 0) { ++bioWasteAccumulation; }
 	}
@@ -447,7 +447,7 @@ void MapViewState::updateResidentialCapacity()
 {
 	mResidentialCapacity = 0;
 	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
-	for (auto* residence : residences)
+	for (const auto* residence : residences)
 	{
 		if (residence->operational()) { mResidentialCapacity += residence->capacity(); }
 	}
@@ -466,7 +466,7 @@ void MapViewState::updateBiowasteRecycling()
 	if (residences.empty() || recyclingFacilities.empty()) { return; }
 
 	auto residenceIterator = residences.begin();
-	for (auto* recycling : recyclingFacilities)
+	for (const auto* recycling : recyclingFacilities)
 	{
 		if (!recycling->operational()) { continue; } // Consider a different control structure
 
@@ -494,7 +494,7 @@ void MapViewState::updateFood()
 
 	foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
-	for (auto* foodProdcer : foodProducers)
+	for (const auto* foodProdcer : foodProducers)
 	{
 		if (foodProdcer->operational() || foodProdcer->isIdle())
 		{
@@ -572,7 +572,7 @@ void MapViewState::checkAgingStructures()
 {
 	const auto& structures = NAS2D::Utility<StructureManager>::get().agingStructures();
 
-	for (auto* structure : structures)
+	for (const auto* structure : structures)
 	{
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
 
@@ -600,7 +600,7 @@ void MapViewState::checkNewlyBuiltStructures()
 {
 	const auto& structures = NAS2D::Utility<StructureManager>::get().newlyBuiltStructures();
 
-	for (auto* structure : structures)
+	for (const auto* structure : structures)
 	{
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -43,7 +43,7 @@ namespace
 
 	void consumeFood(const std::vector<FoodProduction*>& foodProducers, int amountToConsume)
 	{
-		for (auto foodProducer : foodProducers)
+		for (auto* foodProducer : foodProducers)
 		{
 			if (amountToConsume <= 0) { break; }
 			amountToConsume -= consumeFood(*foodProducer, amountToConsume);
@@ -58,7 +58,7 @@ namespace
 
 		RouteList routeList;
 
-		for (auto smelter : smelters)
+		for (auto* smelter : smelters)
 		{
 			if (!smelter->operational()) { continue; }
 
@@ -132,7 +132,7 @@ void MapViewState::updateCommercial()
 	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
 	int commercialCount = luxuryCount;
 
-	for (auto warehouse : warehouses)
+	for (auto* warehouse : warehouses)
 	{
 		ProductPool& productPool = warehouse->products();
 
@@ -198,7 +198,7 @@ void MapViewState::updateMorale()
 
 	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
 	int bioWasteAccumulation = 0;
-	for (auto residence : residences)
+	for (auto* residence : residences)
 	{
 		if (residence->wasteOverflow() > 0) { ++bioWasteAccumulation; }
 	}
@@ -272,7 +272,7 @@ void MapViewState::findMineRoutes()
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();
 	mTruckRouteOverlay.clear();
 
-	for (auto mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
+	for (auto* mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
 		if (!mine->operational() && !mine->isIdle()) { continue; } // consider a different control path.
 
@@ -306,7 +306,7 @@ void MapViewState::findMineRoutes()
 void MapViewState::transportOreFromMines()
 {
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();
-	for (auto mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
+	for (auto* mine : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
 		auto routeIt = routeTable.find(mine);
 		if (routeIt != routeTable.end())
@@ -344,7 +344,7 @@ void MapViewState::transportOreFromMines()
 void MapViewState::transportResourcesToStorage()
 {
 	const auto& smelterList = NAS2D::Utility<StructureManager>::get().getStructures<OreRefining>();
-	for (auto smelter : smelterList)
+	for (auto* smelter : smelterList)
 	{
 		if (!smelter->operational() && !smelter->isIdle()) { continue; }
 
@@ -447,7 +447,7 @@ void MapViewState::updateResidentialCapacity()
 {
 	mResidentialCapacity = 0;
 	const auto& residences = NAS2D::Utility<StructureManager>::get().getStructures<Residence>();
-	for (auto residence : residences)
+	for (auto* residence : residences)
 	{
 		if (residence->operational()) { mResidentialCapacity += residence->capacity(); }
 	}
@@ -466,7 +466,7 @@ void MapViewState::updateBiowasteRecycling()
 	if (residences.empty() || recyclingFacilities.empty()) { return; }
 
 	auto residenceIterator = residences.begin();
-	for (auto recycling : recyclingFacilities)
+	for (auto* recycling : recyclingFacilities)
 	{
 		if (!recycling->operational()) { continue; } // Consider a different control structure
 
@@ -494,7 +494,7 @@ void MapViewState::updateFood()
 
 	foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
-	for (auto foodProdcer : foodProducers)
+	for (auto* foodProdcer : foodProducers)
 	{
 		if (foodProdcer->operational() || foodProdcer->isIdle())
 		{
@@ -510,7 +510,7 @@ void MapViewState::transferFoodToCommandCenter()
 	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 
 	auto foodProducerIterator = foodProducers.begin();
-	for (auto commandCenter : commandCenters)
+	for (auto* commandCenter : commandCenters)
 	{
 		if (!commandCenter->operational()) { continue; }
 
@@ -540,7 +540,7 @@ void MapViewState::updateRoads()
 {
 	const auto& roads = NAS2D::Utility<StructureManager>::get().getStructures<Road>();
 
-	for (auto road : roads)
+	for (auto* road : roads)
 	{
 		if (!road->operational()) { continue; }
 
@@ -572,7 +572,7 @@ void MapViewState::checkAgingStructures()
 {
 	const auto& structures = NAS2D::Utility<StructureManager>::get().agingStructures();
 
-	for (auto structure : structures)
+	for (auto* structure : structures)
 	{
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
 
@@ -600,7 +600,7 @@ void MapViewState::checkNewlyBuiltStructures()
 {
 	const auto& structures = NAS2D::Utility<StructureManager>::get().newlyBuiltStructures();
 
-	for (auto structure : structures)
+	for (auto* structure : structures)
 	{
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
 
@@ -625,7 +625,7 @@ void MapViewState::updateMaintenance()
 	std::sort(structures.begin(), structures.end(), sortLambda);
 
 	const auto& maintenanceFacilities = structureManager.getStructures<MaintenanceFacility>();
-	for (auto maintenanceFacility : maintenanceFacilities)
+	for (auto* maintenanceFacility : maintenanceFacilities)
 	{
 		maintenanceFacility->repairStructures(structures);
 	}
@@ -732,7 +732,7 @@ void MapViewState::nextTurn()
 	updateOverlays();
 
 	const auto& factories = NAS2D::Utility<StructureManager>::get().getStructures<Factory>();
-	for (auto factory : factories)
+	for (auto* factory : factories)
 	{
 		factory->updateProduction();
 	}

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -710,7 +710,7 @@ void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
 			const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 			foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
-			for (auto fp : foodProducers)
+			for (auto* fp : foodProducers)
 			{
 				fp->foodLevel(fp->foodCapacity());
 			}

--- a/OPHD/States/MapViewStateUi.cpp
+++ b/OPHD/States/MapViewStateUi.cpp
@@ -710,9 +710,9 @@ void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
 			const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 			foodProducers.insert(foodProducers.begin(), command.begin(), command.end());
 
-			for (auto* fp : foodProducers)
+			for (auto* foodProducer : foodProducers)
 			{
-				fp->foodLevel(fp->foodCapacity());
+				foodProducer->foodLevel(foodProducer->foodCapacity());
 			}
 		}
 		break;

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -41,7 +41,7 @@ PlanetSelectState::~PlanetSelectState()
 	eventHandler.mouseButtonDown().disconnect({this, &PlanetSelectState::onMouseDown});
 	eventHandler.windowResized().disconnect({this, &PlanetSelectState::onWindowResized});
 
-	for (auto planet : mPlanets) { delete planet; }
+	for (auto* planet : mPlanets) { delete planet; }
 
 	NAS2D::Utility<NAS2D::Mixer>::get().stopAllAudio();
 }

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -385,7 +385,7 @@ void StructureManager::updateEnergyConsumed()
 
 	for (auto& classListPair : mStructureLists)
 	{
-		for (auto* structure : classListPair.second)
+		for (const auto* structure : classListPair.second)
 		{
 			if (structure->operational())
 			{

--- a/OPHD/StructureManager.cpp
+++ b/OPHD/StructureManager.cpp
@@ -364,7 +364,7 @@ void StructureManager::updateEnergyProduction()
 	mTotalEnergyOutput = 0;
 	mTotalEnergyUsed = 0;
 
-	for (auto structure : mStructureLists[Structure::StructureClass::EnergyProduction])
+	for (auto* structure : mStructureLists[Structure::StructureClass::EnergyProduction])
 	{
 		auto powerStructure = static_cast<PowerStructure*>(structure);
 		if (powerStructure->operational())
@@ -385,7 +385,7 @@ void StructureManager::updateEnergyConsumed()
 
 	for (auto& classListPair : mStructureLists)
 	{
-		for (auto structure : classListPair.second)
+		for (auto* structure : classListPair.second)
 		{
 			if (structure->operational())
 			{
@@ -399,7 +399,7 @@ void StructureManager::updateEnergyConsumed()
 void StructureManager::assignColonistsToResidences(PopulationPool& population)
 {
 	int populationCount = population.size();
-	for (auto structure : mStructureLists[Structure::StructureClass::Residence])
+	for (auto* structure : mStructureLists[Structure::StructureClass::Residence])
 	{
 		Residence* residence = static_cast<Residence*>(structure);
 		if (residence->operational())
@@ -414,7 +414,7 @@ void StructureManager::assignColonistsToResidences(PopulationPool& population)
 void StructureManager::assignScientistsToResearchFacilities(PopulationPool& population)
 {
 	int availableScientists = population.availableScientists();
-	for (auto laboratory : mStructureLists[Structure::StructureClass::Laboratory])
+	for (auto* laboratory : mStructureLists[Structure::StructureClass::Laboratory])
 	{
 		ResearchFacility* lab = static_cast<ResearchFacility*>(laboratory);
 		lab->assignScientsts(0);

--- a/OPHD/StructureManager.h
+++ b/OPHD/StructureManager.h
@@ -93,7 +93,7 @@ public:
 
 		std::vector<StructureType*> output;
 		// Filter for instances of the exact type parameter
-		for (auto structure : sameClassStructures)
+		for (auto* structure : sameClassStructures)
 		{
 			StructureType* derivedStructure = dynamic_cast<StructureType*>(structure);
 			if (derivedStructure)

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -67,7 +67,7 @@ void MiniMap::draw() const
 		renderer.drawBoxFilled(NAS2D::Rectangle{ccOffsetPosition - NAS2D::Vector{1, 1}, {3, 3}}, NAS2D::Color::White);
 	}
 
-	for (auto* commTower : structureManager.getStructures<CommTower>())
+	for (const auto* commTower : structureManager.getStructures<CommTower>())
 	{
 		if (commTower->operational())
 		{

--- a/OPHD/UI/MiniMap.cpp
+++ b/OPHD/UI/MiniMap.cpp
@@ -67,7 +67,7 @@ void MiniMap::draw() const
 		renderer.drawBoxFilled(NAS2D::Rectangle{ccOffsetPosition - NAS2D::Vector{1, 1}, {3, 3}}, NAS2D::Color::White);
 	}
 
-	for (auto commTower : structureManager.getStructures<CommTower>())
+	for (auto* commTower : structureManager.getStructures<CommTower>())
 	{
 		if (commTower->operational())
 		{

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -160,7 +160,7 @@ void FactoryReport::fillLists()
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		lstFactoryList.addItem(factory);
 	}
@@ -175,7 +175,7 @@ void FactoryReport::fillFactoryList(ProductType type)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (factory->productType() == type)
 		{
@@ -194,7 +194,7 @@ void FactoryReport::fillFactoryList(bool surface)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (surface && (factory->name() == constants::SurfaceFactory || factory->name() == constants::SeedFactory))
 		{
@@ -217,7 +217,7 @@ void FactoryReport::fillFactoryList(StructureState state)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (factory->state() == state)
 		{

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -116,7 +116,7 @@ void MineReport::fillLists()
 {
 	lstMineFacilities.clear();
 	std::size_t id = 1;
-	for (auto facility : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
+	for (auto* facility : NAS2D::Utility<StructureManager>::get().getStructures<MineFacility>())
 	{
 		lstMineFacilities.addItem(facility);
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -89,7 +89,7 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 	int capacityAvailable = 0;
 
 	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
-	for (auto warehouse : warehouses)
+	for (auto* warehouse : warehouses)
 	{
 		if (warehouse->operational())
 		{
@@ -109,7 +109,7 @@ void WarehouseReport::fillListFromStructureList(const std::vector<Warehouse*>& w
 {
 	lstStructures.clear();
 
-	for (auto warehouse : warehouses)
+	for (auto* warehouse : warehouses)
 	{
 		lstStructures.addItem(warehouse);
 		StructureListBox::StructureListBoxItem* item = lstStructures.last();

--- a/OPHD/UI/ResourceInfoBar.cpp
+++ b/OPHD/UI/ResourceInfoBar.cpp
@@ -218,7 +218,7 @@ int ResourceInfoBar::totalStorage(Structure::StructureClass structureClass, int 
 	}
 
 	const auto& structures = NAS2D::Utility<StructureManager>::get().structureList(structureClass);
-	for (auto structure : structures)
+	for (auto* structure : structures)
 	{
 		if (structure->operational() || structure->isIdle())
 		{

--- a/OPHD/UI/ResourceInfoBar.cpp
+++ b/OPHD/UI/ResourceInfoBar.cpp
@@ -218,7 +218,7 @@ int ResourceInfoBar::totalStorage(Structure::StructureClass structureClass, int 
 	}
 
 	const auto& structures = NAS2D::Utility<StructureManager>::get().structureList(structureClass);
-	for (auto* structure : structures)
+	for (const auto* structure : structures)
 	{
 		if (structure->operational() || structure->isIdle())
 		{


### PR DESCRIPTION
Mark `Structure` iterator variables explicitly as pointers (using `auto*` instead of `auto`), and apply `const` where possible.

Part of:
- Issue #1446
