### PR TITLE
Add `virtual` method `ListBoxBase::drawItem`

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -126,13 +126,25 @@ void FactoryListBox::update()
 	{
 		drawItem(
 			renderer,
-			mFont,
-			mFontBold,
-			mStructureIcons,
-			*static_cast<FactoryListBoxItem*>(mItems[index]),
 			itemDrawArea(index),
-			index == selectedIndex());
+			index,
+			index == selectedIndex()
+		);
 	}
 
 	renderer.clipRectClear();
+}
+
+
+void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
+{
+	::drawItem(
+		renderer,
+		mFont,
+		mFontBold,
+		mStructureIcons,
+		*static_cast<FactoryListBoxItem*>(mItems[index]),
+		drawArea,
+		isSelected
+	);
 }

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -89,18 +89,14 @@ NAS2D::Color FactoryListBox::itemBorderColor(std::size_t index) const
 }
 
 
-void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
+void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
 	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
 	const Factory& factory = *item.factory;
 	const auto productType = factory.productType();
 	const auto factoryState = factory.state();
 	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
-
-	// draw highlight rect so as not to tint/hue colors of everything else
 	const auto& borderColor = itemBorderColor(index);
-	if (isSelected) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
-	renderer.drawBox(drawArea.inset(2), borderColor);
 
 	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
 	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(borderColor.alpha));

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -19,36 +19,6 @@
 using namespace NAS2D;
 
 
