### PR TITLE
Update MacOS image to `15.4.0` (Xcode 15.4, macOS 14.3.1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "13.4.1"
+      xcode: "15.4.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       WARN_EXTRA: "-isystem /opt/homebrew/include"

--- a/makefile
+++ b/makefile
@@ -78,7 +78,7 @@ libOPHD_OBJS := $(patsubst $(libOPHD_SRCDIR)%.cpp,$(libOPHD_OBJDIR)%.o,$(libOPHD
 .PHONY: libOphd
 libOphd: $(libOPHD_OUTPUT)
 
-$(libOPHD_OUTPUT): $(libOPHD_OBJS) $(NAS2DLIB)
+$(libOPHD_OUTPUT): $(libOPHD_OBJS)
 $(libOPHD_OBJS): $(libOPHD_OBJDIR)%.o : $(libOPHD_SRCDIR)%.cpp $(libOPHD_OBJDIR)%.d
 
 include $(wildcard $(patsubst %.o,%.d,$(libOPHD_OBJS)))
@@ -96,7 +96,7 @@ libControls_OBJS := $(patsubst $(libControls_SRCDIR)%.cpp,$(libControls_OBJDIR)%
 .PHONY: libControls
 libControls: $(libControls_OUTPUT)
 
-$(libControls_OUTPUT): $(libControls_OBJS) $(NAS2DLIB)
+$(libControls_OUTPUT): $(libControls_OBJS)
 $(libControls_OBJS): $(libControls_OBJDIR)%.o : $(libControls_SRCDIR)%.cpp $(libControls_OBJDIR)%.d
 
 include $(wildcard $(patsubst %.o,%.d,$(libControls_OBJS)))


### PR DESCRIPTION
Current supported versions list at:
https://circleci.com/docs/using-macos/#supported-xcode-versions

----

Reference:
- https://github.com/lairworks/nas2d-core/issues/1155
- https://github.com/lairworks/nas2d-core/pull/1157
- https://github.com/lairworks/nas2d-core/pull/1161

List of currently supported versions:
- https://circleci.com/docs/using-macos/#supported-xcode-versions
