### PR TITLE
Remove `extern` `Font`

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -42,8 +42,6 @@
 
 extern NAS2D::Point<int> MOUSE_COORDS;
 
-const NAS2D::Font* MAIN_FONT = nullptr;
-
 
 namespace
 {
@@ -295,8 +293,6 @@ void MapViewState::initialize()
 	eventHandler.mouseWheel().connect({this, &MapViewState::onMouseWheel});
 
 	eventHandler.textInputMode(true);
-
-	MAIN_FONT = &Control::getDefaultFont();
 
 	mPathSolver = std::make_unique<micropather::MicroPather>(mTileMap.get(), 250, 6, false);
 }

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -92,9 +92,6 @@ enum class InsertMode
 using RobotTileTable = std::map<Robot*, Tile*>;
 
 
-extern const NAS2D::Font* MAIN_FONT;
-
-
 class MapViewState : public Wrapper
 {
 public:

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -22,7 +22,6 @@
 
 
 extern NAS2D::Point<int> MOUSE_COORDS;
-extern const NAS2D::Font* MAIN_FONT; /// yuck
 
 
 namespace
@@ -150,11 +149,13 @@ void ResourceInfoBar::draw() const
 		std::tuple{ResourceImageRectsRefined[3], mResourcesCount.resources[3], 0},
 	};
 
+	const auto& font = Control::getDefaultFont();
+
 	for (const auto& [imageRect, amount, spacing] : resources)
 	{
 		renderer.drawSubImage(mUiIcons, position, imageRect);
 		const auto color = (amount <= 10 && !mIgnoreGlow) ? glowColor : NAS2D::Color::White;
-		renderer.drawText(*MAIN_FONT, std::to_string(amount), position + textOffset, color);
+		renderer.drawText(font, std::to_string(amount), position + textOffset, color);
 		position.x += spacing;
 	}
 
@@ -173,7 +174,7 @@ void ResourceInfoBar::draw() const
 		renderer.drawSubImage(mUiIcons, position, imageRect);
 		const auto color = (isHighlighted  && !mIgnoreGlow) ? glowColor : NAS2D::Color::White;
 		const auto text = std::to_string(parts) + "/" + std::to_string(total);
-		renderer.drawText(*MAIN_FONT, text, position + textOffset, color);
+		renderer.drawText(font, text, position + textOffset, color);
 		position.x += (x + offsetX) * 2;
 	}
 
@@ -189,7 +190,7 @@ void ResourceInfoBar::draw() const
 	const auto moraleLevel = (std::clamp(mMorale.currentMorale(), 1, 999) / 200);
 	const auto popMoraleImageRect = NAS2D::Rectangle<int>{{176 + moraleLevel * constants::ResourceIconSize, 0}, {constants::ResourceIconSize, constants::ResourceIconSize}};
 	renderer.drawSubImage(mUiIcons, position, popMoraleImageRect);
-	renderer.drawText(*MAIN_FONT, std::to_string(mPopulation.getPopulations().size()), position + textOffset, NAS2D::Color::White);
+	renderer.drawText(font, std::to_string(mPopulation.getPopulations().size()), position + textOffset, NAS2D::Color::White);
 }
 
 

--- a/appOPHD/UI/RobotDeploymentSummary.cpp
+++ b/appOPHD/UI/RobotDeploymentSummary.cpp
@@ -11,9 +11,6 @@
 #include <array>
 
 
-extern const NAS2D::Font* MAIN_FONT; /// yuck
-
-
 RobotDeploymentSummary::RobotDeploymentSummary(const RobotPool& robotPool) :
 	mRobotPool{robotPool},
 	mUiIcons{imageCache.load("ui/icons.png")}
@@ -45,7 +42,7 @@ void RobotDeploymentSummary::draw() const
 	{
 		renderer.drawSubImage(mUiIcons, position, imageRect);
 		const auto text = std::to_string(parts) + "/" + std::to_string(total);
-		renderer.drawText(*MAIN_FONT, text, position + textOffset, NAS2D::Color::White);
+		renderer.drawText(Control::getDefaultFont(), text, position + textOffset, NAS2D::Color::White);
 		position.y += 25;
 	}
 }

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -15,10 +15,14 @@
 
 using namespace NAS2D;
 
-const int LIST_ITEM_HEIGHT = 30;
 
-static const Font* MAIN_FONT = nullptr;
-static const Font* MAIN_FONT_BOLD = nullptr;
+namespace
+{
+	const int LIST_ITEM_HEIGHT = 30;
+
+	const Font* MAIN_FONT = nullptr;
+	const Font* MAIN_FONT_BOLD = nullptr;
+}
 
 
 static void drawItem(Renderer& renderer, StructureListBox::StructureListBoxItem& item, NAS2D::Rectangle<int> rect, bool highlight)


### PR DESCRIPTION
Remove ugly hacks using `extern` to access a `MAIN_FONT` variable. Use `Control::getDefaultFont()` instead.

Related:
- Issue #1548
- PR #1590