-static void drawItem(Renderer& renderer, const NAS2D::Font& font, const NAS2D::Font& fontBold, const NAS2D::Image& structureIcons, FactoryListBox::FactoryListBoxItem& item, NAS2D::Rectangle<int> rect, bool highlight)
-{
-	Factory* f = item.factory;
-
-	const auto productType = f->productType();
-	const auto factoryState = f->state();
-
-	const auto& structureColor = structureColorFromIndex(factoryState);
-	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
-
-	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { renderer.drawBoxFilled(rect, structureColor.alphaFade(75)); }
-	renderer.drawBox(rect.inset(2), structureColor);
-
-	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
-	renderer.drawSubImage(structureIcons, rect.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
-	renderer.drawText(fontBold, f->name(), rect.position + NAS2D::Vector{64, 29 - fontBold.height() / 2}, structureTextColor);
-	if (productType != ProductType::PRODUCT_NONE)
-	{
-		renderer.drawText(font, ProductCatalogue::get(productType).Name, rect.crossXPoint() + NAS2D::Vector{-112, 19 - fontBold.height() / 2}, structureTextColor);
-		drawProgressBar(
-			f->productionTurnsCompleted(),
-			f->productionTurnsToComplete(),
-			NAS2D::Rectangle{rect.crossXPoint() + NAS2D::Vector{-112, 30}, {105, 11}},
-			2
-		);
-	}
-}
-
-
 FactoryListBox::FactoryListBox() :
 	ListBoxBase{
 		fontCache.load(constants::FONT_PRIMARY, 12),
@@ -112,13 +82,30 @@ Factory* FactoryListBox::selectedFactory()
 
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
-	::drawItem(
-		renderer,
-		mFont,
-		mFontBold,
-		mStructureIcons,
-		*static_cast<FactoryListBoxItem*>(mItems[index]),
-		drawArea,
-		isSelected
-	);
+	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
+	Factory* f = item.factory;
+
+	const auto productType = f->productType();
+	const auto factoryState = f->state();
+
+	const auto& structureColor = structureColorFromIndex(factoryState);
+	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
+
+	// draw highlight rect so as not to tint/hue colors of everything else
+	if (isSelected) { renderer.drawBoxFilled(drawArea, structureColor.alphaFade(75)); }
+	renderer.drawBox(drawArea.inset(2), structureColor);
+
+	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
+	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
+	renderer.drawText(mFontBold, f->name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
+	if (productType != ProductType::PRODUCT_NONE)
+	{
+		renderer.drawText(mFont, ProductCatalogue::get(productType).Name, drawArea.crossXPoint() + NAS2D::Vector{-112, 19 - mFontBold.height() / 2}, structureTextColor);
+		drawProgressBar(
+			f->productionTurnsCompleted(),
+			f->productionTurnsToComplete(),
+			NAS2D::Rectangle{drawArea.crossXPoint() + NAS2D::Vector{-112, 30}, {105, 11}},
+			2
+		);
+	}
 }

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -80,23 +80,30 @@ Factory* FactoryListBox::selectedFactory()
 }
 
 
+NAS2D::Color FactoryListBox::itemBorderColor(std::size_t index) const
+{
+	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
+	const Factory& factory = *item.factory;
+	const auto factoryState = factory.state();
+	return structureColorFromIndex(factoryState);
+}
+
+
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
 	const Factory& factory = *item.factory;
-
 	const auto productType = factory.productType();
 	const auto factoryState = factory.state();
-
-	const auto& structureColor = structureColorFromIndex(factoryState);
 	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
 
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (isSelected) { renderer.drawBoxFilled(drawArea, structureColor.alphaFade(75)); }
-	renderer.drawBox(drawArea.inset(2), structureColor);
+	const auto& borderColor = itemBorderColor(index);
+	if (isSelected) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
+	renderer.drawBox(drawArea.inset(2), borderColor);
 
 	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
-	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
+	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(borderColor.alpha));
 	renderer.drawText(mFontBold, factory.name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
 	if (productType != ProductType::PRODUCT_NONE)
 	{

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -124,12 +124,7 @@ void FactoryListBox::update()
 
 	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		drawItem(
-			renderer,
-			itemDrawArea(index),
-			index,
-			index == selectedIndex()
-		);
+		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
 	}
 
 	renderer.clipRectClear();

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -83,10 +83,10 @@ Factory* FactoryListBox::selectedFactory()
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
-	const Factory* factory = item.factory;
+	const Factory& factory = *item.factory;
 
-	const auto productType = factory->productType();
-	const auto factoryState = factory->state();
+	const auto productType = factory.productType();
+	const auto factoryState = factory.state();
 
 	const auto& structureColor = structureColorFromIndex(factoryState);
 	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
@@ -97,13 +97,13 @@ void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 
 	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
 	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
-	renderer.drawText(mFontBold, factory->name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
+	renderer.drawText(mFontBold, factory.name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
 	if (productType != ProductType::PRODUCT_NONE)
 	{
 		renderer.drawText(mFont, ProductCatalogue::get(productType).Name, drawArea.crossXPoint() + NAS2D::Vector{-112, 19 - mFontBold.height() / 2}, structureTextColor);
 		drawProgressBar(
-			factory->productionTurnsCompleted(),
-			factory->productionTurnsToComplete(),
+			factory.productionTurnsCompleted(),
+			factory.productionTurnsToComplete(),
 			NAS2D::Rectangle{drawArea.crossXPoint() + NAS2D::Vector{-112, 30}, {105, 11}},
 			2
 		);

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -83,10 +83,10 @@ Factory* FactoryListBox::selectedFactory()
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
-	Factory* f = item.factory;
+	Factory* factory = item.factory;
 
-	const auto productType = f->productType();
-	const auto factoryState = f->state();
+	const auto productType = factory->productType();
+	const auto factoryState = factory->state();
 
 	const auto& structureColor = structureColorFromIndex(factoryState);
 	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
@@ -97,13 +97,13 @@ void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 
 	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
 	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(structureColor.alpha));
-	renderer.drawText(mFontBold, f->name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
+	renderer.drawText(mFontBold, factory->name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
 	if (productType != ProductType::PRODUCT_NONE)
 	{
 		renderer.drawText(mFont, ProductCatalogue::get(productType).Name, drawArea.crossXPoint() + NAS2D::Vector{-112, 19 - mFontBold.height() / 2}, structureTextColor);
 		drawProgressBar(
-			f->productionTurnsCompleted(),
-			f->productionTurnsToComplete(),
+			factory->productionTurnsCompleted(),
+			factory->productionTurnsToComplete(),
 			NAS2D::Rectangle{drawArea.crossXPoint() + NAS2D::Vector{-112, 30}, {105, 11}},
 			2
 		);

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -83,7 +83,7 @@ Factory* FactoryListBox::selectedFactory()
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
-	Factory* factory = item.factory;
+	const Factory* factory = item.factory;
 
 	const auto productType = factory->productType();
 	const auto factoryState = factory->state();

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -110,27 +110,6 @@ Factory* FactoryListBox::selectedFactory()
 }
 
 
-/**
- * Draws the FactoryListBox
- */
-void FactoryListBox::update()
-{
-	if (!visible()) { return; }
-	ListBoxBase::update();
-
-	auto& renderer = Utility<Renderer>::get();
-
-	renderer.clipRect(mRect);
-
-	for (std::size_t index = 0; index < mItems.size(); ++index)
-	{
-		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
-	}
-
-	renderer.clipRectClear();
-}
-
-
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	::drawItem(

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -41,7 +41,7 @@ public:
 protected:
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 
-	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
 	const NAS2D::Image& mStructureIcons;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -39,6 +39,8 @@ public:
 	Factory* selectedFactory();
 
 protected:
+	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
+
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 
 private:

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -38,8 +38,6 @@ public:
 
 	Factory* selectedFactory();
 
-	void update() override;
-
 protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -41,7 +41,7 @@ public:
 	void update() override;
 
 protected:
-	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const;
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 
 private:
 	const NAS2D::Image& mStructureIcons;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -40,6 +40,9 @@ public:
 
 	void update() override;
 
+protected:
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const;
+
 private:
 	const NAS2D::Image& mStructureIcons;
 };

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -68,29 +68,34 @@ void ProductListBox::update()
 	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
 		const auto drawArea = itemDrawArea(index);
-		const auto highlight = index == selectedIndex();
-		const auto firstStop = drawArea.size.x / 3;
-		const auto secondStop = drawArea.size.x * 2 / 3;
-		const auto& item = *static_cast<ProductListBoxItem*>(mItems[index]);
-
-		// Draw highlight rect so as not to tint/hue colors of everything else
-		if (highlight) { renderer.drawBoxFilled(drawArea, {0, 185, 0, 75}); }
-
-		// Draw item borders and column breaks
-		renderer.drawBox(drawArea.inset(2), constants::PrimaryColor);
-		renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);
-		renderer.drawLine(drawArea.position + NAS2D::Vector{secondStop, 2}, drawArea.position + NAS2D::Vector{secondStop, drawArea.size.y - 2}, constants::PrimaryColor);
-
-		// Draw item column contents
-		renderer.drawText(mFontBold, item.text, drawArea.position + NAS2D::Vector{5, 15 - mFontBold.height() / 2}, constants::PrimaryColor);
-		renderer.drawText(mFont, "Quantity: " + std::to_string(item.count), drawArea.position + NAS2D::Vector{firstStop + 5, 15 - mFontBold.height() / 2}, constants::PrimaryColor);
-		drawProgressBar(
-			item.capacityUsed,
-			item.capacityTotal,
-			{drawArea.position + NAS2D::Vector{secondStop + 5, 10}, {firstStop - 10, 10}},
-			2
-		);
+		drawItem(renderer, drawArea, index, index == selectedIndex());
 	}
 
 	renderer.clipRectClear();
+}
+
+
+void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
+{
+	const auto firstStop = drawArea.size.x / 3;
+	const auto secondStop = drawArea.size.x * 2 / 3;
+	const auto& item = *static_cast<ProductListBoxItem*>(mItems[index]);
+
+	// Draw highlight rect so as not to tint/hue colors of everything else
+	if (isSelected) { renderer.drawBoxFilled(drawArea, {0, 185, 0, 75}); }
+
+	// Draw item borders and column breaks
+	renderer.drawBox(drawArea.inset(2), constants::PrimaryColor);
+	renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);
+	renderer.drawLine(drawArea.position + NAS2D::Vector{secondStop, 2}, drawArea.position + NAS2D::Vector{secondStop, drawArea.size.y - 2}, constants::PrimaryColor);
+
+	// Draw item column contents
+	renderer.drawText(mFontBold, item.text, drawArea.position + NAS2D::Vector{5, 15 - mFontBold.height() / 2}, constants::PrimaryColor);
+	renderer.drawText(mFont, "Quantity: " + std::to_string(item.count), drawArea.position + NAS2D::Vector{firstStop + 5, 15 - mFontBold.height() / 2}, constants::PrimaryColor);
+	drawProgressBar(
+		item.capacityUsed,
+		item.capacityTotal,
+		{drawArea.position + NAS2D::Vector{secondStop + 5, 10}, {firstStop - 10, 10}},
+		2
+	);
 }

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -53,16 +53,11 @@ void ProductListBox::productPool(ProductPool& pool)
 }
 
 
