### PR TITLE
Update MacOS `makefile` build flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       CPPFLAGS_EXTRA: "-isystem /opt/homebrew/include"
+      LDFLAGS_EXTRA: "-L/opt/homebrew/lib"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       xcode: "15.4.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-      WARN_EXTRA: "-isystem /opt/homebrew/include"
+      CPPFLAGS_EXTRA: "-isystem /opt/homebrew/include"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/makefile
+++ b/makefile
@@ -111,10 +111,10 @@ testLibOphd_SRCS := $(shell find $(testLibOphd_SRCDIR) -name '*.cpp')
 testLibOphd_OBJS := $(patsubst $(testLibOphd_SRCDIR)%.cpp,$(testLibOphd_OBJDIR)%.o,$(testLibOphd_SRCS))
 
 testLibOphd_CPPFLAGS := $(CPPFLAGS) -I./
-testLibOphd_LDLIBS := -lgmock_main -lgmock -lgtest -lpthread $(LDLIBS)
+testLibOphd_LDLIBS := -lgmock_main -lgmock -lgtest -lpthread $(LDLIBS_EXTRA)
 
 testLibOphd_PROJECT_FLAGS := $(testLibOphd_CPPFLAGS) $(CXXFLAGS)
-testLibOphd_PROJECT_LINKFLAGS = $(LDFLAGS) $(testLibOphd_LDLIBS)
+testLibOphd_PROJECT_LINKFLAGS = $(LDFLAGS_EXTRA) $(testLibOphd_LDLIBS)
 
 .PHONY: testLibOPHD
 testLibOPHD: $(testLibOphd_OUTPUT)


### PR DESCRIPTION
The `testLibOPHD` project was finding Google Test and Google Mock libraries thanks to a setting supplied by `sdl2-config` for the `homebrew` library path. However, this project doesn't really depend on SDL, and doesn't need to link with it. Removing the libraries and flags would cause build errors for this project on MacOS if the `homebrew` library path flag is not supplied from somewhere else.

Part of:
- Issue #1544
