### PR TITLE
Move `OreRefining` function implementations to source file

### DIFF
--- a/OPHD/MapObjects/Structures/OreRefining.cpp
+++ b/OPHD/MapObjects/Structures/OreRefining.cpp
@@ -1,0 +1,135 @@
+#include "OreRefining.h"
+
+#include "../../Common.h"
+#include "../../Constants/Numbers.h"
+
+
+OreRefining::OreRefining(StructureClass structureClass, StructureID id) :
+	Structure(structureClass, id)
+{
+}
+
+
+StringTable OreRefining::createInspectorViewTable()
+{
+	StringTable stringTable(3, 5);
+
+	stringTable.setColumnFont(0, stringTable.GetDefaultFont());
+	stringTable.setRowFont(0, stringTable.GetDefaultTitleFont());
+	stringTable.setHorizontalPadding(20);
+	stringTable.setColumnJustification(1, StringTable::Justification::Center);
+	stringTable.setColumnJustification(2, StringTable::Justification::Center);
+
+	stringTable.setColumnText(
+		0,
+		{
+			"",
+			ResourceNamesRefined[0],
+			ResourceNamesRefined[1],
+			ResourceNamesRefined[2],
+			ResourceNamesRefined[3],
+		});
+
+	stringTable.setRowText(
+		0,
+		{
+			"Material",
+			"Storage",
+			"Ore Conversion Rate"
+		});
+
+	auto& resources = storage().resources;
+
+	stringTable[{1, 1}].text = writeStorageAmount(resources[0]);
+	stringTable[{2, 1}].text = std::to_string(OreConversionDivisor[0]) + " : 1";
+
+	stringTable[{1, 2}].text = writeStorageAmount(resources[1]);
+	stringTable[{2, 2}].text = std::to_string(OreConversionDivisor[1]) + " : 1";
+
+	stringTable[{1, 3}].text = writeStorageAmount(resources[2]);
+	stringTable[{2, 3}].text = std::to_string(OreConversionDivisor[2]) + " : 1";
+
+	stringTable[{1, 4}].text = writeStorageAmount(resources[3]);
+	stringTable[{2, 4}].text = std::to_string(OreConversionDivisor[3]) + " : 1";
+
+	return stringTable;
+}
+
+
+StorableResources OreRefining::storageCapacities() const
+{
+	return {
+		individualMaterialCapacity(),
+		individualMaterialCapacity(),
+		individualMaterialCapacity(),
+		individualMaterialCapacity(),
+	};
+}
+
+/**
+ * Capacity of an individual type of refined resource
+ */
+int OreRefining::individualMaterialCapacity() const
+{
+	return storageCapacity() / 4;
+}
+
+
+void OreRefining::think()
+{
+	if (isIdle() && storage() < storageCapacities())
+	{
+		enable();
+	}
+
+	if (operational())
+	{
+		updateProduction();
+	}
+}
+
+
+void OreRefining::updateProduction()
+{
+	StorableResources converted{0};
+	auto& ore = production();
+
+	for (size_t i = 0; i < ore.resources.size(); ++i)
+	{
+		if (ore.resources[i] >= constants::SmeltingMinimumResourcesCount)
+		{
+			converted.resources[i] = constants::SmeltingMinimumResourcesCount / OreConversionDivisor[i];
+			ore.resources[i] = ore.resources[i] - constants::SmeltingMinimumResourcesCount;
+		}
+	}
+
+	auto& stored = storage();
+	auto total = stored + converted;
+	auto capped = total.cap(individualMaterialCapacity());
+	auto overflow = total - capped;
+
+	stored = capped;
+
+	if (!overflow.isEmpty())
+	{
+		StorableResources deconvertedResources{
+			overflow.resources[0] * OreConversionDivisor[0],
+			overflow.resources[1] * OreConversionDivisor[1],
+			overflow.resources[2] * OreConversionDivisor[2],
+			overflow.resources[3] * OreConversionDivisor[3]
+		};
+
+		ore += deconvertedResources;
+
+		if (ore >= storageCapacities())
+		{
+			idle(IdleReason::InternalStorageFull);
+		}
+	}
+}
+
+
+std::string OreRefining::writeStorageAmount(int storageAmount) const
+{
+	return std::to_string(storageAmount) + " / " + std::to_string(individualMaterialCapacity());
+}

--- a/OPHD/MapObjects/Structures/OreRefining.h
+++ b/OPHD/MapObjects/Structures/OreRefining.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "../../Common.h"
 #include "../Structure.h"
-#include <string>
+
 #include <array>
