### PR TITLE
Add `Signal` for `CrimeExecution` events

### DIFF
--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -53,6 +53,12 @@ CrimeExecution::CrimeExecution(const Difficulty& difficulty) :
 }
 
 
+CrimeExecution::CrimeExecution(const Difficulty& difficulty, Signal::DelegateType onCrimeEvent) : CrimeExecution{difficulty}
+{
+	mCrimeEventSignal.connect(onCrimeEvent);
+}
+
+
 void CrimeExecution::executeCrimes(const std::vector<Structure*>& structuresCommittingCrime)
 {
 	mMoraleChanges.clear();

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -47,9 +47,8 @@ namespace
 }
 
 
-CrimeExecution::CrimeExecution(NotificationArea& notificationArea, const Difficulty& difficulty) :
-	mDifficulty{difficulty},
-	mNotificationArea{notificationArea}
+CrimeExecution::CrimeExecution(const Difficulty& difficulty) :
+	mDifficulty{difficulty}
 {
 }
 
@@ -88,13 +87,11 @@ void CrimeExecution::stealFood(FoodProduction& structure)
 		int foodStolen = calcAmountForStealing(mDifficulty, 5, 15, structure.foodLevel());
 		structure.foodLevel(structure.foodLevel() - foodStolen);
 
-		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
-
-		mNotificationArea.push({
+		mCrimeEventSignal.emit(
 			"Food Stolen",
 			NAS2D::stringFrom(foodStolen) + " units of food was pilfered from a " + structure.name() + ". " + getReasonForStealing() + ".",
-			structureTile.xyz(),
-			NotificationArea::NotificationType::Warning});
+			structure
+		);
 	}
 }
 
@@ -125,13 +122,11 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5, structure.storage().resources[indexToStealFrom]);
 	structure.storage().resources[indexToStealFrom] -= amountStolen;
 
-	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
-
-	mNotificationArea.push({
+	mCrimeEventSignal.emit(
 		"Resources Stolen",
 		NAS2D::stringFrom(amountStolen) + " units of " + resourceNames[indexToStealFrom] + " were stolen from a " + structure.name() + ". " + getReasonForStealing() + ".",
-		structureTile.xyz(),
-		NotificationArea::NotificationType::Warning});
+		structure
+	);
 }
 
 
@@ -139,11 +134,9 @@ void CrimeExecution::vandalize(Structure& structure)
 {
 	mMoraleChanges.push_back(std::make_pair("Vandalism", -1));
 
-	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
-
-	mNotificationArea.push({
+	mCrimeEventSignal.emit(
 		"Vandalism",
 		"A " + structure.name() + " was vandalized.",
-		structureTile.xyz(),
-		NotificationArea::NotificationType::Warning});
+		structure
+	);
 }

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -20,12 +20,13 @@ public:
 
 	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
 
+	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
+
+protected:
 	void stealFood(FoodProduction& structure);
 	void stealRefinedResources(Structure& structure);
 	void stealRawResources(Structure& structure);
 	void vandalize(Structure& structure);
-
-	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
 
 private:
 	const Difficulty& mDifficulty;

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -21,6 +21,7 @@ public:
 	using Signal = NAS2D::Signal<std::string, std::string, const Structure&>;
 
 	CrimeExecution(const Difficulty& difficulty);
+	CrimeExecution(const Difficulty& difficulty, Signal::DelegateType onCrimeEvent);
 
 	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
 	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -3,6 +3,8 @@
 #include "../MapObjects/Structures/FoodProduction.h"
 #include "../Common.h"
 
+#include <NAS2D/Signal/Signal.h>
+
 #include <vector>
 #include <array>
 #include <map>
@@ -16,11 +18,13 @@ class NotificationArea;
 class CrimeExecution
 {
 public:
-	CrimeExecution(NotificationArea& notificationArea, const Difficulty& difficulty);
+	using Signal = NAS2D::Signal<std::string, std::string, const Structure&>;
+
+	CrimeExecution(const Difficulty& difficulty);
 
 	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
-
 	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
+	Signal::Source& crimeEventSignal() { return mCrimeEventSignal; }
 
 protected:
 	void stealFood(FoodProduction& structure);
@@ -31,6 +35,6 @@ protected:
 
 private:
 	const Difficulty& mDifficulty;
-	NotificationArea& mNotificationArea;
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
+	Signal mCrimeEventSignal;
 };

--- a/OPHD/States/CrimeExecution.h
+++ b/OPHD/States/CrimeExecution.h
@@ -26,12 +26,11 @@ protected:
 	void stealFood(FoodProduction& structure);
 	void stealRefinedResources(Structure& structure);
 	void stealRawResources(Structure& structure);
+	void stealResources(Structure& structure, const std::array<std::string, 4>& resourceNames);
 	void vandalize(Structure& structure);
 
 private:
 	const Difficulty& mDifficulty;
 	NotificationArea& mNotificationArea;
 	std::vector<std::pair<std::string, int>> mMoraleChanges;
