### PR TITLE
Set `VcpkgManifestInstall` to `false`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       BUILD_CONFIGURATION: Release
       SOLUTION_FILE_PATH: .
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      VcpkgManifestInstall: false
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potentially this might speed up the build step if `vcpkg` has already installed all needed packages. It could also cause the build step to fail if we did not run `vcpkg install` ahead of time to install needed packages.

Since we do run `vcpkg install` ahead of time for CI builds, it makes sense to also use `VcpkgManifestInstall` there.

Documentation:
https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/msbuild-integration

----

Part of:
- Issue #1418
Related to:
- PR #1493
- PR #1492
