### PR TITLE
Refactor crime `Difficulty` setting

### DIFF
--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -47,7 +47,7 @@ namespace
 }
 
 
-CrimeExecution::CrimeExecution(NotificationArea& notificationArea, Difficulty difficulty) :
+CrimeExecution::CrimeExecution(NotificationArea& notificationArea, const Difficulty& difficulty) :
 	mDifficulty{difficulty},
 	mNotificationArea{notificationArea}
 {

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -47,7 +47,8 @@ namespace
 }
 
 
-CrimeExecution::CrimeExecution(NotificationArea& notificationArea) :
+CrimeExecution::CrimeExecution(NotificationArea& notificationArea, Difficulty difficulty) :
+	mDifficulty{difficulty},
 	mNotificationArea{notificationArea}
 {
 }

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -16,7 +16,7 @@ class NotificationArea;
 class CrimeExecution
 {
 public:
-	CrimeExecution(NotificationArea& notificationArea);
+	CrimeExecution(NotificationArea& notificationArea, Difficulty difficulty = Difficulty::Medium);
 
 	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
 
@@ -30,7 +30,7 @@ public:
 	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
 
 private:
-	Difficulty mDifficulty{Difficulty::Medium};
+	Difficulty mDifficulty;
 	NotificationArea& mNotificationArea;
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
 

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -16,7 +16,7 @@ class NotificationArea;
 class CrimeExecution
 {
 public:
-	CrimeExecution(NotificationArea& notificationArea, Difficulty difficulty = Difficulty::Medium);
+	CrimeExecution(NotificationArea& notificationArea, Difficulty difficulty);
 
 	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
 

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -16,7 +16,7 @@ class NotificationArea;
 class CrimeExecution
 {
 public:
-	CrimeExecution(NotificationArea& notificationArea, Difficulty difficulty);
+	CrimeExecution(NotificationArea& notificationArea, const Difficulty& difficulty);
 
 	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
 

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -18,8 +18,6 @@ class CrimeExecution
 public:
 	CrimeExecution(NotificationArea& notificationArea, const Difficulty& difficulty);
 
-	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
-
 	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
 
 	void stealFood(FoodProduction& structure);
@@ -30,7 +28,7 @@ public:
 	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
 
 private:
-	Difficulty mDifficulty;
+	const Difficulty& mDifficulty;
 	NotificationArea& mNotificationArea;
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
 

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -9,7 +9,7 @@
 #include <NAS2D/Utility.h>
 
 
-CrimeRateUpdate::CrimeRateUpdate(Difficulty difficulty) :
+CrimeRateUpdate::CrimeRateUpdate(const Difficulty& difficulty) :
 	mDifficulty{difficulty}
 {
 }

--- a/OPHD/States/CrimeRateUpdate.cpp
+++ b/OPHD/States/CrimeRateUpdate.cpp
@@ -9,6 +9,12 @@
 #include <NAS2D/Utility.h>
 
 
+CrimeRateUpdate::CrimeRateUpdate(Difficulty difficulty) :
+	mDifficulty{difficulty}
+{
+}
+
+
 void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverlays)
 {
 	mMeanCrimeRate = 0;

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -15,7 +15,7 @@ class Tile;
 class CrimeRateUpdate
 {
 public:
-	CrimeRateUpdate(Difficulty difficulty = Difficulty::Medium);
+	CrimeRateUpdate(Difficulty difficulty);
 
 	void update(const std::vector<std::vector<Tile*>>& policeOverlays);
 

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -21,7 +21,6 @@ public:
 
 	int meanCrimeRate() const { return mMeanCrimeRate; }
 	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
-	void difficulty(Difficulty difficulty) { mDifficulty = difficulty; }
 	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
 private:
@@ -34,7 +33,7 @@ private:
 		{Difficulty::Hard, 2.0f}
 	};
 
-	Difficulty mDifficulty;
+	const Difficulty& mDifficulty;
 	int mMeanCrimeRate{0};
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
 	std::vector<Structure*> mStructuresCommittingCrimes;

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -15,7 +15,7 @@ class Tile;
 class CrimeRateUpdate
 {
 public:
-	CrimeRateUpdate(Difficulty difficulty);
+	CrimeRateUpdate(const Difficulty& difficulty);
 
 	void update(const std::vector<std::vector<Tile*>>& policeOverlays);
 

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -15,6 +15,8 @@ class Tile;
 class CrimeRateUpdate
 {
 public:
+	CrimeRateUpdate(Difficulty difficulty = Difficulty::Medium);
+
 	void update(const std::vector<std::vector<Tile*>>& policeOverlays);
 
 	int meanCrimeRate() const { return mMeanCrimeRate; }
@@ -32,7 +34,7 @@ private:
 		{Difficulty::Hard, 2.0f}
 	};
 
-	Difficulty mDifficulty{Difficulty::Medium};
+	Difficulty mDifficulty;
 	int mMeanCrimeRate{0};
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
 	std::vector<Structure*> mStructuresCommittingCrimes;

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -204,7 +204,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mRobots{"ui/robots.png", constants::RobotIconSize, constants::MarginTight},
 	mConnections{"ui/structures.png", constants::StructureIconSize, constants::MarginTight},
 	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
-	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()+1)},
+	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth() + 1)},
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, planetAttributes.mapImagePath)},

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -176,7 +176,8 @@ const std::map<Difficulty, int> MapViewState::ColonyShipDeorbitMoraleLossMultipl
 
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
-	mCrimeExecution{mNotificationArea},
+	mCrimeRateUpdate{mDifficulty},
+	mCrimeExecution{mNotificationArea, mDifficulty},
 	mTechnologyReader{"tech0-1.xml"},
 	mLoadingExisting{true},
 	mExistingToLoad{savegame},
