### PR TITLE
Move data array to `ListBoxBase` derived classes

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -45,7 +45,7 @@ void FactoryListBox::addItem(Factory* factory)
 {
 	for (const auto& item : mItems)
 	{
-		if (static_cast<FactoryListBoxItem*>(item.get())->factory == factory)
+		if (item.get()->factory == factory)
 		{
 			throw std::runtime_error("FactoryListBox::addItem(): Can't add factory multiple times");
 		}
@@ -95,7 +95,7 @@ void FactoryListBox::clear()
 
 const FactoryListBox::FactoryListBoxItem& FactoryListBox::getItem(std::size_t index) const
 {
-	return *static_cast<FactoryListBoxItem*>(mItems[index].get());
+	return *mItems[index].get();
 }
 
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -86,6 +86,12 @@ Factory* FactoryListBox::selectedFactory()
 }
 
 
+void FactoryListBox::clear()
+{
+	ListBoxBase::clear();
+}
+
+
 const FactoryListBox::FactoryListBoxItem& FactoryListBox::getItem(std::size_t index) const
 {
 	return *static_cast<FactoryListBoxItem*>(mItems[index].get());

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -30,6 +30,12 @@ FactoryListBox::FactoryListBox() :
 }
 
 
+std::size_t FactoryListBox::count() const
+{
+	return mItems.size();
+}
+
+
 /**
  * Adds a Factory to the FactoryListBox.
  *

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -88,6 +88,7 @@ Factory* FactoryListBox::selectedFactory()
 
 void FactoryListBox::clear()
 {
+	mItems.clear();
 	ListBoxBase::clear();
 }
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -45,7 +45,7 @@ void FactoryListBox::addItem(Factory* factory)
 {
 	for (const auto& item : mItems)
 	{
-		if (item.get()->factory == factory)
+		if (item.factory == factory)
 		{
 			throw std::runtime_error("FactoryListBox::addItem(): Can't add factory multiple times");
 		}
@@ -95,7 +95,7 @@ void FactoryListBox::clear()
 
 const FactoryListBox::FactoryListBoxItem& FactoryListBox::getItem(std::size_t index) const
 {
-	return *mItems[index].get();
+	return mItems[index];
 }
 
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -56,7 +56,7 @@ void FactoryListBox::addItem(Factory* factory)
 		(text == constants::UndergroundFactory) ? NAS2D::Point<int>{138, 276} :
 		(text == constants::SeedFactory) ? NAS2D::Point<int>{460, 368} :
 		NAS2D::Point<int>{0, 46}; // Surface factory
-	add<FactoryListBoxItem>(text, factory, iconPosition);
+	add(text, factory, iconPosition);
 }
 
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -30,6 +30,13 @@ FactoryListBox::FactoryListBox() :
 }
 
 
+void FactoryListBox::add(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition)
+{
+	mItems.emplace_back(FactoryListBoxItem{textDescription, newFactory, iconPosition});
+	updateScrollLayout();
+}
+
+
 std::size_t FactoryListBox::count() const
 {
 	return mItems.size();

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -20,12 +20,6 @@ class FactoryListBox : public ListBoxBase
 public:
 	struct FactoryListBoxItem
 	{
-		FactoryListBoxItem(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition) :
-			text{textDescription},
-			factory{newFactory},
-			icon_slice{iconPosition}
-		{}
-
 		std::string text;
 		Factory* factory = nullptr;
 		NAS2D::Point<int> icon_slice;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -55,5 +55,7 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
+	std::vector<std::unique_ptr<ListBoxItem>> mItems;
+
 	const NAS2D::Image& mStructureIcons;
 };

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -42,7 +42,7 @@ public:
 
 protected:
 	void add(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition) {
-		mItems.emplace_back(new FactoryListBoxItem{textDescription, newFactory, iconPosition});
+		mItems.emplace_back(FactoryListBoxItem{textDescription, newFactory, iconPosition});
 		updateScrollLayout();
 	}
 
@@ -55,7 +55,7 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<std::unique_ptr<FactoryListBoxItem>> mItems;
+	std::vector<FactoryListBoxItem> mItems;
 
 	const NAS2D::Image& mStructureIcons;
 };

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -42,10 +42,7 @@ public:
 	void clear();
 
 protected:
-	void add(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition) {
-		mItems.emplace_back(FactoryListBoxItem{textDescription, newFactory, iconPosition});
-		updateScrollLayout();
-	}
+	void add(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition);
 
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -39,6 +39,8 @@ public:
 	Factory* selectedFactory();
 
 protected:
+	virtual std::size_t count() const override;
+
 	const FactoryListBoxItem& getItem(std::size_t index) const;
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -38,6 +38,8 @@ public:
 
 	Factory* selectedFactory();
 
+	void clear();
+
 protected:
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -55,7 +55,7 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<std::unique_ptr<ListBoxItem>> mItems;
+	std::vector<std::unique_ptr<FactoryListBoxItem>> mItems;
 
 	const NAS2D::Image& mStructureIcons;
 };

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -18,14 +18,15 @@ class Factory;
 class FactoryListBox : public ListBoxBase
 {
 public:
-	struct FactoryListBoxItem : public ListBoxItem
+	struct FactoryListBoxItem
 	{
 		FactoryListBoxItem(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition) :
-			ListBoxItem{textDescription},
+			text{textDescription},
 			factory{newFactory},
 			icon_slice{iconPosition}
 		{}
 
+		std::string text;
 		Factory* factory = nullptr;
 		NAS2D::Point<int> icon_slice;
 	};

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -41,9 +41,8 @@ public:
 	void clear();
 
 protected:
-	template <typename ItemType, typename... Args>
-	void add(Args&&... args) {
-		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+	void add(std::string textDescription, Factory* newFactory, NAS2D::Point<int> iconPosition) {
+		mItems.emplace_back(new FactoryListBoxItem{textDescription, newFactory, iconPosition});
 		updateScrollLayout();
 	}
 

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -41,6 +41,12 @@ public:
 	void clear();
 
 protected:
+	template <typename ItemType, typename... Args>
+	void add(Args&&... args) {
+		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+		updateScrollLayout();
+	}
+
 	virtual std::size_t count() const override;
 
 	const FactoryListBoxItem& getItem(std::size_t index) const;

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -68,7 +68,7 @@ void ProductListBox::clear()
 
 const ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
 {
-	return *static_cast<ProductListBoxItem*>(mItems[index].get());
+	return *mItems[index].get();
 }
 
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -66,6 +66,13 @@ void ProductListBox::clear()
 }
 
 
+void ProductListBox::add(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal)
+{
+	mItems.emplace_back(ProductListBoxItem{initialText, initialProductCount, initialCapacityUsed, initialCapacityTotal});
+	updateScrollLayout();
+}
+
+
 const ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
 {
 	return mItems[index];

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -61,6 +61,7 @@ void ProductListBox::productPool(const ProductPool& pool)
 
 void ProductListBox::clear()
 {
+	mItems.clear();
 	ListBoxBase::clear();
 }
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -59,6 +59,12 @@ void ProductListBox::productPool(const ProductPool& pool)
 }
 
 
+void ProductListBox::clear()
+{
+	ListBoxBase::clear();
+}
+
+
 const ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
 {
 	return *static_cast<ProductListBoxItem*>(mItems[index].get());

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -46,12 +46,12 @@ void ProductListBox::productPool(const ProductPool& pool)
 
 		if (productCount > 0)
 		{
-			mItems.emplace_back(std::make_unique<ProductListBoxItem>(
+			mItems.emplace_back(ProductListBoxItem{
 				ProductCatalogue::get(productType).Name,
 				productCount,
 				productCount * pool.productStorageRequirement(productType),
 				pool.capacity()
-			));
+			});
 		}
 	}
 
@@ -68,7 +68,7 @@ void ProductListBox::clear()
 
 const ProductListBox::ProductListBoxItem& ProductListBox::getItem(std::size_t index) const
 {
-	return *mItems[index].get();
+	return mItems[index];
 }
 
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -24,6 +24,12 @@ ProductListBox::ProductListBox() :
 }
 
 
+std::size_t ProductListBox::count() const
+{
+	return mItems.size();
+}
+
+
 /**
  * Fills the ProductListBox with Products in a ProductPool object.
  */

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -39,10 +39,7 @@ public:
 	void clear();
 
 protected:
-	void add(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal) {
-		mItems.emplace_back(ProductListBoxItem{initialText, initialProductCount, initialCapacityUsed, initialCapacityTotal});
-		updateScrollLayout();
-	}
+	void add(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal);
 
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -48,4 +48,7 @@ protected:
 	const ProductListBoxItem& getItem(std::size_t index) const;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
+
+private:
+	std::vector<std::unique_ptr<ListBoxItem>> mItems;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -50,5 +50,5 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<std::unique_ptr<ListBoxItem>> mItems;
+	std::vector<std::unique_ptr<ProductListBoxItem>> mItems;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -17,15 +17,16 @@ class ProductPool;
 class ProductListBox : public ListBoxBase
 {
 public:
-	struct ProductListBoxItem : public ListBoxItem
+	struct ProductListBoxItem
 	{
 		ProductListBoxItem(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal) :
-			ListBoxItem{initialText},
+			text{initialText},
 			productCount{initialProductCount},
 			capacityUsed{initialCapacityUsed},
 			capacityTotal{initialCapacityTotal}
 		{}
 
+		std::string text;
 		int productCount = 0;
 		int capacityUsed = 0;
 		int capacityTotal = 0;

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -38,9 +38,8 @@ public:
 	void clear();
 
 protected:
-	template <typename ItemType, typename... Args>
-	void add(Args&&... args) {
-		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+	void add(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal) {
+		mItems.emplace_back(new ProductListBoxItem{initialText, initialProductCount, initialCapacityUsed, initialCapacityTotal});
 		updateScrollLayout();
 	}
 

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -35,6 +35,8 @@ public:
 
 	void productPool(const ProductPool&);
 
+	void clear();
+
 protected:
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -36,6 +36,8 @@ public:
 	void productPool(const ProductPool&);
 
 protected:
+	virtual std::size_t count() const override;
+
 	const ProductListBoxItem& getItem(std::size_t index) const;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -38,6 +38,12 @@ public:
 	void clear();
 
 protected:
+	template <typename ItemType, typename... Args>
+	void add(Args&&... args) {
+		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+		updateScrollLayout();
+	}
+
 	virtual std::size_t count() const override;
 
 	const ProductListBoxItem& getItem(std::size_t index) const;

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -39,7 +39,7 @@ public:
 
 protected:
 	void add(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal) {
-		mItems.emplace_back(new ProductListBoxItem{initialText, initialProductCount, initialCapacityUsed, initialCapacityTotal});
+		mItems.emplace_back(ProductListBoxItem{initialText, initialProductCount, initialCapacityUsed, initialCapacityTotal});
 		updateScrollLayout();
 	}
 
@@ -50,5 +50,5 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<std::unique_ptr<ProductListBoxItem>> mItems;
+	std::vector<ProductListBoxItem> mItems;
 };

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -19,13 +19,6 @@ class ProductListBox : public ListBoxBase
 public:
 	struct ProductListBoxItem
 	{
-		ProductListBoxItem(std::string initialText, int initialProductCount, int initialCapacityUsed, int initialCapacityTotal) :
-			text{initialText},
-			productCount{initialProductCount},
-			capacityUsed{initialCapacityUsed},
-			capacityTotal{initialCapacityTotal}
-		{}
-
 		std::string text;
 		int productCount = 0;
 		int capacityUsed = 0;

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -48,7 +48,7 @@ void StructureListBox::addItem(Structure* structure, std::string stateDescriptio
 {
 	for (const auto& item : mItems)
 	{
-		if (static_cast<StructureListBoxItem*>(item.get())->structure == structure)
+		if (item.get()->structure == structure)
 		{
 			throw std::runtime_error("StructureListBox::addItem(): Can't add structure multiple times");
 		}
@@ -90,7 +90,7 @@ Structure* StructureListBox::selectedStructure()
  */
 StructureListBox::StructureListBoxItem* StructureListBox::last()
 {
-	return static_cast<StructureListBoxItem*>(mItems.back().get());
+	return mItems.back().get();
 }
 
 
@@ -103,7 +103,7 @@ void StructureListBox::clear()
 
 const StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
 {
-	return *static_cast<StructureListBoxItem*>(mItems[index].get());
+	return *mItems[index].get();
 }
 
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -48,7 +48,7 @@ void StructureListBox::addItem(Structure* structure, std::string stateDescriptio
 {
 	for (const auto& item : mItems)
 	{
-		if (item.get()->structure == structure)
+		if (item.structure == structure)
 		{
 			throw std::runtime_error("StructureListBox::addItem(): Can't add structure multiple times");
 		}
@@ -90,7 +90,7 @@ Structure* StructureListBox::selectedStructure()
  */
 StructureListBox::StructureListBoxItem* StructureListBox::last()
 {
-	return mItems.back().get();
+	return &mItems.back();
 }
 
 
@@ -103,7 +103,7 @@ void StructureListBox::clear()
 
 const StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
 {
-	return *mItems[index].get();
+	return mItems[index];
 }
 
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -16,13 +16,6 @@
 using namespace NAS2D;
 
 
-StructureListBox::StructureListBoxItem::StructureListBoxItem(Structure* s, std::string initialStateDescription) :
-	text{s->name()},
-	structure{s},
-	stateDescription{std::move(initialStateDescription)}
-{}
-
-
 StructureListBox::StructureListBox() :
 	ListBoxBase{
 		fontCache.load(constants::FONT_PRIMARY, 12),
@@ -103,7 +96,7 @@ void StructureListBox::clear()
 
 void StructureListBox::add(Structure* s, std::string stateDescription)
 {
-	mItems.emplace_back(StructureListBoxItem{s, stateDescription});
+	mItems.emplace_back(StructureListBoxItem{s->name(), s, std::move(stateDescription)});
 	updateScrollLayout();
 }
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -17,7 +17,7 @@ using namespace NAS2D;
 
 
 StructureListBox::StructureListBoxItem::StructureListBoxItem(Structure* s, std::string initialStateDescription) :
-	ListBoxItem{s->name()},
+	text{s->name()},
 	structure{s},
 	stateDescription{std::move(initialStateDescription)}
 {}

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -54,7 +54,7 @@ void StructureListBox::addItem(Structure* structure, std::string stateDescriptio
 		}
 	}
 
-	add<StructureListBoxItem>(structure, std::move(stateDescription));
+	add(structure, std::move(stateDescription));
 }
 
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -96,6 +96,7 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 
 void StructureListBox::clear()
 {
+	mItems.clear();
 	ListBoxBase::clear();
 }
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -33,6 +33,12 @@ StructureListBox::StructureListBox() :
 }
 
 
+std::size_t StructureListBox::count() const
+{
+	return mItems.size();
+}
+
+
 /**
  * Adds a Factory to the FactoryListBox.
  *

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -94,6 +94,12 @@ StructureListBox::StructureListBoxItem* StructureListBox::last()
 }
 
 
+void StructureListBox::clear()
+{
+	ListBoxBase::clear();
+}
+
+
 const StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
 {
 	return *static_cast<StructureListBoxItem*>(mItems[index].get());

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -101,6 +101,13 @@ void StructureListBox::clear()
 }
 
 
+void StructureListBox::add(Structure* s, std::string stateDescription)
+{
+	mItems.emplace_back(StructureListBoxItem{s, stateDescription});
+	updateScrollLayout();
+}
+
+
 const StructureListBox::StructureListBoxItem& StructureListBox::getItem(std::size_t index) const
 {
 	return mItems[index];

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -50,4 +50,7 @@ protected:
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;
 
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
+
+private:
+	std::vector<std::unique_ptr<ListBoxItem>> mItems;
 };

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -36,6 +36,8 @@ public:
 	StructureListBoxItem* last();
 
 protected:
+	virtual std::size_t count() const override;
+
 	const StructureListBoxItem& getItem(std::size_t index) const;
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const override;

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -39,7 +39,7 @@ public:
 
 protected:
 	void add(Structure* s, std::string stateDescription) {
-		mItems.emplace_back(new StructureListBoxItem{s, stateDescription});
+		mItems.emplace_back(StructureListBoxItem{s, stateDescription});
 		updateScrollLayout();
 	}
 
@@ -52,5 +52,5 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<std::unique_ptr<StructureListBoxItem>> mItems;
+	std::vector<StructureListBoxItem> mItems;
 };

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -17,10 +17,11 @@ class StructureListBox : public ListBoxBase
 public:
 	using SelectionChangedSignal = NAS2D::Signal<Structure*>;
 
-	struct StructureListBoxItem : public ListBoxItem
+	struct StructureListBoxItem
 	{
 		StructureListBoxItem(Structure* s, std::string stateDescription = std::string{});
 
+		std::string text;
 		Structure* structure = nullptr;
 		std::string stateDescription;
 	};

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -19,8 +19,6 @@ public:
 
 	struct StructureListBoxItem
 	{
-		StructureListBoxItem(Structure* s, std::string stateDescription = std::string{});
-
 		std::string text;
 		Structure* structure = nullptr;
 		std::string stateDescription;

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -38,6 +38,12 @@ public:
 	void clear();
 
 protected:
+	template <typename ItemType, typename... Args>
+	void add(Args&&... args) {
+		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+		updateScrollLayout();
+	}
+
 	virtual std::size_t count() const override;
 
 	const StructureListBoxItem& getItem(std::size_t index) const;

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -38,9 +38,8 @@ public:
 	void clear();
 
 protected:
-	template <typename ItemType, typename... Args>
-	void add(Args&&... args) {
-		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
+	void add(Structure* s, std::string stateDescription) {
+		mItems.emplace_back(new StructureListBoxItem{s, stateDescription});
 		updateScrollLayout();
 	}
 

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -35,6 +35,8 @@ public:
 
 	StructureListBoxItem* last();
 
+	void clear();
+
 protected:
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -39,10 +39,7 @@ public:
 	void clear();
 
 protected:
-	void add(Structure* s, std::string stateDescription) {
-		mItems.emplace_back(StructureListBoxItem{s, stateDescription});
-		updateScrollLayout();
-	}
+	void add(Structure* s, std::string stateDescription);
 
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -52,5 +52,5 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<std::unique_ptr<ListBoxItem>> mItems;
+	std::vector<std::unique_ptr<StructureListBoxItem>> mItems;
 };

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -44,18 +44,6 @@ bool ListBoxBase::isEmpty() const
 
 
 /**
- * Clears all items from the list.
- */
-void ListBoxBase::clear()
-{
-	mItems.clear();
-	mSelectedIndex = NoSelection;
-	mHighlightIndex = NoSelection;
-	updateScrollLayout();
-}
-
-
-/**
  * Index of the current mouse hover highlight.
  */
 std::size_t ListBoxBase::currentHighlight() const
@@ -103,6 +91,18 @@ void ListBoxBase::clearSelected()
 ListBoxBase::SelectionChangeSignal::Source& ListBoxBase::selectionChanged()
 {
 	return mSelectionChanged;
+}
+
+
+/**
+ * Clears all items from the list.
+ */
+void ListBoxBase::clear()
+{
+	mItems.clear();
+	mSelectedIndex = NoSelection;
+	mHighlightIndex = NoSelection;
+	updateScrollLayout();
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -99,7 +99,6 @@ ListBoxBase::SelectionChangeSignal::Source& ListBoxBase::selectionChanged()
  */
 void ListBoxBase::clear()
 {
-	mItems.clear();
 	mSelectedIndex = NoSelection;
 	mHighlightIndex = NoSelection;
 	updateScrollLayout();

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -95,7 +95,7 @@ bool ListBoxBase::isItemSelected() const
  */
 void ListBoxBase::setSelection(std::size_t selection)
 {
-	mSelectedIndex = (selection < mItems.size()) ? selection : NoSelection;
+	mSelectedIndex = (selection < count()) ? selection : NoSelection;
 	mSelectionChanged();
 }
 
@@ -122,11 +122,11 @@ void ListBoxBase::updateScrollLayout()
 {
 	mItemWidth = mRect.size.x;
 
-	if ((mItemHeight * static_cast<int>(mItems.size())) > mRect.size.y)
+	if ((mItemHeight * static_cast<int>(count())) > mRect.size.y)
 	{
 		mScrollBar.position({rect().position.x + mRect.size.x - 14, mRect.position.y});
 		mScrollBar.size({14, mRect.size.y});
-		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemHeight * static_cast<int>(mItems.size()) - mRect.size.y));
+		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemHeight * static_cast<int>(count()) - mRect.size.y));
 		mScrollOffsetInPixels = static_cast<unsigned int>(mScrollBar.value());
 		mItemWidth -= mScrollBar.size().x;
 		mScrollBar.visible(true);
@@ -179,7 +179,7 @@ void ListBoxBase::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> posit
 	// A few basic checks
 	if (!rect().contains(position) || mHighlightIndex == NoSelection) { return; }
 	if (mScrollBar.visible() && mScrollBar.rect().contains(position)) { return; }
-	if (mHighlightIndex >= mItems.size()) { return; }
+	if (mHighlightIndex >= count()) { return; }
 
 	setSelection(mHighlightIndex);
 }
@@ -207,7 +207,7 @@ void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*r
 
 	mHighlightIndex = (static_cast<unsigned int>(position.y - positionY()) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemHeight);
 
-	if (mHighlightIndex >= mItems.size())
+	if (mHighlightIndex >= count())
 	{
 		mHighlightIndex = NoSelection;
 	}
@@ -292,7 +292,7 @@ void ListBoxBase::update()
 
 	renderer.clipRect(mRect);
 
-	for (std::size_t index = 0; index < mItems.size(); ++index)
+	for (std::size_t index = 0; index < count(); ++index)
 	{
 		const auto drawArea = itemDrawArea(index);
 		const auto& borderColor = itemBorderColor(index);

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -44,15 +44,6 @@ bool ListBoxBase::isEmpty() const
 
 
 /**
- * Number of items in the ListBoxBase.
- */
-std::size_t ListBoxBase::count() const
-{
-	return mItems.size();
-}
-
-
-/**
  * Clears all items from the list.
  */
 void ListBoxBase::clear()

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -39,7 +39,7 @@ ListBoxBase::~ListBoxBase()
  */
 bool ListBoxBase::isEmpty() const
 {
-	return mItems.empty();
+	return count() == 0;
 }
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -63,12 +63,6 @@ public:
 	void draw() const override;
 
 protected:
-	template <typename ItemType, typename... Args>
-	void add(Args&&... args) {
-		mItems.emplace_back(new ItemType{std::forward<Args>(args)...});
-		updateScrollLayout();
-	}
-
 	void clear();
 	void updateScrollLayout();
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -28,19 +28,6 @@ class ListBoxBase : public Control
 public:
 	using SelectionChangeSignal = NAS2D::Signal<>;
 
-	/**
-	 * Derived SpecialListBox types can inherit from this struct
-	 * for specialized information needed for derived types.
-	 */
-	struct ListBoxItem
-	{
-		ListBoxItem() = default;
-		ListBoxItem(std::string initialText) : text(initialText) {}
-		virtual ~ListBoxItem() = default;
-
-		std::string text;
-	};
-
 	static inline constexpr auto NoSelection{std::numeric_limits<std::size_t>::max()};
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -49,7 +49,7 @@ public:
 	~ListBoxBase() override;
 
 	bool isEmpty() const;
-	std::size_t count() const;
+	virtual std::size_t count() const = 0;
 
 	void clear();
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -51,8 +51,6 @@ public:
 	bool isEmpty() const;
 	virtual std::size_t count() const = 0;
 
-	void clear();
-
 	std::size_t currentHighlight() const;
 	std::size_t selectedIndex() const;
 	bool isItemSelected() const;
@@ -71,6 +69,7 @@ protected:
 		updateScrollLayout();
 	}
 
+	void clear();
 	void updateScrollLayout();
 
 	void onVisibilityChange(bool) override;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -90,8 +90,6 @@ protected:
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;
 
-	std::vector<std::unique_ptr<ListBoxItem>> mItems;
-
 private:
 	std::size_t mHighlightIndex = NoSelection;
 	std::size_t mSelectedIndex = NoSelection;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -13,7 +13,6 @@
 #include <vector>
 #include <cstddef>
 #include <limits>
-#include <memory>
 
 
 /**


### PR DESCRIPTION
Move the data collection from `ListBoxBase` to the derived classes.

This allows the data elements to be exactly specified, and specialized for the derived class. This eliminates the need for a common `ListBoxItem` base class, along with the associated indirection. It also removes the need for `static_cast` in many places. It's done without using templates, though an intermediate template class could remove some of the repetition between derived classes. It's not too much repetition though.

Related:
- Issue #479
