### PR TITLE
Reduce `Common.h` transitive includes

### DIFF
--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -24,6 +24,15 @@ namespace
 }
 
 
+const std::map<std::string, Difficulty> difficultyTable
+{
+	{"Beginner", Difficulty::Beginner},
+	{"Easy", Difficulty::Easy},
+	{"Medium", Difficulty::Medium},
+	{"Hard", Difficulty::Hard}
+};
+
+
 std::string difficultyString(Difficulty difficulty)
 {
 	for (const auto& difficultyPair : difficultyTable)

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -1,5 +1,6 @@
 #include "Common.h"
 #include "Constants/Numbers.h"
+#include "EnumDifficulty.h"
 #include "StructureManager.h"
 
 #include "MapObjects/Structure.h"

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -3,6 +3,7 @@
 #include "EnumDifficulty.h"
 #include "EnumDisabledReason.h"
 #include "EnumIdleReason.h"
+#include "EnumMineProductionRate.h"
 #include "StructureManager.h"
 
 #include "MapObjects/Structure.h"

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -5,6 +5,7 @@
 #include "EnumIdleReason.h"
 #include "EnumMineProductionRate.h"
 #include "EnumMoraleIndex.h"
+#include "EnumTerrainType.h"
 #include "StructureManager.h"
 
 #include "MapObjects/Structure.h"

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -2,6 +2,7 @@
 #include "Constants/Numbers.h"
 #include "EnumDifficulty.h"
 #include "EnumDisabledReason.h"
+#include "EnumIdleReason.h"
 #include "StructureManager.h"
 
 #include "MapObjects/Structure.h"

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -4,6 +4,7 @@
 #include "EnumDisabledReason.h"
 #include "EnumIdleReason.h"
 #include "EnumMineProductionRate.h"
+#include "EnumMoraleIndex.h"
 #include "StructureManager.h"
 
 #include "MapObjects/Structure.h"

--- a/OPHD/Common.cpp
+++ b/OPHD/Common.cpp
@@ -1,6 +1,7 @@
 #include "Common.h"
 #include "Constants/Numbers.h"
 #include "EnumDifficulty.h"
+#include "EnumDisabledReason.h"
 #include "StructureManager.h"
 
 #include "MapObjects/Structure.h"

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EnumConnectorDir.h"
-#include "EnumMineProductionRate.h"
 #include "EnumMoraleIndex.h"
 #include "EnumProductType.h"
 #include "EnumStructureID.h"

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -3,7 +3,6 @@
 #include "EnumConnectorDir.h"
 #include "EnumProductType.h"
 #include "EnumStructureID.h"
-#include "EnumTerrainType.h"
 
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Renderer/Color.h>

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -31,14 +31,8 @@ enum class MoraleIndexs;
 enum class StructureState;
 enum class TerrainType;
 
-inline const std::map<std::string, Difficulty> difficultyTable
-{
-	{"Beginner", Difficulty::Beginner},
-	{"Easy", Difficulty::Easy},
-	{"Medium", Difficulty::Medium},
-	{"Hard", Difficulty::Hard}
-};
 
+extern const std::map<std::string, Difficulty> difficultyTable;
 
 std::string difficultyString(Difficulty difficulty);
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EnumConnectorDir.h"
-#include "EnumMoraleIndex.h"
 #include "EnumProductType.h"
 #include "EnumStructureID.h"
 #include "EnumTerrainType.h"

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "EnumConnectorDir.h"
 #include "EnumProductType.h"
 #include "EnumStructureID.h"
 

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EnumConnectorDir.h"
-#include "EnumIdleReason.h"
 #include "EnumMineProductionRate.h"
 #include "EnumMoraleIndex.h"
 #include "EnumProductType.h"

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -23,8 +23,13 @@ namespace NAS2D::Xml
 	class XmlDocument;
 }
 
+enum class Difficulty;
+enum class DisabledReason;
+enum class IdleReason;
+enum class MineProductionRate;
+enum class MoraleIndexs;
 enum class StructureState;