@@ -194,8 +195,10 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) :
+	mDifficulty{selectedDifficulty},
 	mTileMap{std::make_unique<TileMap>(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, HostilityMineYields.at(planetAttributes.hostility))},
-	mCrimeExecution{mNotificationArea},
+	mCrimeRateUpdate{mDifficulty},
+	mCrimeExecution{mNotificationArea, mDifficulty},
 	mTechnologyReader{"tech0-1.xml"},
 	mPlanetAttributes{planetAttributes},
 	mMainReportsState{mainReportsState},
@@ -212,7 +215,6 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mNavControl{std::make_unique<NavControl>(*mMapView, *mTileMap)}
 {
 	setMeanSolarDistance(mPlanetAttributes.meanSolarDistance);
-	difficulty(selectedDifficulty);
 	ccLocation() = CcNotPlaced;
 	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
 }

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -321,8 +321,6 @@ void MapViewState::focusOnStructure(Structure* structure)
 void MapViewState::difficulty(Difficulty difficulty)
 {
 	mDifficulty = difficulty;
-	mCrimeRateUpdate.difficulty(difficulty);
-	mCrimeExecution.difficulty(difficulty);
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -176,11 +176,11 @@ const std::map<Difficulty, int> MapViewState::ColonyShipDeorbitMoraleLossMultipl
 
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
-	mCrimeExecution(mNotificationArea),
-	mTechnologyReader("tech0-1.xml"),
-	mLoadingExisting(true),
-	mExistingToLoad(savegame),
-	mMainReportsState(mainReportsState),
+	mCrimeExecution{mNotificationArea},
+	mTechnologyReader{"tech0-1.xml"},
+	mLoadingExisting{true},
+	mExistingToLoad{savegame},
+	mMainReportsState{mainReportsState},
 	mStructures{"ui/structures.png", constants::StructureIconSize, constants::MarginTight},
 	mRobots{"ui/robots.png", constants::RobotIconSize, constants::MarginTight},
 	mConnections{"ui/structures.png", constants::StructureIconSize, constants::MarginTight},
@@ -194,17 +194,17 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) :
-	mTileMap(std::make_unique<TileMap>(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, HostilityMineYields.at(planetAttributes.hostility))),
-	mCrimeExecution(mNotificationArea),
-	mTechnologyReader("tech0-1.xml"),
-	mPlanetAttributes(planetAttributes),
-	mMainReportsState(mainReportsState),
+	mTileMap{std::make_unique<TileMap>(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, HostilityMineYields.at(planetAttributes.hostility))},
+	mCrimeExecution{mNotificationArea},
+	mTechnologyReader{"tech0-1.xml"},
+	mPlanetAttributes{planetAttributes},
+	mMainReportsState{mainReportsState},
 	mMapView{std::make_unique<MapView>(*mTileMap)},
 	mStructures{"ui/structures.png", constants::StructureIconSize, constants::MarginTight},
 	mRobots{"ui/robots.png", constants::RobotIconSize, constants::MarginTight},
 	mConnections{"ui/structures.png", constants::StructureIconSize, constants::MarginTight},
 	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
-	mPoliceOverlays(static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()+1)),
+	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth()+1)},
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, planetAttributes.mapImagePath)},

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -292,6 +292,7 @@ private:
 	void onTakeMeThere(const MapCoordinate& position);
 
 private:
+	Difficulty mDifficulty = Difficulty::Medium;
 	std::unique_ptr<TileMap> mTileMap;
 	CrimeRateUpdate mCrimeRateUpdate;
 	CrimeExecution mCrimeExecution;
@@ -304,9 +305,6 @@ private:
 	Planet::Attributes mPlanetAttributes;
 
 	int mFood{0};
-
-	// DIFFICULTY
-	Difficulty mDifficulty = Difficulty::Medium;
 
 	// Length of "honeymoon period" of no crime/morale updates after landing, in turns
 	static const std::map<Difficulty, int> GracePeriod;


### PR DESCRIPTION
Set `Difficulty` in constructors of crime related classes. Store a `const&` to the original value, so we don't need to use setters to keep shadow copies up-to-date.

----

Work for:
- #1491

Related to:
- PR #1497
