### PR TITLE
Fix `ProductListBox` scroll

### DIFF
--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -76,19 +76,19 @@ void ProductListBox::update()
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
-		const auto y = positionY() + (static_cast<int>(i) * itemSize.y);
+		const auto y = positionY() + (static_cast<int>(i) * itemSize.y) - offset;
 		const auto highlight = i == selectedIndex();
 
 		// Draw highlight rect so as not to tint/hue colors of everything else
-		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{{x, y - offset}, itemSize}, highlightColor); }
+		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{{x, y}, itemSize}, highlightColor); }
 
 		// Draw item borders and column breaks
-		renderer.drawBox(NAS2D::Rectangle<int>{{x + 2, y + 2 - offset}, {itemSize.x - 4, itemSize.y - 4}}, constants::PrimaryColor);
+		renderer.drawBox(NAS2D::Rectangle<int>{{x + 2, y + 2}, {itemSize.x - 4, itemSize.y - 4}}, constants::PrimaryColor);
 		renderer.drawLine(NAS2D::Point{x + firstStop, y + 2}, NAS2D::Point{x + firstStop, y + itemSize.y - 2}, constants::PrimaryColor);
 		renderer.drawLine(NAS2D::Point{x + secondStop, y + 2}, NAS2D::Point{x + secondStop, y + itemSize.y - 2}, constants::PrimaryColor);
 
 		// Draw item column contents
-		renderer.drawText(mFontBold, item.text, NAS2D::Point{x + 5, ((y + 15) - mFontBold.height() / 2) - offset}, constants::PrimaryColor);
+		renderer.drawText(mFontBold, item.text, NAS2D::Point{x + 5, ((y + 15) - mFontBold.height() / 2)}, constants::PrimaryColor);
 		renderer.drawText(mFont, "Quantity: " + std::to_string(item.count), NAS2D::Point{x + firstStop + 5, ((y + 15) - mFontBold.height() / 2)}, constants::PrimaryColor);
 		drawProgressBar(
 			item.capacityUsed,

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -71,11 +71,11 @@ void ProductListBox::update()
 	const auto firstStop = itemSize.x / 3;
 	const auto secondStop = itemSize.x * 2 / 3;
 
-	for (std::size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		const auto drawPosition = NAS2D::Point{positionX(), positionY() + (static_cast<int>(i) * itemSize.y) - static_cast<int>(drawOffset())};
-		const auto highlight = i == selectedIndex();
-		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
+		const auto drawPosition = NAS2D::Point{positionX(), positionY() + (static_cast<int>(index) * itemSize.y) - static_cast<int>(drawOffset())};
+		const auto highlight = index == selectedIndex();
+		const auto& item = *static_cast<ProductListBoxItem*>(mItems[index]);
 
 		// Draw highlight rect so as not to tint/hue colors of everything else
 		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{drawPosition, itemSize}, highlightColor); }

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -82,7 +82,7 @@ void ProductListBox::update()
 		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{drawPosition, itemSize}, highlightColor); }
 
 		// Draw item borders and column breaks
-		renderer.drawBox(NAS2D::Rectangle<int>{drawPosition + Vector{2, 2}, {itemSize.x - 4, itemSize.y - 4}}, constants::PrimaryColor);
+		renderer.drawBox(NAS2D::Rectangle{drawPosition, itemSize}.inset(2), constants::PrimaryColor);
 		renderer.drawLine(drawPosition + NAS2D::Vector{firstStop, 2}, drawPosition + NAS2D::Vector{firstStop, itemSize.y - 2}, constants::PrimaryColor);
 		renderer.drawLine(drawPosition + NAS2D::Vector{secondStop, 2}, drawPosition + NAS2D::Vector{secondStop, itemSize.y - 2}, constants::PrimaryColor);
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -71,29 +71,28 @@ void ProductListBox::update()
 	const auto firstStop = itemSize.x / 3;
 	const auto secondStop = itemSize.x * 2 / 3;
 	const auto offset = static_cast<int>(drawOffset());
-	const auto x = positionX();
 
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
-		const auto y = positionY() + (static_cast<int>(i) * itemSize.y) - offset;
+		const auto drawPosition = NAS2D::Point{positionX(), positionY() + (static_cast<int>(i) * itemSize.y) - offset};
 		const auto highlight = i == selectedIndex();
 
 		// Draw highlight rect so as not to tint/hue colors of everything else
