### PR TITLE
Convert names from upper case to camel case

### DIFF
--- a/appOPHD/Constants/UiConstants.h
+++ b/appOPHD/Constants/UiConstants.h
@@ -57,8 +57,8 @@ namespace constants
 	// =====================================
 	// = FONT STRINGS
 	// =====================================
-	const std::string FONT_PRIMARY = "fonts/opensans.ttf";
-	const std::string FONT_PRIMARY_BOLD = "fonts/opensans-bold.ttf";
+	const std::string FontPrimary = "fonts/opensans.ttf";
+	const std::string FontPrimaryBold = "fonts/opensans-bold.ttf";
 
 
 	// =====================================

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -30,7 +30,7 @@ const std::map<StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
 /**
  * Translation table for Structure Classes.
  */
-const std::map<Structure::StructureClass, std::string> STRUCTURE_CLASS_TRANSLATION =
+const std::map<Structure::StructureClass, std::string> StructureClassNames =
 {
 	{Structure::StructureClass::Command, "Command"},
 	{Structure::StructureClass::Communication, "Communication"},
@@ -115,7 +115,7 @@ std::string StructureName(StructureID id)
 std::vector<Structure::StructureClass> allStructureClasses()
 {
 	std::vector<Structure::StructureClass> result;
-	for (const auto& entry : STRUCTURE_CLASS_TRANSLATION)
+	for (const auto& entry : StructureClassNames)
 	{
 		result.push_back(entry.first);
 	}
@@ -241,7 +241,7 @@ const std::string& Structure::classDescription() const
 
 const std::string& Structure::classDescription(StructureClass structureClass)
 {
-	return STRUCTURE_CLASS_TRANSLATION.at(structureClass);
+	return StructureClassNames.at(structureClass);
 }
 
 int Structure::turnsToBuild() const

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -17,7 +17,7 @@
 /**
  * Translation table for Structure States.
  */
-const std::map<StructureState, std::string> STRUCTURE_STATE_TRANSLATION =
+const std::map<StructureState, std::string> StructureStateDescriptions =
 {
 	{StructureState::UnderConstruction, "Under Construction"},
 	{StructureState::Operational, "Operational"},
@@ -231,7 +231,7 @@ const std::string& Structure::stateDescription() const
 
 const std::string& Structure::stateDescription(StructureState state)
 {
-	return STRUCTURE_STATE_TRANSLATION.at(state);
+	return StructureStateDescriptions.at(state);
 }
 
 const std::string& Structure::classDescription() const

--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -51,7 +51,7 @@ void MainMenuState::initialize()
 
 	for (auto& button : buttons)
 	{
-		button.font(fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium));
+		button.font(fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium));
 		button.size({200, 30});
 	}
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -157,7 +157,7 @@ namespace
 
 
 MainReportsUiState::MainReportsUiState() :
-	fontMain{fontCache.load(constants::FONT_PRIMARY_BOLD, 16)}
+	fontMain{fontCache.load(constants::FontPrimaryBold, 16)}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.windowResized().connect({this, &MainReportsUiState::onWindowResized});

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -29,7 +29,7 @@ namespace
 
 
 PlanetSelectState::PlanetSelectState() :
-	mFontBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
+	mFontBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	mTinyFont{Control::getDefaultFont()},
 	mBg{"sys/bg1.png"},
 	mCloud1{"sys/cloud_1.png"},
@@ -38,7 +38,7 @@ PlanetSelectState::PlanetSelectState() :
 	mSelect{"sfx/click.ogg"},
 	mHover{"sfx/menu4.ogg"},
 	mQuit{"Main Menu", {100, 20}, {this, &PlanetSelectState::onQuit}},
-	mPlanetDescription{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
+	mPlanetDescription{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	mPlanetSelection{constants::NoSelection},
 	mReturnState{this},
 	mPlanets{attributesToPlanets(parsePlanetAttributes())}

--- a/appOPHD/StructureCatalogue.cpp
+++ b/appOPHD/StructureCatalogue.cpp
@@ -52,7 +52,7 @@ namespace
 		}
 
 		// Set recycling values for landers and automatically built structures.
-		// RESOURCES: COMM_MET_ORE, COMM_MIN_ORE, RARE_MET_ORE, RARE_MIN_ORE, COMM_MET, COMM_MIN, RARE_MET, RARE_MIN
+		// RESOURCES: COMM_MET, COMM_MIN, RARE_MET, RARE_MIN
 		structureRecycleValueTable[StructureID::SID_MINE_FACILITY] = {15, 10, 5, 5};
 		structureRecycleValueTable[StructureID::SID_CARGO_LANDER] = {15, 10, 5, 5};
 		structureRecycleValueTable[StructureID::SID_COLONIST_LANDER] = {15, 10, 5, 5};

--- a/appOPHD/StructureCatalogue.cpp
+++ b/appOPHD/StructureCatalogue.cpp
@@ -52,7 +52,7 @@ namespace
 		}
 
 		// Set recycling values for landers and automatically built structures.
-		// RESOURCES: COMM_MET, COMM_MIN, RARE_MET, RARE_MIN
+		// Resources: {Common Metals, Common Minerals, Rare Metals, Rare Minerals}
 		structureRecycleValueTable[StructureID::SID_MINE_FACILITY] = {15, 10, 5, 5};
 		structureRecycleValueTable[StructureID::SID_CARGO_LANDER] = {15, 10, 5, 5};
 		structureRecycleValueTable[StructureID::SID_COLONIST_LANDER] = {15, 10, 5, 5};

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -21,8 +21,8 @@ using namespace NAS2D;
 
 FactoryListBox::FactoryListBox() :
 	ListBoxBase{
-		fontCache.load(constants::FONT_PRIMARY, 12),
-		fontCache.load(constants::FONT_PRIMARY_BOLD, 12)
+		fontCache.load(constants::FontPrimary, 12),
+		fontCache.load(constants::FontPrimaryBold, 12)
 	},
 	mStructureIcons{imageCache.load("ui/structures.png")}
 {

--- a/appOPHD/UI/NavControl.cpp
+++ b/appOPHD/UI/NavControl.cpp
@@ -116,7 +116,7 @@ void NavControl::draw() const
 
 	// Explicit current level
 	const auto& currentLevelString = levelString(mMapView.currentDepth());
-	const auto& fontBoldMedium = fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium);
+	const auto& fontBoldMedium = fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium);
 	const auto currentLevelPosition = mRect.endPoint() - fontBoldMedium.size(currentLevelString) - NAS2D::Vector{constants::Margin, constants::Margin};
 	renderer.drawText(fontBoldMedium, currentLevelString, currentLevelPosition, NAS2D::Color::White);
 }

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -16,8 +16,8 @@ using namespace NAS2D;
 
 ProductListBox::ProductListBox() :
 	ListBoxBase{
-		fontCache.load(constants::FONT_PRIMARY, 12),
-		fontCache.load(constants::FONT_PRIMARY_BOLD, 12)
+		fontCache.load(constants::FontPrimary, 12),
+		fontCache.load(constants::FontPrimaryBold, 12)
 	}
 {
 	itemHeight(30);

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -52,9 +52,9 @@ namespace
 
 FactoryReport::FactoryReport() :
 	font{Control::getDefaultFont()},
-	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
-	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},
+	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
+	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
+	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	factorySeed{imageCache.load("ui/interface/factory_seed.png")},
 	factoryAboveGround{imageCache.load("ui/interface/factory_ag.png")},
 	factoryUnderGround{imageCache.load("ui/interface/factory_ug.png")},

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -43,9 +43,9 @@ namespace
 MineReport::MineReport() :
 	font{Control::getDefaultFont()},
 	fontBold{Control::getDefaultFontBold()},