-void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
+void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
 	const auto firstStop = drawArea.size.x / 3;
 	const auto secondStop = drawArea.size.x * 2 / 3;
 	const auto& item = *static_cast<ProductListBoxItem*>(mItems[index]);
-
-	// Draw highlight rect so as not to tint/hue colors of everything else
-	const auto& borderColor = itemBorderColor(index);
-	if (isSelected) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
-	renderer.drawBox(drawArea.inset(2), borderColor);
 
 	// Draw column breaks
 	renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -53,27 +53,6 @@ void ProductListBox::productPool(ProductPool& pool)
 }
 
 
-/**
- * Draws the FactoryListBox
- */
-void ProductListBox::update()
-{
-	if (!visible()) { return; }
-	ListBoxBase::update();
-
-	auto& renderer = Utility<Renderer>::get();
-
-	renderer.clipRect(mRect);
-
-	for (std::size_t index = 0; index < mItems.size(); ++index)
-	{
-		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
-	}
-
-	renderer.clipRectClear();
-}
-
-
 void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	const auto firstStop = drawArea.size.x / 3;

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -67,8 +67,7 @@ void ProductListBox::update()
 
 	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		const auto drawArea = itemDrawArea(index);
-		drawItem(renderer, drawArea, index, index == selectedIndex());
+		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
 	}
 
 	renderer.clipRectClear();

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -60,10 +60,11 @@ void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 	const auto& item = *static_cast<ProductListBoxItem*>(mItems[index]);
 
 	// Draw highlight rect so as not to tint/hue colors of everything else
