### PR TITLE
Reduce contents of `Common.h`

### DIFF
--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -27,35 +27,6 @@ using namespace NAS2D;
 namespace
 {
 	float meanSolarDistance = 1;
-
-
-	const std::map<std::string, Difficulty> difficultyTable
-	{
-		{"Beginner", Difficulty::Beginner},
-		{"Easy", Difficulty::Easy},
-		{"Medium", Difficulty::Medium},
-		{"Hard", Difficulty::Hard}
-	};
-}
-
-
-std::string difficultyEnumToString(Difficulty difficulty)
-{
-	for (const auto& difficultyPair : difficultyTable)
-	{
-		if (difficultyPair.second == difficulty)
-		{
-			return difficultyPair.first;
-		}
-	}
-
-	throw std::runtime_error("Provided difficulty does not exist in the difficultyMap");
-}
-
-
-Difficulty difficultyStringToEnum(const std::string& value)
-{
-	return stringToEnum(difficultyTable, value);
 }
 
 

--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -53,6 +53,12 @@ std::string difficultyEnumToString(Difficulty difficulty)
 }
 
 
+Difficulty difficultyStringToEnum(const std::string& value)
+{
+	return stringToEnum(difficultyTable, value);
+}
+
+
 bool productTypeInRange(ProductType productType)
 {
 	return ProductType::PRODUCT_NONE < productType && productType < ProductType::PRODUCT_COUNT;

--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -39,7 +39,7 @@ const std::map<std::string, Difficulty> difficultyTable
 };
 
 
