### PR TITLE
Split `Structure` headers

### DIFF
--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -1,0 +1,31 @@
+#include "AirShaft.h"
+
+
+#include "../../Constants/Strings.h"
+
+
+AirShaft::AirShaft() : Structure(
+	constants::StructureStateOperational,
+	StructureClass::Tube,
+	StructureID::SID_AIR_SHAFT)
+{
+	connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);
+
+	state(StructureState::Operational);
+}
+
+
+void AirShaft::ug()
+{
+	sprite().play(constants::StructureStateOperationalUg);
+	mIsUnderground = true;
+}
+
+
+void AirShaft::forced_state_change(StructureState, DisabledReason, IdleReason)
+{
+	if (mIsUnderground)
+	{
+		return;
+	}
+}

--- a/appOPHD/MapObjects/Structures/AirShaft.h
+++ b/appOPHD/MapObjects/Structures/AirShaft.h
@@ -2,35 +2,15 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-
 
 class AirShaft : public Structure
 {
 public:
-	AirShaft() : Structure(
-		constants::StructureStateOperational,
-		StructureClass::Tube,
-		StructureID::SID_AIR_SHAFT)
-	{
-		connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);
+	AirShaft();
 
-		state(StructureState::Operational);
-	}
+	void ug();
 
-	void ug()
-	{
-		sprite().play(constants::StructureStateOperationalUg);
-		mIsUnderground = true;
-	}
-
-	void forced_state_change(StructureState, DisabledReason, IdleReason) override
-	{
-		if (mIsUnderground)
-		{
-			return;
-		}
-	}
+	void forced_state_change(StructureState, DisabledReason, IdleReason) override;
 
 private:
 	bool mIsUnderground = false;

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -1,0 +1,29 @@
+#include "CargoLander.h"
+
+
+#include "../../Map/Tile.h"
+
+
+CargoLander::CargoLander(Tile* tile) : Structure(
+	StructureClass::Lander,
+	StructureID::SID_CARGO_LANDER),
+	mTile(tile)
+{
+	enable();
+}
+
+
+CargoLander::Signal::Source& CargoLander::deploySignal()
+{
+	return mDeploy;
+}
+
+
+void CargoLander::think()
+{
+	if (age() == turnsToBuild())
+	{
+		mDeploy();
+		mTile->index(TerrainType::Dozed);
+	}
+}

--- a/appOPHD/MapObjects/Structures/CargoLander.h
+++ b/appOPHD/MapObjects/Structures/CargoLander.h
@@ -2,34 +2,21 @@
 
 #include "../Structure.h"
 
