### PR TITLE
Fix CircleCI environment block formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
     macos:
       xcode: "13.4.1"
     environment:
-      - HOMEBREW_NO_AUTO_UPDATE: 1
-      - WARN_EXTRA: "-isystem /opt/homebrew/include"
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      WARN_EXTRA: "-isystem /opt/homebrew/include"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/


### PR DESCRIPTION
As pointed out by Visual Studio Code, the syntax used was incorrect. An object is expected, rather than an array. Hence, no `- ` prefix.

----

Reference:
- https://github.com/lairworks/nas2d-core/pull/1156
- https://github.com/lairworks/nas2d-core/issues/1155