### PR TITLE
Fix Windows CI incremental build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,11 @@ jobs:
         ophdSha="${{ github.sha }}"
 
         config="${{ runner.os }}-${{ matrix.platform }}"
-        cacheKeyPrefixOphd="ophd-${config}-"
+        cacheKeyPrefixOphd="ophd-${config}-${vcpkgSha::8}-${nas2dSha::8}-"
 
         cacheKeyVcpkg="vcpkg-${config}-${vcpkgSha::8}"
         cacheKeyNas2d="nas2d-${config}-${vcpkgSha::8}-${nas2dSha::8}"
-        cacheKeyOphd="${cacheKeyPrefixOphd}-${vcpkgSha::8}-${nas2dSha::8}-${ophdSha::8}"
+        cacheKeyOphd="${cacheKeyPrefixOphd}${ophdSha::8}"
 
         echo "cacheKeyVcpkg=${cacheKeyVcpkg}" >> $GITHUB_ENV
         echo "cacheKeyNas2d=${cacheKeyNas2d}" >> $GITHUB_ENV


### PR DESCRIPTION
Fix `cacheKeyPrefixOphd` and `cacheKeyOphd` values.

The bad prefix made it possible to restore an `ophd` cache that was built with an incompatible build of `vcpkg` or `nas2d`. It also added a double `--` in the name of the `ophd` cache key.

Closes #1553 (Hopefully for real this time)

Related:
- PR #1602
- Issue #1553
