### PR TITLE
Simplify `NavControl` by removing `TileMap` reference

### DIFF
--- a/OPHD/Map/MapView.cpp
+++ b/OPHD/Map/MapView.cpp
@@ -67,6 +67,12 @@ void MapView::currentDepth(int i)
 }
 
 
+int MapView::maxDepth() const
+{
+	return mTileMap.maxDepth();
+}
+
+
 int MapView::viewSize() const
 {
 	return mEdgeLength;

--- a/OPHD/Map/MapView.cpp
+++ b/OPHD/Map/MapView.cpp
@@ -63,7 +63,7 @@ void MapView::moveView(Direction direction)
 
 void MapView::currentDepth(int i)
 {
-	mOriginTilePosition.z = std::clamp(i, 0, mTileMap.maxDepth());
+	mOriginTilePosition.z = std::clamp(i, 0, maxDepth());
 }
 
 

--- a/OPHD/Map/MapView.h
+++ b/OPHD/Map/MapView.h
@@ -36,6 +36,8 @@ public:
 	int currentDepth() const { return mOriginTilePosition.z; }
 	void currentDepth(int i);
 
+	int maxDepth() const;
+
 	int viewSize() const;
 	void viewSize(int edgeSizeInTiles);
 

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -212,7 +212,7 @@ MapViewState::MapViewState(MainReportsUiState& mainReportsState, const Planet::A
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, planetAttributes.mapImagePath)},
 	mDetailMap{std::make_unique<DetailMap>(*mMapView, *mTileMap, planetAttributes.tilesetPath)},
-	mNavControl{std::make_unique<NavControl>(*mMapView, *mTileMap)}
+	mNavControl{std::make_unique<NavControl>(*mMapView)}
 {
 	setMeanSolarDistance(mPlanetAttributes.meanSolarDistance);
 	ccLocation() = CcNotPlaced;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -266,7 +266,7 @@ void MapViewState::load(const std::string& filePath)
 	mMapView->deserialize(root);
 	mMiniMap = std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, mPlanetAttributes.mapImagePath);
 	mDetailMap = std::make_unique<DetailMap>(*mMapView, *mTileMap, mPlanetAttributes.tilesetPath);
-	mNavControl = std::make_unique<NavControl>(*mMapView, *mTileMap);
+	mNavControl = std::make_unique<NavControl>(*mMapView);
 
 	mPathSolver = std::make_unique<micropather::MicroPather>(mTileMap.get(), 250, 6, false);
 	auto& routeTable = NAS2D::Utility<std::map<class MineFacility*, Route>>::get();

--- a/OPHD/UI/NavControl.cpp
+++ b/OPHD/UI/NavControl.cpp
@@ -105,7 +105,7 @@ void NavControl::draw() const
 	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
 	const auto stepSizeWidth = font.width("IX");
 	auto position = mRect.endPoint() - NAS2D::Vector{5, 30 - constants::Margin};
-	for (int i = mTileMap.maxDepth(); i >= 0; i--)
+	for (int i = mMapView.maxDepth(); i >= 0; i--)
 	{
 		const auto levelString = (i == 0) ? std::string{"S"} : std::to_string(i);
 		const auto textSize = font.size(levelString);

--- a/OPHD/UI/NavControl.cpp
+++ b/OPHD/UI/NavControl.cpp
@@ -4,7 +4,6 @@
 #include "../DirectionOffset.h"
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
-#include "../Map/TileMap.h"
 #include "../Map/MapView.h"
 
 #include <NAS2D/Utility.h>
@@ -29,9 +28,8 @@ namespace
 }
 
 
-NavControl::NavControl(MapView& mapView, TileMap& tileMap) :
+NavControl::NavControl(MapView& mapView) :
 	mMapView{mapView},
-	mTileMap{tileMap},
 	mUiIcons{imageCache.load("ui/icons.png")}
 {
 	onMove({0, 0});

--- a/OPHD/UI/NavControl.h
+++ b/OPHD/UI/NavControl.h
@@ -12,7 +12,6 @@ namespace NAS2D
 	class Image;
 }
 
-class TileMap;
 class MapView;
 class MapViewState;
 
@@ -20,7 +19,7 @@ class MapViewState;
 class NavControl : public Control
 {
 public:
-	NavControl(MapView& mapView, TileMap& tileMap);
+	NavControl(MapView& mapView);
 
 	void draw() const override;
 
@@ -32,7 +31,6 @@ protected:
 
 private:
 	MapView& mMapView;
-	TileMap& mTileMap;
 	const NAS2D::Image& mUiIcons;
 
 	NAS2D::Rectangle<int> mMoveNorthIconRect;


### PR DESCRIPTION
The info needed by `NavControl` can be provided by `MapView`, which has a `TileMap` reference. By exposing the information there, we can remove a direct reference to `TileMap` from `NavControl`.