-
-	void stealResources(Structure& structure, const std::array<std::string, 4>& resourceNames);
 };

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -177,7 +177,7 @@ const std::map<Difficulty, int> MapViewState::ColonyShipDeorbitMoraleLossMultipl
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
 	mCrimeRateUpdate{mDifficulty},
-	mCrimeExecution{mDifficulty},
+	mCrimeExecution{mDifficulty, {this, &MapViewState::onCrimeEvent}},
 	mTechnologyReader{"tech0-1.xml"},
 	mLoadingExisting{true},
 	mExistingToLoad{savegame},
@@ -191,7 +191,6 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 {
 	ccLocation() = CcNotPlaced;
 	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
-	mCrimeExecution.crimeEventSignal().connect({this, &MapViewState::onCrimeEvent});
 }
 
 
@@ -199,7 +198,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mDifficulty{selectedDifficulty},
 	mTileMap{std::make_unique<TileMap>(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, HostilityMineYields.at(planetAttributes.hostility))},
 	mCrimeRateUpdate{mDifficulty},
-	mCrimeExecution{mDifficulty},
+	mCrimeExecution{mDifficulty, {this, &MapViewState::onCrimeEvent}},
 	mTechnologyReader{"tech0-1.xml"},
 	mPlanetAttributes{planetAttributes},
 	mMainReportsState{mainReportsState},
@@ -218,7 +217,6 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	setMeanSolarDistance(mPlanetAttributes.meanSolarDistance);
 	ccLocation() = CcNotPlaced;
 	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
-	mCrimeExecution.crimeEventSignal().connect({this, &MapViewState::onCrimeEvent});
 }
 
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -177,7 +177,7 @@ const std::map<Difficulty, int> MapViewState::ColonyShipDeorbitMoraleLossMultipl
 
 MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::string& savegame) :
 	mCrimeRateUpdate{mDifficulty},
-	mCrimeExecution{mNotificationArea, mDifficulty},
+	mCrimeExecution{mDifficulty},
 	mTechnologyReader{"tech0-1.xml"},
 	mLoadingExisting{true},
 	mExistingToLoad{savegame},
@@ -191,6 +191,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const std::stri
 {
 	ccLocation() = CcNotPlaced;
 	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
+	mCrimeExecution.crimeEventSignal().connect({this, &MapViewState::onCrimeEvent});
 }
 
 
@@ -198,7 +199,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mDifficulty{selectedDifficulty},
 	mTileMap{std::make_unique<TileMap>(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxMines, HostilityMineYields.at(planetAttributes.hostility))},
 	mCrimeRateUpdate{mDifficulty},
-	mCrimeExecution{mNotificationArea, mDifficulty},
+	mCrimeExecution{mDifficulty},
 	mTechnologyReader{"tech0-1.xml"},
 	mPlanetAttributes{planetAttributes},
 	mMainReportsState{mainReportsState},
@@ -217,6 +218,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	setMeanSolarDistance(mPlanetAttributes.meanSolarDistance);
 	ccLocation() = CcNotPlaced;
 	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
+	mCrimeExecution.crimeEventSignal().connect({this, &MapViewState::onCrimeEvent});
 }
 
 

--- a/OPHD/States/MapViewState.h
+++ b/OPHD/States/MapViewState.h
@@ -205,6 +205,8 @@ private:
 
 	void onMineFacilityExtend(MineFacility* mf);
 
+	void onCrimeEvent(std::string title, std::string text, const Structure& structure);
+
 	void updatePlayerResources();
 	void updateResearch();
 

--- a/OPHD/States/MapViewStateEvent.cpp
+++ b/OPHD/States/MapViewStateEvent.cpp
@@ -251,3 +251,16 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 	mineDepthTile.index(TerrainType::Dozed);
 	mineDepthTile.excavated(true);
 }
+
+
+void MapViewState::onCrimeEvent(std::string title, std::string text, const Structure& structure)
+{
+	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
+
+	mNotificationArea.push({
+		std::move(title),
+		std::move(text),
+		structureTile.xyz(),
+		NotificationArea::NotificationType::Warning
+	});
+}


### PR DESCRIPTION
Add `Signal` for `CrimeExecution` events, and implement `onCrimeEvent` handler in `MapViewState.

This decouples the `CrimeExecution` class from knowing anything about the UI classes. This is part of ongoing efforts to split responsibilities for core game components from UI related components. It was also done to more immediately address a warning issued for an updated version of GCC.

----

Work for:
- Issue #1491

----

This PR was expected to resolve the warning in Issue #1491, using the long term solution suggested in the issue. However, it was discovered the warning is already no longer present as of commit 823aa6d7d8cab27a31aa88a66557440502cf6f9e in PR #1498, as mentioned in https://github.com/OutpostUniverse/OPHD/pull/1498#issuecomment-2585462713.
