### PR TITLE
Fix missing parenthesis when robot task completes

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1329,7 +1329,7 @@ void MapViewState::updateRobots()
 
 				mNotificationArea.push({
 					"Robot Task Completed",
-					robot->name() + " completed its task at" + std::to_string(tile->xy().x) + ", " + std::to_string(tile->xy().y) + ").",
+					robot->name() + " completed its task at (" + std::to_string(tile->xy().x) + ", " + std::to_string(tile->xy().y) + ").",
 					tile->xyz(),
 					NotificationArea::NotificationType::Success
 				});


### PR DESCRIPTION
Fix missing parenthesis in text display.

The Issue reported this for both completed and cancelled robot tasks. The last PR only fixed the problem for a cancelled task.

Part of:
- Issue #1522

Related:
- PR #1525
