### PR TITLE
Fix `vcpkg` cache doubling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Pre-install vcpkg dependencies - OPHD
       run: |
-        vcpkg install
+        vcpkg install --x-install-root=vcpkg_installed\${{ matrix.platform }}-windows
 
     - name: Save vcpkg dependency cache
       uses: actions/cache/save@v4
@@ -63,7 +63,7 @@ jobs:
     - name: Pre-install vcpkg dependencies - NAS2D
       working-directory: nas2d-core
       run: |
-        vcpkg install
+        vcpkg install --x-install-root=vcpkg_installed\${{ matrix.platform }}-windows
 
     - name: Set NAS2D modification time
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Pre-install vcpkg dependencies - OPHD
       run: |
-        vcpkg install --x-install-root=vcpkg_installed\${{ matrix.platform }}-windows
+        msbuild . /property:Configuration=${{env.BUILD_CONFIGURATION}} /target:appOPHD:VcpkgInstallManifestDependencies
 
     - name: Save vcpkg dependency cache
       uses: actions/cache/save@v4
@@ -63,7 +63,7 @@ jobs:
     - name: Pre-install vcpkg dependencies - NAS2D
       working-directory: nas2d-core
       run: |
-        vcpkg install --x-install-root=vcpkg_installed\${{ matrix.platform }}-windows
+        msbuild . /property:Configuration=${{env.BUILD_CONFIGURATION}} /target:NAS2D:VcpkgInstallManifestDependencies
 
     - name: Set NAS2D modification time
       shell: bash


### PR DESCRIPTION
Use `msbuild` with project specific targets of `VcpkgInstallManifestDependencies`, rather than running `vcpkg install`.

This installs dependencies using the layout that `msbuild` project integration expects, which is different from that produced by `vcpkg install`.

Part of:
- Issue #1567
