### PR TITLE
Resize `FactoryProduction` buttons

### DIFF
--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -46,10 +46,10 @@ FactoryProduction::FactoryProduction() :
 	add(btnApply, {mProductGrid.size().x + 12, 138});
 
 	btnOkay.size(buttonSize);
-	add(btnOkay, {233, 138});
+	add(btnOkay, {mProductGrid.size().x + 12 + buttonSize.x + constants::MarginTight, 138});
 
 	btnCancel.size(buttonSize);
-	add(btnCancel, {276, 138});
+	add(btnCancel, {mProductGrid.size().x + 12 + (buttonSize.x + constants::MarginTight) * 2, 138});
 }
 
 

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -37,7 +37,7 @@ FactoryProduction::FactoryProduction() :
 	chkIdle.size({50, 20});
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
-	const auto buttonArea = Rectangle<int>{{mProductGrid.size().x + 12, 138}, {162, 20}};
+	const auto buttonArea = Rectangle<int>::Create(mProductGrid.area().endPoint(), area().endPoint()).inset({constants::Margin, 3}, {constants::Margin, 4});
 	const auto buttonSize = Vector{(buttonArea.size.x - (constants::MarginTight * 2)) / 3, buttonArea.size.y};
 	const auto buttonSpacing = buttonSize.x + constants::MarginTight;
 

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -37,16 +37,18 @@ FactoryProduction::FactoryProduction() :
 	chkIdle.size({50, 20});
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
+	const auto buttonSize = Vector{40, 20};
+
 	btnClearSelection.size({mProductGrid.size().x, 20});
 	add(btnClearSelection, {constants::Margin, 138});
 
-	btnApply.size({40, 20});
+	btnApply.size(buttonSize);
 	add(btnApply, {mProductGrid.size().x + 12, 138});
 
-	btnOkay.size({40, 20});
+	btnOkay.size(buttonSize);
 	add(btnOkay, {233, 138});
 
-	btnCancel.size({40, 20});
+	btnCancel.size(buttonSize);
 	add(btnCancel, {276, 138});
 }
 

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -41,8 +41,8 @@ FactoryProduction::FactoryProduction() :
 	const auto buttonSize = Vector{(buttonArea.size.x - (constants::MarginTight * 2)) / 3, buttonArea.size.y};
 	const auto buttonSpacing = buttonSize.x + constants::MarginTight;
 
-	btnClearSelection.size({mProductGrid.size().x, 20});
-	add(btnClearSelection, {constants::Margin, 138});
+	btnClearSelection.size({mProductGrid.size().x, buttonSize.y});
+	add(btnClearSelection, {constants::Margin, buttonArea.position.y});
 
 	btnApply.size(buttonSize);
 	add(btnApply, {buttonArea.position.x, buttonArea.position.y});

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -38,7 +38,7 @@ FactoryProduction::FactoryProduction() :
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
 	btnClearSelection.size({mProductGrid.size().x, 20});
-	add(btnClearSelection, {5, 138});
+	add(btnClearSelection, {constants::Margin, 138});
 
 	btnApply.size({40, 20});
 	add(btnApply, {mProductGrid.size().x + 12, 138});

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -37,7 +37,7 @@ FactoryProduction::FactoryProduction() :
 	chkIdle.size({50, 20});
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
-	const auto buttonSize = Vector{40, 20};
+	const auto buttonSize = Vector{52, 20};
 
 	btnClearSelection.size({mProductGrid.size().x, 20});
 	add(btnClearSelection, {constants::Margin, 138});

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -20,11 +20,11 @@ FactoryProduction::FactoryProduction() :
 	mFactory{nullptr},
 	mProduct{ProductType::PRODUCT_NONE},
 	mProductGrid{"ui/factory.png", 32, constants::MarginTight},
-	btnOkay{"Okay", {this, &FactoryProduction::onOkay}},
-	btnCancel{"Cancel", {this, &FactoryProduction::onCancel}},
+	chkIdle{"Idle", {this, &FactoryProduction::onCheckBoxIdleChange}},
 	btnClearSelection{"Clear Selection", {this, &FactoryProduction::onClearSelection}},
 	btnApply{"Apply", {this, &FactoryProduction::onApply}},
