### PR TITLE
Added difficulty-dependent "grace period" for crime and morale

### DIFF
--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -214,6 +214,7 @@ private:
 	void updateCommercial();
 	void updateMaintenance();
 	void updateMorale();
+	void notifyBirthsAndDeaths();
 	void updateResidentialCapacity();
 	void updateBiowasteRecycling();
 	void updateResources();
@@ -299,12 +300,25 @@ private:
 	TechnologyCatalog mTechnologyReader;
 
 	Planet::Attributes mPlanetAttributes;
-	Difficulty mDifficulty = Difficulty::Medium;
 
 	int mFood{0};
 
+	// DIFFICULTY
+	Difficulty mDifficulty = Difficulty::Medium;
+
+	// Length of "honeymoon period" of no crime/morale updates after landing, in turns
+	std::map<Difficulty, int> gracePeriod
+	{
+		{Difficulty::Beginner, 30},
+		{Difficulty::Easy, 25},
+		{Difficulty::Medium, 20},
+		{Difficulty::Hard, 15}
+	};
+
 	// MISCELLANEOUS
 	int mTurnCount = 0;
+
+	int mTurnNumberOfLanding = std::numeric_limits<int>::max(); /**< First turn that human colonists landed. If never landed, default is int max (representing the future). */
 
 	int mCurrentMorale;
 	int mPreviousMorale;

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -11,6 +11,8 @@
 #include "../StorableResources.h"
 #include "../RobotPool.h"
 
+#include "../Constants/Numbers.h"
+
 #include "../Map/MapCoordinate.h"
 
 #include "../MapObjects/Robot.h"
@@ -318,7 +320,7 @@ private:
 	// MISCELLANEOUS
 	int mTurnCount = 0;
 
-	int mTurnNumberOfLanding = std::numeric_limits<int>::max(); /**< First turn that human colonists landed. If never landed, default is int max (representing the future). */
+	int mTurnNumberOfLanding = constants::ColonyShipOrbitTime; /**< First turn that human colonists landed. */
 
 	int mCurrentMorale;
 	int mPreviousMorale;

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -89,6 +89,7 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
  */
 void MapViewState::onDeployColonistLander()
 {
+	mTurnNumberOfLanding = mTurnCount;
 	mPopulation.addPopulation({0, 10, 20, 20, 0});
 }
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -89,7 +89,9 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
  */
 void MapViewState::onDeployColonistLander()
 {
-	mTurnNumberOfLanding = mTurnCount;
+	if (mTurnNumberOfLanding > mTurnCount) {
+		mTurnNumberOfLanding = mTurnCount;
+	}
 	mPopulation.addPopulation({0, 10, 20, 20, 0});
 }
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -171,6 +171,7 @@ void MapViewState::save(const std::string& filePath)
 			{"prev_morale", mPreviousMorale},
 			{"colonist_landers", mLandersColonist},
 			{"cargo_landers", mLandersCargo},
+			{"turn_number_of_landing", mTurnNumberOfLanding},
 			{"children", population.child},
 			{"students", population.student},
 			{"workers", population.worker},
@@ -565,6 +566,8 @@ void MapViewState::readPopulation(NAS2D::Xml::XmlElement* element)
 
 		mCurrentMorale = dictionary.get<int>("morale");
 		mPreviousMorale = dictionary.get<int>("prev_morale");
+
+		mTurnNumberOfLanding = dictionary.get<int>("turn_number_of_landing");
 
 		const auto meanCrimeRate = dictionary.get<int>("mean_crime", 0);
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -567,7 +567,7 @@ void MapViewState::readPopulation(NAS2D::Xml::XmlElement* element)
 		mCurrentMorale = dictionary.get<int>("morale");
 		mPreviousMorale = dictionary.get<int>("prev_morale");
 
-		mTurnNumberOfLanding = dictionary.get<int>("turn_number_of_landing");
+		mTurnNumberOfLanding = dictionary.get<int>("turn_number_of_landing", constants::ColonyShipOrbitTime);
 
 		const auto meanCrimeRate = dictionary.get<int>("mean_crime", 0);
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -716,10 +716,10 @@ void MapViewState::nextTurn()
 
 	updateResidentialCapacity();
 
-	int turnsSinceLanding = mTurnCount - mTurnNumberOfLanding; // If negative, landing has not yet occurred.
+	// Colony will not have morale or crime effects until at least n turns from landing, depending on difficulty
+	bool isMoraleEnabled = mTurnCount > mTurnNumberOfLanding + gracePeriod[mDifficulty];
 
-	// Colony will not have a crime rate until at least n turns from landing, depending on difficulty
-	if (turnsSinceLanding > gracePeriod[mDifficulty])
+	if (isMoraleEnabled)
 	{
 		mCrimeRateUpdate.update(mPoliceOverlays);
 		auto structuresCommittingCrimes = mCrimeRateUpdate.structuresCommittingCrimes();
@@ -733,8 +733,7 @@ void MapViewState::nextTurn()
 	updateCommercial();
 	updateBiowasteRecycling();
 
-	// Morale will not change until at least n turns from landing, depending on difficulty
-	if (turnsSinceLanding > gracePeriod[mDifficulty])
+	if (isMoraleEnabled)
 	{
 		updateMorale();
 	}
@@ -763,12 +762,6 @@ void MapViewState::nextTurn()
 	checkWarehouseCapacity();
 
 	mMineOperationsWindow.updateTruckAvailability();
-
-	// If this is the first turn with population, then set mTurnNumberOfLanding
-	if (mPopulation.getPopulations().size() > 0 && mTurnCount < mTurnNumberOfLanding)
-	{
-		mTurnNumberOfLanding = mTurnCount;
-	}
 
 	// Check for Game Over conditions
 	if (mPopulation.getPopulations().size() <= 0 && mLandersColonist == 0)


### PR DESCRIPTION
Skips morale and crime calculation until a difficulty-level-dependent "grace period" of 15-30 turns after human colonists have landed.

Fixes #1229, #1230, #1231