### PR TITLE
Improve and fix `vcpkg` caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,19 @@ jobs:
         path: nas2d-core/.build/
         key: nas2dCache-${{ runner.os }}-${{ matrix.platform }}-${{ env.nas2dSha }}
 
+    - name: Build NAS2D
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: |
+        vcpkg integrate install
+        msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /target:NAS2D
+
+    - name: Save build cache - NAS2D
+      uses: actions/cache/save@v4
+      with:
+        path: nas2d-core/.build/
+        key: nas2dCache-${{ runner.os }}-${{ matrix.platform }}-${{ env.nas2dSha }}
+
     - name: Restore incremental build cache
       uses: actions/cache/restore@v4
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
@@ -111,19 +124,6 @@ jobs:
           # Save copy of current SHA to be cached, and used for reference in future builds
           mkdir --parents .build/
           echo "${{ github.sha }}" > .build/lastBuildSha.txt
-
-    - name: Build NAS2D
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: |
-        vcpkg integrate install
-        msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /target:NAS2D
-
-    - name: Save build cache - NAS2D
-      uses: actions/cache/save@v4
-      with:
-        path: nas2d-core/.build/
-        key: nas2dCache-${{ runner.os }}-${{ matrix.platform }}-${{ env.nas2dSha }}
 
     - name: Build OPHD
       # Add additional options to the MSBuild command line here (like platform or verbosity level).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Copy vcpkg cache to NAS2D folder
       run: |
-        xcopy vcpkg_installed nas2d-core /s /e
+        xcopy vcpkg_installed nas2d-core\vcpkg_installed\ /s /e
 
     - name: Set NAS2D modification time
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,7 @@ jobs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache@v4
-      id: cache
+      uses: actions/cache/restore@v4
       with:
         path: vcpkg_installed
         key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
@@ -43,6 +42,12 @@ jobs:
     - name: Pre-install vcpkg dependencies
       run: |
         vcpkg install
+
+    - name: Save vcpkg dependency cache
+      uses: actions/cache/save@v4
+      with:
+        path: vcpkg_installed
+        key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Copy vcpkg cache to NAS2D folder
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         find nas2d-core/ -type f -exec touch -d "${commitTime}" '{}' +
 
     - name: Restore NAS2D cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: nas2d-core/.build/
         key: nas2dCache-${{ runner.os }}-${{ matrix.platform }}-${{ env.nas2dSha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         path: vcpkg_installed
         key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
-    - name: Pre-install vcpkg dependencies
+    - name: Pre-install vcpkg dependencies - OPHD
       run: |
         vcpkg install
 
@@ -52,6 +52,10 @@ jobs:
     - name: Copy vcpkg cache to NAS2D folder
       run: |
         xcopy vcpkg_installed nas2d-core\vcpkg_installed\ /s /e
+
+    - name: Pre-install vcpkg dependencies - NAS2D
+      run: |
+        vcpkg install --x-manifest-root=nas2d-core
 
     - name: Set NAS2D modification time
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
         path: vcpkg_installed
         key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
+    - name: Pre-install vcpkg dependencies
+      run: |
+        vcpkg install
+
     - name: Copy vcpkg cache to NAS2D folder
       run: |
         xcopy vcpkg_installed nas2d-core\vcpkg_installed\ /s /e


### PR DESCRIPTION
Split `vcpkg install` of dependencies into it's own step. This separates the timing for the `vcpkg` step from the build step.

Fix copying of `vcpkg_installed` folders from OPHD to NAS2D.

Turns out there isn't a serious doubling of time for `vcpkg` initialization when it's split out like this. Rather, there was a doubling of timing because there were two separate `vcpkg_installed` folders, one for OPHD and one for NAS2D. By copying from one to the other we can reduce initialization time.

There is still a bit of a slowdown when building NAS2D, even when no changes need to be compiled. I'm currently uncertain of the source of this.

----

Work for:
- Issue #1418

Contains a fix for:
- PR #1492
