### PR TITLE
Use `getDefaultFont()`

### DIFF
--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -59,7 +59,7 @@ void MainMenuState::initialize()
 	mFileIoDialog.anchored(false);
 	mFileIoDialog.hide();
 
-	const NAS2D::Font* tiny_font = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const NAS2D::Font* tiny_font = &Control::getDefaultFont();
 	lblVersion.font(tiny_font);
 	lblVersion.color(NAS2D::Color::White);
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -10,7 +10,6 @@
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 
-#include "../Cache.h"
 #include "../PointerType.h"
 #include "../MeanSolarDistance.h"
 #include "../ProductCatalogue.h"

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -297,7 +297,7 @@ void MapViewState::initialize()
 
 	eventHandler.textInputMode(true);
 
-	MAIN_FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	MAIN_FONT = &Control::getDefaultFont();
 
 	mPathSolver = std::make_unique<micropather::MicroPather>(mTileMap.get(), 250, 6, false);
 }

--- a/appOPHD/States/MapViewStateDraw.cpp
+++ b/appOPHD/States/MapViewStateDraw.cpp
@@ -32,7 +32,7 @@ void MapViewState::drawSystemButton() const
 	// Turns
 	const auto turnImageRect = NAS2D::Rectangle<int>{{128, 0}, {constants::ResourceIconSize, constants::ResourceIconSize}};
 	renderer.drawSubImage(mUiIcons, position, turnImageRect);
-	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const auto& font = Control::getDefaultFont();
 	renderer.drawText(font, std::to_string(mTurnCount), position + textOffset, NAS2D::Color::White);
 
 	position = mTooltipSystemButton.rect().position + NAS2D::Vector{constants::MarginTight, constants::MarginTight};

--- a/appOPHD/States/MapViewStateDraw.cpp
+++ b/appOPHD/States/MapViewStateDraw.cpp
@@ -7,7 +7,6 @@
 #include "Route.h"
 
 #include "../Constants/UiConstants.h"
-#include "../Cache.h"
 #include "../StructureManager.h"
 #include "../Map/TileMap.h"
 #include "../MapObjects/Mine.h"

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -30,7 +30,7 @@ namespace
 
 PlanetSelectState::PlanetSelectState() :
 	mFontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	mTinyFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mTinyFont{Control::getDefaultFont()},
 	mBg{"sys/bg1.png"},
 	mCloud1{"sys/cloud_1.png"},
 	mCloud2{"sys/cloud_2.png"},

--- a/appOPHD/UI/GameOverDialog.cpp
+++ b/appOPHD/UI/GameOverDialog.cpp
@@ -40,6 +40,6 @@ void GameOverDialog::update()
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
-	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const auto& font = Control::getDefaultFont();
 	renderer.drawText(font, "You have failed. Your colony is dead.", position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -16,7 +16,7 @@ using namespace NAS2D;
 
 
 IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{Control::getDefaultFont()},
 	mIconSize{iconEdgeSize},
 	mIconMargin{margin},
 	mIconSheet{imageCache.load(filePath)},

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -53,6 +53,6 @@ void MajorEventAnnouncement::update()
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
-	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const auto& font = Control::getDefaultFont();
 	renderer.drawText(font, mMessage, position() + NAS2D::Vector{5, 290}, NAS2D::Color::White);
 }

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -24,7 +24,7 @@ using namespace NAS2D;
 MineOperationsWindow::MineOperationsWindow() :
 	Window{constants::WindowMineOperations},
 	mFont{Control::getDefaultFont()},
-	mFontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
+	mFontBold{Control::getDefaultFontBold()},
 	mUiIcon{imageCache.load("ui/interface/mine.png")},
 	mIcons{imageCache.load("ui/icons.png")},
 	mPanel{

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -23,7 +23,7 @@ using namespace NAS2D;
 
 MineOperationsWindow::MineOperationsWindow() :
 	Window{constants::WindowMineOperations},
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{Control::getDefaultFont()},
 	mFontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
 	mUiIcon{imageCache.load("ui/interface/mine.png")},
 	mIcons{imageCache.load("ui/icons.png")},

--- a/appOPHD/UI/NavControl.cpp
+++ b/appOPHD/UI/NavControl.cpp
@@ -101,7 +101,7 @@ void NavControl::draw() const
 	}
 
 	// Display the levels "bar"
-	const auto& font = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const auto& font = Control::getDefaultFont();
 	const auto stepSizeWidth = font.width("IX");
 	auto position = mRect.endPoint() - NAS2D::Vector{5, 30 - constants::Margin};
 	for (int i = mMapView.maxDepth(); i >= 0; i--)

