### PR TITLE
Reduce misc transitive headers

### DIFF
--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <numeric>
 #include <array>
 
 

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -30,10 +30,10 @@ StringTable StorageTanks::createInspectorViewTable()
 		1,
 		{
 			std::to_string(storage().total()) + " / " + std::to_string(storageCapacity()),
-			storage().resources[0],
-			storage().resources[1],
-			storage().resources[2],
-			storage().resources[3]
+			std::to_string(storage().resources[0]),
+			std::to_string(storage().resources[1]),
+			std::to_string(storage().resources[2]),
+			std::to_string(storage().resources[3]),
 		});
 
 	return stringTable;

--- a/appOPHD/ProductPool.cpp
+++ b/appOPHD/ProductPool.cpp
@@ -3,6 +3,7 @@
 #include "Constants/Numbers.h"
 #include "Constants/Strings.h"
 
+#include <NAS2D/Dictionary.h>
 #include <NAS2D/ParserHelper.h>
 
 #include <algorithm>

--- a/appOPHD/ProductPool.h
+++ b/appOPHD/ProductPool.h
@@ -2,9 +2,13 @@
 
 #include <libOPHD/EnumProductType.h>
 
-#include <NAS2D/Dictionary.h>
-
 #include <array>
+
+
+namespace NAS2D
+{
+	class Dictionary;
+}
 
 
 int storageRequiredPerUnit(ProductType type);

--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -134,16 +134,17 @@ void CrimeExecution::stealRawResources(Structure& structure)
 
 void CrimeExecution::stealResources(Structure& structure, const std::array<std::string, 4>& resourceNames)
 {
-	if (structure.storage().isEmpty())
+	auto& storage = structure.storage();
+	if (storage.isEmpty())
 	{
 		return;
 	}
 
-	auto resourceIndicesWithStock = getIndicesWithStock(structure.storage());
+	auto resourceIndicesWithStock = getIndicesWithStock(storage);
 	auto indexToStealFrom = randomNumber.generate<std::size_t>(0, resourceIndicesWithStock.size() - 1);
 
-	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5, structure.storage().resources[indexToStealFrom]);
-	structure.storage().resources[indexToStealFrom] -= amountStolen;
+	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5, storage.resources[indexToStealFrom]);
+	storage.resources[indexToStealFrom] -= amountStolen;
 
 	mCrimeEventSignal.emit(
 		"Resources Stolen",

--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -39,6 +39,22 @@ namespace
 	}
 
 
+	std::vector<std::size_t> getIndicesWithStock(const StorableResources& storabeResources)
+	{
+		std::vector<std::size_t> indicesWithStock;
+
+		for (std::size_t i = 0; i < storabeResources.resources.size(); ++i)
+		{
+			if (storabeResources.resources[i] > 0)
+			{
+				indicesWithStock.push_back(i);
+			}
+		}
+
+		return indicesWithStock;
+	}
+
+
 	int calcAmountForStealing(Difficulty difficulty, int low, int high, int max)
 	{
 		auto stealRandom = randomNumber.generate(low, high);
@@ -123,7 +139,7 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 		return;
 	}
 
-	auto resourceIndicesWithStock = structure.storage().getIndicesWithStock();
+	auto resourceIndicesWithStock = getIndicesWithStock(structure.storage());
 	auto indexToStealFrom = randomNumber.generate<std::size_t>(0, resourceIndicesWithStock.size() - 1);
 
 	int amountStolen = calcAmountForStealing(mDifficulty, 2, 5, structure.storage().resources[indexToStealFrom]);