-	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
-	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},
+	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
+	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
+	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	mineFacility{imageCache.load("ui/interface/mine.png")},
 	uiIcons{imageCache.load("ui/icons.png")},
 	btnShowAll{"All", {this, &MineReport::onShowAll}},

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -86,14 +86,14 @@ namespace
 
 
 ResearchReport::ResearchReport() :
-	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
-	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},
+	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
+	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
+	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageLab{imageCache.load("ui/interface/lab_ug.png")},
 	imageUiIcons{imageCache.load("ui/icons.png")},
 	imageCategoryIcons{imageCache.load("categoryicons.png")},
 	imageTopicIcons{imageCache.load("topicicons.png")},
-	txtTopicDescription{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)}
+	txtTopicDescription{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)}
 {
 	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &ResearchReport::onMouseDown});
 

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -11,9 +11,9 @@ using namespace NAS2D;
 
 
 SatellitesReport::SatellitesReport() :
-	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
-	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},
+	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
+	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
+	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageNotImplemented{imageCache.load("ui/interface/ni.png")}
 {
 }

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -9,9 +9,9 @@
 using namespace NAS2D;
 
 SpaceportsReport::SpaceportsReport() :
-	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
-	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},
+	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
+	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
+	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageNotImplemented{imageCache.load("ui/interface/ni.png")}
 {
 }

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -51,9 +51,9 @@ namespace
 
 
 WarehouseReport::WarehouseReport() :
