### PR TITLE
Use `vcpkg` GitHub Actions Cache support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
       BUILD_CONFIGURATION: Release
       SOLUTION_FILE_PATH: .
-      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
     - uses: actions/checkout@v4
@@ -26,20 +26,12 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3.2
 
-    - name: Setup NuGet credentials
-      shell: bash
-      run: |
-        $(vcpkg fetch nuget | tail -n1) \
-        sources add \
-        -source "https://nuget.pkg.github.com/OutpostUniverse/index.json" \
-        -storepasswordincleartext \
-        -name "GitHub" \
-        -username "OutpostUniverse" \
-        -password "${{ secrets.GITHUB_TOKEN }}"
-
-        $(vcpkg fetch nuget | tail -n1) \
-        setApiKey "${{ secrets.GITHUB_TOKEN }}" \
-        -source "https://nuget.pkg.github.com/OutpostUniverse/index.json"
+    - name: Export GitHub Actions cache environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       id: cache
       with:
         path: vcpkg_installed
-        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Build
       # Add additional options to the MSBuild command line here (like platform or verbosity level).


### PR DESCRIPTION
Use `vcpkg` GitHub Actions Cache support to replace the Nuget option for binary package caching.

Rename the overall package collection cache key for better clarity.

Related:
- Issue #1418
- https://github.com/lairworks/nas2d-core/pull/1177
