### PR TITLE
Make cache restore conditional on previous cache being restored

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
     - name: Restore NAS2D cache
       uses: actions/cache/restore@v4
       id: cacheRestoreNas2d
+      if: steps.cacheRestoreVcpkg.outputs.cache-hit == 'true'
       with:
         path: nas2d-core/.build/
         key: nas2dCache-${{ runner.os }}-${{ matrix.platform }}-${{ env.nas2dSha }}
@@ -104,7 +105,7 @@ jobs:
     - name: Restore incremental build cache
       uses: actions/cache/restore@v4
       id: cacheRestoreOphd
-      if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+      if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && steps.cacheRestoreNas2d.outputs.cache-hit == 'true'
       with:
         path: .build
         key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}


### PR DESCRIPTION
The build of NAS2D depends on `vcpkg` packages. If `vcpkg` packages have changed, then we likely need to rebuild (almost all of) NAS2D.

Similarly OPHD depends on NAS2D (and on `vcpkg` packages). If NAS2D couldn't be restored, we likely need to rebuild (almost all of) OPHD.

Part of:
- Issue #1553