-
+enum class TerrainType;
 
 inline const std::map<std::string, Difficulty> difficultyTable
 {

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EnumConnectorDir.h"
-#include "EnumDifficulty.h"
 #include "EnumDisabledReason.h"
 #include "EnumIdleReason.h"
 #include "EnumMineProductionRate.h"

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EnumConnectorDir.h"
-#include "EnumDisabledReason.h"
 #include "EnumIdleReason.h"
 #include "EnumMineProductionRate.h"
 #include "EnumMoraleIndex.h"

--- a/OPHD/Common.h
+++ b/OPHD/Common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EnumProductType.h"
-#include "EnumStructureID.h"
 
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Renderer/Color.h>

--- a/OPHD/Map/Tile.h
+++ b/OPHD/Map/Tile.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Common.h"
+#include "../EnumTerrainType.h"
 
 #include "MapCoordinate.h"
 

--- a/OPHD/MapObjects/Mine.h
+++ b/OPHD/MapObjects/Mine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Common.h"
+#include "../EnumMineProductionRate.h"
 #include "../StorableResources.h"
 
 #include <NAS2D/Math/Point.h>

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -4,6 +4,7 @@
 
 #include "../Common.h"
 #include "../EnumDisabledReason.h"
+#include "../EnumIdleReason.h"
 #include "../StorableResources.h"
 #include "../UI/StringTable.h"
 

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -3,6 +3,7 @@
 #include "MapObject.h"
 
 #include "../Common.h"
+#include "../EnumDisabledReason.h"
 #include "../StorableResources.h"
 #include "../UI/StringTable.h"
 

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -3,6 +3,7 @@
 #include "MapObject.h"
 
 #include "../Common.h"
+#include "../EnumConnectorDir.h"
 #include "../EnumDisabledReason.h"
 #include "../EnumIdleReason.h"
 #include "../StorableResources.h"

--- a/OPHD/MapObjects/Structure.h
+++ b/OPHD/MapObjects/Structure.h
@@ -6,6 +6,7 @@
 #include "../EnumConnectorDir.h"
 #include "../EnumDisabledReason.h"
 #include "../EnumIdleReason.h"
+#include "../EnumStructureID.h"
 #include "../StorableResources.h"
 #include "../UI/StringTable.h"
 

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -1,5 +1,6 @@
 #include "CrimeExecution.h"
 
+#include "../EnumDifficulty.h"
 #include "../StructureManager.h"
 #include "../UI/NotificationArea.h"
 

--- a/OPHD/States/CrimeRateUpdate.h
+++ b/OPHD/States/CrimeRateUpdate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Common.h"
+#include "../EnumDifficulty.h"
 
 #include <vector>
 #include <map>

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../Common.h"
+#include "../EnumConnectorDir.h"
 #include "../EnumDirection.h"
 
 #include "../Map/MapCoordinate.h"

--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -12,6 +12,7 @@
 #include "../Common.h"
 #include "../EnumConnectorDir.h"
 #include "../EnumDirection.h"
+#include "../EnumStructureID.h"
 
 #include "../Map/MapCoordinate.h"
 

--- a/OPHD/States/MapViewStateTurn.cpp
+++ b/OPHD/States/MapViewStateTurn.cpp
@@ -12,6 +12,7 @@
 #include "../Cache.h"
 #include "../Common.h"
 #include "../DirectionOffset.h"
+#include "../EnumMoraleIndex.h"
 #include "../StorableResources.h"
 #include "../StructureManager.h"
 

--- a/OPHD/States/StructureTracker.cpp
+++ b/OPHD/States/StructureTracker.cpp
@@ -1,5 +1,6 @@
 #include "StructureTracker.h"
 
+#include "../EnumStructureID.h"
 #include "../Constants/Strings.h"
 
 namespace

--- a/OPHD/StructureCatalogue.h
+++ b/OPHD/StructureCatalogue.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Common.h"
+#include "EnumStructureID.h"
 
 #include <map>
 

--- a/OPHD/UI/PopulationPanel.cpp
+++ b/OPHD/UI/PopulationPanel.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Common.h"
+#include "../EnumMoraleIndex.h"
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 

--- a/OPHD/UI/TileInspector.cpp
+++ b/OPHD/UI/TileInspector.cpp
@@ -1,6 +1,7 @@
 #include "TileInspector.h"
 
 #include "TextRender.h"
+#include "../Common.h"
 #include "../Constants/Strings.h"
 #include "../MapObjects/Mine.h"
 


### PR DESCRIPTION
Reduce transitive includes from `Common.h` for `enum` headers. Require code to include `enum` headers directly.

Work for:
- Issue #1506
