### PR TITLE
Refactor `ListBoxBase` item height related code

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -21,7 +21,6 @@ using namespace NAS2D;
 
 namespace
 {
-	const int LIST_ITEM_HEIGHT = 58;
 	const Image* STRUCTURE_ICONS = nullptr;
 }
 
@@ -62,7 +61,7 @@ FactoryListBox::FactoryListBox() :
 		fontCache.load(constants::FONT_PRIMARY_BOLD, 12)
 	}
 {
-	itemHeight(LIST_ITEM_HEIGHT);
+	itemHeight(58);
 	STRUCTURE_ICONS = &imageCache.load("ui/structures.png");
 }
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -139,9 +139,9 @@ void FactoryListBox::update()
 			*static_cast<FactoryListBoxItem*>(mItems[i]),
 			{
 				{positionX(),
-				positionY() + (static_cast<int>(i) * LIST_ITEM_HEIGHT) - static_cast<int>(drawOffset())},
+				positionY() + static_cast<int>(i * itemHeight() - drawOffset())},
 				{static_cast<int>(itemWidth()),
-				LIST_ITEM_HEIGHT}
+				static_cast<int>(itemHeight())}
 			},
 			i == selectedIndex());
 	}

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -16,12 +16,6 @@
 using namespace NAS2D;
 
 
-namespace
-{
-	const int LIST_ITEM_HEIGHT = 30;
-}
-
-
 static void drawItem(Renderer& renderer, const NAS2D::Font& font, const NAS2D::Font& fontBold, StructureListBox::StructureListBoxItem& item, NAS2D::Rectangle<int> rect, bool highlight)
 {
 	const auto structureState = item.structure->state();
@@ -52,7 +46,7 @@ StructureListBox::StructureListBox() :
 		fontCache.load(constants::FONT_PRIMARY_BOLD, 12)
 	}
 {
-	itemHeight(LIST_ITEM_HEIGHT);
+	itemHeight(30);
 }
 
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -133,9 +133,9 @@ void StructureListBox::update()
 			*static_cast<StructureListBoxItem*>(mItems[i]),
 			{
 				{positionX(),
-				positionY() + (static_cast<int>(i) * LIST_ITEM_HEIGHT) - static_cast<int>(drawOffset())},
+				positionY() + static_cast<int>(i * itemHeight() - drawOffset())},
 				{static_cast<int>(itemWidth()),
-				LIST_ITEM_HEIGHT}
+				static_cast<int>(itemHeight())}
 			},
 			i == selectedIndex());
 	}


### PR DESCRIPTION
Make use of the `itemHeight()` member function in `ListBoxBase` derived subclasses.

Related:
- Issue #1548
- PR #1592
- Issue #479
