### PR TITLE
Refactor `ListBoxBase` - Organize methods

### DIFF
--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -242,6 +242,18 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 }
 
 
+unsigned int ListBoxBase::itemWidth() const
+{
+	return static_cast<unsigned int>(mItemWidth);
+}
+
+
+unsigned int ListBoxBase::itemHeight() const
+{
+	return static_cast<unsigned int>(mItemHeight);
+}
+
+
 /**
  * Sets item height.
  *

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -217,7 +217,7 @@ const ListBoxBase::ListBoxItem& ListBoxBase::selected() const
 
 /**
  * Sets the current selection index.
- * 
+ *
  * \note	Out of range selection indicies will set the ListBoxBase to no selection.
  */
 void ListBoxBase::setSelection(std::size_t selection)
@@ -238,7 +238,7 @@ void ListBoxBase::clearSelected()
 
 /**
  * Sets item height.
- * 
+ *
  * \note	Internal function for specialized types.
  */
 void ListBoxBase::itemHeight(int h)

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -265,6 +265,12 @@ void ListBoxBase::itemHeight(int h)
 }
 
 
+unsigned int ListBoxBase::drawOffset() const
+{
+	return mScrollOffsetInPixels;
+}
+
+
 NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 {
 	return NAS2D::Vector{itemWidth(), itemHeight()}.to<int>();

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -57,6 +57,19 @@ std::size_t ListBoxBase::count() const
 }
 
 
+/**
+ * Clears all items from the list.
+ */
+void ListBoxBase::clear()
+{
+	for (auto item : mItems) { delete item; }
+	mItems.clear();
+	mSelectedIndex = NoSelection;
+	mHighlightIndex = NoSelection;
+	updateScrollLayout();
+}
+
+
 void ListBoxBase::onVisibilityChange(bool)
 {
 	updateScrollLayout();
@@ -163,19 +176,6 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
  */
 void ListBoxBase::onSlideChange(ScrollBar::ValueType /*newPosition*/)
 {
-	updateScrollLayout();
-}
-
-
-/**
- * Clears all items from the list.
- */
-void ListBoxBase::clear()
-{
-	for (auto item : mItems) { delete item; }
-	mItems.clear();
-	mSelectedIndex = NoSelection;
-	mHighlightIndex = NoSelection;
 	updateScrollLayout();
 }
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -70,6 +70,62 @@ void ListBoxBase::clear()
 }
 
 
+/**
+ * Index of the current mouse hover highlight.
+ */
+std::size_t ListBoxBase::currentHighlight() const
+{
+	return mHighlightIndex;
+}
+
+
+/**
+ * Index of the current selection.
+ */
+std::size_t ListBoxBase::selectedIndex() const
+{
+	return mSelectedIndex;
+}
+
+
+bool ListBoxBase::isItemSelected() const
+{
+	return mSelectedIndex != NoSelection;
+}
+
+
+const ListBoxBase::ListBoxItem& ListBoxBase::selected() const
+{
+	if (mSelectedIndex == NoSelection)
+	{
+		throw std::runtime_error("ListBox has no selected item");
+	}
+
+	return *mItems[mSelectedIndex];
+}
+
+
+/**
+ * Sets the current selection index.
+ *
+ * \note	Out of range selection indicies will set the ListBoxBase to no selection.
+ */
+void ListBoxBase::setSelection(std::size_t selection)
+{
+	mSelectedIndex = (selection < mItems.size()) ? selection : NoSelection;
+	mSelectionChanged();
+}
+
+
+/**
+ * Clears the current selection.
+ */
+void ListBoxBase::clearSelected()
+{
+	mSelectedIndex = NoSelection;
+}
+
+
 void ListBoxBase::onVisibilityChange(bool)
 {
 	updateScrollLayout();
@@ -177,62 +233,6 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 void ListBoxBase::onSlideChange(ScrollBar::ValueType /*newPosition*/)
 {
 	updateScrollLayout();
-}
-
-
-/**
- * Index of the current mouse hover highlight.
- */
-std::size_t ListBoxBase::currentHighlight() const
-{
-	return mHighlightIndex;
-}
-
-
-/**
- * Index of the current selection.
- */
-std::size_t ListBoxBase::selectedIndex() const
-{
-	return mSelectedIndex;
-}
-
-
-bool ListBoxBase::isItemSelected() const
-{
-	return mSelectedIndex != NoSelection;
-}
-
-
-const ListBoxBase::ListBoxItem& ListBoxBase::selected() const
-{
-	if (mSelectedIndex == NoSelection)
-	{
-		throw std::runtime_error("ListBox has no selected item");
-	}
-
-	return *mItems[mSelectedIndex];
-}
-
-
-/**
- * Sets the current selection index.
- *
- * \note	Out of range selection indicies will set the ListBoxBase to no selection.
- */
-void ListBoxBase::setSelection(std::size_t selection)
-{
-	mSelectedIndex = (selection < mItems.size()) ? selection : NoSelection;
-	mSelectionChanged();
-}
-
-
-/**
- * Clears the current selection.
- */
-void ListBoxBase::clearSelected()
-{
-	mSelectedIndex = NoSelection;
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -132,12 +132,6 @@ ListBoxBase::SelectionChangeSignal::Source& ListBoxBase::selectionChanged()
 }
 
 
-void ListBoxBase::onVisibilityChange(bool)
-{
-	updateScrollLayout();
-}
-
-
 /**
  * Updates values required for properly displaying list items.
  */
@@ -163,10 +157,25 @@ void ListBoxBase::updateScrollLayout()
 }
 
 
