### PR TITLE
Update `TileInspector`

### DIFF
--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -17,7 +17,7 @@ using namespace NAS2D;
 
 namespace
 {
-	const auto lineSpacing = 10;
+	const auto lineSpacing = 12;
 	const auto sectionSpacing = constants::Margin;
 
 	const std::map<TerrainType, std::string> terrainTypeStringTable =

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -17,6 +17,9 @@ using namespace NAS2D;
 
 namespace
 {
+	const auto lineSpacing = 10;
+	const auto sectionSpacing = 7;
+
 	const std::map<TerrainType, std::string> terrainTypeStringTable =
 	{
 		{TerrainType::Dozed, constants::TileBulldozed},
@@ -50,7 +53,6 @@ void TileInspector::update()
 	Window::update();
 
 	auto position = mRect.position + NAS2D::Vector{5, 25};
-	const auto lineSpacing = 10;
 	const auto tilePosition = mTile->xy();
 	drawLabelAndValue(position, "Location: ", std::string{tilePosition});
 
@@ -59,7 +61,7 @@ void TileInspector::update()
 
 	const auto* mine = mTile->mine();
 
-	position = mRect.position + NAS2D::Vector{5, 52};
+	position.y += lineSpacing + sectionSpacing;
 	drawLabelAndValue(position, "Has Mine: ", (mine ? "Yes" : "No"));
 
 	if (mine)

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -3,6 +3,7 @@
 #include "TextRender.h"
 #include "../MineProductionRateString.h"
 #include "../Constants/Strings.h"
+#include "../Constants/UiConstants.h"
 #include "../MapObjects/Mine.h"
 
 #include <libOPHD/EnumTerrainType.h>
@@ -34,7 +35,7 @@ TileInspector::TileInspector() :
 	size({200, 88});
 
 	btnClose.size({50, 20});
-	add(btnClose, size() - btnClose.size() - Vector{5, 5});
+	add(btnClose, size() - btnClose.size() - Vector{constants::Margin, constants::Margin});
 }
 
 

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -34,7 +34,7 @@ TileInspector::TileInspector() :
 	size({200, 88});
 
 	btnClose.size({50, 20});
-	add(btnClose, {145, 63});
+	add(btnClose, size() - btnClose.size() - Vector{5, 5});
 }
 
 

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -48,9 +48,16 @@ void TileInspector::update()
 
 	Window::update();
 
+	auto position = mRect.position + NAS2D::Vector{5, 25};
+	const auto tilePosition = mTile->xy();
+	drawLabelAndValue(position, "Location: ", std::string{tilePosition});
+
+	position.y += 10;
+	drawLabelAndValue(position, "Terrain: ", terrainTypeStringTable.at(mTile->index()));
+
 	const auto* mine = mTile->mine();
 
-	auto position = mRect.position + NAS2D::Vector{5, 52};
+	position = mRect.position + NAS2D::Vector{5, 52};
 	drawLabelAndValue(position, "Has Mine: ", (mine ? "Yes" : "No"));
 
 	if (mine)
@@ -61,13 +68,6 @@ void TileInspector::update()
 		position.y += 10;
 		drawLabelAndValue(position, "Production Rate: ", mineProductionRateEnumToString(mTile->mine()->productionRate()));
 	}
-
-	position = mRect.position + NAS2D::Vector{5, 25};
-	const auto tilePosition = mTile->xy();
-	drawLabelAndValue(position, "Location: ", std::string{tilePosition});
-
-	position.y += 10;
-	drawLabelAndValue(position, "Terrain: ", terrainTypeStringTable.at(mTile->index()));
 }
 
 

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -18,7 +18,7 @@ using namespace NAS2D;
 namespace
 {
 	const auto lineSpacing = 10;
-	const auto sectionSpacing = 7;
+	const auto sectionSpacing = constants::Margin;
 
 	const std::map<TerrainType, std::string> terrainTypeStringTable =
 	{
@@ -35,7 +35,7 @@ TileInspector::TileInspector() :
 	Window{constants::WindowTileInspector},
 	btnClose{"Close", {this, &TileInspector::onClose}}
 {
-	size({200, sWindowTitleBarHeight + lineSpacing * 5 + sectionSpacing + constants::Margin * 2 - 1});
+	size({200, sWindowTitleBarHeight + lineSpacing * 5 + sectionSpacing + constants::Margin * 2});
 
 	btnClose.size({50, 20});
 	add(btnClose, size() - btnClose.size() - Vector{constants::Margin, constants::Margin});

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -49,10 +49,11 @@ void TileInspector::update()
 	Window::update();
 
 	auto position = mRect.position + NAS2D::Vector{5, 25};
+	const auto lineSpacing = 10;
 	const auto tilePosition = mTile->xy();
 	drawLabelAndValue(position, "Location: ", std::string{tilePosition});
 
-	position.y += 10;
+	position.y += lineSpacing;
 	drawLabelAndValue(position, "Terrain: ", terrainTypeStringTable.at(mTile->index()));
 
 	const auto* mine = mTile->mine();
@@ -62,10 +63,10 @@ void TileInspector::update()
 
 	if (mine)
 	{
-		position.y += 10;
+		position.y += lineSpacing;
 		drawLabelAndValue(position, "Active: ", (mine->active() ? "Yes" : "No"));
 
-		position.y += 10;
+		position.y += lineSpacing;
 		drawLabelAndValue(position, "Production Rate: ", mineProductionRateEnumToString(mTile->mine()->productionRate()));
 	}
 }

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -33,8 +33,8 @@ TileInspector::TileInspector() :
 {
 	size({200, 88});
 
-	add(btnClose, {145, 63});
 	btnClose.size({50, 20});
+	add(btnClose, {145, 63});
 }
 
 

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -50,7 +50,7 @@ void TileInspector::update()
 
 	const auto* mine = mTile->mine();
 
-	auto position = mRect.position + NAS2D::Vector{5, 25};
+	auto position = mRect.position + NAS2D::Vector{5, 52};
 	drawLabelAndValue(position, "Has Mine: ", (mine ? "Yes" : "No"));
 
 	if (mine)
@@ -62,7 +62,7 @@ void TileInspector::update()
 		drawLabelAndValue(position, "Production Rate: ", mineProductionRateEnumToString(mTile->mine()->productionRate()));
 	}
 
-	position = mRect.position + NAS2D::Vector{5, 62};
+	position = mRect.position + NAS2D::Vector{5, 25};
 	const auto tilePosition = mTile->xy();
 	drawLabelAndValue(position, "Location: ", std::string{tilePosition});
 

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -35,7 +35,7 @@ TileInspector::TileInspector() :
 	Window{constants::WindowTileInspector},
 	btnClose{"Close", {this, &TileInspector::onClose}}
 {
-	size({200, 88});
+	size({200, sWindowTitleBarHeight + lineSpacing * 5 + sectionSpacing + constants::Margin * 2 - 1});
 
 	btnClose.size({50, 20});
 	add(btnClose, size() - btnClose.size() - Vector{constants::Margin, constants::Margin});


### PR DESCRIPTION
Update `TileInspector` window to allow for more dynamic size and position calculations. Swap order of info. Increase line spacing and window size slightly.

Original:

![image](https://github.com/user-attachments/assets/6597501b-595e-4045-a35b-5b86779a0c83)

Updated:

![image](https://github.com/user-attachments/assets/73d70e48-8193-4a0a-89ca-1cf909aa5bbf)

Related:
- Issue #1548
