### PR TITLE
Update Linux build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - build
   build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc:1.4
+      - image: outpostuniverse/nas2d-gcc:1.5
     environment:
       WARN_EXTRA: -Wsuggest-override
     steps:
@@ -36,7 +36,7 @@ jobs:
       - build
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.3
+      - image: outpostuniverse/nas2d-clang:1.4
     environment:
       WARN_EXTRA: -Wunknown-pragmas -Wimplicit-int-conversion -Wunreachable-code -Wunreachable-code-return -Wunreachable-code-break -Wcovered-switch-default -Wshadow-field -Wextra-semi -Wextra-semi-stmt -Wnewline-eof -Wdocumentation -Wdocumentation-unknown-command -Wheader-hygiene -Winconsistent-missing-destructor-override -Wdeprecated-copy-dtor -Wformat-nonliteral
     steps:
@@ -45,7 +45,7 @@ jobs:
       - build
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.8
+      - image: outpostuniverse/nas2d-mingw:1.10
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/


### PR DESCRIPTION
This brings the builds up-to-date with the images NAS2D is using.

Reference:
- https://github.com/lairworks/nas2d-core/issues/1155
- https://github.com/lairworks/nas2d-core/pull/1070
- https://github.com/lairworks/nas2d-core/pull/1148