-	chkIdle{"Idle", {this, &FactoryProduction::onCheckBoxIdleChange}}
+	btnOkay{"Okay", {this, &FactoryProduction::onOkay}},
+	btnCancel{"Cancel", {this, &FactoryProduction::onCancel}}
 {
 	size({320, 162});
 
@@ -34,11 +34,8 @@ FactoryProduction::FactoryProduction() :
 	mProductGrid.selectionChanged().connect({this, &FactoryProduction::onProductSelectionChange});
 	add(mProductGrid, {constants::Margin, 25});
 
-	btnOkay.size({40, 20});
-	add(btnOkay, {233, 138});
-
-	btnCancel.size({40, 20});
-	add(btnCancel, {276, 138});
+	chkIdle.size({50, 20});
+	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
 	btnClearSelection.size({mProductGrid.size().x, 20});
 	add(btnClearSelection, {5, 138});
@@ -46,8 +43,11 @@ FactoryProduction::FactoryProduction() :
 	btnApply.size({40, 20});
 	add(btnApply, {mProductGrid.size().x + 12, btnClearSelection.positionY()});
 
-	chkIdle.size({50, 20});
-	add(chkIdle, {mProductGrid.size().x + 12, 115});
+	btnOkay.size({40, 20});
+	add(btnOkay, {233, 138});
+
+	btnCancel.size({40, 20});
+	add(btnCancel, {276, 138});
 }
 
 

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -26,7 +26,7 @@ FactoryProduction::FactoryProduction() :
 	btnOkay{"Okay", {this, &FactoryProduction::onOkay}},
 	btnCancel{"Cancel", {this, &FactoryProduction::onCancel}}
 {
-	size({320, 163});
+	size({320, 165});
 
 	mProductGrid.size({140, 110});
 	mProductGrid.showTooltip(true);

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -41,7 +41,7 @@ FactoryProduction::FactoryProduction() :
 	add(btnClearSelection, {5, 138});
 
 	btnApply.size({40, 20});
-	add(btnApply, {mProductGrid.size().x + 12, btnClearSelection.positionY()});
+	add(btnApply, {mProductGrid.size().x + 12, 138});
 
 	btnOkay.size({40, 20});
 	add(btnOkay, {233, 138});

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -26,7 +26,7 @@ FactoryProduction::FactoryProduction() :
 	btnOkay{"Okay", {this, &FactoryProduction::onOkay}},
 	btnCancel{"Cancel", {this, &FactoryProduction::onCancel}}
 {
-	size({320, 162});
+	size({320, 163});
 
 	mProductGrid.size({140, 110});
 	mProductGrid.showTooltip(true);
@@ -37,7 +37,7 @@ FactoryProduction::FactoryProduction() :
 	chkIdle.size({50, 20});
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
-	const auto buttonArea = Rectangle<int>::Create(mProductGrid.area().endPoint(), area().endPoint()).inset({constants::Margin, 3}, {constants::Margin, 4});
+	const auto buttonArea = Rectangle<int>::Create(mProductGrid.area().endPoint() + Vector{constants::Margin, constants::MarginTight}, area().inset(constants::Margin).endPoint());
 	const auto buttonSize = Vector{(buttonArea.size.x - (constants::MarginTight * 2)) / 3, buttonArea.size.y};
 	const auto buttonSpacing = buttonSize.x + constants::MarginTight;
 

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -37,19 +37,21 @@ FactoryProduction::FactoryProduction() :
 	chkIdle.size({50, 20});
 	add(chkIdle, {mProductGrid.size().x + 12, 115});
 
-	const auto buttonSize = Vector{52, 20};
+	const auto buttonArea = Rectangle<int>{{mProductGrid.size().x + 12, 138}, {162, 20}};
+	const auto buttonSize = Vector{(buttonArea.size.x - (constants::MarginTight * 2)) / 3, buttonArea.size.y};
+	const auto buttonSpacing = buttonSize.x + constants::MarginTight;
 
 	btnClearSelection.size({mProductGrid.size().x, 20});
 	add(btnClearSelection, {constants::Margin, 138});
 
 	btnApply.size(buttonSize);
-	add(btnApply, {mProductGrid.size().x + 12, 138});
+	add(btnApply, {buttonArea.position.x, buttonArea.position.y});
 
 	btnOkay.size(buttonSize);
-	add(btnOkay, {mProductGrid.size().x + 12 + buttonSize.x + constants::MarginTight, 138});
+	add(btnOkay, {buttonArea.position.x + buttonSpacing, buttonArea.position.y});
 
 	btnCancel.size(buttonSize);
-	add(btnCancel, {mProductGrid.size().x + 12 + (buttonSize.x + constants::MarginTight) * 2, 138});
+	add(btnCancel, {buttonArea.position.x + buttonSpacing * 2, buttonArea.position.y});
 }
 
 

--- a/appOPHD/UI/FactoryProduction.h
+++ b/appOPHD/UI/FactoryProduction.h
@@ -48,10 +48,10 @@ private:
 
 	IconGrid mProductGrid;
 
-	Button btnOkay;
-	Button btnCancel;
+	CheckBox chkIdle;
+
 	Button btnClearSelection;
 	Button btnApply;
-
-	CheckBox chkIdle;
+	Button btnOkay;
+	Button btnCancel;
 };


### PR DESCRIPTION
Resize `Buttons` in `FactoryProduction` window.

Curiously the "Clear Selection" button was slightly offset from the `IconGrid` position. Margins were also a bit non-standard in some places.

Original:

![image](https://github.com/user-attachments/assets/7b7efa4f-b422-47cb-a3ae-68e44c995b85)

Updated:

![image](https://github.com/user-attachments/assets/e7850605-e308-42ab-83fd-3855455278bc)

Related:
- Issue #1548
