### PR TITLE
Use reference syntax for `Robot` task completion events

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -72,7 +72,7 @@ void Robot::update()
 
 	if (mTurnsToCompleteTask == 0)
 	{
-		mTaskCompleteSignal(this);
+		mTaskCompleteSignal(*this);
 	}
 
 	mFuelCellAge++;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -20,7 +20,7 @@ public:
 		None
 	};
 
-	using TaskSignal = NAS2D::Signal<Robot*>;
+	using TaskSignal = NAS2D::Signal<Robot&>;
 
 public:
 	Robot(const std::string&, const std::string&, Type);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1204,7 +1204,7 @@ void MapViewState::placeRobominer(Tile& tile)
 
 Robot& MapViewState::addRobot(Robot::Type type)
 {
-	const std::map<Robot::Type, void (MapViewState::*)(Robot*)> RobotTypeToHandler
+	const std::map<Robot::Type, void (MapViewState::*)(Robot&)> RobotTypeToHandler
 	{
 		{Robot::Type::Digger, &MapViewState::onDiggerTaskComplete},
 		{Robot::Type::Dozer, &MapViewState::onDozerTaskComplete},

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -162,9 +162,9 @@ private:
 	void onSystemMenu();
 
 	// ROBOT EVENT HANDLERS
-	void onDozerTaskComplete(Robot* robot);
-	void onDiggerTaskComplete(Robot* robot);
-	void onMinerTaskComplete(Robot* robot);
+	void onDozerTaskComplete(Robot& robot);
+	void onDiggerTaskComplete(Robot& robot);
+	void onMinerTaskComplete(Robot& robot);
 
 	// DRAWING FUNCTIONS
 	void drawUI();

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -164,7 +164,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 /**
  * Called whenever a RoboDozer completes its task.
  */
-void MapViewState::onDozerTaskComplete(Robot* /*robot*/)
+void MapViewState::onDozerTaskComplete(Robot& /*robot*/)
 {
 	populateRobotMenu();
 }
@@ -173,14 +173,14 @@ void MapViewState::onDozerTaskComplete(Robot* /*robot*/)
 /**
  * Called whenever a RoboDigger completes its task.
  */
-void MapViewState::onDiggerTaskComplete(Robot* robot)
+void MapViewState::onDiggerTaskComplete(Robot& robot)
 {
-	if (mRobotList.find(robot) == mRobotList.end())
+	if (mRobotList.find(&robot) == mRobotList.end())
 	{
 		throw std::runtime_error("MapViewState::onDiggerTaskComplete() called with a Robot not in the Robot List!");
 	}
 
-	auto& tile = *mRobotList[robot];
+	auto& tile = *mRobotList[&robot];
 	const auto& position = tile.xyz();
 
 	if (position.z > mTileMap->maxDepth())
@@ -188,7 +188,7 @@ void MapViewState::onDiggerTaskComplete(Robot* robot)
 		throw std::runtime_error("Digger defines a depth that exceeds the maximum digging depth!");
 	}
 
-	const auto dir = static_cast<Robodigger*>(robot)->direction(); // fugly
+	const auto dir = static_cast<Robodigger*>(&robot)->direction(); // fugly
 	auto newPosition = position;
 
 	if (dir == Direction::Down)
@@ -228,12 +228,12 @@ void MapViewState::onDiggerTaskComplete(Robot* robot)
 /**
  * Called whenever a RoboMiner completes its task.
  */
-void MapViewState::onMinerTaskComplete(Robot* robot)
+void MapViewState::onMinerTaskComplete(Robot& robot)
 {
-	if (mRobotList.find(robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::onMinerTaskComplete() called with a Robot not in the Robot List!"); }
+	if (mRobotList.find(&robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::onMinerTaskComplete() called with a Robot not in the Robot List!"); }
 
-	auto& robotTile = *mRobotList[robot];
-	auto& miner = *static_cast<Robominer*>(robot);
+	auto& robotTile = *mRobotList[&robot];
+	auto& miner = *static_cast<Robominer*>(&robot);
 
 	auto& mineFacility = miner.buildMine(*mTileMap, robotTile.xyz());
 	mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});


### PR DESCRIPTION
Some old work that was sitting around forgotten about in a local branch for about a year and a half. I think I sat on it because there was going to be more bundled with it. Plus, the change on it's own slightly increases the size of the code, with each line being at least at long as the original. Though really, the `Robot` reference is never nullable, so reference syntax probably makes more sense than pointer syntax.

Related to:
- Issue #1335
