### PR TITLE
Add `getItem` to `ListBoxBase` derived classes

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -64,8 +64,8 @@ void FactoryListBox::setSelected(Factory* f)
 	if (mItems.empty() || f == nullptr) { return; }
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		FactoryListBoxItem* item = getItem(i);
-		if (item->factory == f)
+		const auto& item = getItem(i);
+		if (item.factory == f)
 		{
 			setSelection(i);
 			return;
@@ -76,19 +76,19 @@ void FactoryListBox::setSelected(Factory* f)
 
 Factory* FactoryListBox::selectedFactory()
 {
-	return !isItemSelected() ? nullptr : getItem(selectedIndex())->factory;
+	return !isItemSelected() ? nullptr : getItem(selectedIndex()).factory;
 }
 
 
-FactoryListBox::FactoryListBoxItem* FactoryListBox::getItem(std::size_t index) const
+FactoryListBox::FactoryListBoxItem& FactoryListBox::getItem(std::size_t index) const
 {
-	return static_cast<FactoryListBoxItem*>(mItems[index]);
+	return *static_cast<FactoryListBoxItem*>(mItems[index]);
 }
 
 
 NAS2D::Color FactoryListBox::itemBorderColor(std::size_t index) const
 {
-	const auto& item = *getItem(index);
+	const auto& item = getItem(index);
 	const Factory& factory = *item.factory;
 	const auto factoryState = factory.state();
 	return structureColorFromIndex(factoryState);
@@ -97,7 +97,7 @@ NAS2D::Color FactoryListBox::itemBorderColor(std::size_t index) const
 
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
-	const auto& item = *getItem(index);
+	const auto& item = getItem(index);
 	const Factory& factory = *item.factory;
 	const auto productType = factory.productType();
 	const auto factoryState = factory.state();

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -80,7 +80,7 @@ Factory* FactoryListBox::selectedFactory()
 }
 
 
-FactoryListBox::FactoryListBoxItem& FactoryListBox::getItem(std::size_t index) const
+const FactoryListBox::FactoryListBoxItem& FactoryListBox::getItem(std::size_t index) const
 {
 	return *static_cast<FactoryListBoxItem*>(mItems[index]);
 }

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -64,7 +64,7 @@ void FactoryListBox::setSelected(Factory* f)
 	if (mItems.empty() || f == nullptr) { return; }
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems[i]);
+		FactoryListBoxItem* item = getItem(i);
 		if (item->factory == f)
 		{
 			setSelection(i);
@@ -76,13 +76,19 @@ void FactoryListBox::setSelected(Factory* f)
 
 Factory* FactoryListBox::selectedFactory()
 {
-	return !isItemSelected() ? nullptr : static_cast<FactoryListBoxItem*>(mItems[selectedIndex()])->factory;
+	return !isItemSelected() ? nullptr : getItem(selectedIndex())->factory;
+}
+
+
+FactoryListBox::FactoryListBoxItem* FactoryListBox::getItem(std::size_t index) const
+{
+	return static_cast<FactoryListBoxItem*>(mItems[index]);
 }
 
 
 NAS2D::Color FactoryListBox::itemBorderColor(std::size_t index) const
 {
-	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
+	const auto& item = *getItem(index);
 	const Factory& factory = *item.factory;
 	const auto factoryState = factory.state();
 	return structureColorFromIndex(factoryState);
@@ -91,7 +97,7 @@ NAS2D::Color FactoryListBox::itemBorderColor(std::size_t index) const
 
 void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
-	const auto& item = *static_cast<FactoryListBoxItem*>(mItems[index]);
+	const auto& item = *getItem(index);
 	const Factory& factory = *item.factory;
 	const auto productType = factory.productType();
 	const auto factoryState = factory.state();

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -62,12 +62,12 @@ void FactoryListBox::addItem(Factory* factory)
 void FactoryListBox::setSelected(Factory* f)
 {
 	if (mItems.empty() || f == nullptr) { return; }
-	for (std::size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		const auto& item = getItem(i);
+		const auto& item = getItem(index);
 		if (item.factory == f)
 		{
-			setSelection(i);
+			setSelection(index);
 			return;
 		}
 	}

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -57,15 +57,15 @@ void FactoryListBox::addItem(Factory* factory)
 /**
  * Sets the current selection.
  *
- * \param f	Pointer to a Factory object. Safe to pass \c nullptr.
+ * \param factory	Pointer to a Factory object. Safe to pass \c nullptr.
  */
-void FactoryListBox::setSelected(Factory* f)
+void FactoryListBox::setSelected(Factory* factory)
 {
-	if (mItems.empty() || f == nullptr) { return; }
+	if (mItems.empty() || factory == nullptr) { return; }
 	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
 		const auto& item = getItem(index);
-		if (item.factory == f)
+		if (item.factory == factory)
 		{
 			setSelection(index);
 			return;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -39,6 +39,8 @@ public:
 	Factory* selectedFactory();
 
 protected:
+	FactoryListBoxItem* getItem(std::size_t index) const;
+
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -39,7 +39,7 @@ public:
 	Factory* selectedFactory();
 
 protected:
-	FactoryListBoxItem* getItem(std::size_t index) const;
+	FactoryListBoxItem& getItem(std::size_t index) const;
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -39,7 +39,7 @@ public:
 	Factory* selectedFactory();
 
 protected:
-	FactoryListBoxItem& getItem(std::size_t index) const;
+	const FactoryListBoxItem& getItem(std::size_t index) const;
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -53,7 +53,7 @@ void ProductListBox::productPool(const ProductPool& pool)
 }
 
 
-ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
+const ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
 {
 	return *static_cast<ProductListBoxItem*>(mItems[index]);
 }

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -53,11 +53,17 @@ void ProductListBox::productPool(const ProductPool& pool)
 }
 
 
+ProductListBox::ProductListBoxItem* ProductListBox::getItem(std::size_t index) const
+{
+	return static_cast<ProductListBoxItem*>(mItems[index]);
+}
+
+
 void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
 	const auto firstStop = drawArea.size.x / 3;
 	const auto secondStop = drawArea.size.x * 2 / 3;
-	const auto& item = *static_cast<ProductListBoxItem*>(mItems[index]);
+	const auto& item = *getItem(index);
 
 	// Draw column breaks
 	renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -53,9 +53,9 @@ void ProductListBox::productPool(const ProductPool& pool)
 }
 
 
-ProductListBox::ProductListBoxItem* ProductListBox::getItem(std::size_t index) const
+ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
 {
-	return static_cast<ProductListBoxItem*>(mItems[index]);
+	return *static_cast<ProductListBoxItem*>(mItems[index]);
 }
 
 
@@ -63,7 +63,7 @@ void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 {
 	const auto firstStop = drawArea.size.x / 3;
 	const auto secondStop = drawArea.size.x * 2 / 3;
-	const auto& item = *getItem(index);
+	const auto& item = getItem(index);
 
 	// Draw column breaks
 	renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -36,7 +36,7 @@ public:
 	void productPool(const ProductPool&);
 
 protected:
-	ProductListBoxItem* getItem(std::size_t index) const;
+	ProductListBoxItem& getItem(std::size_t index) const;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -36,7 +36,7 @@ public:
 	void productPool(const ProductPool&);
 
 protected:
-	ProductListBoxItem& getItem(std::size_t index) const;
+	const ProductListBoxItem& getItem(std::size_t index) const;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -36,5 +36,7 @@ public:
 	void productPool(const ProductPool&);
 
 protected:
+	ProductListBoxItem* getItem(std::size_t index) const;
+
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 };

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -63,8 +63,8 @@ void StructureListBox::setSelected(const Structure* structure)
 
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		StructureListBoxItem* item = getItem(i);
-		if (item->structure == structure)
+		const auto& item = getItem(i);
+		if (item.structure == structure)
 		{
 			setSelection(i);
 			return;
@@ -75,7 +75,7 @@ void StructureListBox::setSelected(const Structure* structure)
 
 Structure* StructureListBox::selectedStructure()
 {
-	return !isItemSelected() ? nullptr : getItem(selectedIndex())->structure;
+	return !isItemSelected() ? nullptr : getItem(selectedIndex()).structure;
 }
 
 
@@ -88,15 +88,15 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 }
 
 
-StructureListBox::StructureListBoxItem* StructureListBox::getItem(std::size_t index) const
+StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
 {
-	return static_cast<StructureListBoxItem*>(mItems[index]);
+	return *static_cast<StructureListBoxItem*>(mItems[index]);
 }
 
 
 NAS2D::Color StructureListBox::itemBorderColor(std::size_t index) const
 {
-	const auto& item = *getItem(index);
+	const auto& item = getItem(index);
 	const auto structureState = item.structure->state();
 	return structureColorFromIndex(structureState);
 }
@@ -104,7 +104,7 @@ NAS2D::Color StructureListBox::itemBorderColor(std::size_t index) const
 
 void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
-	const auto& item = *getItem(index);
+	const auto& item = getItem(index);
 	const auto structureState = item.structure->state();
 	const auto& structureTextColor = structureTextColorFromIndex(structureState);
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -63,7 +63,7 @@ void StructureListBox::setSelected(const Structure* structure)
 
 	for (std::size_t i = 0; i < mItems.size(); ++i)
 	{
-		StructureListBoxItem* item = static_cast<StructureListBoxItem*>(mItems[i]);
+		StructureListBoxItem* item = getItem(i);
 		if (item->structure == structure)
 		{
 			setSelection(i);
@@ -75,7 +75,7 @@ void StructureListBox::setSelected(const Structure* structure)
 
 Structure* StructureListBox::selectedStructure()
 {
-	return !isItemSelected() ? nullptr : static_cast<StructureListBoxItem*>(mItems[selectedIndex()])->structure;
+	return !isItemSelected() ? nullptr : getItem(selectedIndex())->structure;
 }
 
 
@@ -88,9 +88,15 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 }
 
 
+StructureListBox::StructureListBoxItem* StructureListBox::getItem(std::size_t index) const
+{
+	return static_cast<StructureListBoxItem*>(mItems[index]);
+}
+
+
 NAS2D::Color StructureListBox::itemBorderColor(std::size_t index) const
 {
-	const auto& item = *static_cast<StructureListBoxItem*>(mItems[index]);
+	const auto& item = *getItem(index);
 	const auto structureState = item.structure->state();
 	return structureColorFromIndex(structureState);
 }
@@ -98,7 +104,7 @@ NAS2D::Color StructureListBox::itemBorderColor(std::size_t index) const
 
 void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
 {
-	const auto& item = *static_cast<StructureListBoxItem*>(mItems[index]);
+	const auto& item = *getItem(index);
 	const auto structureState = item.structure->state();
 	const auto& structureTextColor = structureTextColorFromIndex(structureState);
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -61,12 +61,12 @@ void StructureListBox::setSelected(const Structure* structure)
 {
 	if (mItems.empty() || structure == nullptr) { return; }
 
-	for (std::size_t i = 0; i < mItems.size(); ++i)
+	for (std::size_t index = 0; index < mItems.size(); ++index)
 	{
-		const auto& item = getItem(i);
+		const auto& item = getItem(index);
 		if (item.structure == structure)
 		{
-			setSelection(i);
+			setSelection(index);
 			return;
 		}
 	}

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -88,7 +88,7 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 }
 
 
-StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
+const StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
 {
 	return *static_cast<StructureListBoxItem*>(mItems[index]);
 }

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -36,6 +36,8 @@ public:
 	StructureListBoxItem* last();
 
 protected:
+	StructureListBoxItem* getItem(std::size_t index) const;
+
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -36,7 +36,7 @@ public:
 	StructureListBoxItem* last();
 
 protected:
-	StructureListBoxItem* getItem(std::size_t index) const;
+	StructureListBoxItem& getItem(std::size_t index) const;
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -36,7 +36,7 @@ public:
 	StructureListBoxItem* last();
 
 protected:
-	StructureListBoxItem& getItem(std::size_t index) const;
+	const StructureListBoxItem& getItem(std::size_t index) const;
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 


### PR DESCRIPTION
This eliminates a lot of the need for `static_cast`. Each derived class knows it's own item type, and so can implement this function without using `static_cast`.

All `getItem` methods are basically identical, so potentially they can be extracted to an intermediate template class. That may be a future task.

Related:
- Issue #479
