### PR TITLE
Run unit tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ commands:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibOPHD
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibControls
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkOPHD
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkControls
       - run: make package
       - store_artifacts:
           path: .build/package/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ commands:
     steps:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibOPHD
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibControls
       - run: make package
       - store_artifacts:
           path: .build/package/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,3 +145,6 @@ jobs:
       with:
         path: .build
         key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}
+
+    - name: Run libOPHD unit tests
+      run: .build/${{env.BUILD_CONFIGURATION}}_${{env.PLATFORM}}_testLibOPHD/testLibOPHD.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,3 +148,6 @@ jobs:
 
     - name: Run libOPHD unit tests
       run: .build/${{env.BUILD_CONFIGURATION}}_${{env.PLATFORM}}_testLibOPHD/testLibOPHD.exe
+
+    - name: Run libControl unit tests
+      run: .build/${{env.BUILD_CONFIGURATION}}_${{env.PLATFORM}}_testLibControls/testLibControls.exe

--- a/testLibOPHD/MapOffset.test.cpp
+++ b/testLibOPHD/MapOffset.test.cpp
@@ -5,32 +5,32 @@
 
 TEST(MapOffset, EqualOperator)
 {
-	EXPECT_TRUE((MapOffset{1, 2, 3}) == (MapOffset{1, 2, 3}));
-	EXPECT_FALSE((MapOffset{1, 2, 3}) == (MapOffset{2, 1, 3}));
-	EXPECT_FALSE((MapOffset{1, 2, 0}) == (MapOffset{1, 2, 3}));
+	EXPECT_TRUE((MapOffset{{1, 2}, 3}) == (MapOffset{{1, 2}, 3}));
+	EXPECT_FALSE((MapOffset{{1, 2}, 3}) == (MapOffset{{2, 1}, 3}));
+	EXPECT_FALSE((MapOffset{{1, 2}, 0}) == (MapOffset{{1, 2}, 3}));
 }
 
 
 TEST(MapOffset, NotEqualOperator)
 {
-	EXPECT_TRUE((MapOffset{1, 2, 3}) != (MapOffset{2, 1, 3}));
-	EXPECT_TRUE((MapOffset{1, 2, 0}) != (MapOffset{1, 2, 3}));
-	EXPECT_FALSE((MapOffset{1, 2, 3}) != (MapOffset{1, 2, 3}));
+	EXPECT_TRUE((MapOffset{{1, 2}, 3}) != (MapOffset{{2, 1}, 3}));
+	EXPECT_TRUE((MapOffset{{1, 2}, 0}) != (MapOffset{{1, 2}, 3}));
+	EXPECT_FALSE((MapOffset{{1, 2}, 3}) != (MapOffset{{1, 2}, 3}));
 }
 
 
 TEST(MapOffset, ScalarMultiplication)
 {
-	EXPECT_EQ((MapOffset{-1, 2, 3}) * 2, (MapOffset{-2, 4, 6}));
-	EXPECT_EQ(2 * (MapOffset{-1, 2, 3}), (MapOffset{-2, 4, 6}));
-	EXPECT_EQ((MapOffset{-1, 2, 3}) * -2, (MapOffset{2, -4, -6}));
-	EXPECT_EQ((MapOffset{-1, 2, 3}) * 0, (MapOffset{0, 0, 0}));
+	EXPECT_EQ((MapOffset{{-1, 2}, 3}) * 2, (MapOffset{{-2, 4}, 6}));
+	EXPECT_EQ(2 * (MapOffset{{-1, 2}, 3}), (MapOffset{{-2, 4}, 6}));
+	EXPECT_EQ((MapOffset{{-1, 2}, 3}) * -2, (MapOffset{{2, -4}, -6}));
+	EXPECT_EQ((MapOffset{{-1, 2}, 3}) * 0, (MapOffset{{0, 0}, 0}));
 }
 
 TEST(MapOffset, ScalarMultiplicationWithAssignment)
 {
-	MapOffset offset = MapOffset{-1, 2, 3};
-	EXPECT_EQ(offset *= 2, (MapOffset{-2, 4, 6}));
-	EXPECT_EQ(offset *= -2, (MapOffset{4, -8, -12}));
-	EXPECT_EQ(offset *= 0, (MapOffset{0, 0, 0}));
+	MapOffset offset = MapOffset{{-1, 2}, 3};
+	EXPECT_EQ(offset *= 2, (MapOffset{{-2, 4}, 6}));
+	EXPECT_EQ(offset *= -2, (MapOffset{{4, -8}, -12}));
+	EXPECT_EQ(offset *= 0, (MapOffset{{0, 0}, 0}));
 }


### PR DESCRIPTION
Build and run the unit tests projects at part of the CI builds.

Previously we added unit test projects, though we only built them on Windows, and weren't running them anywhere on CI. This fixes that oversight.

Related:
- Issue #1422
- Issue #1191
