### PR TITLE
Refactor `StructureTracker`

### DIFF
--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -237,7 +237,7 @@ void MapViewState::load(const std::string& filePath)
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();
 	ccLocation() = CcNotPlaced;
 
-	mStructureTracker.reset();
+	mStructureTracker = StructureTracker{};
 
 	mTileMap.reset();
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -328,10 +328,7 @@ void MapViewState::populateStructureMenu()
 	else if (mMapView->isSurface())
 	{
 		fillList(mStructures, mStructureTracker.availableSurfaceStructures());
-
-		mConnections.addItem({constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION});
-		mConnections.addItem({constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_RIGHT});
-		mConnections.addItem({constants::AgTubeLeft, 111, ConnectorDir::CONNECTOR_LEFT});
+		fillList(mConnections, mStructureTracker.surfaceTubes());
 
 		// Special case code, not thrilled with this
 		if (mLandersColonist > 0) { mStructures.addItem({constants::ColonistLander, 2, StructureID::SID_COLONIST_LANDER}); }
@@ -340,10 +337,7 @@ void MapViewState::populateStructureMenu()
 	else
 	{
 		fillList(mStructures, mStructureTracker.availableUndergroundStructures());
-
-		mConnections.addItem({constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION});
-		mConnections.addItem({constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_RIGHT});
-		mConnections.addItem({constants::UgTubelLeft, 114, ConnectorDir::CONNECTOR_LEFT});
+		fillList(mConnections, mStructureTracker.undergroundTubes());
 	}
 
 	updateStructuresAvailability();

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -1,5 +1,6 @@
 #include "StructureTracker.h"
 
+#include "../EnumConnectorDir.h"
 #include "../EnumStructureID.h"
 #include "../Constants/Strings.h"
 
@@ -37,6 +38,19 @@ namespace
 		{constants::University, 63, StructureID::SID_UNIVERSITY},
 	};
 
+	const std::vector<IconGrid::Item> SurfaceTubes = {
+		{constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION},
+		{constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_RIGHT},
+		{constants::AgTubeLeft, 111, ConnectorDir::CONNECTOR_LEFT},
+	};
+
+	const std::vector<IconGrid::Item> UndergroundTubes = {
+		{constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION},
+		{constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_RIGHT},
+		{constants::UgTubelLeft, 114, ConnectorDir::CONNECTOR_LEFT},
+	};
+
+
 	void addItemToList(const IconGrid::Item& structureItem, std::vector<IconGrid::Item>& list)
 	{
 		for (const auto& item : list)
@@ -56,6 +70,18 @@ StructureTracker::StructureTracker() :
 	mAvailableSurfaceStructures{DefaultAvailableSurfaceStructures},
 	mAvailableUndergroundStructures{DefaultAvailableUndergroundStructures}
 {
+}
+
+
+const std::vector<IconGrid::Item>& StructureTracker::surfaceTubes() const
+{
+	return SurfaceTubes;
+}
+
+
+const std::vector<IconGrid::Item>& StructureTracker::undergroundTubes() const
+{
+	return UndergroundTubes;
 }
 
 

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -58,6 +58,18 @@ StructureTracker::StructureTracker()
 }
 
 
+const std::vector<IconGrid::Item>& StructureTracker::availableSurfaceStructures() const
+{
+	return mAvailableSurfaceStructures;
+}
+
+
+const std::vector<IconGrid::Item>& StructureTracker::availableUndergroundStructures() const
+{
+	return mAvailableUndergroundStructures;
+}
+
+
 void StructureTracker::addUnlockedSurfaceStructure(const IconGrid::Item& structureItem)
 {
 	addItemToList(structureItem, mAvailableSurfaceStructures);

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -3,6 +3,7 @@
 #include "../EnumStructureID.h"
 #include "../Constants/Strings.h"
 
+
 namespace
 {
 	const std::vector<IconGrid::Item> DefaultAvailableSurfaceStructures = {

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -52,9 +52,10 @@ namespace
 }
 
 
-StructureTracker::StructureTracker()
+StructureTracker::StructureTracker() :
+	mAvailableSurfaceStructures{DefaultAvailableSurfaceStructures},
+	mAvailableUndergroundStructures{DefaultAvailableUndergroundStructures}
 {
-	reset();
 }
 
 
@@ -79,11 +80,4 @@ void StructureTracker::addUnlockedSurfaceStructure(const IconGrid::Item& structu
 void StructureTracker::addUnlockedUndergroundStructure(const IconGrid::Item& structureItem)
 {
 	addItemToList(structureItem, mAvailableUndergroundStructures);
-}
-
-
-void StructureTracker::reset()
-{
-	mAvailableSurfaceStructures = DefaultAvailableSurfaceStructures;
-	mAvailableUndergroundStructures = DefaultAvailableUndergroundStructures;
 }

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -21,7 +21,6 @@ public:
 	void reset();
 
 private:
-
 	std::vector<IconGrid::Item> mAvailableSurfaceStructures;
 	std::vector<IconGrid::Item> mAvailableUndergroundStructures;
 };

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -18,8 +18,6 @@ public:
 	void addUnlockedSurfaceStructure(const IconGrid::Item& structureItem);
 	void addUnlockedUndergroundStructure(const IconGrid::Item& structureItem);
 
-	void reset();
-
 private:
 	std::vector<IconGrid::Item> mAvailableSurfaceStructures;
 	std::vector<IconGrid::Item> mAvailableUndergroundStructures;

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -9,7 +9,6 @@
 class StructureTracker
 {
 public:
-
 	StructureTracker();
 
 	const std::vector<IconGrid::Item>& surfaceTubes() const;

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+
 class StructureTracker
 {
 public:

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -12,6 +12,9 @@ public:
 
 	StructureTracker();
 
+	const std::vector<IconGrid::Item>& surfaceTubes() const;
+	const std::vector<IconGrid::Item>& undergroundTubes() const;
+
 	const std::vector<IconGrid::Item>& availableSurfaceStructures() const;
 	const std::vector<IconGrid::Item>& availableUndergroundStructures() const;
 

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -12,8 +12,8 @@ public:
 
 	StructureTracker();
 
-	const std::vector<IconGrid::Item>& availableSurfaceStructures() const { return mAvailableSurfaceStructures; }
-	const std::vector<IconGrid::Item>& availableUndergroundStructures() const { return mAvailableUndergroundStructures; }
+	const std::vector<IconGrid::Item>& availableSurfaceStructures() const;
+	const std::vector<IconGrid::Item>& availableUndergroundStructures() const;
 
 	void addUnlockedSurfaceStructure(const IconGrid::Item& structureItem);
 	void addUnlockedUndergroundStructure(const IconGrid::Item& structureItem);


### PR DESCRIPTION
Noticed this while looking into:
- Issue #319

I was kind of debating if the tube lists should go in `StructureTracker` or in an unnamed namespace in `MapViewStateUi.cpp`, though it seems the long term trend is to split up `MapViewState`, and this seemed to fit nicely with `StructureTracker`.