-std::string difficultyString(Difficulty difficulty)
+std::string difficultyEnumToString(Difficulty difficulty)
 {
 	for (const auto& difficultyPair : difficultyTable)
 	{

--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -138,32 +138,6 @@ const std::array<NAS2D::Rectangle<int>, 4> ResourceImageRectsOre =
 };
 
 
-const std::map<std::array<bool, 4>, std::string> IntersectionPatternTable =
-{
-	{{true, false, true, false}, "left"},
-	{{true, false, false, false}, "left"},
-	{{false, false, true, false}, "left"},
-
-	{{false, true, false, true}, "right"},
-	{{false, true, false, false}, "right"},
-	{{false, false, false, true}, "right"},
-
-	{{false, false, false, false}, "intersection"},
-	{{true, true, false, false}, "intersection"},
-	{{false, false, true, true}, "intersection"},
-	{{false, true, true, true}, "intersection"},
-	{{true, true, true, false}, "intersection"},
-	{{true, true, true, true}, "intersection"},
-	{{true, false, false, true}, "intersection"},
-	{{false, true, true, false}, "intersection"},
-
-	{{false, true, true, true}, "intersection"},
-	{{true, false, true, true}, "intersection"},
-	{{true, true, false, true}, "intersection"},
-	{{true, true, true, false}, "intersection"}
-};
-
-
 Color structureColorFromIndex(StructureState structureState)
 {
 	return STRUCTURE_COLOR_TABLE.at(structureState);

--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -30,12 +30,6 @@ namespace
 }
 
 
-bool productTypeInRange(ProductType productType)
-{
-	return ProductType::PRODUCT_NONE < productType && productType < ProductType::PRODUCT_COUNT;
-}
-
-
 const std::map<StructureState, Color> STRUCTURE_COLOR_TABLE
 {
 	{StructureState::UnderConstruction, Color{150, 150, 150, 100}},

--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -27,16 +27,16 @@ using namespace NAS2D;
 namespace
 {
 	float meanSolarDistance = 1;
+
+
+	const std::map<std::string, Difficulty> difficultyTable
+	{
+		{"Beginner", Difficulty::Beginner},
+		{"Easy", Difficulty::Easy},
+		{"Medium", Difficulty::Medium},
+		{"Hard", Difficulty::Hard}
+	};
 }
-
-
-const std::map<std::string, Difficulty> difficultyTable
-{
-	{"Beginner", Difficulty::Beginner},
-	{"Easy", Difficulty::Easy},
-	{"Medium", Difficulty::Medium},
-	{"Hard", Difficulty::Hard}
-};
 
 
 std::string difficultyEnumToString(Difficulty difficulty)

--- a/appOPHD/Common.cpp
+++ b/appOPHD/Common.cpp
@@ -1,8 +1,5 @@
 #include "Common.h"
 #include "Constants/Numbers.h"
-#include "EnumDifficulty.h"
-#include "EnumDisabledReason.h"
-#include "EnumIdleReason.h"
 #include "EnumMineProductionRate.h"
 #include "EnumMoraleIndex.h"
 #include "EnumTerrainType.h"

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -24,10 +24,6 @@ enum class StructureState;
 enum class TerrainType;
 
 
-std::string difficultyEnumToString(Difficulty difficulty);
-Difficulty difficultyStringToEnum(const std::string& value);
-
-
 bool productTypeInRange(ProductType productType);
 
 

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -24,9 +24,6 @@ enum class StructureState;
 enum class TerrainType;
 
 
-bool productTypeInRange(ProductType productType);
-
-
 extern const std::map<TerrainType, std::string> TILE_INDEX_TRANSLATION;
 extern const std::map<MineProductionRate, std::string> MINE_YIELD_TRANSLATION;
 

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -26,7 +26,7 @@ enum class TerrainType;
 
 extern const std::map<std::string, Difficulty> difficultyTable;
 
-std::string difficultyString(Difficulty difficulty);
+std::string difficultyEnumToString(Difficulty difficulty);
 
 
 bool productTypeInRange(ProductType productType);

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -15,9 +15,6 @@ namespace NAS2D::Xml
 	class XmlDocument;
 }
 
-enum class Difficulty;
-enum class DisabledReason;
-enum class IdleReason;
 enum class MineProductionRate;
 enum class MoraleIndexs;
 enum class StructureState;

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -24,8 +24,6 @@ enum class StructureState;
 enum class TerrainType;
 
 
-extern const std::map<std::string, Difficulty> difficultyTable;
-
 std::string difficultyEnumToString(Difficulty difficulty);
 Difficulty difficultyStringToEnum(const std::string& value);
 

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -33,8 +33,6 @@ extern const std::array<std::string, 4> ResourceNamesOre;
 extern const std::array<NAS2D::Rectangle<int>, 4> ResourceImageRectsRefined;
 extern const std::array<NAS2D::Rectangle<int>, 4> ResourceImageRectsOre;
 
-extern const std::map<std::array<bool, 4>, std::string> IntersectionPatternTable;
-
 void checkSavegameVersion(const std::string& filename);
 NAS2D::Xml::XmlDocument openSavegame(const std::string& filename);
 

--- a/appOPHD/Common.h
+++ b/appOPHD/Common.h
@@ -27,6 +27,7 @@ enum class TerrainType;
 extern const std::map<std::string, Difficulty> difficultyTable;
 
 std::string difficultyEnumToString(Difficulty difficulty);
+Difficulty difficultyStringToEnum(const std::string& value);
 
 
 bool productTypeInRange(ProductType productType);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -209,7 +209,7 @@ NAS2D::Xml::XmlElement* MapViewState::serializeProperties()
 			{"tset", mPlanetAttributes.tilesetPath},
 			{"diggingdepth", mPlanetAttributes.maxDepth},
 			{"meansolardistance", mPlanetAttributes.meanSolarDistance},
-			{"difficulty", difficultyString(difficulty())},
+			{"difficulty", difficultyEnumToString(difficulty())},
 		}}
 	);
 }

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -40,6 +40,35 @@
 
 namespace
 {
+	const std::map<std::string, Difficulty> difficultyTable
+	{
+		{"Beginner", Difficulty::Beginner},
+		{"Easy", Difficulty::Easy},
+		{"Medium", Difficulty::Medium},
+		{"Hard", Difficulty::Hard}
+	};
+
+
+	std::string difficultyEnumToString(Difficulty difficulty)
+	{
+		for (const auto& difficultyPair : difficultyTable)
+		{
+			if (difficultyPair.second == difficulty)
+			{
+				return difficultyPair.first;
+			}
+		}
+
+		throw std::runtime_error("Provided difficulty does not exist in the difficultyMap");
+	}
+
+
+	Difficulty difficultyStringToEnum(const std::string& value)
+	{
+		return stringToEnum(difficultyTable, value);
+	}
+
+
 	MapCoordinate loadMapCoordinate(const NAS2D::Dictionary& dictionary)
 	{
 		const auto x = dictionary.get<int>("x");

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -259,7 +259,7 @@ void MapViewState::load(const std::string& filePath)
 
 	setMeanSolarDistance(mPlanetAttributes.meanSolarDistance);
 
-	difficulty(stringToEnum(difficultyTable, dictionary.get("difficulty", std::string{"Medium"})));
+	difficulty(difficultyStringToEnum(dictionary.get("difficulty", std::string{"Medium"})));
 
 	mTileMap = std::make_unique<TileMap>(mPlanetAttributes.mapImagePath, mPlanetAttributes.maxDepth);
 	mTileMap->deserialize(root);

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -68,6 +68,23 @@ namespace
 	}
 
 
+	auto getSurroundingRoads(const TileMap& tileMap, const NAS2D::Point<int>& tileLocation)
+	{
+		std::array<bool, 4> surroundingTiles{false, false, false, false};
+		for (size_t i = 0; i < 4; ++i)
+		{
+			const auto tileToInspect = tileLocation + DirectionClockwise4[i];
+			const auto surfacePosition = MapCoordinate{tileToInspect, 0};
+			if (!tileMap.isValidPosition(surfacePosition)) { continue; }
+			const auto& tile = tileMap.getTile(surfacePosition);
+			if (!tile.thingIsStructure()) { continue; }
+
+			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
+		}
+		return surroundingTiles;
+	}
+
+
 	int consumeFood(FoodProduction& producer, int amountToConsume)
 	{
 		const auto foodLevel = producer.foodLevel();
@@ -573,18 +590,7 @@ void MapViewState::updateRoads()
 		if (!road->operational()) { continue; }
 
 		const auto tileLocation = NAS2D::Utility<StructureManager>::get().tileFromStructure(road).xy();
-
-		std::array<bool, 4> surroundingTiles{false, false, false, false};
-		for (size_t i = 0; i < 4; ++i)
-		{
-			const auto tileToInspect = tileLocation + DirectionClockwise4[i];
-			const auto surfacePosition = MapCoordinate{tileToInspect, 0};
-			if (!mTileMap->isValidPosition(surfacePosition)) { continue; }
-			const auto& tile = mTileMap->getTile(surfacePosition);
-			if (!tile.thingIsStructure()) { continue; }
-
-			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
-		}
+		const auto surroundingTiles = getSurroundingRoads(*mTileMap, tileLocation);
 
 		road->sprite().play(roadAnimationName(road->integrity(), surroundingTiles));
 	}

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -31,6 +31,32 @@ namespace
 	};
 
 
