### PR TITLE
Fix/police overlay on load from main menu

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -204,6 +204,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mRobots{"ui/robots.png", 46, constants::MarginTight},
 	mConnections{"ui/structures.png", 46, constants::MarginTight},
 	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
+	mPoliceOverlays(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth())),
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, planetAttributes.mapImagePath)},
@@ -270,7 +271,6 @@ void MapViewState::initialize()
 	mResourceInfoBar.ignoreGlow(mTurnCount == 0);
 
 	setupUiPositions(renderer.size());
-	resetPoliceOverlays();
 
 	mMainReportsState.injectTechnology(mTechnologyReader, mResearchTracker);
 

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -218,6 +218,11 @@ void MapViewState::load(const std::string& filePath)
 {
 	resetUi();
 
+	mBtnToggleConnectedness.toggle(false);
+	mBtnToggleCommRangeOverlay.toggle(false);
+	mBtnToggleRouteOverlay.toggle(false);
+	mBtnTogglePoliceOverlay.toggle(false);
+
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.drawBoxFilled(NAS2D::Rectangle{{0, 0}, renderer.size()}, NAS2D::Color{0, 0, 0, 100});
 	const auto imageLoading = &imageCache.load("sys/loading.png");


### PR DESCRIPTION
When loading a game from the main menu toggling the police overlay will not display a police overlay even if there is a working police station. As an additional minor detail the toggle state of the overlay buttons carries over between loads which will not reflect the current display of the overlays in the map. 