### PR TITLE
Update NAS2D submodule

### DIFF
--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -8,7 +8,6 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
-#include <NAS2D/Math/MathUtils.h>
 
 #include <string>
 #include <vector>

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -5,7 +5,6 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
-#include <NAS2D/Math/MathUtils.h>
 
 #include <algorithm>
 #include <stdexcept>

--- a/appOPHD/UI/ProgressBar.cpp
+++ b/appOPHD/UI/ProgressBar.cpp
@@ -3,6 +3,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Color.h>
+#include <NAS2D/Math/Rectangle.h>
 
 #include <algorithm>
 

--- a/appOPHD/UI/ProgressBar.cpp
+++ b/appOPHD/UI/ProgressBar.cpp
@@ -4,6 +4,8 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Color.h>
 
+#include <algorithm>
+
 
 void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding)
 {

--- a/appOPHD/UI/ProgressBar.h
+++ b/appOPHD/UI/ProgressBar.h
@@ -1,6 +1,11 @@
 #pragma once
 
-#include <NAS2D/Math/Rectangle.h>
+
+namespace NAS2D
+{
+	template <typename BaseType>
+	struct Rectangle;
+}
 
 
 void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding = 4);

--- a/appOPHD/UI/StringTable.cpp
+++ b/appOPHD/UI/StringTable.cpp
@@ -4,6 +4,7 @@
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
 
 #include <stdexcept>
 #include <algorithm>

--- a/appOPHD/UI/StringTable.h
+++ b/appOPHD/UI/StringTable.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Rectangle.h>
@@ -10,6 +9,13 @@
 #include <string>
 #include <vector>
 #include <cstddef>
+
+
+namespace NAS2D
+{
+	class Font;
+	class Renderer;
+}
 
 
 // Draw a 2 dimensional table of text. Determine cell size based on inserted text, font, and padding. Only allows one line of text per cell.

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -2,7 +2,6 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
-#include <NAS2D/Math/MathUtils.h>
 
 
 Button::Button(std::string newText) :

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -17,7 +17,6 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
-#include <NAS2D/Math/MathUtils.h>
 
 #include <algorithm>
 

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -1,7 +1,6 @@
 #include "ComboBox.h"
 
 #include <NAS2D/Utility.h>
-#include <NAS2D/Math/MathUtils.h>
 #include <NAS2D/StringUtils.h>
 
 #include <utility>

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -4,7 +4,6 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Math/Point.h>
-#include <NAS2D/Math/MathUtils.h>
 
 #include <algorithm>
 

--- a/libControls/RadioButtonGroup.cpp
+++ b/libControls/RadioButtonGroup.cpp
@@ -2,7 +2,6 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
-#include <NAS2D/Math/MathUtils.h>
 
 #include <algorithm>
 

--- a/libControls/RadioButtonGroup.h
+++ b/libControls/RadioButtonGroup.h
@@ -8,7 +8,6 @@
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
-#include <NAS2D/Math/MathUtils.h>
 #include <NAS2D/Math/Point.h>
 
 #include <algorithm>

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -10,7 +10,6 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
-#include <NAS2D/Math/MathUtils.h>
 
 #include <locale>
 


### PR DESCRIPTION
Reduce header includes for faster compiles, and update NAS2D submodule.

NAS2D Updates:
- Fixed `Font::size` and `Font::width` calculations, for tighter bounding boxes
- Support for multi-line strings in `drawText` and `Font::size`
- Reduced header includes for faster compiles

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/1196
- Issue https://github.com/lairworks/nas2d-core/issues/1211
- Issue #1573
- PR https://github.com/lairworks/nas2d-core/pull/1210
- PR https://github.com/lairworks/nas2d-core/pull/1212
- PR https://github.com/lairworks/nas2d-core/pull/1214

----

Possible added bonus of reducing includes, and imported symbols:
The incremental build cache dropped by about 20MB (110MB -> 90MB).