+	const std::map<std::array<bool, 4>, std::string> IntersectionPatternTable =
+	{
+		{{true, false, true, false}, "left"},
+		{{true, false, false, false}, "left"},
+		{{false, false, true, false}, "left"},
+
+		{{false, true, false, true}, "right"},
+		{{false, true, false, false}, "right"},
+		{{false, false, false, true}, "right"},
+
+		{{false, false, false, false}, "intersection"},
+		{{true, true, false, false}, "intersection"},
+		{{false, false, true, true}, "intersection"},
+		{{false, true, true, true}, "intersection"},
+		{{true, true, true, false}, "intersection"},
+		{{true, true, true, true}, "intersection"},
+		{{true, false, false, true}, "intersection"},
+		{{false, true, true, false}, "intersection"},
+
+		{{false, true, true, true}, "intersection"},
+		{{true, false, true, true}, "intersection"},
+		{{true, true, false, true}, "intersection"},
+		{{true, true, true, false}, "intersection"}
+	};
+
+
 	int consumeFood(FoodProduction& producer, int amountToConsume)
 	{
 		const auto foodLevel = producer.foodLevel();

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -57,6 +57,17 @@ namespace
 	};
 
 
+	std::string roadAnimationName(int integrity, const std::array<bool, 4>& surroundingTiles)
+	{
+		std::string tag = "";
+
+		if (integrity < constants::RoadIntegrityChange) { tag = "-decayed"; }
+		else if (integrity == 0) { tag = "-destroyed"; }
+
+		return IntersectionPatternTable.at(surroundingTiles) + tag;
+	}
+
+
 	int consumeFood(FoodProduction& producer, int amountToConsume)
 	{
 		const auto foodLevel = producer.foodLevel();
@@ -575,12 +586,7 @@ void MapViewState::updateRoads()
 			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
 		}
 
-		std::string tag = "";
-
-		if (road->integrity() < constants::RoadIntegrityChange) { tag = "-decayed"; }
-		else if (road->integrity() == 0) { tag = "-destroyed"; }
-
-		road->sprite().play(IntersectionPatternTable.at(surroundingTiles) + tag);
+		road->sprite().play(roadAnimationName(road->integrity(), surroundingTiles));
 	}
 }
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -25,6 +25,12 @@ using namespace NAS2D;
 
 namespace
 {
+	bool productTypeInRange(ProductType productType)
+	{
+		return ProductType::PRODUCT_NONE < productType && productType < ProductType::PRODUCT_COUNT;
+	}
+
+
 	const NAS2D::Image& productImage(ProductType productType)
 	{
 		static const std::map<ProductType, const Image*> productImages{

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -422,14 +422,7 @@ void FactoryReport::onListSelectionChange()
 	lstProducts.selectIf([productType = selectedFactory->productType()](const auto& item){ return item.tag == productType; });
 	selectedProductType = selectedFactory->productType();
 
-	if (productTypeInRange(selectedProductType))
-	{
-		mTxtProductDescription.text(ProductCatalogue::get(selectedProductType).Description);
-	}
-	else
-	{
-		mTxtProductDescription.text("");
-	}
+	mTxtProductDescription.text(productTypeInRange(selectedProductType) ? ProductCatalogue::get(selectedProductType).Description : "");
 
 	StructureState state = selectedFactory->state();
 	btnApply.visible(state == StructureState::Operational || state == StructureState::Idle);


### PR DESCRIPTION
Move data and functions out of `Common.h` that are only used in one place. Define them where they are used.

Part of:
- #1506
