### PR TITLE
Remove include for `Common.h` in `MapViewStateHelper.h`

### DIFF
--- a/OPHD/States/MapViewStateHelper.h
+++ b/OPHD/States/MapViewStateHelper.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "../Common.h"
 #include "../EnumConnectorDir.h"
 #include "../EnumDirection.h"
+#include "../EnumProductType.h"
 #include "../EnumStructureID.h"
 
 #include "../Map/MapCoordinate.h"

--- a/OPHD/UI/RobotDeploymentSummary.cpp
+++ b/OPHD/UI/RobotDeploymentSummary.cpp
@@ -8,6 +8,8 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+#include <array>
+
 
 extern const NAS2D::Font* MAIN_FONT; /// yuck
 


### PR DESCRIPTION
Remove the last include of `Common.h` from a header file.

----

Without the include for `array`, MSVC produced the error:
> error C2641: cannot deduce template arguments for 'std::array'

Similarly, without the include for `array`, older version of Clang produced the error:
> error: no viable constructor or deduction guide for deduction of template arguments of 'array'

----

Part of:
- Issue #1506

Related work:
- PR #1511
- PR #1518
- PR #1519
- PR #1513
