### PR TITLE
Improve `const` correctness

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -116,6 +116,9 @@ public:
 	StorableResources& storage() { return mStoragePool; }
 	StorableResources& production() { return mProductionPool; }
 
+	const StorableResources& storage() const { return mStoragePool; }
+	const StorableResources& production() const { return mProductionPool; }
+
 	const PopulationRequirements& populationRequirements() const;
 	PopulationRequirements& populationAvailable() { return mPopulationAvailable; }
 

--- a/appOPHD/MapObjects/Structures/Warehouse.h
+++ b/appOPHD/MapObjects/Structures/Warehouse.h
@@ -16,6 +16,7 @@ public:
 	}
 
 	ProductPool& products() { return mProducts; }
+	const ProductPool& products() const { return mProducts; }
 
 private:
 	ProductPool mProducts;

--- a/appOPHD/ProductPool.cpp
+++ b/appOPHD/ProductPool.cpp
@@ -217,7 +217,7 @@ int ProductPool::pull(ProductType type, int c)
 }
 
 
-int ProductPool::count(ProductType type)
+int ProductPool::count(ProductType type) const
 {
 	return mProducts[static_cast<std::size_t>(type)];
 }

--- a/appOPHD/ProductPool.cpp
+++ b/appOPHD/ProductPool.cpp
@@ -229,7 +229,7 @@ void ProductPool::verifyCount()
 }
 
 