--- a/appOPHD/StorableResources.cpp
+++ b/appOPHD/StorableResources.cpp
@@ -1,0 +1,142 @@
+#include "StorableResources.h"
+
+#include <algorithm>
+#include <numeric>
+
+
+StorableResources StorableResources::operator*(int multiplier) const
+{
+	StorableResources result = *this;
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		result.resources[i] *= multiplier;
+	}
+	return result;
+}
+
+
+StorableResources StorableResources::operator/(int divisor) const
+{
+	StorableResources result = *this;
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		result.resources[i] /= divisor;
+	}
+	return result;
+}
+
+
+StorableResources& StorableResources::operator+=(const StorableResources& other)
+{
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		resources[i] += other.resources[i];
+	}
+
+	return *this;
+}
+
+
+StorableResources& StorableResources::operator-=(const StorableResources& other)
+{
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		resources[i] -= other.resources[i];
+	}
+
+	return *this;
+}
+
+
+bool StorableResources::operator<=(const StorableResources& other) const
+{
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		if (!(resources[i] <= other.resources[i]))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+
+bool StorableResources::operator<(const StorableResources& other) const
+{
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		if (!(resources[i] < other.resources[i]))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+
+bool StorableResources::operator>=(const StorableResources& other) const
+{
+	return other <= *this;
+}
+
+
+bool StorableResources::operator>(const StorableResources& other) const
+{
+	return other < *this;
+}
+
+
+StorableResources StorableResources::cap(const StorableResources& other) const
+{
+	StorableResources out;
+	for (std::size_t i = 0; i < resources.size(); ++i)
+	{
+		out.resources[i] = std::clamp(resources[i], 0, other.resources[i]);
+	}
+
+	return out;
+}
+
+
+StorableResources StorableResources::cap(int max) const
+{
+	StorableResources out;
+	for (std::size_t i = 0; i < resources.size(); ++i)
+	{
+		out.resources[i] = std::clamp(resources[i], 0, max);
+	}
+
+	return out;
+}
+
+
+bool StorableResources::isEmpty() const
+{
+	for (size_t i = 0; i < resources.size(); ++i)
+	{
+		if (resources[i] > 0)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+
+// Sum of all resource types
+int StorableResources::total() const
+{
+	return std::accumulate(resources.begin(), resources.end(), 0);
+}
+
+
+StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
+{
+	return lhs += rhs;
+}
+
+
+StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
+{
+	return lhs -= rhs;
+}

--- a/appOPHD/StorableResources.h
+++ b/appOPHD/StorableResources.h
@@ -1,138 +1,30 @@
 #pragma once
 
-#include <algorithm>
 #include <array>
-#include <numeric>
 
 
 struct StorableResources
 {
-	constexpr StorableResources operator*(int multiplier) const
-	{
-		StorableResources result = *this;
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			result.resources[i] *= multiplier;
-		}
-		return result;
-	}
+	StorableResources operator*(int multiplier) const;
+	StorableResources operator/(int divisor) const;
 
-	constexpr StorableResources operator/(int divisor) const
-	{
-		StorableResources result = *this;
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			result.resources[i] /= divisor;
-		}
-		return result;
-	}
+	StorableResources& operator+=(const StorableResources& other);
+	StorableResources& operator-=(const StorableResources& other);
 
-	constexpr StorableResources& operator+=(const StorableResources& other)
-	{
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			resources[i] += other.resources[i];
-		}
+	bool operator<=(const StorableResources& other) const;
+	bool operator<(const StorableResources& other) const;
+	bool operator>=(const StorableResources& other) const;
+	bool operator>(const StorableResources& other) const;
 
-		return *this;
-	}
+	StorableResources cap(const StorableResources& other) const;
+	StorableResources cap(int max) const;
 
-	constexpr StorableResources& operator-=(const StorableResources& other)
-	{
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			resources[i] -= other.resources[i];
-		}
-
-		return *this;
-	}
-
-	constexpr bool operator<=(const StorableResources& other) const
-	{
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			if (!(resources[i] <= other.resources[i]))
-			{
-				return false;
-			}
-		}
-		return true;
-	}
-
-	constexpr bool operator<(const StorableResources& other) const
-	{
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			if (!(resources[i] < other.resources[i]))
-			{
-				return false;
-			}
-		}
-		return true;
-	}
-
-	constexpr bool operator>=(const StorableResources& other) const
-	{
-		return other <= *this;
-	}
-
-	constexpr bool operator>(const StorableResources& other) const
-	{
-		return other < *this;
-	}
-
-	constexpr StorableResources cap(const StorableResources& other) const
-	{
-		StorableResources out;
-		for (std::size_t i = 0; i < resources.size(); ++i)
-		{
-			out.resources[i] = std::clamp(resources[i], 0, other.resources[i]);
-		}
-
-		return out;
-	}
-
-	constexpr StorableResources cap(int max) const
-	{
-		StorableResources out;
-		for (std::size_t i = 0; i < resources.size(); ++i)
-		{
-			out.resources[i] = std::clamp(resources[i], 0, max);
-		}
-
-		return out;
-	}
-
-	constexpr bool isEmpty() const
-	{
-		for (size_t i = 0; i < resources.size(); ++i)
-		{
-			if (resources[i] > 0)
-			{
-				return false;
-			}
-		}
-		return true;
-	}
-
-
-	// Sum of all resource types
-	int total() const
-	{
-		return std::accumulate(resources.begin(), resources.end(), 0);
-	}
-
+	bool isEmpty() const;
+	int total() const;
 
 	std::array<int, 4> resources{};
 };
 
 
-constexpr StorableResources operator+(StorableResources lhs, const StorableResources& rhs)
-{
-	return lhs += rhs;
-}
-
-constexpr StorableResources operator-(StorableResources lhs, const StorableResources& rhs)
-{
-	return lhs -= rhs;
-}
+StorableResources operator+(StorableResources lhs, const StorableResources& rhs);
+StorableResources operator-(StorableResources lhs, const StorableResources& rhs);

