### PR TITLE
Lander Tile nullptr

### DIFF
--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -420,6 +420,16 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		auto& structure = *StructureCatalogue::get(structureId, &tile);
 
+		if (structureId == StructureID::SID_COLONIST_LANDER)
+		{
+			static_cast<ColonistLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployColonistLander});
+		}
+
+		if (structureId == StructureID::SID_CARGO_LANDER)
+		{
+			static_cast<CargoLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployCargoLander});
+		}
+
 		if (structureId == StructureID::SID_COMMAND_CENTER)
 		{
 			ccLocation() = mapCoordinate.xy;

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -418,7 +418,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			continue; // FIXME: ugly
 		}
 
-		auto& structure = *StructureCatalogue::get(structureId);
+		auto& structure = *StructureCatalogue::get(structureId, &tile);
 
 		if (structureId == StructureID::SID_COMMAND_CENTER)
 		{

--- a/OPHD/StructureCatalogue.cpp
+++ b/OPHD/StructureCatalogue.cpp
@@ -165,7 +165,7 @@ const StructureType& StructureCatalogue::getType(StructureID type)
  * \return	Pointer to a newly constructed Structure
  * \throw	std::runtime_error if the StructureID is unsupported/invalid
  */
-Structure* StructureCatalogue::get(StructureID type)
+Structure* StructureCatalogue::get(StructureID type, Tile* tile)
 {
 	Structure* structure = nullptr;
 
@@ -183,7 +183,7 @@ Structure* StructureCatalogue::get(StructureID type)
 			break;
 
 		case StructureID::SID_CARGO_LANDER: // only here for loading games
-			structure = new CargoLander(nullptr);
+			structure = new CargoLander(tile);
 			break;
 
 		case StructureID::SID_CHAP:
@@ -191,7 +191,7 @@ Structure* StructureCatalogue::get(StructureID type)
 			break;
 
 		case StructureID::SID_COLONIST_LANDER: // only here for loading games
-			structure = new ColonistLander(nullptr);
+			structure = new ColonistLander(tile);
 			break;
 
 		case StructureID::SID_COMMAND_CENTER:

--- a/OPHD/StructureCatalogue.h
+++ b/OPHD/StructureCatalogue.h
@@ -6,6 +6,7 @@
 
 
 class Structure;
+class Tile;
 struct StructureType;
 struct StorableResources;
 
@@ -28,7 +29,7 @@ public:
 
 	static const StructureType& getType(StructureID type);
 
-	static Structure* get(StructureID type);
+	static Structure* get(StructureID type, Tile* tile = nullptr);
 
 	static const StorableResources& costToBuild(StructureID type);
 	static const StorableResources& recyclingValue(StructureID type);


### PR DESCRIPTION
I checked this issue similarly applies to the colonist lander when in the state of being deployed on the next turn. Method `CargoLander::think` is called. 

```
void think() override
{
	if (age() == turnsToBuild())
	{
		mDeploy();
		mTile->index(TerrainType::Dozed); // mTile is nullptr here
	}
}
```
This happens because MapViewState::load object slices cargo and colonist lander before adding them to the StructureManager 
Fixes #1512 