-#include "../../Map/Tile.h"
+
+class Tile;
 
 
 class CargoLander : public Structure
 {
 public:
-
 	using Signal = NAS2D::Signal<>;
 
-	CargoLander(Tile* tile) : Structure(
-		StructureClass::Lander,
-		StructureID::SID_CARGO_LANDER),
-		mTile(tile)
-	{
-		enable();
-	}
+	CargoLander(Tile* tile);
 
-	Signal::Source& deploySignal() { return mDeploy; }
+	Signal::Source& deploySignal();
 
 protected:
-	void think() override
-	{
-		if (age() == turnsToBuild())
-		{
-			mDeploy();
-			mTile->index(TerrainType::Dozed);
-		}
-	}
+	void think() override;
 
 private:
 	CargoLander() = delete;

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -1,0 +1,27 @@
+#include "ColonistLander.h"
+
+
+#include "../../Constants/Strings.h"
+#include "../../Map/Tile.h"
+
+
+ColonistLander::ColonistLander(Tile* tile) : Structure(
+	StructureClass::Lander,
+	StructureID::SID_COLONIST_LANDER),
+	mTile(tile)
+{
+	enable();
+}
+
+
+ColonistLander::Signal::Source& ColonistLander::deploySignal() { return mDeploy; }
+
+
+void ColonistLander::think()
+{
+	if (age() == turnsToBuild())
+	{
+		mDeploy();
+		mTile->index(TerrainType::Dozed);
+	}
+}

--- a/appOPHD/MapObjects/Structures/ColonistLander.h
+++ b/appOPHD/MapObjects/Structures/ColonistLander.h
@@ -2,8 +2,8 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-#include "../../Map/Tile.h"
+
+class Tile;
 
 
 class ColonistLander : public Structure
@@ -12,26 +12,12 @@ public:
 	using Signal = NAS2D::Signal<>;
 
 public:
+	ColonistLander(Tile* tile);
 
-	ColonistLander(Tile* tile) : Structure(
-		StructureClass::Lander,
-		StructureID::SID_COLONIST_LANDER),
-		mTile(tile)
-	{
-		enable();
-	}
-
-	Signal::Source& deploySignal() { return mDeploy; }
+	Signal::Source& deploySignal();
 
 protected:
-	void think() override
-	{
-		if (age() == turnsToBuild())
-		{
-			mDeploy();
-			mTile->index(TerrainType::Dozed);
-		}
-	}
+	void think() override;
 
 private:
 	Signal mDeploy;

--- a/appOPHD/MapObjects/Structures/CommandCenter.cpp
+++ b/appOPHD/MapObjects/Structures/CommandCenter.cpp
@@ -1,0 +1,29 @@
+#include "CommandCenter.h"
+
+
+#include "../../Constants/Numbers.h"
+
+
+CommandCenter::CommandCenter() : FoodProduction(
+	StructureClass::Command,
+	StructureID::SID_COMMAND_CENTER)
+{
+}
+
+
+int CommandCenter::foodCapacity()
+{
+	return constants::BaseStorageCapacity;
+}
+
+
+int CommandCenter::getRange() const
+{
+	return operational() ? constants::RobotCommRange : 0;
+}
+
+
+int CommandCenter::calculateProduction()
+{
+	return 0;
+}

--- a/appOPHD/MapObjects/Structures/CommandCenter.h
+++ b/appOPHD/MapObjects/Structures/CommandCenter.h
@@ -2,8 +2,6 @@
 
 #include "FoodProduction.h"
 
-#include "../../Constants/Numbers.h"
-
 
 /**
  * Implements the Command Center structure.
@@ -11,25 +9,12 @@
 class CommandCenter : public FoodProduction
 {
 public:
-	CommandCenter() : FoodProduction(
-		StructureClass::Command,
-		StructureID::SID_COMMAND_CENTER)
-	{
-	}
+	CommandCenter();
 
-	int foodCapacity() override
-	{
-		return constants::BaseStorageCapacity;
-	}
+	int foodCapacity() override;
 
-	int getRange() const
-	{
-		return operational() ? constants::RobotCommRange : 0;
-	}
+	int getRange() const;
 
 protected:
-	int calculateProduction() override
-	{
-		return 0;
-	}
+	int calculateProduction() override;
 };

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -1,0 +1,29 @@
+#include "Tube.h"
+
+#include "../../Constants/Strings.h"
+
+#include <stdexcept>
+
+
+Tube::Tube(ConnectorDir dir, bool underground) :
+	Structure(
+		getAnimationName(dir, underground),
+		StructureClass::Tube,
+		StructureID::SID_TUBE)
+{
+	connectorDirection(dir);
+	state(StructureState::Operational);
+}
+
+
+const std::string& Tube::getAnimationName(ConnectorDir dir, bool underground)
+{
+	return *(
+		(dir == ConnectorDir::CONNECTOR_INTERSECTION) ?
+			(underground ? &constants::UgTubeIntersection : &constants::AgTubeIntersection) :
+		(dir == ConnectorDir::CONNECTOR_EAST_WEST) ?
+			(underground ? &constants::UgTubeRight : &constants::AgTubeRight) :
+		(dir == ConnectorDir::CONNECTOR_NORTH_SOUTH) ?
+			(underground ? &constants::UgTubelLeft : &constants::AgTubeLeft) :
+		throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter."));
+}

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -2,8 +2,6 @@
 
 #include "../Structure.h"
 
-#include "../../Constants/Strings.h"
-
 
 /**
  * Implements a Tube Structure.
@@ -11,27 +9,8 @@
 class Tube : public Structure
 {
 public:
-	Tube(ConnectorDir dir, bool underground) :
-		Structure(
-			getAnimationName(dir, underground),
-			StructureClass::Tube,
-			StructureID::SID_TUBE)
-	{
-		connectorDirection(dir);
-		state(StructureState::Operational);
-	}
+	Tube(ConnectorDir dir, bool underground);
 
 private:
-
-	static const std::string& getAnimationName(ConnectorDir dir, bool underground)
-	{
-		return *(
-			(dir == ConnectorDir::CONNECTOR_INTERSECTION) ?
-				(underground ? &constants::UgTubeIntersection : &constants::AgTubeIntersection) :
-			(dir == ConnectorDir::CONNECTOR_EAST_WEST) ?
-				(underground ? &constants::UgTubeRight : &constants::AgTubeRight) :
-			(dir == ConnectorDir::CONNECTOR_NORTH_SOUTH) ?
-				(underground ? &constants::UgTubelLeft : &constants::AgTubeLeft) :
-			throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter."));
-	}
+	static const std::string& getAnimationName(ConnectorDir dir, bool underground);
 };

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -6,6 +6,7 @@
 #include "Wrapper.h"
 #include "../StructureManager.h"
 #include "../UI/MessageBox.h"
+#include "../Constants/Strings.h"
 
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/Utility.h>

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -13,6 +13,7 @@
 #include "../MoraleString.h"
 #include "../StorableResources.h"
 #include "../StructureManager.h"
+#include "../Constants/Strings.h"
 
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumMoraleIndex.h>

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -15,6 +15,7 @@
 
 #include "../../States/Route.h"
 
+#include "../../Map/Tile.h"
 #include "../../MapObjects/Mine.h"
 #include "../../MapObjects/Structures/MineFacility.h"
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -4,6 +4,7 @@
 
 #include "../../Cache.h"
 #include "../../StructureManager.h"
+#include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 #include "../../MapObjects/Structure.h"
 #include "../../MapObjects/Structures/Warehouse.h"

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Resources.h"
+#include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../States/MapViewStateHelper.h"
 

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\AirShaft.cpp" />
     <ClCompile Include="MapObjects\Structures\CargoLander.cpp" />
+    <ClCompile Include="MapObjects\Structures\CommandCenter.cpp" />
     <ClCompile Include="MapObjects\Structures\CommTower.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\FoodProduction.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\AirShaft.cpp" />
     <ClCompile Include="MapObjects\Structures\CargoLander.cpp" />
+    <ClCompile Include="MapObjects\Structures\ColonistLander.cpp" />
     <ClCompile Include="MapObjects\Structures\CommandCenter.cpp" />
     <ClCompile Include="MapObjects\Structures\CommTower.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -210,6 +210,7 @@
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPlant.cpp" />
     <ClCompile Include="MapObjects\Structures\StorageTanks.cpp" />
+    <ClCompile Include="MapObjects\Structures\Tube.cpp" />
     <ClCompile Include="MicroPather\micropather.cpp" />
     <ClCompile Include="MeanSolarDistance.cpp" />
     <ClCompile Include="MineProductionRateString.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -197,6 +197,7 @@
     <ClCompile Include="MapObjects\Robots\Robominer.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
+    <ClCompile Include="MapObjects\Structures\AirShaft.cpp" />
     <ClCompile Include="MapObjects\Structures\CommTower.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\FoodProduction.cpp" />

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -198,6 +198,7 @@
     <ClCompile Include="MapObjects\Structure.cpp" />
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\AirShaft.cpp" />
+    <ClCompile Include="MapObjects\Structures\CargoLander.cpp" />
     <ClCompile Include="MapObjects\Structures\CommTower.cpp" />
     <ClCompile Include="MapObjects\Structures\Factory.cpp" />
     <ClCompile Include="MapObjects\Structures\FoodProduction.cpp" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="MapObjects\Structures\CargoLander.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\ColonistLander.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\CommandCenter.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="MapObjects\Structures\Agridome.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\AirShaft.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\CommTower.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClCompile Include="MapObjects\Structures\StorageTanks.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\Tube.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MicroPather\micropather.cpp">
       <Filter>Source Files\MicroPather</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClCompile Include="MapObjects\Structures\AirShaft.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\CargoLander.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\CommTower.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="MapObjects\Structures\CargoLander.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\CommandCenter.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\CommTower.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>


### PR DESCRIPTION
Split implementations in certain headers for `Structure` derived classes to source files.

This allows includes specific to implementations to be moved out of headers, reducing transitive includes.

This revealed a few places where includes should have been made in unrelated code, but were missed due to transitive includes supplying the needed header.

Related:
- Issue #307 (Clang warning `-Wweak-vtables`)
