### PR TITLE
Refactor `Planet` code to use ranged-for

### DIFF
--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -60,17 +60,17 @@ void PlanetSelectState::initialize()
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto viewportSize = renderer.size().to<int>();
-	const auto centralPlanetPosition = NAS2D::Point{-64, -64} + viewportSize / 2;
 	const auto sidePlanetOffset = NAS2D::Vector{viewportSize.x / 4, 0};
-	mPlanets[0]->position(centralPlanetPosition - sidePlanetOffset);
+	const auto startPlanetPosition = NAS2D::Point{-64, -64} + viewportSize / 2 - sidePlanetOffset;
+	mPlanets[0]->position(startPlanetPosition);
 	mPlanets[0]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
 	mPlanets[0]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 
-	mPlanets[1]->position(centralPlanetPosition);
+	mPlanets[1]->position(startPlanetPosition + sidePlanetOffset);
 	mPlanets[1]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
 	mPlanets[1]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 
-	mPlanets[2]->position(centralPlanetPosition + sidePlanetOffset);
+	mPlanets[2]->position(startPlanetPosition + sidePlanetOffset * 2);
 	mPlanets[2]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
 	mPlanets[2]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -93,10 +93,6 @@ NAS2D::State* PlanetSelectState::update()
 	for (auto* planet : mPlanets)
 	{
 		planet->update();
-	}
-
-	for (auto* planet : mPlanets)
-	{
 		renderer.drawText(mFontBold, planet->attributes().name, planet->position() + NAS2D::Vector{64 - (mFontBold.width(planet->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
 	}
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -56,10 +56,7 @@ void PlanetSelectState::initialize()
 	for (const auto& planetAttribute : PlanetAttributes)
 	{
 		mPlanets.push_back(new Planet(planetAttribute));
-	}
-
-	for (auto* planet : mPlanets)
-	{
+		auto* planet = mPlanets.back();
 		planet->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
 		planet->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
 	}

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -104,9 +104,10 @@ NAS2D::State* PlanetSelectState::update()
 		planet->update();
 	}
 
-	renderer.drawText(mFontBold, mPlanets[0]->attributes().name, mPlanets[0]->position() + NAS2D::Vector{64 - (mFontBold.width(mPlanets[0]->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
-	renderer.drawText(mFontBold, mPlanets[1]->attributes().name, mPlanets[1]->position() + NAS2D::Vector{64 - (mFontBold.width(mPlanets[1]->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
-	renderer.drawText(mFontBold, mPlanets[2]->attributes().name, mPlanets[2]->position() + NAS2D::Vector{64 - (mFontBold.width(mPlanets[2]->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
+	for (auto* planet : mPlanets)
+	{
+		renderer.drawText(mFontBold, planet->attributes().name, planet->position() + NAS2D::Vector{64 - (mFontBold.width(planet->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
+	}
 
 	mQuit.update();
 

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -58,18 +58,15 @@ void PlanetSelectState::initialize()
 		mPlanets.push_back(new Planet(planetAttribute));
 	}
 
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto viewportSize = renderer.size().to<int>();
-	const auto sidePlanetOffset = NAS2D::Vector{viewportSize.x / 4, 0};
-	auto planetPosition = NAS2D::Point{-64, -64} + viewportSize / 2 - sidePlanetOffset;
-
 	for (auto* planet : mPlanets)
 	{
-		planet->position(planetPosition);
 		planet->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
 		planet->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
-		planetPosition += sidePlanetOffset;
 	}
+
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	const auto viewportSize = renderer.size().to<int>();
+	onWindowResized(viewportSize);
 
 	mQuit.size({100, 20});
 	mQuit.position({renderer.size().x - 105, 30});

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -175,11 +175,11 @@ void PlanetSelectState::onMousePlanetExit()
 
 void PlanetSelectState::onWindowResized(NAS2D::Vector<int> newSize)
 {
-	const auto middlePosition = NAS2D::Point{0, 0} + (newSize - NAS2D::Vector{128, 128}) / 2;
 	const auto offset = NAS2D::Vector{newSize.x / 4, 0};
-	mPlanets[0]->position(middlePosition - offset);
-	mPlanets[1]->position(middlePosition);
-	mPlanets[2]->position(middlePosition + offset);
+	const auto planetPosition = NAS2D::Point{0, 0} + (newSize - NAS2D::Vector{128, 128}) / 2 - offset;
+	mPlanets[0]->position(planetPosition);
+	mPlanets[1]->position(planetPosition + offset);
+	mPlanets[2]->position(planetPosition + offset * 2);
 
 	mQuit.position(NAS2D::Point{newSize.x - 105, 30});
 	mPlanetDescription.position(NAS2D::Point{(newSize.x / 2) - 275, newSize.y - 225});

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -61,18 +61,15 @@ void PlanetSelectState::initialize()
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto viewportSize = renderer.size().to<int>();
 	const auto sidePlanetOffset = NAS2D::Vector{viewportSize.x / 4, 0};
-	const auto startPlanetPosition = NAS2D::Point{-64, -64} + viewportSize / 2 - sidePlanetOffset;
-	mPlanets[0]->position(startPlanetPosition);
-	mPlanets[0]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
-	mPlanets[0]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
+	auto planetPosition = NAS2D::Point{-64, -64} + viewportSize / 2 - sidePlanetOffset;
 
-	mPlanets[1]->position(startPlanetPosition + sidePlanetOffset);
-	mPlanets[1]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
-	mPlanets[1]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
-
-	mPlanets[2]->position(startPlanetPosition + sidePlanetOffset * 2);
-	mPlanets[2]->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
-	mPlanets[2]->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
+	for (auto* planet : mPlanets)
+	{
+		planet->position(planetPosition);
+		planet->mouseEnter().connect({this, &PlanetSelectState::onMousePlanetEnter});
+		planet->mouseExit().connect({this, &PlanetSelectState::onMousePlanetExit});
+		planetPosition += sidePlanetOffset;
+	}
 
 	mQuit.size({100, 20});
 	mQuit.position({renderer.size().x - 105, 30});

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -159,11 +159,11 @@ void PlanetSelectState::onMousePlanetEnter()
 {
 	NAS2D::Utility<NAS2D::Mixer>::get().playSound(mHover);
 
-	for (std::size_t i = 0; i < mPlanets.size(); ++i)
+	for (auto* planet : mPlanets)
 	{
-		if (mPlanets[i]->mouseHovering())
+		if (planet->mouseHovering())
 		{
-			mPlanetDescription.text(mPlanets[i]->attributes().description);
+			mPlanetDescription.text(planet->attributes().description);
 			break;
 		}
 	}

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -176,10 +176,12 @@ void PlanetSelectState::onMousePlanetExit()
 void PlanetSelectState::onWindowResized(NAS2D::Vector<int> newSize)
 {
 	const auto offset = NAS2D::Vector{newSize.x / 4, 0};
-	const auto planetPosition = NAS2D::Point{0, 0} + (newSize - NAS2D::Vector{128, 128}) / 2 - offset;
-	mPlanets[0]->position(planetPosition);
-	mPlanets[1]->position(planetPosition + offset);
-	mPlanets[2]->position(planetPosition + offset * 2);
+	auto planetPosition = NAS2D::Point{0, 0} + (newSize - NAS2D::Vector{128, 128}) / 2 - offset;
+	for (auto* planet : mPlanets)
+	{
+		planet->position(planetPosition);
+		planetPosition += offset;
+	}
 
 	mQuit.position(NAS2D::Point{newSize.x - 105, 30});
 	mPlanetDescription.position(NAS2D::Point{(newSize.x / 2) - 275, newSize.y - 225});

--- a/OPHD/States/PlanetSelectState.cpp
+++ b/OPHD/States/PlanetSelectState.cpp
@@ -104,9 +104,9 @@ NAS2D::State* PlanetSelectState::update()
 		planet->update();
 	}
 
-	renderer.drawText(mFontBold, PlanetAttributes[0].name, mPlanets[0]->position() + NAS2D::Vector{64 - (mFontBold.width(PlanetAttributes[0].name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
-	renderer.drawText(mFontBold, PlanetAttributes[1].name, mPlanets[1]->position() + NAS2D::Vector{64 - (mFontBold.width(PlanetAttributes[1].name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
-	renderer.drawText(mFontBold, PlanetAttributes[2].name, mPlanets[2]->position() + NAS2D::Vector{64 - (mFontBold.width(PlanetAttributes[2].name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
+	renderer.drawText(mFontBold, mPlanets[0]->attributes().name, mPlanets[0]->position() + NAS2D::Vector{64 - (mFontBold.width(mPlanets[0]->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
+	renderer.drawText(mFontBold, mPlanets[1]->attributes().name, mPlanets[1]->position() + NAS2D::Vector{64 - (mFontBold.width(mPlanets[1]->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
+	renderer.drawText(mFontBold, mPlanets[2]->attributes().name, mPlanets[2]->position() + NAS2D::Vector{64 - (mFontBold.width(mPlanets[2]->attributes().name) / 2), -mFontBold.height() - 10}, NAS2D::Color::White);
 
 	mQuit.update();
 


### PR DESCRIPTION
This was noticed while looking into:
- #480

This refactoring reduces the number of references to `mPlanets`, which should hopefully make it easier to modify this field to stop using `new` and `delete`.
