### PR TITLE
Move `ListBoxBase::NoSelection` definition out of header file

### DIFF
--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -2,6 +2,8 @@
 
 #include <libControls/ListBoxBase.h>
 
+#include <vector>
+
 
 namespace NAS2D
 {

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -4,6 +4,8 @@
 
 #include <NAS2D/Signal/Signal.h>
 
+#include <vector>
+
 
 enum class StructureState;
 class Structure;

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -6,6 +6,10 @@
 #include <NAS2D/Math/Point.h>
 
 #include <algorithm>
+#include <limits>
+
+
+std::size_t ListBoxBase::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
 ListBoxBase::ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold) :

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -10,7 +10,6 @@
 #include <NAS2D/Renderer/Color.h>
 
 #include <string>
-#include <vector>
 #include <cstddef>
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 #include <cstddef>
-#include <limits>
 
 
 /**
@@ -28,7 +27,7 @@ class ListBoxBase : public Control
 public:
 	using SelectionChangeSignal = NAS2D::Signal<>;
 
-	static inline constexpr auto NoSelection{std::numeric_limits<std::size_t>::max()};
+	static std::size_t NoSelection;
 
 
 	ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold);


### PR DESCRIPTION
This allows moving the include for `<limits>` out of the header file.

Related:
- Issue #479
