### PR TITLE
Split `Structure` class implementations using `Common.h` to cpp

### DIFF
--- a/OPHD/MapObjects/Structures/SolarPanelArray.cpp
+++ b/OPHD/MapObjects/Structures/SolarPanelArray.cpp
@@ -1,0 +1,26 @@
+#include "SolarPanelArray.h"
+
+#include "../../Common.h"
+#include "../../Constants/Strings.h"
+
+
+namespace
+{
+	const int SOLAR_PANEL_BASE_PRODUCUCTION = 50;
+}
+
+
+SolarPanelArray::SolarPanelArray() :
+	PowerStructure
+	{
+		StructureClass::EnergyProduction,
+		StructureID::SID_SOLAR_PANEL1
+	}
+{
+}
+
+
+int SolarPanelArray::calculateMaxEnergyProduction()
+{
+	return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / getMeanSolarDistance());
+}

--- a/OPHD/MapObjects/Structures/SolarPanelArray.h
+++ b/OPHD/MapObjects/Structures/SolarPanelArray.h
@@ -2,28 +2,12 @@
 
 #include "PowerStructure.h"
 
-#include "../../Common.h"
-#include "../../Constants/Strings.h"
-
-
-const int SOLAR_PANEL_BASE_PRODUCUCTION = 50;
-
 
 class SolarPanelArray : public PowerStructure
 {
 public:
-	SolarPanelArray() :
-		PowerStructure
-		{
-			StructureClass::EnergyProduction,
-			StructureID::SID_SOLAR_PANEL1
-		}
-	{
-	}
+	SolarPanelArray();
 
 protected:
-	int calculateMaxEnergyProduction() override
-	{
-		return static_cast<int>(SOLAR_PANEL_BASE_PRODUCUCTION / getMeanSolarDistance());
-	}
+	int calculateMaxEnergyProduction() override;
 };

--- a/OPHD/MapObjects/Structures/SolarPlant.cpp
+++ b/OPHD/MapObjects/Structures/SolarPlant.cpp
@@ -1,0 +1,26 @@
+#include "SolarPlant.h"
+
+#include "../../Common.h"
+#include "../../Constants/Strings.h"
+
+
+namespace
+{
+	const int SOLAR_PLANT_BASE_PRODUCUCTION = 2000;
+}
+
+
+SolarPlant::SolarPlant() :
+	PowerStructure
+	{
+		StructureClass::EnergyProduction,
+		StructureID::SID_SOLAR_PLANT
+	}
+{
+}
+
+
+int SolarPlant::calculateMaxEnergyProduction()
+{
+	return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / getMeanSolarDistance());
+}

--- a/OPHD/MapObjects/Structures/SolarPlant.h
+++ b/OPHD/MapObjects/Structures/SolarPlant.h
@@ -2,28 +2,12 @@
 
 #include "PowerStructure.h"
 
-#include "../../Common.h"
-#include "../../Constants/Strings.h"
-
-
-const int SOLAR_PLANT_BASE_PRODUCUCTION = 2000;
-
 
 class SolarPlant : public PowerStructure
 {
 public:
-	SolarPlant() :
-		PowerStructure
-		{
-			StructureClass::EnergyProduction,
-			StructureID::SID_SOLAR_PLANT
-		}
-	{
-	}
+	SolarPlant();
 
 protected:
-	int calculateMaxEnergyProduction() override
-	{
-		return static_cast<int>(SOLAR_PLANT_BASE_PRODUCUCTION / getMeanSolarDistance());
-	}
+	int calculateMaxEnergyProduction() override;
 };