--- a/appOPHD/StorableResources.h
+++ b/appOPHD/StorableResources.h
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <array>
 #include <numeric>
-#include <vector>
 
 
 struct StorableResources
@@ -121,22 +120,6 @@ struct StorableResources
 	int total() const
 	{
 		return std::accumulate(resources.begin(), resources.end(), 0);
-	}
-
-
-	std::vector<std::size_t> getIndicesWithStock() const
-	{
-		std::vector<std::size_t> indicesWithStock;
-
-		for (std::size_t i = 0; i < resources.size(); ++i)
-		{
-			if (resources[i] > 0)
-			{
-				indicesWithStock.push_back(i);
-			}
-		}
-
-		return indicesWithStock;
 	}
 
 

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -173,10 +173,10 @@ void FactoryProduction::update()
 	stringTable.setColumnText(1,
 		{
 			std::to_string(mFactory->productionTurnsCompleted()) + " of " + std::to_string(mProductCost.turnsToBuild),
-			totalCost.resources[0],
-			totalCost.resources[1],
-			totalCost.resources[2],
-			totalCost.resources[3],
+			std::to_string(totalCost.resources[0]),
+			std::to_string(totalCost.resources[1]),
+			std::to_string(totalCost.resources[2]),
+			std::to_string(totalCost.resources[3]),
 		});
 
 	stringTable.computeRelativeCellPositions();

--- a/appOPHD/UI/StringTable.cpp
+++ b/appOPHD/UI/StringTable.cpp
@@ -95,23 +95,23 @@ void StringTable::setVerticalPadding(int padding)
 	mVerticalPadding = padding;
 }
 
-void StringTable::setColumnText(std::size_t column, const std::vector<NAS2D::StringValue>& rows)
+void StringTable::setColumnText(std::size_t column, const std::vector<std::string>& rows)
 {
 	checkCellIndex({column, rows.size() - 1});
 
 	for (std::size_t row = 0; row < rows.size(); ++row)
 	{
-		mCells[getCellIndex({column, row})].text = rows[row].value;
+		mCells[getCellIndex({column, row})].text = rows[row];
 	}
 }
 
-void StringTable::setRowText(std::size_t row, const std::vector<NAS2D::StringValue>& columns)
+void StringTable::setRowText(std::size_t row, const std::vector<std::string>& columns)
 {
 	checkCellIndex({columns.size() - 1, row});
 
 	for (std::size_t column = 0; column < columns.size(); ++column)
 	{
-		mCells[getCellIndex({column, row})].text = columns[column].value;
+		mCells[getCellIndex({column, row})].text = columns[column];
 	}
 }
 

--- a/appOPHD/UI/StringTable.h
+++ b/appOPHD/UI/StringTable.h
@@ -4,7 +4,6 @@
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Math/Vector.h>
-#include <NAS2D/StringValue.h>
 
 #include <string>
 #include <vector>
@@ -65,8 +64,8 @@ public:
 	void setHorizontalPadding(int horizontalPadding);
 	void setVerticalPadding(int verticalPadding);
 
-	void setColumnText(std::size_t column, const std::vector<NAS2D::StringValue>& rows);
-	void setRowText(std::size_t row, const std::vector<NAS2D::StringValue>& columns);
+	void setColumnText(std::size_t column, const std::vector<std::string>& rows);
+	void setRowText(std::size_t row, const std::vector<std::string>& columns);
 	void setColumnJustification(std::size_t column, Justification justification);
 
 	void setColumnFont(std::size_t column, const NAS2D::Font* const font);

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -237,6 +237,7 @@
     <ClCompile Include="States\PlanetSelectState.cpp" />
     <ClCompile Include="States\SplashState.cpp" />
     <ClCompile Include="States\StructureTracker.cpp" />
+    <ClCompile Include="StorableResources.cpp" />
     <ClCompile Include="StructureCatalogue.cpp" />
     <ClCompile Include="StructureManager.cpp" />
     <ClCompile Include="TruckAvailability.cpp" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -234,6 +234,9 @@
     <ClCompile Include="States\StructureTracker.cpp">
       <Filter>Source Files\States</Filter>
     </ClCompile>
+    <ClCompile Include="StorableResources.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="StructureCatalogue.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Related:
- Issue #1573

Updates:
- Move `getIndicesWithStock` out of `StorableResources` and place it with crime code
  - Removes `<vector>` include from `StorableResources` header
- Split `StorableResources` method implementations to source file
  - Removes implementation required includes for `<algorithm>` and `<numeric>` from header
- Make `StringTable` only accept `std::string`
  - Removes `<StringValue.h>` include from header
- Use forward declare for `Dictionary` in `ProductPool.h`
