### PR TITLE
Split `Structure` implementations to source files

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -7,6 +7,8 @@
 
 #include <libOPHD/RandomNumberGenerator.h>
 
+#include <NAS2D/Dictionary.h>
+
 #include <algorithm>
 
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -5,6 +5,8 @@
 #include "../StructureCatalogue.h"
 #include "../Constants/Strings.h"
 
+#include "../UI/StringTable.h"
+
 #include <libOPHD/RandomNumberGenerator.h>
 
 #include <NAS2D/Dictionary.h>
@@ -442,6 +444,12 @@ void Structure::increaseCrimeRate(int deltaCrimeRate)
 void Structure::integrity(int integrity)
 {
 	mIntegrity = integrity;
+}
+
+
+StringTable Structure::createInspectorViewTable()
+{
+	return StringTable(0, 0);
 }
 
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -11,7 +11,11 @@
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/Population/PopulationPool.h>
 
-#include <NAS2D/Dictionary.h>
+
+namespace NAS2D
+{
+	class Dictionary;
+}
 
 
 struct StructureType;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -3,7 +3,6 @@
 #include "MapObject.h"
 
 #include "../StorableResources.h"
-#include "../UI/StringTable.h"
 
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumDisabledReason.h>
@@ -19,6 +18,7 @@ namespace NAS2D
 
 
 struct StructureType;
+class StringTable;
 
 
 /**
@@ -176,7 +176,7 @@ public:
 	/**
 	* Pass limited structure specific details for drawing. Use a custom UI window if needed.
 	*/
-	virtual StringTable createInspectorViewTable() { return StringTable(0, 0); }
+	virtual StringTable createInspectorViewTable();
 
 	virtual NAS2D::Dictionary getDataDict() const;
 

