### PR TITLE
Update NAS2D submodule for `Fade` updates

### DIFF
--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -37,7 +37,6 @@ MainMenuState::~MainMenuState()
 	eventHandler.keyDown().disconnect({this, &MainMenuState::onKeyDown});
 
 	NAS2D::Utility<NAS2D::Mixer>::get().stopAllAudio();
-	mFade.fadeComplete().disconnect({this, &MainMenuState::onFadeComplete});
 }
 
 

--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -25,7 +25,8 @@ MainMenuState::MainMenuState() :
 		{constants::MainMenuQuit, {this, &MainMenuState::onQuit}}
 	}},
 	lblVersion{constants::Version},
-	mReturnState{this}
+	mReturnState{this},
+	mFade{{this, &MainMenuState::onFadeComplete}}
 {}
 
 
@@ -69,7 +70,6 @@ void MainMenuState::initialize()
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.showSystemPointer(true);
-	mFade.fadeComplete().connect({this, &MainMenuState::onFadeComplete});
 	mFade.fadeIn(constants::FadeSpeed);
 
 	NAS2D::Mixer& mixer = NAS2D::Utility<NAS2D::Mixer>::get();


### PR DESCRIPTION
Update NAS2D submodule to make use of the new `Fade` constructors taking a `Delegate` for the `onFadeComplete` handler.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1217
