### PR TITLE
Refactor and bug fix for `CrimeExecution`

### DIFF
--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -9,6 +9,28 @@
 #include <NAS2D/Utility.h>
 
 
+namespace
+{
+	const static inline std::map<Difficulty, double> stealingMultipliers
+	{
+		{Difficulty::Beginner, 0.5f},
+		{Difficulty::Easy, 0.75f},
+		{Difficulty::Medium, 1.0f},
+		{Difficulty::Hard, 1.5f}
+	};
+
+	const static inline std::vector<std::string> stealingResoureReasons
+	{
+		"There are no identified suspects",
+		"An investigation has been opened",
+		"A local crime syndicate is under investigation",
+		"A suspect was aprehended but the goods remain unaccounted for",
+		"A separatist political movement has claimed responsibility",
+		"The rebel faction is suspected in preparation for a splinter colony"
+	};
+}
+
+
 CrimeExecution::CrimeExecution(NotificationArea& notificationArea) : mNotificationArea(notificationArea) {}
 
 

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -56,11 +56,6 @@ void CrimeExecution::executeCrimes(const std::vector<Structure*>& structuresComm
 
 	for (auto& structure : structuresCommittingCrime)
 	{
-		if (structure == nullptr)
-		{
-			continue;
-		}
-
 		switch (structure->structureId())
 		{
 		case StructureID::SID_AGRIDOME:

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -11,12 +11,13 @@
 
 namespace
 {
-	const static inline std::map<Difficulty, double> stealingMultipliers
+	const static inline int stealingScale = 4;
+	const static inline std::map<Difficulty, int> stealingMultipliers
 	{
-		{Difficulty::Beginner, 0.5f},
-		{Difficulty::Easy, 0.75f},
-		{Difficulty::Medium, 1.0f},
-		{Difficulty::Hard, 1.5f}
+		{Difficulty::Beginner, 2},
+		{Difficulty::Easy, 3},
+		{Difficulty::Medium, 4},
+		{Difficulty::Hard, 6}
 	};
 
 	const static inline std::vector<std::string> stealingResoureReasons
@@ -39,7 +40,7 @@ namespace
 	int calcAmountForStealing(Difficulty difficulty, int low, int high, int max)
 	{
 		auto stealRandom = randomNumber.generate(low, high);
-		auto stealModified = static_cast<int>(stealingMultipliers.at(difficulty) * stealRandom);
+		auto stealModified = stealRandom * stealingMultipliers.at(difficulty) / stealingScale;
 		auto stealClipped = std::min(stealModified, max);
 		return stealClipped;
 	}

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -11,7 +11,7 @@
 
 namespace
 {
-	const int stealingScale = 4;
+	constexpr int stealingScale = 4;
 	const std::map<Difficulty, int> stealingMultipliers
 	{
 		{Difficulty::Beginner, 2},

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -28,6 +28,12 @@ namespace
 		"A separatist political movement has claimed responsibility",
 		"The rebel faction is suspected in preparation for a splinter colony"
 	};
+
+
+	std::string getReasonForStealing()
+	{
+		return stealingResoureReasons[randomNumber.generate<std::size_t>(0, stealingResoureReasons.size() - 1)];
+	}
 }
 
 
@@ -149,10 +155,4 @@ int CrimeExecution::calcAmountForStealing(int unadjustedMin, int unadjustedMax)
 	auto amountToSteal = randomNumber.generate(unadjustedMin, unadjustedMax);
 
 	return static_cast<int>(stealingMultipliers.at(mDifficulty) * amountToSteal);
-}
-
-
-std::string CrimeExecution::getReasonForStealing()
-{
-	return stealingResoureReasons[randomNumber.generate<std::size_t>(0, stealingResoureReasons.size() - 1)];
 }

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -47,7 +47,10 @@ namespace
 }
 
 
-CrimeExecution::CrimeExecution(NotificationArea& notificationArea) : mNotificationArea(notificationArea) {}
+CrimeExecution::CrimeExecution(NotificationArea& notificationArea) :
+	mNotificationArea{notificationArea}
+{
+}
 
 
 void CrimeExecution::executeCrimes(const std::vector<Structure*>& structuresCommittingCrime)

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -11,8 +11,8 @@
 
 namespace
 {
-	const static inline int stealingScale = 4;
-	const static inline std::map<Difficulty, int> stealingMultipliers
+	const int stealingScale = 4;
+	const std::map<Difficulty, int> stealingMultipliers
 	{
 		{Difficulty::Beginner, 2},
 		{Difficulty::Easy, 3},
@@ -20,7 +20,7 @@ namespace
 		{Difficulty::Hard, 6}
 	};
 
-	const static inline std::vector<std::string> stealingResoureReasons
+	const std::vector<std::string> stealingResoureReasons
 	{
 		"There are no identified suspects",
 		"An investigation has been opened",

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -86,7 +86,7 @@ void CrimeExecution::stealFood(FoodProduction& structure)
 	if (structure.foodLevel() > 0)
 	{
 		int foodStolen = calcAmountForStealing(mDifficulty, 5, 15, structure.foodLevel());
-		structure.foodLevel(-foodStolen);
+		structure.foodLevel(structure.foodLevel() - foodStolen);
 
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
 

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -34,6 +34,14 @@ namespace
 	{
 		return stealingResoureReasons[randomNumber.generate<std::size_t>(0, stealingResoureReasons.size() - 1)];
 	}
+
+
+	int calcAmountForStealing(Difficulty difficulty, int unadjustedMin, int unadjustedMax)
+	{
+		auto amountToSteal = randomNumber.generate(unadjustedMin, unadjustedMax);
+
+		return static_cast<int>(stealingMultipliers.at(difficulty) * amountToSteal);
+	}
 }
 
 
@@ -76,7 +84,7 @@ void CrimeExecution::stealFood(FoodProduction& structure)
 {
 	if (structure.foodLevel() > 0)
 	{
-		int foodStolen = calcAmountForStealing(5, 15);
+		int foodStolen = calcAmountForStealing(mDifficulty, 5, 15);
 		if (foodStolen > structure.foodLevel())
 		{
 			foodStolen = structure.foodLevel();
@@ -118,7 +126,7 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 
 	auto indexToStealFrom = randomNumber.generate<std::size_t>(0, resourceIndicesWithStock.size() - 1);
 
-	int amountStolen = calcAmountForStealing(2, 5);
+	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5);
 	if (amountStolen > structure.storage().resources[indexToStealFrom])
 	{
 		amountStolen = structure.storage().resources[indexToStealFrom];
@@ -147,12 +155,4 @@ void CrimeExecution::vandalize(Structure& structure)
 		"A " + structure.name() + " was vandalized.",
 		structureTile.xyz(),
 		NotificationArea::NotificationType::Warning});
-}
-
-
-int CrimeExecution::calcAmountForStealing(int unadjustedMin, int unadjustedMax)
-{
-	auto amountToSteal = randomNumber.generate(unadjustedMin, unadjustedMax);
-
-	return static_cast<int>(stealingMultipliers.at(mDifficulty) * amountToSteal);
 }

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -36,11 +36,12 @@ namespace
 	}
 
 
-	int calcAmountForStealing(Difficulty difficulty, int unadjustedMin, int unadjustedMax)
+	int calcAmountForStealing(Difficulty difficulty, int low, int high, int max)
 	{
-		auto amountToSteal = randomNumber.generate(unadjustedMin, unadjustedMax);
-
-		return static_cast<int>(stealingMultipliers.at(difficulty) * amountToSteal);
+		auto stealRandom = randomNumber.generate(low, high);
+		auto stealModified = static_cast<int>(stealingMultipliers.at(difficulty) * stealRandom);
+		auto stealClipped = std::min(stealModified, max);
+		return stealClipped;
 	}
 }
 
@@ -84,12 +85,7 @@ void CrimeExecution::stealFood(FoodProduction& structure)
 {
 	if (structure.foodLevel() > 0)
 	{
-		int foodStolen = calcAmountForStealing(mDifficulty, 5, 15);
-		if (foodStolen > structure.foodLevel())
-		{
-			foodStolen = structure.foodLevel();
-		}
-
+		int foodStolen = calcAmountForStealing(mDifficulty, 5, 15, structure.foodLevel());
 		structure.foodLevel(-foodStolen);
 
 		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
@@ -126,12 +122,7 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 
 	auto indexToStealFrom = randomNumber.generate<std::size_t>(0, resourceIndicesWithStock.size() - 1);
 
-	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5);
-	if (amountStolen > structure.storage().resources[indexToStealFrom])
-	{
-		amountStolen = structure.storage().resources[indexToStealFrom];
-	}
-
+	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5, structure.storage().resources[indexToStealFrom]);
 	structure.storage().resources[indexToStealFrom] -= amountStolen;
 
 	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -36,5 +36,4 @@ private:
 
 	void stealResources(Structure& structure, const std::array<std::string, 4>& resourceNames);
 	int calcAmountForStealing(int unadjustedMin, int unadjustedMax);
-	std::string getReasonForStealing();
 };

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -35,5 +35,4 @@ private:
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
 
 	void stealResources(Structure& structure, const std::array<std::string, 4>& resourceNames);
-	int calcAmountForStealing(int unadjustedMin, int unadjustedMax);
 };

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -30,24 +30,6 @@ public:
 	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
 
 private:
-	const static inline std::map<Difficulty, double> stealingMultipliers
-	{
-		{Difficulty::Beginner, 0.5f},
-		{Difficulty::Easy, 0.75f},
-		{Difficulty::Medium, 1.0f},
-		{Difficulty::Hard, 1.5f}
-	};
-
-	const static inline std::vector<std::string> stealingResoureReasons
-	{
-		"There are no identified suspects",
-		"An investigation has been opened",
-		"A local crime syndicate is under investigation",
-		"A suspect was aprehended but the goods remain unaccounted for",
-		"A separatist political movement has claimed responsibility",
-		"The rebel faction is suspected in preparation for a splinter colony"
-	};
-
 	Difficulty mDifficulty{Difficulty::Medium};
 	NotificationArea& mNotificationArea;
 	std::vector<std::pair<std::string, int>> mMoraleChanges;


### PR DESCRIPTION
Contains a bug fix in `stealFood`, where `foodLevel` was set to the negative of the stolen amount, rather than had the stolen amount subtracted.

----

Pre-work to support:
- Issue #1491
