### PR TITLE
Add explicit includes for `Common.h`

### DIFF
--- a/OPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/OPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -2,12 +2,12 @@
 
 #include "../Structure.h"
 
-#include <algorithm>
-
 #include "../../Constants/Strings.h"
 #include "../../StorableResources.h"
 
 #include "../../States/MapViewStateHelper.h" // yuck
+
+#include <algorithm>
 
 
 class MaintenanceFacility : public Structure

--- a/OPHD/MapObjects/Structures/RobotCommand.h
+++ b/OPHD/MapObjects/Structures/RobotCommand.h
@@ -4,8 +4,6 @@
 
 #include "../../Constants/Strings.h"
 
-#include <vector>
-
 
 /**
  * Implements the Robot Command structure.

--- a/OPHD/MapObjects/Structures/SolarPanelArray.h
+++ b/OPHD/MapObjects/Structures/SolarPanelArray.h
@@ -2,6 +2,7 @@
 
 #include "PowerStructure.h"
 
+#include "../../Common.h"
 #include "../../Constants/Strings.h"
 
 

--- a/OPHD/MapObjects/Structures/SolarPlant.h
+++ b/OPHD/MapObjects/Structures/SolarPlant.h
@@ -2,6 +2,7 @@
 
 #include "PowerStructure.h"
 
+#include "../../Common.h"
 #include "../../Constants/Strings.h"
 
 

--- a/OPHD/MapObjects/Structures/StorageTanks.h
+++ b/OPHD/MapObjects/Structures/StorageTanks.h
@@ -2,6 +2,7 @@
 
 #include "../Structure.h"
 
+#include "../../Common.h"
 #include "../../Constants/Strings.h"
 
 

--- a/OPHD/States/CrimeExecution.cpp
+++ b/OPHD/States/CrimeExecution.cpp
@@ -1,5 +1,6 @@
 #include "CrimeExecution.h"
 
+#include "../Common.h"
 #include "../EnumDifficulty.h"
 #include "../StructureManager.h"
 #include "../UI/NotificationArea.h"

--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -10,6 +10,7 @@
 
 #include "../DirectionOffset.h"
 #include "../Cache.h"
+#include "../Common.h"
 #include "../ProductCatalogue.h"
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"

--- a/OPHD/States/MapViewStateHelper.cpp
+++ b/OPHD/States/MapViewStateHelper.cpp
@@ -9,6 +9,7 @@
 
 #include "MapViewStateHelper.h"
 
+#include "../Common.h"
 #include "../Constants/Strings.h"
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"

--- a/OPHD/States/MapViewStateIO.cpp
+++ b/OPHD/States/MapViewStateIO.cpp
@@ -9,6 +9,7 @@
 #include "Route.h"
 
 #include "../Cache.h"
+#include "../Common.h"
 #include "../Constants/Strings.h"
 #include "../IOHelper.h"
 #include "../ProductCatalogue.h"

--- a/OPHD/UI/Reports/FactoryReport.cpp
+++ b/OPHD/UI/Reports/FactoryReport.cpp
@@ -2,6 +2,7 @@
 
 #include "../TextRender.h"
 #include "../../Cache.h"
+#include "../../Common.h"
 #include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 #include "../../StructureManager.h"

--- a/OPHD/UI/Reports/MineReport.cpp
+++ b/OPHD/UI/Reports/MineReport.cpp
@@ -7,6 +7,7 @@
 #include "../../Constants/UiConstants.h"
 
 #include "../../Cache.h"
+#include "../../Common.h"
 #include "../../StructureManager.h"
 #include "../../ProductionCost.h"
 

--- a/OPHD/UI/Reports/WarehouseReport.cpp
+++ b/OPHD/UI/Reports/WarehouseReport.cpp
@@ -1,6 +1,7 @@
 #include "WarehouseReport.h"
 
 #include "../../Cache.h"
+#include "../../Common.h"
 #include "../../StructureManager.h"
 #include "../../MapObjects/Structure.h"
 #include "../../MapObjects/Structures/Warehouse.h"


### PR DESCRIPTION
Before we can remove includes for `Common.h` from places were it isn't strictly needed, we must include it in places where it was needed but was forgotten.

We want to remove includes for `Common.h` from header files (where it would be transitively included). However some files that use functions and data from `Common.h` don't actually include it themselves, but rather rely on it's transitive inclusion from other included headers. By pushing these inclusions down towards less widely shared header files (or ideally non-shared source files), we can remove the inclusions from more widely shared header files.

A few of the `Structure` related header files have no associated source files. They would need to have implementations split in order to move the include from a header file to a source file. (`SolarPanelArray`, `SolarPlant`, `StorageTanks`)

----

Part of:
- Issue #1506
