### PR TITLE
Split `ReportInterface` "Take Me There" `SignalSource`

### DIFF
--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -377,9 +377,9 @@ void MainReportsUiState::clearLists()
  *
  * Acts as a pass-through for GameState.
  */
-MainReportsUiState::TakeMeThereList MainReportsUiState::takeMeThere()
+MainReportsUiState::TakeMeThereSignalList MainReportsUiState::takeMeThere()
 {
-	TakeMeThereList takeMeThereList;
+	TakeMeThereSignalList takeMeThereList;
 	for (auto& panel : Panels)
 	{
 		if (panel.UiPanel)

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -377,9 +377,9 @@ void MainReportsUiState::clearLists()
  *
  * Acts as a pass-through for GameState.
  */
-MainReportsUiState::TakeMeThereSignalList MainReportsUiState::takeMeThere()
+MainReportsUiState::TakeMeThereSignalSourceList MainReportsUiState::takeMeThere()
 {
-	TakeMeThereSignalList takeMeThereList;
+	TakeMeThereSignalSourceList takeMeThereList;
 	for (auto& panel : Panels)
 	{
 		if (panel.UiPanel)

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -22,8 +22,8 @@ class MainReportsUiState : public Wrapper
 {
 public:
 	using ReportsUiSignal = NAS2D::Signal<>;
-	using TakeMeThere = NAS2D::Signal<const Structure*>;
-	using TakeMeThereList = std::vector<TakeMeThere*>;
+	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
+	using TakeMeThereList = std::vector<TakeMeThereSignal*>;
 
 public:
 	MainReportsUiState();

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -23,7 +23,7 @@ class MainReportsUiState : public Wrapper
 public:
 	using ReportsUiSignal = NAS2D::Signal<>;
 	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
-	using TakeMeThereList = std::vector<TakeMeThereSignal*>;
+	using TakeMeThereSignalList = std::vector<TakeMeThereSignal*>;
 
 public:
 	MainReportsUiState();
@@ -39,7 +39,7 @@ public:
 	void clearLists();
 
 	ReportsUiSignal::Source& hideReports() { return mReportsUiSignal; }
-	TakeMeThereList takeMeThere();
+	TakeMeThereSignalList takeMeThere();
 
 protected:
 	void initialize() override;

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -22,8 +22,8 @@ class MainReportsUiState : public Wrapper
 {
 public:
 	using ReportsUiSignal = NAS2D::Signal<>;
-	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
-	using TakeMeThereSignalList = std::vector<TakeMeThereSignal*>;
+	using TakeMeThereSignalSource = NAS2D::SignalSource<const Structure*>;
+	using TakeMeThereSignalSourceList = std::vector<TakeMeThereSignalSource*>;
 
 public:
 	MainReportsUiState();
@@ -39,7 +39,7 @@ public:
 	void clearLists();
 
 	ReportsUiSignal::Source& hideReports() { return mReportsUiSignal; }
-	TakeMeThereSignalList takeMeThere();
+	TakeMeThereSignalSourceList takeMeThere();
 
 protected:
 	void initialize() override;

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -382,7 +382,7 @@ void FactoryReport::onClearProduction()
 
 void FactoryReport::onTakeMeThere()
 {
-	takeMeThereSignal()(selectedFactory);
+	mTakeMeThereSignal(selectedFactory);
 }
 
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -237,7 +237,7 @@ void MineReport::onDigNewLevel()
 
 void MineReport::onTakeMeThere()
 {
-	takeMeThereSignal()(mSelectedFacility);
+	mTakeMeThereSignal(mSelectedFacility);
 }
 
 

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -18,7 +18,7 @@ public:
 	 * Signal used to handle clicks of a "Take Me There" button to center
 	 * the map view on a given structure.
 	 */
-	using TakeMeThere = NAS2D::Signal<const Structure*>;
+	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
 
 	ReportInterface() {}
 
@@ -50,8 +50,8 @@ public:
 	 */
 	virtual void selectStructure(Structure*) = 0;
 
-	TakeMeThere& takeMeThereSignal() { return mTakeMeThereSignal; }
+	TakeMeThereSignal& takeMeThereSignal() { return mTakeMeThereSignal; }
 
 private:
-	TakeMeThere mTakeMeThereSignal;
+	TakeMeThereSignal mTakeMeThereSignal;
 };

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -52,6 +52,6 @@ public:
 
 	TakeMeThereSignal& takeMeThereSignal() { return mTakeMeThereSignal; }
 
-private:
+protected:
 	TakeMeThereSignal mTakeMeThereSignal;
 };

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -50,7 +50,7 @@ public:
 	 */
 	virtual void selectStructure(Structure*) = 0;
 
-	TakeMeThereSignal& takeMeThereSignal() { return mTakeMeThereSignal; }
+	TakeMeThereSignal::Source& takeMeThereSignal() { return mTakeMeThereSignal; }
 
 protected:
 	TakeMeThereSignal mTakeMeThereSignal;

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -194,7 +194,7 @@ void WarehouseReport::onDoubleClick(MouseButton button, NAS2D::Point<int> positi
 
 	if (selectedWarehouse && lstStructures.rect().contains(position))
 	{
-		takeMeThereSignal()(selectedWarehouse);
+		mTakeMeThereSignal(selectedWarehouse);
 	}
 }
 
@@ -288,7 +288,7 @@ void WarehouseReport::onDisabled()
 
 void WarehouseReport::onTakeMeThere()
 {
-	takeMeThereSignal()(selectedWarehouse);
+	mTakeMeThereSignal(selectedWarehouse);
 }
 
 


### PR DESCRIPTION
Split access to the "Take Me There" `Signal`, so external uses only see `SignalSource`. This prevents external clients from calling `emit`.

Related:
- PR #1609
- PR #866
- Issue #853
- Issue #875
