### PR TITLE
Import updates from NAS2D for `make show-warnings`

### DIFF
--- a/makefile
+++ b/makefile
@@ -278,7 +278,9 @@ install-dependencies:
 
 .PHONY: show-warnings
 show-warnings:
-	$(MAKE) -j1 clean all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	@$(MAKE) clean > /dev/null
+	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	@$(MAKE) clean > /dev/null
 
 .PHONY: lint
 lint: cppcheck cppclean cppinclude


### PR DESCRIPTION
Based on:
- https://github.com/lairworks/nas2d-core/pull/1170

Relates to:
- Issue #307
