### PR TITLE
Do full Mingw builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,12 @@ jobs:
   build-linux-mingw:
     docker:
       - image: outpostuniverse/nas2d-mingw:1.11
+    environment:
+      LDFLAGS_EXTRA: -L/usr/local/x86_64-w64-mingw32/lib
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
-      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" intermediate
+      - build
 
 workflows:
   build:

--- a/makefile
+++ b/makefile
@@ -154,7 +154,7 @@ testLibControls_CPPFLAGS := $(CPPFLAGS) -I./
 testLibControls_LDLIBS := -lgmock_main -lgmock -lgtest -lpthread $(LDLIBS)
 
 testLibControls_PROJECT_FLAGS := $(testLibControls_CPPFLAGS) $(CXXFLAGS)
-testLibControls_PROJECT_LINKFLAGS = $(LDFLAGS) $(testLibControls_LDLIBS)
+testLibControls_PROJECT_LINKFLAGS = $(LDFLAGS_EXTRA) $(testLibControls_LDLIBS)
 
 .PHONY: testLibControls
 testLibControls: $(testLibControls_OUTPUT)


### PR DESCRIPTION
Do a full build of `ophd` using Mingw, as well as building and running the unit tests.

Previously we only compiled to intermediate files for `appOPHD`. There was no attempt to link `appOPHD` into an executable file. Similarly the unit test projects were not built, not even to intermediate files, and so of course not run either.

Closes #1544