--- a/OPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/OPHD/MapObjects/Structures/StorageTanks.cpp
@@ -1,0 +1,39 @@
+#include "StorageTanks.h"
+
+
+#include "../../Common.h"
+#include "../../Constants/Strings.h"
+
+
+StorageTanks::StorageTanks() : Structure(
+	StructureClass::Storage,
+	StructureID::SID_STORAGE_TANKS)
+{
+}
+
+StringTable StorageTanks::createInspectorViewTable()
+{
+	StringTable stringTable(2, 5);
+
+	stringTable.setColumnText(
+		0,
+		{
+			"Storage Capacity",
+			ResourceNamesRefined[0],
+			ResourceNamesRefined[1],
+			ResourceNamesRefined[2],
+			ResourceNamesRefined[3],
+		});
+
+	stringTable.setColumnText(
+		1,
+		{
+			std::to_string(storage().total()) + " / " + std::to_string(storageCapacity()),
+			storage().resources[0],
+			storage().resources[1],
+			storage().resources[2],
+			storage().resources[3]
+		});
+
+	return stringTable;
+}

--- a/OPHD/MapObjects/Structures/StorageTanks.h
+++ b/OPHD/MapObjects/Structures/StorageTanks.h
@@ -6,9 +6,6 @@
 #include "../../Constants/Strings.h"
 
 
-const int StorageTanksCapacity = 1000;
-
-
 class StorageTanks : public Structure
 {
 public:

--- a/OPHD/MapObjects/Structures/StorageTanks.h
+++ b/OPHD/MapObjects/Structures/StorageTanks.h
@@ -2,43 +2,11 @@
 
 #include "../Structure.h"
 
-#include "../../Common.h"
-#include "../../Constants/Strings.h"
-
 
 class StorageTanks : public Structure
 {
 public:
-	StorageTanks() : Structure(
-		StructureClass::Storage,
-		StructureID::SID_STORAGE_TANKS)
-	{
-	}
+	StorageTanks();
 
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 5);
-
-		stringTable.setColumnText(
-			0,
-			{
-				"Storage Capacity",
-				ResourceNamesRefined[0],
-				ResourceNamesRefined[1],
-				ResourceNamesRefined[2],
-				ResourceNamesRefined[3],
-			});
-
-		stringTable.setColumnText(
-			1,
-			{
-				std::to_string(storage().total()) + " / " + std::to_string(storageCapacity()),
-				storage().resources[0],
-				storage().resources[1],
-				storage().resources[2],
-				storage().resources[3]
-			});
-
-		return stringTable;
-	}
+	StringTable createInspectorViewTable() override;
 };

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -204,6 +204,7 @@
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPlant.cpp" />
+    <ClCompile Include="MapObjects\Structures\StorageTanks.cpp" />
     <ClCompile Include="MicroPather\micropather.cpp" />
     <ClCompile Include="ProductCatalogue.cpp" />
     <ClCompile Include="ProductPool.cpp" />

--- a/OPHD/ophd.vcxproj
+++ b/OPHD/ophd.vcxproj
@@ -202,6 +202,8 @@
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
+    <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />
+    <ClCompile Include="MapObjects\Structures\SolarPlant.cpp" />
     <ClCompile Include="MicroPather\micropather.cpp" />
     <ClCompile Include="ProductCatalogue.cpp" />
     <ClCompile Include="ProductPool.cpp" />

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -135,6 +135,12 @@
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
+    <ClCompile Include="MapObjects\Structures\SolarPlant.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MicroPather\micropather.cpp">
       <Filter>Source Files\MicroPather</Filter>
     </ClCompile>

--- a/OPHD/ophd.vcxproj.filters
+++ b/OPHD/ophd.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClCompile Include="MapObjects\Structures\SolarPlant.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\StorageTanks.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MicroPather\micropather.cpp">
       <Filter>Source Files\MicroPather</Filter>
     </ClCompile>


### PR DESCRIPTION
Split header only implementations to `.cpp` files for:
- `SolarPanelArray`
- `SolarPlant`
- `StorageTanks`

This allows moving an include for `Common.h` from the header files to a `.cpp` file. This reduces transitive includes of `Common.h`.

This also reduces the number of Clang warnings `-Wweak-vtables`.

----

Part of:
- Issue #1506
- Issue #307

Related:
- PR #1518
