### PR TITLE
Remove unnecessary destructor `disconnect` calls

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -42,11 +42,6 @@ GameState::~GameState()
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseMotion().disconnect({this, &GameState::onMouseMove});
 
-	for (auto takeMeThere : mMainReportsState->takeMeThere())
-	{
-		takeMeThere->disconnect({this, &GameState::onTakeMeThere});
-	}
-
 	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().disconnect({this, &GameState::onMusicComplete});
 	NAS2D::Utility<NAS2D::Mixer>::get().stopAllAudio();
 }

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -42,11 +42,6 @@ GameState::~GameState()
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseMotion().disconnect({this, &GameState::onMouseMove});
 
-	mMainReportsState->hideReports().disconnect({this, &GameState::onHideReports});
-	mMapView->quit().disconnect({this, &GameState::onQuit});
-	mMapView->showReportsUi().disconnect({this, &GameState::onShowReports});
-	mMapView->mapChanged().disconnect({this, &GameState::onMapChange});
-
 	for (auto takeMeThere : mMainReportsState->takeMeThere())
 	{
 		takeMeThere->disconnect({this, &GameState::onTakeMeThere});

--- a/appOPHD/UI/GameOptionsDialog.cpp
+++ b/appOPHD/UI/GameOptionsDialog.cpp
@@ -32,11 +32,6 @@ GameOptionsDialog::GameOptionsDialog() :
 
 GameOptionsDialog::~GameOptionsDialog()
 {
-	btnSave.click().disconnect({this, &GameOptionsDialog::onSave});
-	btnLoad.click().disconnect({this, &GameOptionsDialog::onLoad});
-	btnHelp.click().disconnect({this, &GameOptionsDialog::onHelp});
-	btnReturn.click().disconnect({this, &GameOptionsDialog::onReturn});
-	btnClose.click().disconnect({this, &GameOptionsDialog::onClose});
 }
 
 

--- a/appOPHD/UI/GameOptionsDialog.cpp
+++ b/appOPHD/UI/GameOptionsDialog.cpp
@@ -30,11 +30,6 @@ GameOptionsDialog::GameOptionsDialog() :
 }
 
 
-GameOptionsDialog::~GameOptionsDialog()
-{
-}
-
-
 void GameOptionsDialog::onEnableChange()
 {
 	btnSave.enabled(enabled());

--- a/appOPHD/UI/GameOptionsDialog.h
+++ b/appOPHD/UI/GameOptionsDialog.h
@@ -10,7 +10,6 @@ public:
 	using ClickSignal = NAS2D::Signal<>;
 
 	GameOptionsDialog();
-	~GameOptionsDialog() override;
 
 	void update() override;
 

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -35,7 +35,6 @@ ComboBox::ComboBox() :
 
 ComboBox::~ComboBox()
 {
-	lstItems.selectionChanged().disconnect({this, &ComboBox::onListSelectionChange});
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().disconnect({this, &ComboBox::onMouseWheel});
 }

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -83,8 +83,6 @@ public:
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &ListBox::onMouseDown});
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect({this, &ListBox::onMouseMove});
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseWheel().disconnect({this, &ListBox::onMouseWheel});
-
-		mScrollBar.change().disconnect({this, &ListBox::onSlideChange});
 	}
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -29,8 +29,6 @@ ListBoxBase::ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold) :
 
 ListBoxBase::~ListBoxBase()
 {
-	mScrollBar.change().disconnect({this, &ListBoxBase::onSlideChange});
-
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().disconnect({this, &ListBoxBase::onMouseWheel});
 	eventHandler.mouseButtonDown().disconnect({this, &ListBoxBase::onMouseDown});


### PR DESCRIPTION
Calling `disconnect` is important was the `Signal` source is from a global or `static` object. It's generally not needed when the `Signal` is from a component member object. In that case, destructing the parent object will destruct the component member fields, which will destruct the component's `Signal` fields, which will `disconnect` all listeners. Hence it's not necessary to manually `disconnect` in those cases.

Related:
- Issue #479
- Issue #894