--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -1,0 +1,57 @@
+#include "Agridome.h"
+
+
+#include "../../Constants/Strings.h"
+
+#include <algorithm>
+
+
+const int AGRIDOME_CAPACITY = 1000;
+const int AGRIDOME_BASE_PRODUCUCTION = 10;
+
+
+Agridome::Agridome() : FoodProduction(StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
+{
+}
+
+
+void Agridome::think()
+{
+	if (isIdle()) { return; }
+
+	mFoodLevel = std::clamp(mFoodLevel + calculateProduction(), 0, AGRIDOME_CAPACITY);
+
+	if (isStorageFull())
+	{
+		idle(IdleReason::InternalStorageFull);
+	}
+}
+
+
+void Agridome::disabledStateSet()
+{
+	mFoodLevel = 0;
+}
+
+
+int Agridome::foodCapacity()
+{
+	return AGRIDOME_CAPACITY;
+}
+
+
+int Agridome::calculateProduction()
+{
+	if (!operational())
+	{
+		return 0;
+	}
+
+	return std::min(AGRIDOME_BASE_PRODUCUCTION, AGRIDOME_CAPACITY - mFoodLevel);
+}
+
+
+bool Agridome::isStorageFull()
+{
+	return mFoodLevel >= AGRIDOME_CAPACITY;
+}

--- a/appOPHD/MapObjects/Structures/Agridome.h
+++ b/appOPHD/MapObjects/Structures/Agridome.h
@@ -2,57 +2,21 @@
 
 #include "FoodProduction.h"
 
-#include "../../Constants/Strings.h"
-
-#include <algorithm>
-
-
-const int AGRIDOME_CAPACITY = 1000;
-const int AGRIDOME_BASE_PRODUCUCTION = 10;
 
 class Agridome : public FoodProduction
 {
 public:
-	Agridome() : FoodProduction(StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
-	{
-	}
+	Agridome();
 
 protected:
-	void think() override
-	{
-		if (isIdle()) { return; }
+	void think() override;
 
-		mFoodLevel = std::clamp(mFoodLevel + calculateProduction(), 0, AGRIDOME_CAPACITY);
+	void disabledStateSet() override;
 
-		if (isStorageFull())
-		{
-			idle(IdleReason::InternalStorageFull);
-		}
-	}
-
-	void disabledStateSet() override
-	{
-		mFoodLevel = 0;
-	}
-
-	virtual int foodCapacity() override
-	{
-		return AGRIDOME_CAPACITY;
-	}
+	virtual int foodCapacity() override;
 
 private:
-	virtual int calculateProduction() override
-	{
-		if (!operational())
-		{
-			return 0;
-		}
+	virtual int calculateProduction() override;
 
-		return std::min(AGRIDOME_BASE_PRODUCUCTION, AGRIDOME_CAPACITY - mFoodLevel);
-	}
-
-	bool isStorageFull()
-	{
-		return mFoodLevel >= AGRIDOME_CAPACITY;
-	}
+	bool isStorageFull();
 };

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -4,6 +4,8 @@
 #include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 
+#include "../../UI/StringTable.h"
+
 
 namespace
 {

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -1,0 +1,42 @@
+#include "CommTower.h"
+
+
+#include "../../Constants/Strings.h"
+#include "../../Constants/UiConstants.h"
+
+
+namespace
+{
+	const int BaseRange = 10;
+}
+
+
+CommTower::CommTower() : Structure(
+	StructureClass::Communication,
+	StructureID::SID_COMM_TOWER)
+{
+}
+
+
+int CommTower::getRange() const
+{
+	return operational() ? BaseRange : 0;
+}
+
+
+StringTable CommTower::createInspectorViewTable()
+{
+	StringTable stringTable(2, 1);
+
+	stringTable[{0, 0}].text = "Communication Range:";
+
+	auto communicationRange = getRange();
+	stringTable[{1, 0}].text = std::to_string(communicationRange);
+
+	if (communicationRange == 0)
+	{
+		stringTable[{1, 0}].textColor = constants::WarningTextColor;
+	}
+
+	return stringTable;
+}

--- a/appOPHD/MapObjects/Structures/CommTower.h
+++ b/appOPHD/MapObjects/Structures/CommTower.h
@@ -2,43 +2,13 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-#include "../../Constants/UiConstants.h"
-
 
 class CommTower : public Structure
 {
-private:
-	const int BaseRange = 10;
-
 public:
-	CommTower() : Structure(
-		StructureClass::Communication,
-		StructureID::SID_COMM_TOWER)
-	{
-	}
+	CommTower();
 
+	int getRange() const;
 
-	int getRange() const
-	{
-		return operational() ? BaseRange : 0;
-	}
-
-
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 1);
-
-		stringTable[{0, 0}].text = "Communication Range:";
-
-		auto communicationRange = getRange();
-		stringTable[{1, 0}].text = std::to_string(communicationRange);
-
-		if (communicationRange == 0)
-		{
-			stringTable[{1, 0}].textColor = constants::WarningTextColor;
-		}
-
-		return stringTable;
-	}
+	StringTable createInspectorViewTable() override;
 };

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -3,6 +3,8 @@
 #include "../../ProductionCost.h"
 #include "../../States/MapViewStateHelper.h" // yuck
 
+#include <NAS2D/Dictionary.h>
+
 #include <algorithm>
 
 

--- a/appOPHD/MapObjects/Structures/FoodProduction.cpp
+++ b/appOPHD/MapObjects/Structures/FoodProduction.cpp
@@ -1,5 +1,7 @@
 #include "FoodProduction.h"
 
+#include "../../UI/StringTable.h"
+
 
 FoodProduction::FoodProduction(StructureClass structureClass, StructureID id) :
 	Structure(structureClass, id)

--- a/appOPHD/MapObjects/Structures/FoodProduction.cpp
+++ b/appOPHD/MapObjects/Structures/FoodProduction.cpp
@@ -1,0 +1,33 @@
+#include "FoodProduction.h"
+
+
+FoodProduction::FoodProduction(StructureClass structureClass, StructureID id) :
+	Structure(structureClass, id)
+{
+}
+
+
+StringTable FoodProduction::createInspectorViewTable()
+{
+	StringTable stringTable(2, 2);
+
+	stringTable[{0, 0}].text = "Food Stored:";
+	stringTable[{1, 0}].text = std::to_string(mFoodLevel) + " / " + std::to_string(foodCapacity());
+
+	stringTable[{0, 1}].text = "Production Rate:";
+	stringTable[{1, 1}].text = std::to_string(calculateProduction());
+
+	return stringTable;
+}
+
+
+int FoodProduction::foodLevel() const
+{
+	return mFoodLevel;
+}
+
+
+void FoodProduction::foodLevel(int level)
+{
+	mFoodLevel = std::clamp(level, 0, foodCapacity());
+}

--- a/appOPHD/MapObjects/Structures/FoodProduction.h
+++ b/appOPHD/MapObjects/Structures/FoodProduction.h
@@ -2,6 +2,7 @@
 
 #include "../Structure.h"
 
+
 /**
 * Virtual class for structures whose primary purpose is agricultural production
 *
@@ -10,24 +11,12 @@
 class FoodProduction : public Structure
 {
 public:
-	FoodProduction(StructureClass structureClass, StructureID id) :
-		Structure(structureClass, id) {}
+	FoodProduction(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 2);
+	StringTable createInspectorViewTable() override;
 
-		stringTable[{0, 0}].text = "Food Stored:";
-		stringTable[{1, 0}].text = std::to_string(mFoodLevel) + " / " + std::to_string(foodCapacity());
-
-		stringTable[{0, 1}].text = "Production Rate:";
-		stringTable[{1, 1}].text = std::to_string(calculateProduction());
-
-		return stringTable;
-	}
-
-	int foodLevel() const { return mFoodLevel; }
-	void foodLevel(int level) { mFoodLevel = std::clamp(level, 0, foodCapacity()); }
+	int foodLevel() const;
+	void foodLevel(int level);
 
 	virtual int foodCapacity() = 0;
 

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -4,7 +4,7 @@
 #include "../../Constants/Strings.h"
 #include "../../StorableResources.h"
 
-#include "../../States/MapViewStateHelper.h" // yuck
+#include "../../States/MapViewStateHelper.h"
 
 #include <algorithm>
 

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -9,9 +9,23 @@
 #include <algorithm>
 
 
-MaintenanceFacility::MaintenanceFacility() : Structure(
-	StructureClass::Maintenance,
-	StructureID::SID_MAINTENANCE_FACILITY)
+namespace
+{
+	constexpr int MaintenanceSuppliesCapacity{100};
+	constexpr int MaximumPersonnel{10};
+	constexpr int MinimumPersonnel{1};
+}
+
+
+MaintenanceFacility::MaintenanceFacility() :
+	Structure(
+		StructureClass::Maintenance,
+		StructureID::SID_MAINTENANCE_FACILITY
+	),
+	mMaterialsLevel{0},
+	mMaintenancePersonnel{MinimumPersonnel},
+	mAssignedPersonnel{0},
+	mResources{nullptr}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -1,0 +1,195 @@
+#include "MaintenanceFacility.h"
+
+
+#include "../../Constants/Strings.h"
+#include "../../StorableResources.h"
+
+#include "../../States/MapViewStateHelper.h" // yuck
+
+#include <algorithm>
+
+
+MaintenanceFacility::MaintenanceFacility() : Structure(
+	StructureClass::Maintenance,
+	StructureID::SID_MAINTENANCE_FACILITY)
+{
+}
+
+
+void MaintenanceFacility::resources(const StorableResources& resources)
+{
+	mResources = &resources;
+}
+
+
+bool MaintenanceFacility::suppliesAvailable() const
+{
+	return mMaterialsLevel > 0;
+}
+
+
+int MaintenanceFacility::maintenancePersonnel() const
+{
+	return mMaintenancePersonnel;
+}
+
+
+void MaintenanceFacility::addPersonnel()
+{
+	mMaintenancePersonnel = std::clamp(mMaintenancePersonnel + 1, MinimumPersonnel, MaximumPersonnel);
+}
+
+
+void MaintenanceFacility::removePersonnel()
+{
+	mMaintenancePersonnel = std::clamp(mMaintenancePersonnel - 1, MinimumPersonnel, MaximumPersonnel);
+}
+
+
+int MaintenanceFacility::personnel() const
+{
+	return mMaintenancePersonnel;
+}
+
+
+void MaintenanceFacility::personnel(int assigned)
+{
+	mMaintenancePersonnel = assigned;
+}
+
+
+bool MaintenanceFacility::personnelAvailable() const
+{
+	return mAssignedPersonnel < mMaintenancePersonnel;
+}
+
+
+void MaintenanceFacility::addPriorityStructure(Structure* structure)
+{
+	mPriorityList.push_back(structure);
+}
+
+
+void MaintenanceFacility::removePriorityStructure(Structure* structure)
+{
+	auto it = std::find(mPriorityList.begin(), mPriorityList.end(), structure);
+	if (it != mPriorityList.end())
+	{
+		mPriorityList.erase(it);
+	}
+}
+
+
+bool MaintenanceFacility::hasPriorityStructures() const
+{
+	return !mPriorityList.empty();
+}
+
+
+void MaintenanceFacility::repairStructures(StructureList& structures)
+{
+	if (!operational()) { return; }
+
+	if (hasPriorityStructures())
+	{
+		repairPriorityStructures(structures);
+	}
+
+	for (auto* structure : structures)
+	{
+		repairStructure(structure);
+		std::rotate(structures.begin(), structures.begin() + 1, structures.end());
+	}
+}
+
+
+bool MaintenanceFacility::canMakeRepairs() const
+{
+	return (personnelAvailable() && suppliesAvailable());
+}
+
+
+void MaintenanceFacility::moveStructureToBack(StructureList& structures, Structure* structure)
+{
+	auto it = std::find(structures.begin(), structures.end(), structure);
+	if (it != structures.end())
+	{
+		structures.erase(it);
+		structures.push_back(structure);
+	}
+}
+
+
+void MaintenanceFacility::repairPriorityStructures(StructureList& structures)
+{
+	for (auto* structure : mPriorityList)
+	{
+		if (!canMakeRepairs()) { return; }
+
+		repairStructure(structure);
+
+		moveStructureToBack(structures, structure);
+
+		if (structure->operational())
+		{
+			removePriorityStructure(structure);
+		}
+	}
+}
+
+
+void MaintenanceFacility::repairStructure(Structure* structure)
+{
+	if (structure->destroyed() || structure->underConstruction()) { return; }
+
+	if (!canMakeRepairs()) { return; }
+
+	if (structure->disabled() && structure->disabledReason() == DisabledReason::StructuralIntegrity)
+	{
+		--mMaterialsLevel;
+		++mAssignedPersonnel;
+		if (structure->integrity() > 35) // \fixme magic number
+		{
+			structure->integrity(100);
+			structure->enable();
+		}
+		else
+		{
+			structure->integrity(50);
+			addPriorityStructure(structure);
+		}
+	}
+	else if (structure->operational() || structure->isIdle())
+	{
+		--mMaterialsLevel;
+		++mAssignedPersonnel;
+		structure->integrity(100);
+
+		if (structure->structureId() == StructureID::SID_ROAD)
+		{
+			structure->rebuild();
+		}
+	}
+}
+
+
+void MaintenanceFacility::think()
+{
+	if (mMaterialsLevel == MaintenanceSuppliesCapacity) { return; }
+
+	StorableResources maintenanceSuppliesCost{1, 1, 1, 1};
+
+	if (resources() >= maintenanceSuppliesCost)
+	{
+		removeRefinedResources(maintenanceSuppliesCost);
+		mMaterialsLevel = std::clamp(mMaterialsLevel + 1, 0, MaintenanceSuppliesCapacity);
+	}
+
+	mAssignedPersonnel = 0;
+}
+
+
+const StorableResources& MaintenanceFacility::resources()
+{
+	return *mResources;
+}

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -18,189 +18,36 @@ public:
 	static constexpr int MinimumPersonnel{1};
 
 public:
-	MaintenanceFacility() : Structure(
-		StructureClass::Maintenance,
-		StructureID::SID_MAINTENANCE_FACILITY)
-	{
-	}
+	MaintenanceFacility();
 
+	void resources(const StorableResources& resources);
+	bool suppliesAvailable() const;
 
-	void resources(const StorableResources& resources)
-	{
-		mResources = &resources;
-	}
+	int maintenancePersonnel() const;
+	void addPersonnel();
+	void removePersonnel();
+	int personnel() const;
+	void personnel(int assigned);
+	bool personnelAvailable() const;
 
+	void addPriorityStructure(Structure* structure);
+	void removePriorityStructure(Structure* structure);
+	bool hasPriorityStructures() const;
 
-	bool suppliesAvailable() const
-	{
-		return mMaterialsLevel > 0;
-	}
-
-
-	int maintenancePersonnel() const
-	{
-		return mMaintenancePersonnel;
-	}
-
-
-	void addPersonnel()
-	{
-		mMaintenancePersonnel = std::clamp(mMaintenancePersonnel + 1, MinimumPersonnel, MaximumPersonnel);
-	}
-
-
-	void removePersonnel()
-	{
-		mMaintenancePersonnel = std::clamp(mMaintenancePersonnel - 1, MinimumPersonnel, MaximumPersonnel);
-	}
-
-
-	int personnel() const
-	{
-		return mMaintenancePersonnel;
-	}
-
-
-	void personnel(int assigned)
-	{
-		mMaintenancePersonnel = assigned;
-	}
-
-
-	bool personnelAvailable() const
-	{
-		return mAssignedPersonnel < mMaintenancePersonnel;
-	}
-
-
-	void addPriorityStructure(Structure* structure)
-	{
-		mPriorityList.push_back(structure);
-	}
-
-
-	void removePriorityStructure(Structure* structure)
-	{
-		auto it = std::find(mPriorityList.begin(), mPriorityList.end(), structure);
-		if (it != mPriorityList.end())
-		{
-			mPriorityList.erase(it);
-		}
-	}
-
-
-	bool hasPriorityStructures() const
-	{
-		return !mPriorityList.empty();
-	}
-
-
-	void repairStructures(StructureList& structures)
-	{
-		if (!operational()) { return; }
-
-		if (hasPriorityStructures())
-		{
-			repairPriorityStructures(structures);
-		}
-
-		for (auto* structure : structures)
-		{
-			repairStructure(structure);
-			std::rotate(structures.begin(), structures.begin() + 1, structures.end());
-		}
-	}
-
+	void repairStructures(StructureList& structures);
 
 protected:
-	bool canMakeRepairs() const
-	{
-		return (personnelAvailable() && suppliesAvailable());
-	}
+	bool canMakeRepairs() const;
 
+	void moveStructureToBack(StructureList& structures, Structure* structure);
 
-	void moveStructureToBack(StructureList& structures, Structure* structure)
-	{
-		auto it = std::find(structures.begin(), structures.end(), structure);
-		if (it != structures.end())
-		{
-			structures.erase(it);
-			structures.push_back(structure);
-		}
-	}
+	void repairPriorityStructures(StructureList& structures);
+	void repairStructure(Structure* structure);
 
-
-	void repairPriorityStructures(StructureList& structures)
-	{
-		for (auto* structure : mPriorityList)
-		{
-			if (!canMakeRepairs()) { return; }
-
-			repairStructure(structure);
-
-			moveStructureToBack(structures, structure);
-
-			if (structure->operational())
-			{
-				removePriorityStructure(structure);
-			}
-		}
-	}
-
-
-	void repairStructure(Structure* structure)
-	{
-		if (structure->destroyed() || structure->underConstruction()) { return; }
-
-		if (!canMakeRepairs()) { return; }
-
-		if (structure->disabled() && structure->disabledReason() == DisabledReason::StructuralIntegrity)
-		{
-			--mMaterialsLevel;
-			++mAssignedPersonnel;
-			if (structure->integrity() > 35) // \fixme magic number
-			{
-				structure->integrity(100);
-				structure->enable();
-			}
-			else
-			{
-				structure->integrity(50);
-				addPriorityStructure(structure);
-			}
-		}
-		else if (structure->operational() || structure->isIdle())
-		{
-			--mMaterialsLevel;
-			++mAssignedPersonnel;
-			structure->integrity(100);
-
-			if (structure->structureId() == StructureID::SID_ROAD)
-			{
-				structure->rebuild();
-			}
-		}
-	}
-
-
-	void think() override
-	{
-		if (mMaterialsLevel == MaintenanceSuppliesCapacity) { return; }
-
-		StorableResources maintenanceSuppliesCost{1, 1, 1, 1};
-
-		if (resources() >= maintenanceSuppliesCost)
-		{
-			removeRefinedResources(maintenanceSuppliesCost);
-			mMaterialsLevel = std::clamp(mMaterialsLevel + 1, 0, MaintenanceSuppliesCapacity);
-		}
-
-		mAssignedPersonnel = 0;
-	}
-
+	void think() override;
 
 private:
-	const StorableResources& resources() { return *mResources; }
+	const StorableResources& resources();
 
 	int mMaterialsLevel{0};
 	int mMaintenancePersonnel{MinimumPersonnel};

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -13,11 +13,6 @@
 class MaintenanceFacility : public Structure
 {
 public:
-	static constexpr int MaintenanceSuppliesCapacity{100};
-	static constexpr int MaximumPersonnel{10};
-	static constexpr int MinimumPersonnel{1};
-
-public:
 	MaintenanceFacility();
 
 	void resources(const StorableResources& resources);
@@ -49,11 +44,11 @@ protected:
 private:
 	const StorableResources& resources();
 
-	int mMaterialsLevel{0};
-	int mMaintenancePersonnel{MinimumPersonnel};
-	int mAssignedPersonnel{0};
+	int mMaterialsLevel;
+	int mMaintenancePersonnel;
+	int mAssignedPersonnel;
 
 	StructureList mPriorityList;
 
-	const StorableResources* mResources{nullptr};
+	const StorableResources* mResources;
 };

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -2,12 +2,8 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-#include "../../StorableResources.h"
 
-#include "../../States/MapViewStateHelper.h" // yuck
-
-#include <algorithm>
+struct StorableResources;
 
 
 class MaintenanceFacility : public Structure

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -6,6 +6,8 @@
 #include "../../Constants/Strings.h"
 #include "../../StorableResources.h"
 
+#include <algorithm>
+
 
 namespace
 {
@@ -28,6 +30,18 @@ MineFacility::MineFacility(Mine* mine) :
 	mMine(mine)
 {
 	sprite().play(constants::StructureStateConstruction);
+}
+
+
+void MineFacility::mine(Mine* mine)
+{
+	mMine = mine;
+}
+
+
+void MineFacility::maxDepth(int depth)
+{
+	mMaxDepth = depth;
 }
 
 
@@ -126,4 +140,55 @@ bool MineFacility::extending() const
 int MineFacility::digTimeRemaining() const
 {
 	return mDigTurnsRemaining;
+}
+
+
+int MineFacility::assignedTrucks() const
+{
+	return mAssignedTrucks;
+}
+
+
+int MineFacility::maxTruckCount() const
+{
+	return mMaxTruckCount;
+}
+
+
+void MineFacility::addTruck()
+{
+	mAssignedTrucks = std::clamp(mAssignedTrucks + 1, 1, mMaxTruckCount);
+}
+
+
+void MineFacility::removeTruck()
+{
+	mAssignedTrucks = std::clamp(mAssignedTrucks - 1, 1, mMaxTruckCount);
+}
+
+
+/**
+ * Gets a pointer to the mine the MineFacility manages.
+ */
+Mine* MineFacility::mine()
+{
+	return mMine;
+}
+
+
+MineFacility::ExtensionCompleteSignal::Source& MineFacility::extensionComplete()
+{
+	return mExtensionComplete;
+}
+
+
+void MineFacility::assignedTrucks(int count)
+{
+	mAssignedTrucks = count;
+}
+
+
+void MineFacility::digTimeRemaining(int count)
+{
+	mDigTurnsRemaining = count;
 }

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -1,5 +1,7 @@
 #include "MineFacility.h"
 
+#include "../Mine.h"
+
 #include "../../Constants/Numbers.h"
 #include "../../Constants/Strings.h"
 #include "../../StorableResources.h"

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -167,9 +167,6 @@ void MineFacility::removeTruck()
 }
 
 