+
 
 /**
  * Virtual class for structures whose primary purpose is ore processing
@@ -13,127 +13,24 @@
 class OreRefining : public Structure
 {
 public:
-	OreRefining(StructureClass structureClass, StructureID id) :
-		Structure(structureClass, id) {}
+	OreRefining(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(3, 5);
-
-		stringTable.setColumnFont(0, stringTable.GetDefaultFont());
-		stringTable.setRowFont(0, stringTable.GetDefaultTitleFont());
-		stringTable.setHorizontalPadding(20);
-		stringTable.setColumnJustification(1, StringTable::Justification::Center);
-		stringTable.setColumnJustification(2, StringTable::Justification::Center);
-
-		stringTable.setColumnText(
-			0,
-			{
-				"",
-				ResourceNamesRefined[0],
-				ResourceNamesRefined[1],
-				ResourceNamesRefined[2],
-				ResourceNamesRefined[3],
-			});
-
-		stringTable.setRowText(
-			0,
-			{
-				"Material",
-				"Storage",
-				"Ore Conversion Rate"
-			});
-
-		auto& resources = storage().resources;
-
-		stringTable[{1, 1}].text = writeStorageAmount(resources[0]);
-		stringTable[{2, 1}].text = std::to_string(OreConversionDivisor[0]) + " : 1";
-
-		stringTable[{1, 2}].text = writeStorageAmount(resources[1]);
-		stringTable[{2, 2}].text = std::to_string(OreConversionDivisor[1]) + " : 1";
-
-		stringTable[{1, 3}].text = writeStorageAmount(resources[2]);
-		stringTable[{2, 3}].text = std::to_string(OreConversionDivisor[2]) + " : 1";
-
-		stringTable[{1, 4}].text = writeStorageAmount(resources[3]);
-		stringTable[{2, 4}].text = std::to_string(OreConversionDivisor[3]) + " : 1";
-
-		return stringTable;
-	}
+	StringTable createInspectorViewTable() override;
 
 protected:
 	std::array<int, 4> OreConversionDivisor{2, 2, 3, 3};
 
-	StorableResources storageCapacities() const
-	{
-		return {
-			individualMaterialCapacity(),
-			individualMaterialCapacity(),
-			individualMaterialCapacity(),
-			individualMaterialCapacity(),
-		};
-	}
+	StorableResources storageCapacities() const;
 
 	/**
 	 * Capacity of an individual type of refined resource
 	 */
-	int individualMaterialCapacity() const { return storageCapacity() / 4; }
+	int individualMaterialCapacity() const;
 
-	void think() override
-	{
-		if (isIdle() && storage() < storageCapacities())
-		{
-			enable();
-		}
+	void think() override;
 
-		if (operational())
-		{
-			updateProduction();
-		}
-	}
-
-	virtual void updateProduction()
-	{
-		StorableResources converted{0};
-		auto& ore = production();
-
-		for (size_t i = 0; i < ore.resources.size(); ++i)
-		{
-			if (ore.resources[i] >= constants::SmeltingMinimumResourcesCount)
-			{
-				converted.resources[i] = constants::SmeltingMinimumResourcesCount / OreConversionDivisor[i];
-				ore.resources[i] = ore.resources[i] - constants::SmeltingMinimumResourcesCount;
-			}
-		}
-
-		auto& stored = storage();
-		auto total = stored + converted;
-		auto capped = total.cap(individualMaterialCapacity());
-		auto overflow = total - capped;
-
-		stored = capped;
-
-		if (!overflow.isEmpty())
-		{
-			StorableResources deconvertedResources{
-				overflow.resources[0] * OreConversionDivisor[0],
-				overflow.resources[1] * OreConversionDivisor[1],
-				overflow.resources[2] * OreConversionDivisor[2],
-				overflow.resources[3] * OreConversionDivisor[3]
-			};
-
-			ore += deconvertedResources;
-
-			if (ore >= storageCapacities())
-			{
-				idle(IdleReason::InternalStorageFull);
-			}
-		}
-	}
+	virtual void updateProduction();
 
 private:
-	std::string writeStorageAmount(int storageAmount) const
-	{
-		return std::to_string(storageAmount) + " / " + std::to_string(individualMaterialCapacity());
-	}
+	std::string writeStorageAmount(int storageAmount) const;
 };

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -201,6 +201,7 @@
     <ClCompile Include="MapObjects\Structure.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
+    <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
     <ClCompile Include="MicroPather\micropather.cpp" />
     <ClCompile Include="ProductCatalogue.cpp" />
     <ClCompile Include="ProductPool.cpp" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\OreRefining.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MicroPather\micropather.cpp">
       <Filter>Source Files\MicroPather</Filter>
     </ClCompile>


### PR DESCRIPTION
By moving function implementations, we can also move includes for anything strictly related to the implementation rather than the interface. That reduces transitive includes.

This may also reduce some Clang warnings about emitting virtual function tables in every translation unit [`-Wweak-vtables`].

----

Work for:
- Issue #1506
- Issue #307