-NAS2D::Dictionary ProductPool::serialize()
+NAS2D::Dictionary ProductPool::serialize() const
 {
 	return NAS2D::Dictionary{{
 		{constants::SaveGameProductDigger, count(ProductType::PRODUCT_DIGGER)},

--- a/appOPHD/ProductPool.h
+++ b/appOPHD/ProductPool.h
@@ -41,7 +41,7 @@ public:
 	int availableStorage() const;
 	int availableStoragePercent() const;
 
-	NAS2D::Dictionary serialize();
+	NAS2D::Dictionary serialize() const;
 	void deserialize(const NAS2D::Dictionary& dictionary);
 
 	void verifyCount();

--- a/appOPHD/ProductPool.h
+++ b/appOPHD/ProductPool.h
@@ -36,7 +36,7 @@ public:
 	void transferAllTo(ProductPool& destination);
 	void store(ProductType type, int count);
 	int pull(ProductType type, int count);
-	int count(ProductType type);
+	int count(ProductType type) const;
 
 	int availableStorage() const;
 	int availableStoragePercent() const;

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -171,7 +171,7 @@ void GameState::onMapChange()
  * This event is raised by the MainReportsUiState whenever a "Take Me There" button in any
  * of the report UI panels is clicked.
  */
-void GameState::onTakeMeThere(Structure* structure)
+void GameState::onTakeMeThere(const Structure* structure)
 {
 	onHideReports();
 	mMapView->focusOnStructure(structure);

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -37,7 +37,7 @@ private:
 	void onHideReports();
 	void onMapChange();
 
-	void onTakeMeThere(Structure*);
+	void onTakeMeThere(const Structure*);
 
 private:
 	NAS2D::State* mReturnState = this;

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -22,7 +22,7 @@ class MainReportsUiState : public Wrapper
 {
 public:
 	using ReportsUiSignal = NAS2D::Signal<>;
-	using TakeMeThere = NAS2D::Signal<Structure*>;
+	using TakeMeThere = NAS2D::Signal<const Structure*>;
 	using TakeMeThereList = std::vector<TakeMeThere*>;
 
 public:

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -313,7 +313,7 @@ void MapViewState::_deactivate()
 }
 
 
-void MapViewState::focusOnStructure(Structure* structure)
+void MapViewState::focusOnStructure(const Structure* structure)
 {
 	if (!structure) { return; }
 	onTakeMeThere(NAS2D::Utility<StructureManager>::get().tileFromStructure(structure).xyz());

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -117,7 +117,7 @@ public:
 	QuitSignal::Source& quit() { return mQuitSignal; }
 	MapChangedSignal::Source& mapChanged() { return mMapChangedSignal; }
 
-	void focusOnStructure(Structure* s);
+	void focusOnStructure(const Structure* s);
 
 	Difficulty difficulty() { return mDifficulty; }
 	void difficulty(Difficulty difficulty);

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -44,7 +44,7 @@ namespace
 	}
 
 
-	NAS2D::Xml::XmlElement* serializeStructure(Structure& structure, Tile& tile)
+	NAS2D::Xml::XmlElement* serializeStructure(const Structure& structure, Tile& tile)
 	{
 		const auto& position = tile.xyz();
 		NAS2D::Dictionary dictionary =
@@ -73,7 +73,7 @@ namespace
 		{
 			structureElement->linkEndChild(NAS2D::dictionaryToAttributes(
 				"warehouse_products",
-				static_cast<Warehouse&>(structure).products().serialize()
+				static_cast<const Warehouse&>(structure).products().serialize()
 			));
 		}
 
@@ -82,14 +82,14 @@ namespace
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
 					"food",
-					{{{"level", static_cast<FoodProduction&>(structure).foodLevel()}}}
+					{{{"level", static_cast<const FoodProduction&>(structure).foodLevel()}}}
 				)
 			);
 		}
 
 		if (structure.structureClass() == Structure::StructureClass::Residence)
 		{
-			Residence& residence = static_cast<Residence&>(structure);
+			const auto& residence = static_cast<const Residence&>(structure);
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
 					"waste",
@@ -103,7 +103,7 @@ namespace
 
 		if (structure.isMineFacility())
 		{
-			MineFacility& facility = static_cast<MineFacility&>(structure);
+			const auto& facility = static_cast<const MineFacility&>(structure);
 
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
@@ -121,7 +121,7 @@ namespace
 
 		if (structure.structureClass() == Structure::StructureClass::Maintenance)
 		{
-			auto& maintenance = static_cast<MaintenanceFacility&>(structure);
+			auto& maintenance = static_cast<const MaintenanceFacility&>(structure);
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
 					"personnel",

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -37,7 +37,7 @@ FactoryListBox::FactoryListBox() :
  */
 void FactoryListBox::addItem(Factory* factory)
 {
-	for (auto item : mItems)
+	for (const auto& item : mItems)
 	{
 		if (static_cast<FactoryListBoxItem*>(item)->factory == factory)
 		{

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -27,7 +27,7 @@ ProductListBox::ProductListBox() :
 /**
  * Fills the ProductListBox with Products in a ProductPool object.
  */
-void ProductListBox::productPool(ProductPool& pool)
+void ProductListBox::productPool(const ProductPool& pool)
 {
 	clear();
 

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -26,7 +26,7 @@ public:
 
 	ProductListBox();
 
-	void productPool(ProductPool&);
+	void productPool(const ProductPool&);
 
 protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -18,7 +18,7 @@ public:
 	 * Signal used to handle clicks of a "Take Me There" button to center
 	 * the map view on a given structure.
 	 */
-	using TakeMeThere = NAS2D::Signal<Structure*>;
+	using TakeMeThere = NAS2D::Signal<const Structure*>;
 
 	ReportInterface() {}
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -119,7 +119,7 @@ void WarehouseReport::fillListFromStructureList(const std::vector<Warehouse*>& w
 		StructureListBox::StructureListBoxItem* item = lstStructures.last();
 
 		// \fixme	Abuse of interface to achieve custom results.
-		ProductPool& products = warehouse->products();
+		const auto& products = warehouse->products();
 
 		if (warehouse->state() != StructureState::Operational) { item->structureState = warehouse->stateDescription(); }
 		else if (products.empty()) { item->structureState = constants::WarehouseEmpty; }

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -290,7 +290,7 @@ void WarehouseReport::onTakeMeThere()
 
 void WarehouseReport::onStructureSelectionChange()
 {
-	selectedWarehouse = static_cast<Warehouse*>(lstStructures.selectedStructure());
+	selectedWarehouse = static_cast<const Warehouse*>(lstStructures.selectedStructure());
 
 	if (selectedWarehouse != nullptr)
 	{

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -70,7 +70,7 @@ private:
 	const NAS2D::Font& fontBigBold;
 	const NAS2D::Image& imageWarehouse;
 
-	Warehouse* selectedWarehouse = nullptr;
+	const Warehouse* selectedWarehouse = nullptr;
 
 	Button btnShowAll;
 	Button btnSpaceAvailable;

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -58,7 +58,7 @@ void StructureListBox::addItem(Structure* structure)
  *
  * \param structure		Pointer to a Structure object. Save to pass \c nullptr.
  */
-void StructureListBox::setSelected(Structure* structure)
+void StructureListBox::setSelected(const Structure* structure)
 {
 	if (mItems.empty() || structure == nullptr) { return; }
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -41,7 +41,7 @@ StructureListBox::StructureListBox() :
  */
 void StructureListBox::addItem(Structure* structure)
 {
-	for (auto item : mItems)
+	for (const auto& item : mItems)
 	{
 		if (static_cast<StructureListBoxItem*>(item)->structure == structure)
 		{

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -30,7 +30,7 @@ public:
 	StructureListBox();
 
 	void addItem(Structure*);
-	void setSelected(Structure*);
+	void setSelected(const Structure*);
 
 	Structure* selectedStructure();
 

--- a/appOPHD/UI/WarehouseInspector.cpp
+++ b/appOPHD/UI/WarehouseInspector.cpp
@@ -23,7 +23,7 @@ WarehouseInspector::WarehouseInspector() :
 }
 
 
-void WarehouseInspector::warehouse(Warehouse* w)
+void WarehouseInspector::warehouse(const Warehouse* w)
 {
 	mWarehouse = w;
 }
@@ -48,7 +48,7 @@ void WarehouseInspector::update()
 
 	Window::update();
 
-	ProductPool& pool = mWarehouse->products();
+	const auto& pool = mWarehouse->products();
 
 	const int labelWidth = 100;
 

--- a/appOPHD/UI/WarehouseInspector.h
+++ b/appOPHD/UI/WarehouseInspector.h
@@ -15,7 +15,7 @@ class WarehouseInspector : public Window
 public:
 	WarehouseInspector();
 
-	void warehouse(Warehouse* w);
+	void warehouse(const Warehouse* w);
 
 	void hide() override;
 	void update() override;
@@ -23,6 +23,6 @@ public:
 private:
 	void onClose();
 
-	Warehouse* mWarehouse = nullptr;
+	const Warehouse* mWarehouse = nullptr;
 	Button btnClose;
 };


### PR DESCRIPTION
Related:
- Issue #1446
- Issue #479

Moments like this, I understand why Rust uses `const` by default, and requires `mut` to be specified for mutable data. It's much easier to catch errors going the opposite direction.