-/**
- * Gets a pointer to the mine the MineFacility manages.
- */
 Mine* MineFacility::mine()
 {
 	return mMine;

--- a/appOPHD/MapObjects/Structures/MineFacility.h
+++ b/appOPHD/MapObjects/Structures/MineFacility.h
@@ -2,6 +2,7 @@
 
 #include "../Structure.h"
 
+
 struct StorableResources;
 class Mine;
 
@@ -16,8 +17,8 @@ public:
 public:
 	MineFacility(Mine* mine);
 
-	void mine(Mine* mine) { mMine = mine; }
-	void maxDepth(int depth) { mMaxDepth = depth; }
+	void mine(Mine* mine);
+	void maxDepth(int depth);
 
 	bool extending() const;
 	bool canExtend() const;
@@ -25,26 +26,22 @@ public:
 
 	int digTimeRemaining() const;
 
-	int assignedTrucks() const { return mAssignedTrucks; }
-	int maxTruckCount() const { return mMaxTruckCount; }
+	int assignedTrucks() const;
+	int maxTruckCount() const;
 
-	void addTruck() { mAssignedTrucks = std::clamp(mAssignedTrucks + 1, 1, mMaxTruckCount); }
-	void removeTruck() { mAssignedTrucks = std::clamp(mAssignedTrucks - 1, 1, mMaxTruckCount); }
+	void addTruck();
+	void removeTruck();
+	Mine* mine();
 
-	/**
-	 * Gets a pointer to the mine the MineFacility manages.
-	 */
-	Mine* mine() { return mMine; }
-
-	ExtensionCompleteSignal::Source& extensionComplete() { return mExtensionComplete; }
+	ExtensionCompleteSignal::Source& extensionComplete();
 
 protected:
 	friend class MapViewState;
 
 	StorableResources maxTransferAmounts();
 
-	void assignedTrucks(int count) { mAssignedTrucks = count; }
-	void digTimeRemaining(int count) { mDigTurnsRemaining = count; }
+	void assignedTrucks(int count);
+	void digTimeRemaining(int count);
 
 protected:
 	void think() override;

--- a/appOPHD/MapObjects/Structures/MineFacility.h
+++ b/appOPHD/MapObjects/Structures/MineFacility.h
@@ -2,9 +2,8 @@
 
 #include "../Structure.h"
 
-#include "../Mine.h"
-
 struct StorableResources;
+class Mine;
 
 
 /**

--- a/appOPHD/MapObjects/Structures/MineFacility.h
+++ b/appOPHD/MapObjects/Structures/MineFacility.h
@@ -7,9 +7,6 @@ struct StorableResources;
 class Mine;
 
 
-/**
- * Implements the Mine Facility.
- */
 class MineFacility : public Structure
 {
 public:

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -3,6 +3,8 @@
 #include "../../Resources.h"
 #include "../../Constants/Numbers.h"
 
+#include "../../UI/StringTable.h"
+
 
 OreRefining::OreRefining(StructureClass structureClass, StructureID id) :
 	Structure(structureClass, id)

--- a/appOPHD/MapObjects/Structures/PowerStructure.cpp
+++ b/appOPHD/MapObjects/Structures/PowerStructure.cpp
@@ -1,0 +1,37 @@
+#include "PowerStructure.h"
+
+
+#include "../../Constants/UiConstants.h"
+
+#include <string>
+
+
+PowerStructure::PowerStructure(StructureClass structureClass, StructureID id) :
+	Structure(structureClass, id)
+{
+}
+
+
+StringTable PowerStructure::createInspectorViewTable()
+{
+	StringTable stringTable(2, 1);
+
+	stringTable[{0, 0}].text = "Power Produced:";
+
+	auto produced = energyProduced();
+
+	stringTable[{1, 0}].text = std::to_string(produced) + " / " + std::to_string(calculateMaxEnergyProduction());
+
+	if (produced == 0)
+	{
+		stringTable[{1, 0}].textColor = constants::WarningTextColor;
+	}
+
+	return stringTable;
+}
+
+
+int PowerStructure::energyProduced()
+{
+	return operational() ? calculateMaxEnergyProduction() : 0;
+}

--- a/appOPHD/MapObjects/Structures/PowerStructure.cpp
+++ b/appOPHD/MapObjects/Structures/PowerStructure.cpp
@@ -1,7 +1,8 @@
 #include "PowerStructure.h"
 
-
 #include "../../Constants/UiConstants.h"
+
+#include "../../UI/StringTable.h"
 
 #include <string>
 

--- a/appOPHD/MapObjects/Structures/PowerStructure.h
+++ b/appOPHD/MapObjects/Structures/PowerStructure.h
@@ -2,10 +2,6 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/UiConstants.h"
-
-#include <string>
-
 
 /**
  * Virtual class for structures whose primary purpose is power production
@@ -15,31 +11,11 @@
 class PowerStructure : public Structure
 {
 public:
-	PowerStructure(StructureClass structureClass, StructureID id) :
-		Structure(structureClass, id) {}
+	PowerStructure(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 1);
+	StringTable createInspectorViewTable() override;
 
-		stringTable[{0, 0}].text = "Power Produced:";
-
-		auto produced = energyProduced();
-
-		stringTable[{1, 0}].text = std::to_string(produced) + " / " + std::to_string(calculateMaxEnergyProduction());
-
-		if (produced == 0)
-		{
-			stringTable[{1, 0}].textColor = constants::WarningTextColor;
-		}
-
-		return stringTable;
-	}
-
-	int energyProduced()
-	{
-		return operational() ? calculateMaxEnergyProduction() : 0;
-	}
+	int energyProduced();
 
 protected:
 	virtual int calculateMaxEnergyProduction() = 0;

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -4,6 +4,8 @@
 #include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 
+#include "../../UI/StringTable.h"
+
 #include <NAS2D/StringUtils.h>
 
 

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -1,0 +1,67 @@
+#include "Recycling.h"
+
+
+#include "../../Constants/Strings.h"
+#include "../../Constants/UiConstants.h"
+
+#include <NAS2D/StringUtils.h>
+
+
+namespace
+{
+	const int WasteProcessingCapacity = 30;
+	const int ResidentialSupportCount = 10;
+}
+
+
+Recycling::Recycling() : Structure(
+	StructureClass::Recycling,
+	StructureID::SID_RECYCLING)
+{
+}
+
+
+/**
+ * Amount of waste the facility can process per turn.
+ */
+int Recycling::wasteProcessingCapacity() const
+{
+	if (!operational()) {
+		return 0;
+	}
+
+	return WasteProcessingCapacity;
+}
+
+
+/**
+ * Number of residential units the facility can support
+ * each turn.
+ */
+int Recycling::residentialSupportCount() const
+{
+	if (!operational()) {
+		return 0;
+	}
+
+	return ResidentialSupportCount;
+}
+
+
+StringTable Recycling::createInspectorViewTable()
+{
+	StringTable stringTable(2, 2);
+
+	stringTable[{0, 0}].text = "Max Residents Supported:";
+	stringTable[{1, 0}].text = NAS2D::stringFrom(residentialSupportCount());
+
+	stringTable[{0, 1}].text = "Max Waste Processing Capacity:";
+	stringTable[{1, 1}].text = NAS2D::stringFrom(wasteProcessingCapacity());
+
+	if (!operational()) {
+		stringTable[{1, 0}].textColor = constants::WarningTextColor;
+		stringTable[{1, 1}].textColor = constants::WarningTextColor;
+	}
+
+	return stringTable;
+}

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -26,11 +26,7 @@ Recycling::Recycling() : Structure(
  */
 int Recycling::wasteProcessingCapacity() const
 {
-	if (!operational()) {
-		return 0;
-	}
-
-	return WasteProcessingCapacity;
+	return operational() ? WasteProcessingCapacity : 0;
 }
 
 
@@ -40,11 +36,7 @@ int Recycling::wasteProcessingCapacity() const
  */
 int Recycling::residentialSupportCount() const
 {
-	if (!operational()) {
-		return 0;
-	}
-
-	return ResidentialSupportCount;
+	return operational() ? ResidentialSupportCount : 0;
 }
 
 

--- a/appOPHD/MapObjects/Structures/Recycling.h
+++ b/appOPHD/MapObjects/Structures/Recycling.h
@@ -2,68 +2,14 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-#include "../../Constants/UiConstants.h"
-
-#include <NAS2D/StringUtils.h>
-
 
 class Recycling : public Structure
 {
-private:
-	const int WasteProcessingCapacity = 30;
-	const int ResidentialSupportCount = 10;
-
 public:
-	Recycling() : Structure(
-		StructureClass::Recycling,
-		StructureID::SID_RECYCLING)
-	{
-	}
+	Recycling();
 
+	virtual int wasteProcessingCapacity() const;
+	virtual int residentialSupportCount() const;
 
-	/**
-	 * Amount of waste the facility can process per turn.
-	 */
-	virtual int wasteProcessingCapacity() const
-	{
-		if (!operational()) {
-			return 0;
-		}
-
-		return WasteProcessingCapacity;
-	}
-
-
-	/**
-	 * Number of residential units the facility can support
-	 * each turn.
-	 */
-	virtual int residentialSupportCount() const
-	{
-		if (!operational()) {
-			return 0;
-		}
-
-		return ResidentialSupportCount;
-	}
-
-
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 2);
-
-		stringTable[{0, 0}].text = "Max Residents Supported:";
-		stringTable[{1, 0}].text = NAS2D::stringFrom(residentialSupportCount());
-
-		stringTable[{0, 1}].text = "Max Waste Processing Capacity:";
-		stringTable[{1, 1}].text = NAS2D::stringFrom(wasteProcessingCapacity());
-
-		if (!operational()) {
-			stringTable[{1, 0}].textColor = constants::WarningTextColor;
-			stringTable[{1, 1}].textColor = constants::WarningTextColor;
-		}
-
-		return stringTable;
-	}
+	StringTable createInspectorViewTable() override;
 };

--- a/appOPHD/MapObjects/Structures/ResearchFacility.cpp
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.cpp
@@ -1,5 +1,6 @@
 #include "ResearchFacility.h"
 
+#include "../../UI/StringTable.h"
 
 #include <algorithm>
 #include <cmath>

--- a/appOPHD/MapObjects/Structures/ResearchFacility.cpp
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.cpp
@@ -1,0 +1,75 @@
+#include "ResearchFacility.h"
+
+
+#include <algorithm>
+#include <cmath>
+
+
+ResearchFacility::ResearchFacility(StructureClass structureClass, StructureID id) :
+	Structure(structureClass, id)
+{}
+
+
+StringTable ResearchFacility::createInspectorViewTable()
+{
+	StringTable stringTable(2, 3);
+
+	stringTable[{0, 0}].text = "Research Produced:";
+	stringTable[{0, 1}].text = "Regular";
+	stringTable[{0, 2}].text = "Hot";
+
+	stringTable[{1, 1}].text = std::to_string(regularResearchProduced());
+	stringTable[{1, 2}].text = std::to_string(hotResearchProduced());
+
+	return stringTable;
+}
+
+
+int ResearchFacility::regularResearchProduced() const
+{
+	return static_cast<int>(
+		std::floor(static_cast<float>(mActualScientistsEmployed) * mRegularPointsPerScientist));
+}
+
+
+int ResearchFacility::hotResearchProduced() const
+{
+	return static_cast<int>(
+		std::floor(static_cast<float>(mActualScientistsEmployed) * mHotPointsPerScientist));
+}
+
+
+int ResearchFacility::scientistsNeeded() const
+{
+	return mMaxScientistsAllowed - mActualScientistsEmployed;
+}
+
+
+void ResearchFacility::assignScientists(int count)
+{
+	mActualScientistsEmployed = std::clamp(count, 0, mMaxScientistsAllowed);
+}
+
+
+int ResearchFacility::assignedScientists() const
+{
+	return mActualScientistsEmployed;
+}
+
+
+void ResearchFacility::maxScientistsAllowed(int count)
+{
+	mMaxScientistsAllowed = count;
+}
+
+
+void ResearchFacility::regularPointsPerScientist(float count)
+{
+	mRegularPointsPerScientist = count;
+}
+
+
+void ResearchFacility::hotPointsPerScientist(float count)
+{
+	mHotPointsPerScientist = count;
+}

--- a/appOPHD/MapObjects/Structures/ResearchFacility.h
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.h
@@ -2,71 +2,27 @@
 
 #include "../Structure.h"
 
-#include <algorithm>
-#include <cmath>
-
 
 class ResearchFacility : public Structure
 {
 public:
-	ResearchFacility(StructureClass structureClass, StructureID id) :
-		Structure(structureClass, id)
-	{}
+	ResearchFacility(StructureClass structureClass, StructureID id);
 
+	StringTable createInspectorViewTable() override;
 
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 3);
+	int regularResearchProduced() const;
+	int hotResearchProduced() const;
 
-		stringTable[{0, 0}].text = "Research Produced:";
-		stringTable[{0, 1}].text = "Regular";
-		stringTable[{0, 2}].text = "Hot";
+	int scientistsNeeded() const;
 
-		stringTable[{1, 1}].text = std::to_string(regularResearchProduced());
-		stringTable[{1, 2}].text = std::to_string(hotResearchProduced());
-
-		return stringTable;
-	}
-
-
-	int regularResearchProduced() const
-	{
-		return static_cast<int>(
-			std::floor(static_cast<float>(mActualScientistsEmployed) * mRegularPointsPerScientist));
-	}
-
-
-	int hotResearchProduced() const
-	{
-		return static_cast<int>(
-			std::floor(static_cast<float>(mActualScientistsEmployed) * mHotPointsPerScientist));
-	}
-
-
-	int scientistsNeeded() const
-	{
-		return mMaxScientistsAllowed - mActualScientistsEmployed;
-	}
-
-
-	void assignScientists(int count)
-	{
-		mActualScientistsEmployed = std::clamp(count, 0, mMaxScientistsAllowed);
-	}
-
-
-	int assignedScientists() const
-	{
-		return mActualScientistsEmployed;
-	}
-
+	void assignScientists(int count);
+	int assignedScientists() const;
 
 protected:
-	void maxScientistsAllowed(int count) { mMaxScientistsAllowed = count; }
+	void maxScientistsAllowed(int count);
 
-	void regularPointsPerScientist(float count) { mRegularPointsPerScientist = count; }
-	void hotPointsPerScientist(float count) { mHotPointsPerScientist = count; }
-
+	void regularPointsPerScientist(float count);
+	void hotPointsPerScientist(float count);
 
 private:
 	int mMaxScientistsAllowed{0};

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -2,6 +2,8 @@
 
 #include "../../Constants/Strings.h"
 
+#include "../../UI/StringTable.h"
+
 #include <algorithm>
 
 

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -1,0 +1,89 @@
+#include "Residence.h"
+
+#include "../../Constants/Strings.h"
+
+#include <algorithm>
+
+
+namespace
+{
+	const int ResidentialWasteCapacityBase = 1000;
+	const int ResidentialColonistCapacityBase = 25;
+}
+
+
+Residence::Residence() : Structure(
+	StructureClass::Residence,
+	StructureID::SID_RESIDENCE)
+{
+}
+
+
+int Residence::capacity() const { return ResidentialColonistCapacityBase; }
+
+int Residence::wasteCapacity() const { return ResidentialWasteCapacityBase; }
+
+int Residence::wasteAccumulated() const { return mWasteAccumulated; }
+void Residence::wasteAccumulated(int amount) { mWasteAccumulated = amount; }
+
+int Residence::wasteOverflow() const { return mWasteOverflow; }
+void Residence::wasteOverflow(int amount) { mWasteOverflow = amount; }
+
+
+int Residence::pullWaste(int amount)
+{
+	const int pulledAmount = std::clamp(amount, 0, wasteAccumulated() + wasteOverflow());
+
+	const int pulledOverflow = std::clamp(pulledAmount, 0, wasteOverflow());
+	mWasteOverflow -= pulledOverflow;
+
+	if (pulledOverflow < amount)
+	{
+		mWasteAccumulated -= pulledAmount - pulledOverflow;
+	}
+
+	return pulledAmount;
+}
+
+
+void Residence::assignColonists(int amount)
+{
+	mAssignedColonists = std::clamp(amount, 0, capacity());
+}
+
+
+int Residence::assignedColonists() const { return mAssignedColonists; }
+
+
+StringTable Residence::createInspectorViewTable()
+{
+	StringTable stringTable(2, 6);
+
+	stringTable[{0, 0}].text = "Colonist Capacity:";
+	stringTable[{1, 0}].text = std::to_string(capacity());
+
+	stringTable[{0, 1}].text = "Colonists Assigned:";
+	stringTable[{1, 1}].text = std::to_string(assignedColonists());
+
+	stringTable[{0, 3}].text = "Waste Capacity:";
+	stringTable[{1, 3}].text = std::to_string(wasteCapacity());
+
+	stringTable[{0, 4}].text = "Waste Accumulated:";
+	stringTable[{1, 4}].text = std::to_string(wasteAccumulated());
+
+	stringTable[{0, 5}].text = "Waste Overflow:";
+	stringTable[{1, 5}].text = std::to_string(wasteOverflow());
+
+	return stringTable;
+}
+
+
+void Residence::think()
+{
+	mWasteAccumulated += mAssignedColonists;
+	if (mWasteAccumulated > wasteCapacity())
+	{
+		mWasteOverflow += mWasteAccumulated - wasteCapacity();
+		mWasteAccumulated = wasteCapacity();
+	}
+}

