### PR TITLE
Move `writeRobots` from `MapViewState` to `RobotPool`

### DIFF
--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -11,6 +11,14 @@
 class Tile;
 using RobotList = std::vector<Robot*>;
 
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+}
+
 
 class RobotPool
 {
@@ -53,6 +61,8 @@ public:
 	std::size_t currentControlCount() const { return mRobotControlCount; }
 
 	const RobotList& robots() const { return mRobots; }
+
+	NAS2D::Xml::XmlElement* writeRobots(RobotTileTable& robotMap);
 
 private:
 	DiggerList mDiggers;

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -79,40 +79,6 @@ namespace
 	}
 
 
-	NAS2D::Dictionary robotToDictionary(RobotTileTable& robotTileTable, Robot& robot)
-	{
-		NAS2D::Dictionary dictionary = robot.getDataDict();
-
-		const auto it = robotTileTable.find(&robot);
-		if (it != robotTileTable.end())
-		{
-			const auto& tile = *it->second;
-			const auto position = tile.xy();
-			dictionary += NAS2D::Dictionary{{
-				{"x", position.x},
-				{"y", position.y},
-				{"depth", tile.depth()},
-			}};
-		}
-
-		return dictionary;
-	}
-
-
-	NAS2D::Xml::XmlElement* writeRobots(RobotPool& robotPool, RobotTileTable& robotMap)
-	{
-		auto* robots = new NAS2D::Xml::XmlElement("robots");
-
-		for (auto robot : robotPool.robots())
-		{
-			auto dictionary = robotToDictionary(robotMap, *robot);
-			robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
-		}
-
-		return robots;
-	}
-
-
 	NAS2D::Xml::XmlElement* writeResearch(const ResearchTracker& tracker)
 	{
 		auto* research = new NAS2D::Xml::XmlElement("research");
@@ -189,7 +155,7 @@ void MapViewState::save(const std::string& filePath)
 	mTileMap->serialize(root);
 	mMapView->serialize(root);
 	root->linkEndChild(NAS2D::Utility<StructureManager>::get().serialize());
-	root->linkEndChild(writeRobots(mRobotPool, mRobotList));
+	root->linkEndChild(mRobotPool.writeRobots(mRobotList));
 	root->linkEndChild(writeResources(mResourceBreakdownPanel.previousResources(), "prev_resources"));
 	root->linkEndChild(writeResearch(mResearchTracker));
 	root->linkEndChild(NAS2D::dictionaryToAttributes("turns", {{{"count", mTurnCount}}}));


### PR DESCRIPTION
Move `writeRobots` method from `MapViewState` to `RobotPool`.

This is some old work that was sitting around forgotten about in a local branch for about a year and a half. Originally the plan was to move ownership of `mRobotList` from `MapViewState` to `RobotPool`, though that work was never completed. This section of the work that moves `writeRobots` does stand on it's own though, so is worth using now.

----

Related to:
- Issue #1335
- Issue #650
- PR #1536
