### PR TITLE
Removed MapViewState::resetPoliceOverlays()

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -204,7 +204,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mRobots{"ui/robots.png", 46, constants::MarginTight},
 	mConnections{"ui/structures.png", 46, constants::MarginTight},
 	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
-	mPoliceOverlays(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth())),
+	mPoliceOverlays(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()+1)),
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, planetAttributes.mapImagePath)},

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1401,18 +1401,14 @@ void MapViewState::updateCommRangeOverlay()
 
 void MapViewState::updatePoliceOverlay()
 {
-	resetPoliceOverlays();
+	for (auto& policeOverlayLevel : mPoliceOverlays)
+	{
+		policeOverlayLevel.clear();
+	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	fillOverlay(*mTileMap, mPoliceOverlays[0], structureManager.getStructures<SurfacePolice>());
 	fillOverlay(*mTileMap, mPoliceOverlays, structureManager.getStructures<UndergroundPolice>());
-}
-
-
-void MapViewState::resetPoliceOverlays()
-{
-	const auto adjustedZ = mTileMap->maxDepth() + 1;
-	mPoliceOverlays = std::vector<std::vector<Tile*>>(static_cast<std::size_t>(adjustedZ));
 }
 
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -194,7 +194,6 @@ private:
 
 	void updateCommRangeOverlay();
 	void updatePoliceOverlay();
-	void resetPoliceOverlays();
 	void updateConnectedness();
 	void changeViewDepth(int);
 	void moveView(MapOffset offset);

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -333,7 +333,7 @@ void MapViewState::load(const std::string& filePath)
 	}
 
 	updateCommRangeOverlay();
-	mPoliceOverlays.resize(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()));
+	mPoliceOverlays.resize(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()+1));
 	updatePoliceOverlay();
 
 	mMapChangedSignal();

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -333,6 +333,7 @@ void MapViewState::load(const std::string& filePath)
 	}
 
 	updateCommRangeOverlay();
+	mPoliceOverlays.resize(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()));
 	updatePoliceOverlay();
 
 	mMapChangedSignal();


### PR DESCRIPTION
MapViewState::resetPoliceOverlays() is only used in MapViewState::updatePoliceOverlay. 