+void ListBoxBase::onVisibilityChange(bool)
+{
+	updateScrollLayout();
+}
+
+
 /**
  * Resized event handler.
  */
 void ListBoxBase::onResize()
+{
+	updateScrollLayout();
+}
+
+
+/**
+ * ScrollBar changed event handler.
+ */
+void ListBoxBase::onSlideChange(ScrollBar::ValueType /*newPosition*/)
 {
 	updateScrollLayout();
 }
@@ -230,15 +239,6 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 	auto change = static_cast<ScrollBar::ValueType>(mItemHeight);
 
 	mScrollBar.changeValue((scrollAmount.y < 0 ? change : -change));
-}
-
-
-/**
- * ScrollBar changed event handler.
- */
-void ListBoxBase::onSlideChange(ScrollBar::ValueType /*newPosition*/)
-{
-	updateScrollLayout();
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -126,6 +126,12 @@ void ListBoxBase::clearSelected()
 }
 
 
+ListBoxBase::SelectionChangeSignal::Source& ListBoxBase::selectionChanged()
+{
+	return mSelectionChanged;
+}
+
+
 void ListBoxBase::onVisibilityChange(bool)
 {
 	updateScrollLayout();

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -52,13 +52,12 @@ public:
 
 	void clear();
 
+	std::size_t currentHighlight() const;
+	std::size_t selectedIndex() const;
 	bool isItemSelected() const;
 	const ListBoxItem& selected() const;
-	std::size_t selectedIndex() const;
 	void setSelection(std::size_t selection);
 	void clearSelected();
-
-	std::size_t currentHighlight() const;
 
 	SelectionChangeSignal::Source& selectionChanged() { return mSelectionChanged; }
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -59,7 +59,7 @@ public:
 	void setSelection(std::size_t selection);
 	void clearSelected();
 
-	SelectionChangeSignal::Source& selectionChanged() { return mSelectionChanged; }
+	SelectionChangeSignal::Source& selectionChanged();
 
 	void update() override = 0;
 	void draw() const override;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -80,8 +80,8 @@ protected:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
-	unsigned int itemWidth() const { return static_cast<unsigned int>(mItemWidth); }
-	unsigned int itemHeight() const { return static_cast<unsigned int>(mItemHeight); }
+	unsigned int itemWidth() const;
+	unsigned int itemHeight() const;
 	void itemHeight(int);
 
 	unsigned int drawOffset() const { return mScrollOffsetInPixels; }

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -84,7 +84,7 @@ protected:
 	unsigned int itemHeight() const;
 	void itemHeight(int);
 
-	unsigned int drawOffset() const { return mScrollOffsetInPixels; }
+	unsigned int drawOffset() const;
 	NAS2D::Vector<int> itemDrawSize() const;
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -73,6 +73,13 @@ protected:
 
 	void updateScrollLayout();
 
+	void onVisibilityChange(bool) override;
+	void onResize() override;
+	void onSlideChange(ScrollBar::ValueType newPosition);
+	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
+	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
+
 	unsigned int itemWidth() const { return static_cast<unsigned int>(mItemWidth); }
 	unsigned int itemHeight() const { return static_cast<unsigned int>(mItemHeight); }
 	void itemHeight(int);
@@ -82,8 +89,6 @@ protected:
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;
 
-	void onVisibilityChange(bool) override;
-
 
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;
@@ -91,15 +96,6 @@ protected:
 	std::vector<ListBoxItem*> mItems;
 
 private:
-	void onSlideChange(ScrollBar::ValueType newPosition);
-
-	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
-	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
-	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
-
-	void onResize() override;
-
-
 	std::size_t mHighlightIndex = NoSelection;
 	std::size_t mSelectedIndex = NoSelection;
 	unsigned int mScrollOffsetInPixels = 0;


### PR DESCRIPTION
Organize `ListBoxBase` functions and move implementations to source file.

Related:
- Issue #479