-	if (isSelected) { renderer.drawBoxFilled(drawArea, {0, 185, 0, 75}); }
+	const auto& borderColor = itemBorderColor(index);
+	if (isSelected) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
+	renderer.drawBox(drawArea.inset(2), borderColor);
 
-	// Draw item borders and column breaks
-	renderer.drawBox(drawArea.inset(2), constants::PrimaryColor);
+	// Draw column breaks
 	renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);
 	renderer.drawLine(drawArea.position + NAS2D::Vector{secondStop, 2}, drawArea.position + NAS2D::Vector{secondStop, drawArea.size.y - 2}, constants::PrimaryColor);
 

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -29,5 +29,5 @@ public:
 	void productPool(ProductPool&);
 
 protected:
-	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -29,4 +29,7 @@ public:
 	void productPool(ProductPool&);
 
 	void update() override;
+
+protected:
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -31,5 +31,5 @@ public:
 	void update() override;
 
 protected:
-	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const;
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -28,8 +28,6 @@ public:
 
 	void productPool(ProductPool&);
 
-	void update() override;
-
 protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 };

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -121,12 +121,24 @@ void StructureListBox::update()
 	{
 		drawItem(
 			renderer,
-			mFont,
-			mFontBold,
-			*static_cast<StructureListBoxItem*>(mItems[index]),
 			itemDrawArea(index),
-			index == selectedIndex());
+			index,
+			index == selectedIndex()
+		);
 	}
 
 	renderer.clipRectClear();