--- a/appOPHD/UI/NotificationArea.cpp
+++ b/appOPHD/UI/NotificationArea.cpp
@@ -51,7 +51,7 @@ void drawNotificationIcon(NAS2D::Point<int> position, NotificationArea::Notifica
 
 NotificationArea::NotificationArea() :
 	mIcons{imageCache.load("ui/icons.png")},
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{Control::getDefaultFont()},
 	mNotificationIndex{NoSelection}
 {
 	auto& eventhandler = Utility<EventHandler>::get();

--- a/appOPHD/UI/PopulationPanel.cpp
+++ b/appOPHD/UI/PopulationPanel.cpp
@@ -47,7 +47,7 @@ namespace
 
 PopulationPanel::PopulationPanel(const Population& pop, const PopulationPool& popPool, const Morale& morale) :
 	mFont{Control::getDefaultFont()},
-	mFontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
+	mFontBold{Control::getDefaultFontBold()},
 	mIcons{imageCache.load("ui/icons.png")},
 	mSkin
 	{

--- a/appOPHD/UI/PopulationPanel.cpp
+++ b/appOPHD/UI/PopulationPanel.cpp
@@ -46,7 +46,7 @@ namespace
 
 
 PopulationPanel::PopulationPanel(const Population& pop, const PopulationPool& popPool, const Morale& morale) :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{Control::getDefaultFont()},
 	mFontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
 	mIcons{imageCache.load("ui/icons.png")},
 	mSkin

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -51,7 +51,7 @@ namespace
 
 
 FactoryReport::FactoryReport() :
-	font{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	font{Control::getDefaultFont()},
 	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -31,7 +31,7 @@ using namespace NAS2D;
 
 MineReport::MineReport() :
 	font{Control::getDefaultFont()},
-	fontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
+	fontBold{Control::getDefaultFontBold()},
 	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -30,7 +30,7 @@ using namespace NAS2D;
 
 
 MineReport::MineReport() :
-	font{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	font{Control::getDefaultFont()},
 	fontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal)},
 	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},

--- a/appOPHD/UI/ResourceBreakdownPanel.cpp
+++ b/appOPHD/UI/ResourceBreakdownPanel.cpp
@@ -27,7 +27,7 @@ namespace
 
 
 ResourceBreakdownPanel::ResourceBreakdownPanel() :
-	mFont{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal)},
+	mFont{Control::getDefaultFont()},
 	mIcons{imageCache.load("ui/icons.png")},
 	mSkin{
 		imageCache.load("ui/skin/window_top_left.png"),

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -35,7 +35,7 @@ RobotInspector::RobotInspector() :
 	btnSelfDestruct{"Self Destruct", {this, &RobotInspector::onSelfDestruct}},
 	btnCancel{constants::Cancel, {this, &RobotInspector::onCancel}}
 {
-	const NAS2D::Font& mainFont = fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const NAS2D::Font& mainFont = Control::getDefaultFont();
 	const NAS2D::Font& mainFontBold = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
 
 	constexpr int padding = constants::Margin * 2;

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -36,7 +36,7 @@ RobotInspector::RobotInspector() :
 	btnCancel{constants::Cancel, {this, &RobotInspector::onCancel}}
 {
 	const NAS2D::Font& mainFont = Control::getDefaultFont();
-	const NAS2D::Font& mainFontBold = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+	const NAS2D::Font& mainFontBold = Control::getDefaultFontBold();
 
 	constexpr int padding = constants::Margin * 2;
 	const auto buttonSize = mainFont.size("Cancel Orders") + NAS2D::Vector{padding, padding};

--- a/appOPHD/UI/StringTable.cpp
+++ b/appOPHD/UI/StringTable.cpp
@@ -27,7 +27,7 @@ StringTable::StringTable(std::size_t columns, std::size_t rows) :
 	mCells.resize(columns * rows);
 
 	mDefaultFont = &Control::getDefaultFont();
-	mDefaultTitleFont = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+	mDefaultTitleFont = &Control::getDefaultFontBold();
 }
 
 void StringTable::draw(NAS2D::Renderer& renderer) const

--- a/appOPHD/UI/StringTable.cpp
+++ b/appOPHD/UI/StringTable.cpp
@@ -6,6 +6,8 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+#include <libControls/Control.h>
+
 #include <stdexcept>
 #include <algorithm>
 
@@ -24,7 +26,7 @@ StringTable::StringTable(std::size_t columns, std::size_t rows) :
 {
 	mCells.resize(columns * rows);
 
-	mDefaultFont = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	mDefaultFont = &Control::getDefaultFont();
 	mDefaultTitleFont = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
 }
 

--- a/appOPHD/UI/TextRender.cpp
+++ b/appOPHD/UI/TextRender.cpp
@@ -15,7 +15,7 @@ void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, con
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const NAS2D::Font* FONT = &Control::getDefaultFont();
-	const NAS2D::Font* FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+	const NAS2D::Font* FONT_BOLD = &Control::getDefaultFontBold();
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += FONT_BOLD->width(title);
@@ -27,7 +27,7 @@ void drawLabelAndValueLeftJustify(NAS2D::Point<int> position, int labelWidth, co
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const NAS2D::Font* FONT = &Control::getDefaultFont();
-	const NAS2D::Font* FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+	const NAS2D::Font* FONT_BOLD = &Control::getDefaultFontBold();
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += labelWidth;
@@ -39,7 +39,7 @@ void drawLabelAndValueRightJustify(NAS2D::Point<int> position, int labelWidth, c
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	const NAS2D::Font* FONT = &Control::getDefaultFont();
-	const NAS2D::Font* FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
+	const NAS2D::Font* FONT_BOLD = &Control::getDefaultFontBold();
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
 	position.x += labelWidth - FONT->width(text);

--- a/appOPHD/UI/TextRender.cpp
+++ b/appOPHD/UI/TextRender.cpp
@@ -1,6 +1,5 @@
 #include "TextRender.h"
 
-#include "../Cache.h"
 #include "../Constants/UiConstants.h"
 
 #include <NAS2D/Resource/Font.h>

--- a/appOPHD/UI/TextRender.cpp
+++ b/appOPHD/UI/TextRender.cpp
@@ -14,34 +14,34 @@ void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, con
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = &Control::getDefaultFont();
-	const NAS2D::Font* FONT_BOLD = &Control::getDefaultFontBold();
+	const auto& font = Control::getDefaultFont();
+	const auto& fontBold = Control::getDefaultFontBold();
 
-	renderer.drawText(*FONT_BOLD, title, position, color);
-	position.x += FONT_BOLD->width(title);
-	renderer.drawText(*FONT, text, position, color);
+	renderer.drawText(fontBold, title, position, color);
+	position.x += fontBold.width(title);
+	renderer.drawText(font, text, position, color);
 }
 
 void drawLabelAndValueLeftJustify(NAS2D::Point<int> position, int labelWidth, const std::string& title, const std::string& text, NAS2D::Color color)
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = &Control::getDefaultFont();
-	const NAS2D::Font* FONT_BOLD = &Control::getDefaultFontBold();
+	const auto& font = Control::getDefaultFont();
+	const auto& fontBold = Control::getDefaultFontBold();
 
-	renderer.drawText(*FONT_BOLD, title, position, color);
+	renderer.drawText(fontBold, title, position, color);
 	position.x += labelWidth;
-	renderer.drawText(*FONT, text, position, color);
+	renderer.drawText(font, text, position, color);
 }
 
 void drawLabelAndValueRightJustify(NAS2D::Point<int> position, int labelWidth, const std::string& title, const std::string& text, NAS2D::Color color)
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = &Control::getDefaultFont();
-	const NAS2D::Font* FONT_BOLD = &Control::getDefaultFontBold();
+	const auto& font = Control::getDefaultFont();
+	const auto& fontBold = Control::getDefaultFontBold();
 
-	renderer.drawText(*FONT_BOLD, title, position, color);
-	position.x += labelWidth - FONT->width(text);
-	renderer.drawText(*FONT, text, position, color);
+	renderer.drawText(fontBold, title, position, color);
+	position.x += labelWidth - font.width(text);
+	renderer.drawText(font, text, position, color);
 }

--- a/appOPHD/UI/TextRender.cpp
+++ b/appOPHD/UI/TextRender.cpp
@@ -7,12 +7,14 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Utility.h>
 
+#include <libControls/Control.h>
+
 
 void drawLabelAndValue(NAS2D::Point<int> position, const std::string& title, const std::string& text, NAS2D::Color color)
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const NAS2D::Font* FONT = &Control::getDefaultFont();
 	const NAS2D::Font* FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
@@ -24,7 +26,7 @@ void drawLabelAndValueLeftJustify(NAS2D::Point<int> position, int labelWidth, co
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const NAS2D::Font* FONT = &Control::getDefaultFont();
 	const NAS2D::Font* FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);
@@ -36,7 +38,7 @@ void drawLabelAndValueRightJustify(NAS2D::Point<int> position, int labelWidth, c
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const NAS2D::Font* FONT = &fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal);
+	const NAS2D::Font* FONT = &Control::getDefaultFont();
 	const NAS2D::Font* FONT_BOLD = &fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal);
 
 	renderer.drawText(*FONT_BOLD, title, position, color);


### PR DESCRIPTION
Use `getDefaultFont()` and `getDefaultFontBold()`.

Refactor `TextRenderer.cpp` to use reference syntax and camelCased names for `Font` variables.

Remove no longer needed includes for `Cache.h`.

Related:
- Issue #1548