-	fontMedium{fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryMedium)},
-	fontMediumBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryMedium)},
-	fontBigBold{fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryHuge)},
+	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
+	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
+	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All", {this, &WarehouseReport::onShowAll}},
 	btnSpaceAvailable{"Space Available", {this, &WarehouseReport::onSpaceAvailable}},

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -26,8 +26,8 @@ extern NAS2D::Point<int> MOUSE_COORDS;
 
 namespace
 {
-	constexpr NAS2D::Rectangle<int> RESOURCE_PANEL_PIN{{0, 1}, {8, 19}};
-	constexpr NAS2D::Rectangle<int> POPULATION_PANEL_PIN{{675, 1}, {8, 19}};
+	constexpr NAS2D::Rectangle<int> ResourcePanelPinRect{{0, 1}, {8, 19}};
+	constexpr NAS2D::Rectangle<int> PopulationPanelPinRect{{675, 1}, {8, 19}};
 
 
 	uint8_t calcGlowIntensity()
@@ -200,8 +200,8 @@ void ResourceInfoBar::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> p
 
 	if (button == NAS2D::MouseButton::Left)
 	{
-		if (RESOURCE_PANEL_PIN.contains(MOUSE_COORDS)) { mPinResourcePanel = !mPinResourcePanel; }
-		if (POPULATION_PANEL_PIN.contains(MOUSE_COORDS)) { mPinPopulationPanel = !mPinPopulationPanel; }
+		if (ResourcePanelPinRect.contains(MOUSE_COORDS)) { mPinResourcePanel = !mPinResourcePanel; }
+		if (PopulationPanelPinRect.contains(MOUSE_COORDS)) { mPinPopulationPanel = !mPinPopulationPanel; }
 	}
 }
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -26,8 +26,8 @@ extern NAS2D::Point<int> MOUSE_COORDS;
 
 namespace
 {
-	NAS2D::Rectangle<int> RESOURCE_PANEL_PIN{{0, 1}, {8, 19}};
-	NAS2D::Rectangle<int> POPULATION_PANEL_PIN{{675, 1}, {8, 19}};
+	constexpr NAS2D::Rectangle<int> RESOURCE_PANEL_PIN{{0, 1}, {8, 19}};
+	constexpr NAS2D::Rectangle<int> POPULATION_PANEL_PIN{{675, 1}, {8, 19}};
 
 
 	uint8_t calcGlowIntensity()

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -18,8 +18,8 @@ using namespace NAS2D;
 
 StructureListBox::StructureListBox() :
 	ListBoxBase{
-		fontCache.load(constants::FONT_PRIMARY, 12),
-		fontCache.load(constants::FONT_PRIMARY_BOLD, 12)
+		fontCache.load(constants::FontPrimary, 12),
+		fontCache.load(constants::FontPrimaryBold, 12)
 	}
 {
 	itemHeight(30);

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -167,8 +167,8 @@ int main(int argc, char *argv[])
 		addCursor(PointerType::PlaceTile, constants::MousePointerPlaceTile, {16, 16});
 		setCursor(PointerType::Normal);
 
-		Control::setDefaultFont(fontCache.load(constants::FONT_PRIMARY, constants::FontPrimaryNormal));
-		Control::setDefaultFontBold(fontCache.load(constants::FONT_PRIMARY_BOLD, constants::FontPrimaryNormal));
+		Control::setDefaultFont(fontCache.load(constants::FontPrimary, constants::FontPrimaryNormal));
+		Control::setDefaultFontBold(fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryNormal));
 		Control::setImageCache(imageCache);
 
 		const auto& options = cf["options"];


### PR DESCRIPTION
All uppercase is often considered the convention for preprocessor macros. We should avoid using all uppercase names that aren't macros.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1230
