### PR TITLE
Fix missing parenthesis when cancelling `Robot` task

### DIFF
--- a/OPHD/States/MapViewState.cpp
+++ b/OPHD/States/MapViewState.cpp
@@ -1344,7 +1344,7 @@ void MapViewState::updateRobots()
 
 				mNotificationArea.push({
 					"Robot Task Canceled",
-					robot->name() + " canceled its task at" + std::to_string(tile->xy().x) + ", " + std::to_string(tile->xy().y) + ").",
+					robot->name() + " canceled its task at (" + std::to_string(tile->xy().x) + ", " + std::to_string(tile->xy().y) + ").",
 					tile->xyz(),
 					NotificationArea::NotificationType::Information
 				});


### PR DESCRIPTION
Fixes the UI bug from:
- Issue #1522

We should probably leave the issue open though, as it makes a good point about a better long term solution for displaying `Point`, `Vector` and `Rectangle` values.