+}
+
+
+void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
+{
+	::drawItem(
+		renderer,
+		mFont,
+		mFontBold,
+		*static_cast<StructureListBoxItem*>(mItems[index]),
+		drawArea,
+		isSelected
+	);
 }

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -105,27 +105,6 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 }
 
 
-/**
- * Draws the FactoryListBox
- */
-void StructureListBox::update()
-{
-	if (!visible()) { return; }
-	ListBoxBase::update();
-
-	auto& renderer = Utility<Renderer>::get();
-
-	renderer.clipRect(mRect);
-
-	for (std::size_t index = 0; index < mItems.size(); ++index)
-	{
-		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
-	}
-
-	renderer.clipRectClear();
-}
-
-
 void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	::drawItem(

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -97,16 +97,11 @@ NAS2D::Color StructureListBox::itemBorderColor(std::size_t index) const
 }
 
 
-void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
+void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
 	const auto& item = *static_cast<StructureListBoxItem*>(mItems[index]);
 	const auto structureState = item.structure->state();
 	const auto& structureTextColor = structureTextColorFromIndex(structureState);
-
-	// draw highlight rect so as not to tint/hue colors of everything else
-	const auto& borderColor = itemBorderColor(index);
-	if (isSelected) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
-	renderer.drawBox(drawArea.inset(2), borderColor);
 
 	const auto yOffset = 15 - mFontBold.height() / 2;
 	renderer.drawText(mFontBold, item.text, drawArea.position + NAS2D::Vector{5, yOffset}, structureTextColor);

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -119,12 +119,7 @@ void StructureListBox::update()
 
 	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		drawItem(
-			renderer,
-			itemDrawArea(index),
-			index,
-			index == selectedIndex()
-		);
+		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
 	}
 
 	renderer.clipRectClear();

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -89,16 +89,24 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 }
 
 
+NAS2D::Color StructureListBox::itemBorderColor(std::size_t index) const
+{
+	const auto& item = *static_cast<StructureListBoxItem*>(mItems[index]);
+	const auto structureState = item.structure->state();
+	return structureColorFromIndex(structureState);
+}
+
+
 void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
 	const auto& item = *static_cast<StructureListBoxItem*>(mItems[index]);
 	const auto structureState = item.structure->state();
-	const auto& structureColor = structureColorFromIndex(structureState);
 	const auto& structureTextColor = structureTextColorFromIndex(structureState);
 
 	// draw highlight rect so as not to tint/hue colors of everything else
-	if (isSelected) { renderer.drawBoxFilled(drawArea, structureColor.alphaFade(75)); }
-	renderer.drawBox(drawArea.inset(2), structureColor);
+	const auto& borderColor = itemBorderColor(index);
+	if (isSelected) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
+	renderer.drawBox(drawArea.inset(2), borderColor);
 
 	const auto yOffset = 15 - mFontBold.height() / 2;
 	renderer.drawText(mFontBold, item.text, drawArea.position + NAS2D::Vector{5, yOffset}, structureTextColor);

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -16,22 +16,6 @@
 using namespace NAS2D;
 
 
-static void drawItem(Renderer& renderer, const NAS2D::Font& font, const NAS2D::Font& fontBold, StructureListBox::StructureListBoxItem& item, NAS2D::Rectangle<int> rect, bool highlight)
-{
-	const auto structureState = item.structure->state();
-	const auto& structureColor = structureColorFromIndex(structureState);
-	const auto& structureTextColor = structureTextColorFromIndex(structureState);
-
-	// draw highlight rect so as not to tint/hue colors of everything else
-	if (highlight) { renderer.drawBoxFilled(rect, structureColor.alphaFade(75)); }
-	renderer.drawBox(rect.inset(2), structureColor);
-
-	const auto yOffset = 15 - fontBold.height() / 2;
-	renderer.drawText(fontBold, item.text, rect.position + NAS2D::Vector{5, yOffset}, structureTextColor);
-	renderer.drawText(font, item.structureState, rect.crossXPoint() + NAS2D::Vector{-font.width(item.structureState) - 5, yOffset}, structureTextColor);
-}
-
-
 StructureListBox::StructureListBoxItem::StructureListBoxItem(Structure* s) :
 	ListBoxItem{s->name()},
 	structure{s},
