### PR TITLE
Run MSVC Code Analysis on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |
-        msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /maxCpuCount /warnAsError /property:RunCodeAnalysis=true /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Save incremental build cache - OPHD
       uses: actions/cache/save@v4

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -434,4 +434,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;MicroPather;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>

--- a/testLibControls/testLibControls.vcxproj
+++ b/testLibControls/testLibControls.vcxproj
@@ -172,4 +172,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>

--- a/testLibOPHD/testLibOPHD.vcxproj
+++ b/testLibOPHD/testLibOPHD.vcxproj
@@ -173,4 +173,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Disable MSVC Code Analysis warnings for external code. Enable Code Analysis on CI builds.

Closes #320

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/528
- PR https://github.com/lairworks/nas2d-core/pull/578