--- a/appOPHD/MapObjects/Structures/Residence.h
+++ b/appOPHD/MapObjects/Structures/Residence.h
@@ -2,14 +2,6 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-
-#include <algorithm>
-
-
-const int ResidentialWasteCapacityBase = 1000;
-const int ResidentialColonistCapacityBase = 25;
-
 
 /**
  * Base Residential structure.
@@ -20,83 +12,23 @@ const int ResidentialColonistCapacityBase = 25;
 class Residence : public Structure
 {
 public:
-	Residence() : Structure(
-		StructureClass::Residence,
-		StructureID::SID_RESIDENCE)
-	{
-	}
+	Residence();
 
+	int capacity() const;
+	int wasteCapacity() const;
+	int wasteAccumulated() const;
+	void wasteAccumulated(int amount);
+	int wasteOverflow() const;
+	void wasteOverflow(int amount);
+	int pullWaste(int amount);
 
-	int capacity() const { return ResidentialColonistCapacityBase; }
+	void assignColonists(int amount);
+	int assignedColonists() const;
 
-	int wasteCapacity() const { return ResidentialWasteCapacityBase; }
-
-	int wasteAccumulated() const { return mWasteAccumulated; }
-	void wasteAccumulated(int amount) { mWasteAccumulated = amount; }
-
-	int wasteOverflow() const { return mWasteOverflow; }
-	void wasteOverflow(int amount) { mWasteOverflow = amount; }
-
-
-	int pullWaste(int amount)
-	{
-		const int pulledAmount = std::clamp(amount, 0, wasteAccumulated() + wasteOverflow());
-
-		const int pulledOverflow = std::clamp(pulledAmount, 0, wasteOverflow());
-		mWasteOverflow -= pulledOverflow;
-
-		if (pulledOverflow < amount)
-		{
-			mWasteAccumulated -= pulledAmount - pulledOverflow;
-		}
-
-		return pulledAmount;
-	}
-
-
-	void assignColonists(int amount)
-	{
-		mAssignedColonists = std::clamp(amount, 0, capacity());
-	}
-
-
-	int assignedColonists() const { return mAssignedColonists; }
-
-
-	StringTable createInspectorViewTable() override
-	{
-		StringTable stringTable(2, 6);
-
-		stringTable[{0, 0}].text = "Colonist Capacity:";
-		stringTable[{1, 0}].text = std::to_string(capacity());
-
-		stringTable[{0, 1}].text = "Colonists Assigned:";
-		stringTable[{1, 1}].text = std::to_string(assignedColonists());
-
-		stringTable[{0, 3}].text = "Waste Capacity:";
-		stringTable[{1, 3}].text = std::to_string(wasteCapacity());
-
-		stringTable[{0, 4}].text = "Waste Accumulated:";
-		stringTable[{1, 4}].text = std::to_string(wasteAccumulated());
-
-		stringTable[{0, 5}].text = "Waste Overflow:";
-		stringTable[{1, 5}].text = std::to_string(wasteOverflow());
-
-		return stringTable;
-	}
-
+	StringTable createInspectorViewTable() override;
 
 protected:
-	void think() override
-	{
-		mWasteAccumulated += mAssignedColonists;
-		if (mWasteAccumulated > wasteCapacity())
-		{
-			mWasteOverflow += mWasteAccumulated - wasteCapacity();
-			mWasteAccumulated = wasteCapacity();
-		}
-	}
-
+	void think() override;
 
 protected:
 	int mWasteAccumulated = 0;

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -1,8 +1,9 @@
 #include "StorageTanks.h"
 
-
 #include "../../Resources.h"
 #include "../../Constants/Strings.h"
+
+#include "../../UI/StringTable.h"
 
 
 StorageTanks::StorageTanks() : Structure(

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -21,6 +21,8 @@
 #include "../Map/TileMap.h"
 #include "../Map/MapView.h"
 
+#include "../MapObjects/Mine.h"
+
 #include "../UI/MessageBox.h"
 #include "../UI/DetailMap.h"
 #include "../UI/NavControl.h"

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1,5 +1,7 @@
 #include "MapViewState.h"
 
+#include "MapViewStateHelper.h"
+
 #include "MainMenuState.h"
 #include "MainReportsUiState.h"
 #include "Route.h"

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -10,6 +10,7 @@
 #include "../StructureManager.h"
 #include "../Map/TileMap.h"
 #include "../MapObjects/Robots.h"
+#include "../MapObjects/Mine.h"
 
 #include <libOPHD/DirectionOffset.h>
 

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -4,6 +4,8 @@
 // ==================================================================================
 #include "MapViewState.h"
 
+#include "MapViewStateHelper.h"
+
 #include "../StructureCatalogue.h"
 #include "../StructureManager.h"
 #include "../Map/TileMap.h"

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -6,6 +6,8 @@
 
 #include "MapViewState.h"
 
+#include "MapViewStateHelper.h"
+
 #include "Route.h"
 
 #include "../Cache.h"

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -10,6 +10,7 @@
 #include "../Constants/UiConstants.h"
 #include "../StructureManager.h"
 #include "../TruckAvailability.h"
+#include "../MapObjects/Mine.h"
 #include "../MapObjects/Structures/MineFacility.h"
 #include "../MapObjects/Structures/Warehouse.h"
 

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -3,6 +3,7 @@
 #include "../Cache.h"
 #include "../Map/TileMap.h"
 #include "../Map/MapView.h"
+#include "../MapObjects/Mine.h"
 #include "../MapObjects/Robot.h"
 #include "../States/Route.h"
 #include "../StructureManager.h"

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -15,6 +15,7 @@
 
 #include "../../States/Route.h"
 
+#include "../../MapObjects/Mine.h"
 #include "../../MapObjects/Structures/MineFacility.h"
 
 #include <NAS2D/Utility.h>

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -4,6 +4,7 @@
 
 #include "../../Cache.h"
 #include "../../StructureManager.h"
+#include "../../Constants/UiConstants.h"
 #include "../../MapObjects/Structure.h"
 #include "../../MapObjects/Structures/Warehouse.h"
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -1,8 +1,10 @@
 #include "ResourceInfoBar.h"
 
+
 #include "../Cache.h"
 #include "../Resources.h"
 #include "../Constants/UiConstants.h"
+#include "../States/MapViewStateHelper.h"
 
 #include "../StructureManager.h"
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -1,6 +1,5 @@
 #include "ResourceInfoBar.h"
 
-
 #include "../Cache.h"
 #include "../Resources.h"
 #include "../Constants/UiConstants.h"

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -201,6 +201,7 @@
     <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
+    <ClCompile Include="MapObjects\Structures\PowerStructure.cpp" />
     <ClCompile Include="MapObjects\Structures\Recycling.cpp" />
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\Residence.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
+    <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPlant.cpp" />
     <ClCompile Include="MapObjects\Structures\StorageTanks.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -198,6 +198,7 @@
     <ClCompile Include="MapObjects\Structure.cpp" />
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
+    <ClCompile Include="MapObjects\Structures\FoodProduction.cpp" />
     <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -202,6 +202,7 @@
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp" />
+    <ClCompile Include="MapObjects\Structures\Residence.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPlant.cpp" />
     <ClCompile Include="MapObjects\Structures\StorageTanks.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -197,6 +197,7 @@
     <ClCompile Include="MapObjects\Robots\Robominer.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
+    <ClCompile Include="MapObjects\Structures\CommTower.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\FoodProduction.cpp" />
     <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -198,6 +198,7 @@
     <ClCompile Include="MapObjects\Structure.cpp" />
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
+    <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -196,6 +196,7 @@
     <ClCompile Include="MapObjects\Robots\Robodozer.cpp" />
     <ClCompile Include="MapObjects\Robots\Robominer.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />
+    <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -201,6 +201,7 @@
     <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp" />
+    <ClCompile Include="MapObjects\Structures\Recycling.cpp" />
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\Residence.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\FoodProduction.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="MapObjects\Structure.cpp">
       <Filter>Source Files\MapObjects</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\Agridome.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="MapObjects\Structures\Agridome.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\CommTower.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\Recycling.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\PowerStructure.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Recycling.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClCompile Include="MapObjects\Structures\Factory.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\MaintenanceFacility.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\MineFacility.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="MapObjects\Structures\OreRefining.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\Residence.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>


### PR DESCRIPTION
Splitting method implementations to source files helps to limit transitive includes of files that were only needed for the implementation. Considering how widely the `Structure` classes are included, we should strive to limit what is included from their header files.

Reducing transitive includes should help speed up compile times, as translation units become smaller. It should also improve incremental recompiles, as fewer changes result in a cascade of recompiles.

Additionally, this removes some of the warnings from the Clang flag `-Wweak-vtables`.

Related:
- Issue #1573
- Issue #307
