### PR TITLE
Update `makefile` targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
   build:
     steps:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
-      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" ophd
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibOPHD
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibControls
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkOPHD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,5 +168,5 @@ jobs:
     - name: Run libOPHD unit tests
       run: .build/${{env.Configuration}}_${{env.Platform}}_testLibOPHD/testLibOPHD.exe
 
-    - name: Run libControl unit tests
+    - name: Run libControls unit tests
       run: .build/${{env.Configuration}}_${{env.Platform}}_testLibControls/testLibControls.exe

--- a/makefile
+++ b/makefile
@@ -187,7 +187,7 @@ demoLibControls_PROJECT_FLAGS := $(demoLibControls_CPPFLAGS) $(CXXFLAGS)
 demoLibControls: $(demoLibControls_OUTPUT)
 
 .PHONY: runDemoControls
-runDemoControls:
+runDemoControls: $(demoLibControls_OUTPUT)
 	$(RUN_PREFIX) $(demoLibControls_OUTPUT)
 
 $(demoLibControls_OUTPUT): $(demoLibControls_OBJS) $(libControls_OUTPUT) $(NAS2DLIB)

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ all: ophd test demoLibControls
 test: testLibOPHD testLibControls
 
 .PHONY: check
-check: checkOPHD checkControls
+check: all checkOPHD checkControls
 
 
 ## NAS2D project ##

--- a/makefile
+++ b/makefile
@@ -21,6 +21,8 @@ BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
 
 ## Default and top-level targets ##
 
+.DEFAULT_GOAL := ophd
+
 .PHONY: all
 all: ophd
 

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
 .DEFAULT_GOAL := ophd
 
 .PHONY: all
-all: ophd
+all: ophd test demoLibControls
 
 .PHONY: test
 test: testLibOPHD testLibControls

--- a/makefile
+++ b/makefile
@@ -220,6 +220,10 @@ include $(wildcard $(patsubst %.o,%.d,$(ophd_OBJS)))
 .PHONY: intermediate
 intermediate: $(ophd_OBJS)
 
+.PHONY: run
+run: $(ophd_OUTPUT)
+	./$(ophd_OUTPUT) $(OPHD_RUN_FLAGS)
+
 
 ## Compile rules ##
 

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
 ## Default and top-level targets ##
 
 .PHONY: all
-all: ophd$(EXE_SUFFIX)
+all: ophd
 
 .PHONY: test
 test: testLibOPHD testLibControls
@@ -202,7 +202,7 @@ include $(wildcard $(patsubst %.o,%.d,$(demoLibControls_OBJS)))
 
 ophd_SRCDIR := appOPHD/
 ophd_OBJDIR := $(BUILDDIRPREFIX)$(ophd_SRCDIR)Intermediate/
-ophd_OUTPUT := ophd$(EXE_SUFFIX)
+ophd_OUTPUT := $(BUILDDIRPREFIX)$(ophd_SRCDIR)ophd$(EXE_SUFFIX)
 ophd_SRCS := $(shell find $(ophd_SRCDIR) -name '*.cpp')
 ophd_OBJS := $(patsubst $(ophd_SRCDIR)%.cpp,$(ophd_OBJDIR)%.o,$(ophd_SRCS))
 
@@ -219,6 +219,9 @@ include $(wildcard $(patsubst %.o,%.d,$(ophd_OBJS)))
 
 .PHONY: intermediate
 intermediate: $(ophd_OBJS)
+
+.PHONY: ophd
+ophd: $(ophd_OUTPUT)
 
 .PHONY: run
 run: $(ophd_OUTPUT)

--- a/makefile
+++ b/makefile
@@ -227,7 +227,7 @@ ophd: $(ophd_OUTPUT)
 
 .PHONY: run
 run: $(ophd_OUTPUT)
-	./$(ophd_OUTPUT) $(OPHD_RUN_FLAGS)
+	$(ophd_OUTPUT) $(OPHD_RUN_FLAGS)
 
 
 ## Compile rules ##


### PR DESCRIPTION
Move `ophd` executable to build folder.

Add `run` target to easily run executable from the build folder. Supports env var `OPHD_RUN_FLAGS`, which can be used to load a saved game file for easy testing.

Add `ophd` phony target, and set as default target. This ensures `make ophd` is still a valid target, and maintains the same default build.

Update `all` target to also build the unit test executables (`testLibOPHD`, `testLibControls`) and the demo project `demoLibControls`.

Update `check` target to build `all`, ensuring that `appOPHD` is built as well as running the unit test executables. Normally when we run the unit test executables (for the libraries), we also want to ensure the main app builds too, and any compiler warnings or errors are seen.

Update `runDemoControls` to ensure output is up-to-date before running it.