@@ -107,12 +91,16 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 
 void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const
 {
-	::drawItem(
-		renderer,
-		mFont,
-		mFontBold,
-		*static_cast<StructureListBoxItem*>(mItems[index]),
-		drawArea,
-		isSelected
-	);
+	const auto& item = *static_cast<StructureListBoxItem*>(mItems[index]);
+	const auto structureState = item.structure->state();
+	const auto& structureColor = structureColorFromIndex(structureState);
+	const auto& structureTextColor = structureTextColorFromIndex(structureState);
+
+	// draw highlight rect so as not to tint/hue colors of everything else
+	if (isSelected) { renderer.drawBoxFilled(drawArea, structureColor.alphaFade(75)); }
+	renderer.drawBox(drawArea.inset(2), structureColor);
+
+	const auto yOffset = 15 - mFontBold.height() / 2;
+	renderer.drawText(mFontBold, item.text, drawArea.position + NAS2D::Vector{5, yOffset}, structureTextColor);
+	renderer.drawText(mFont, item.structureState, drawArea.crossXPoint() + NAS2D::Vector{-mFont.width(item.structureState) - 5, yOffset}, structureTextColor);
 }

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -36,8 +36,6 @@ public:
 
 	StructureListBoxItem* last();
 
-	void update() override;
-
 protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 };

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -39,5 +39,5 @@ public:
 protected:
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 
-	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 };

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -39,5 +39,5 @@ public:
 	void update() override;
 
 protected:
-	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const;
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 };

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -37,4 +37,7 @@ public:
 	StructureListBoxItem* last();
 
 	void update() override;
+
+protected:
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const;
 };

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -37,5 +37,7 @@ public:
 	StructureListBoxItem* last();
 
 protected:
+	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
+
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const override;
 };

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -295,8 +295,20 @@ NAS2D::Rectangle<int> ListBoxBase::itemDrawArea(std::size_t index) const
 void ListBoxBase::update()
 {
 	if (!visible()) { return; }
+
 	draw();
 	mScrollBar.update();
+
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+
+	renderer.clipRect(mRect);
+
+	for (std::size_t index = 0; index < mItems.size(); ++index)
+	{
+		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
+	}
+
+	renderer.clipRectClear();
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -310,7 +310,17 @@ void ListBoxBase::update()
 
 	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		drawItem(renderer, itemDrawArea(index), index, index == selectedIndex());
+		const auto drawArea = itemDrawArea(index);
+		const auto& borderColor = itemBorderColor(index);
+		if (index == selectedIndex())
+		{
+			// Draw background highlight (drawn first to avoid tinting everything else)
+			renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75));
+		}
+		// Draw border
+		renderer.drawBox(drawArea.inset(2), borderColor);
+
+		drawItem(renderer, drawArea, index);
 	}
 
 	renderer.clipRectClear();

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -1,6 +1,5 @@
 #include "ListBoxBase.h"
 
-
 #include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -286,6 +285,12 @@ NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 NAS2D::Rectangle<int> ListBoxBase::itemDrawArea(std::size_t index) const
 {
 	return {itemDrawPosition(index), itemDrawSize()};
+}
+
+
+NAS2D::Color ListBoxBase::itemBorderColor(std::size_t /*index*/) const
+{
+	return {0, 185, 0};
 }
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -89,6 +89,8 @@ protected:
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;
 
+	virtual NAS2D::Color itemBorderColor(std::size_t index) const;
+
 	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const = 0;
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -89,6 +89,8 @@ protected:
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;
 
+	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const = 0;
+
 
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -61,7 +61,7 @@ public:
 
 	SelectionChangeSignal::Source& selectionChanged();
 
-	void update() override = 0;
+	void update() override;
 	void draw() const override;
 
 protected:

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -91,7 +91,7 @@ protected:
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const;
 
-	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index, bool isSelected) const = 0;
+	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const = 0;
 
 
 	const NAS2D::Font& mFont;


### PR DESCRIPTION
Add `virtual` method `ListBoxBase::drawItem` and merge `static` `drawItem` methods into an `override` of it for all derived classes.

This cleanly separates derived specific drawing code, allowing the remainder of the higher level list box drawing code to be coalesced into a single method on the base class.

Add `virtual` method for `itemBorderColor`, taking the item `index`. This can be used to move the background highlight and border drawing code into the common base class draw method.

Related:
- Issue #479