-		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{{x, y}, itemSize}, highlightColor); }
+		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{drawPosition, itemSize}, highlightColor); }
 
 		// Draw item borders and column breaks
-		renderer.drawBox(NAS2D::Rectangle<int>{{x + 2, y + 2}, {itemSize.x - 4, itemSize.y - 4}}, constants::PrimaryColor);
-		renderer.drawLine(NAS2D::Point{x + firstStop, y + 2}, NAS2D::Point{x + firstStop, y + itemSize.y - 2}, constants::PrimaryColor);
-		renderer.drawLine(NAS2D::Point{x + secondStop, y + 2}, NAS2D::Point{x + secondStop, y + itemSize.y - 2}, constants::PrimaryColor);
+		renderer.drawBox(NAS2D::Rectangle<int>{drawPosition + Vector{2, 2}, {itemSize.x - 4, itemSize.y - 4}}, constants::PrimaryColor);
+		renderer.drawLine(drawPosition + NAS2D::Vector{firstStop, 2}, drawPosition + NAS2D::Vector{firstStop, itemSize.y - 2}, constants::PrimaryColor);
+		renderer.drawLine(drawPosition + NAS2D::Vector{secondStop, 2}, drawPosition + NAS2D::Vector{secondStop, itemSize.y - 2}, constants::PrimaryColor);
 
 		// Draw item column contents
-		renderer.drawText(mFontBold, item.text, NAS2D::Point{x + 5, ((y + 15) - mFontBold.height() / 2)}, constants::PrimaryColor);
-		renderer.drawText(mFont, "Quantity: " + std::to_string(item.count), NAS2D::Point{x + firstStop + 5, ((y + 15) - mFontBold.height() / 2)}, constants::PrimaryColor);
+		renderer.drawText(mFontBold, item.text, drawPosition + NAS2D::Vector{5, 15 - mFontBold.height() / 2}, constants::PrimaryColor);
+		renderer.drawText(mFont, "Quantity: " + std::to_string(item.count), drawPosition + NAS2D::Vector{firstStop + 5, 15 - mFontBold.height() / 2}, constants::PrimaryColor);
 		drawProgressBar(
 			item.capacityUsed,
 			item.capacityTotal,
-			{{x + secondStop + 5, y + 10}, {firstStop - 10, 10}},
+			{drawPosition + NAS2D::Vector{secondStop + 5, 10}, {firstStop - 10, 10}},
 			2
 		);
 	}

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -73,9 +73,9 @@ void ProductListBox::update()
 
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
 		const auto drawPosition = NAS2D::Point{positionX(), positionY() + (static_cast<int>(i) * itemSize.y) - static_cast<int>(drawOffset())};
 		const auto highlight = i == selectedIndex();
+		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
 
 		// Draw highlight rect so as not to tint/hue colors of everything else
 		if (highlight) { renderer.drawBoxFilled(NAS2D::Rectangle{drawPosition, itemSize}, highlightColor); }

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -70,12 +70,11 @@ void ProductListBox::update()
 	const auto itemSize = NAS2D::Vector{itemWidth(), itemHeight()}.to<int>();
 	const auto firstStop = itemSize.x / 3;
 	const auto secondStop = itemSize.x * 2 / 3;
-	const auto offset = static_cast<int>(drawOffset());
 
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
 		const auto& item = *static_cast<ProductListBoxItem*>(mItems[i]);
-		const auto drawPosition = NAS2D::Point{positionX(), positionY() + (static_cast<int>(i) * itemSize.y) - offset};
+		const auto drawPosition = NAS2D::Point{positionX(), positionY() + (static_cast<int>(i) * itemSize.y) - static_cast<int>(drawOffset())};
 		const auto highlight = i == selectedIndex();
 
 		// Draw highlight rect so as not to tint/hue colors of everything else


### PR DESCRIPTION
Fix drawing code that was not scrolling all drawn elements of `ProductListBox` items.

Apply a bit of refactoring to the drawing code.

Related:
- Issue #1548
- Issue #479
