### PR TITLE
Draw tube `IconGrid` before structure `IconGrid`

### DIFF
--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -398,8 +398,8 @@ void MapViewState::drawUI()
 
 	// Menus
 	mRobots.update();
-	mStructures.update();
 	mConnections.update();
+	mStructures.update();
 
 	// Windows
 	mFileIoDialog.update();


### PR DESCRIPTION
This fixes the tool tip under draw issue for structures. The tube panel is now drawn first, so any tool tip displayed by the structure panel will overlap on top of the tube panel.

Closes #1550
