### PR TITLE
GitHub Actions - Build NAS2D separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,12 @@ jobs:
         vcpkg integrate install
         msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /target:NAS2D
 
+    - name: Save build cache - NAS2D
+      uses: actions/cache/save@v4
+      with:
+        path: nas2d-core/.build/
+        key: nas2dCache-${{ runner.os }}-${{ matrix.platform }}-${{ env.nas2dSha }}
+
     - name: Build OPHD
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
@@ -113,7 +119,7 @@ jobs:
         vcpkg integrate install
         msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
-    - name: Save incremental build cache
+    - name: Save incremental build cache - OPHD
       uses: actions/cache/save@v4
       with:
         path: .build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
         path: vcpkg_installed
         key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
+    - name: Copy vcpkg cache to NAS2D folder
+      run: |
+        xcopy vcpkg_installed nas2d-core /s /e
+
     - name: Set NAS2D modification time
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,14 @@ jobs:
           mkdir --parents .build/
           echo "${{ github.sha }}" > .build/lastBuildSha.txt
 
-    - name: Build
+    - name: Build NAS2D
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: |
+        vcpkg integrate install
+        msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /target:NAS2D
+
+    - name: Build OPHD
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |


### PR DESCRIPTION
There were frequently rebuild problems since build caching was implemented so Windows builds could be done incrementally. The error was:
> error LNK4020: a type record in '_path/filename.pdb_' is corrupted; some symbols and types may not be accessible from the debugger

Clearing the NAS2D cache wasn't sufficient to resolve the issues, despite them listing NAS2D related PDB files. On a hunch, I tried building NAS2D completely before attempting to build OPHD, in case there is some kind of variance in build output that might be interacting badly with parallel builds. I'm afraid I don't have great reason for this. Nevertheless, the build passed with this change.

I also wanted to separate the two build steps anyway, since I wanted to see timing for the two steps separately.

I suspect splitting the steps may result in increased build time due to `vcpkg` initialization time being doubled up. That may be something to watch and address going forward.

----

Part of:
- Issue #1418

Related work:
- PR #1470
- PR #1471
