### PR TITLE
Refactor `FactoryReport` layout code

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -67,10 +67,10 @@ FactoryReport::FactoryReport() :
 	btnShowActive{"Active", viewFilterButtonSize, {this, &FactoryReport::onShowActive}},
 	btnShowIdle{"Idle", viewFilterButtonSize, {this, &FactoryReport::onShowIdle}},
 	btnShowDisabled{"Disabled", viewFilterButtonSize, {this, &FactoryReport::onShowDisabled}},
-	btnIdle{"Idle", {this, &FactoryReport::onIdle}},
-	btnClearProduction{"Clear Production", {this, &FactoryReport::onClearProduction}},
-	btnTakeMeThere{constants::TakeMeThere, {this, &FactoryReport::onTakeMeThere}},
-	btnApply{"Apply", {this, &FactoryReport::onApply}}
+	btnIdle{"Idle", mainButtonSize, {this, &FactoryReport::onIdle}},
+	btnClearProduction{"Clear Production", mainButtonSize, {this, &FactoryReport::onClearProduction}},
+	btnTakeMeThere{constants::TakeMeThere, mainButtonSize, {this, &FactoryReport::onTakeMeThere}},
+	btnApply{"Apply", mainButtonSize, {this, &FactoryReport::onApply}}
 {
 	add(lstFactoryList, {10, 63});
 	lstFactoryList.selectionChanged().connect({this, &FactoryReport::onListSelectionChange});
@@ -97,16 +97,12 @@ FactoryReport::FactoryReport() :
 	int position_x = Utility<Renderer>::get().size().x - 110;
 	add(btnIdle, {position_x, 35});
 	btnIdle.type(Button::Type::Toggle);
-	btnIdle.size(mainButtonSize);
 
 	add(btnClearProduction, {position_x, 75});
-	btnClearProduction.size(mainButtonSize);
 
 	add(btnTakeMeThere, {position_x, 115});
-	btnTakeMeThere.size(mainButtonSize);
 
 	add(btnApply, {0, 0});
-	btnApply.size(mainButtonSize);
 
 	add(cboFilterByProduct, {250, 33});
 	cboFilterByProduct.size({200, 20});

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -28,6 +28,7 @@ using namespace NAS2D;
 namespace
 {
 	const auto viewFilterButtonSize = NAS2D::Vector{75, 20};
+	const auto mainButtonSize = NAS2D::Vector{140, 30};
 
 	bool productTypeInRange(ProductType productType)
 	{
@@ -96,16 +97,16 @@ FactoryReport::FactoryReport() :
 	int position_x = Utility<Renderer>::get().size().x - 110;
 	add(btnIdle, {position_x, 35});
 	btnIdle.type(Button::Type::Toggle);
-	btnIdle.size({140, 30});
+	btnIdle.size(mainButtonSize);
 
 	add(btnClearProduction, {position_x, 75});
-	btnClearProduction.size({140, 30});
+	btnClearProduction.size(mainButtonSize);
 
 	add(btnTakeMeThere, {position_x, 115});
-	btnTakeMeThere.size({140, 30});
+	btnTakeMeThere.size(mainButtonSize);
 
 	add(btnApply, {0, 0});
-	btnApply.size({140, 30});
+	btnApply.size(mainButtonSize);
 
 	add(cboFilterByProduct, {250, 33});
 	cboFilterByProduct.size({200, 20});

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -27,6 +27,8 @@ using namespace NAS2D;
 
 namespace
 {
+	const auto viewFilterButtonSize = NAS2D::Vector{75, 20};
+
 	bool productTypeInRange(ProductType productType)
 	{
 		return ProductType::PRODUCT_NONE < productType && productType < ProductType::PRODUCT_COUNT;
@@ -73,28 +75,28 @@ FactoryReport::FactoryReport() :
 	lstFactoryList.selectionChanged().connect({this, &FactoryReport::onListSelectionChange});
 
 	add(btnShowAll, {10, 10});
-	btnShowAll.size({75, 20});
+	btnShowAll.size(viewFilterButtonSize);
 	btnShowAll.type(Button::Type::Toggle);
 	btnShowAll.toggle(true);
 
 	add(btnShowSurface, {87, 10});
-	btnShowSurface.size({75, 20});
+	btnShowSurface.size(viewFilterButtonSize);
 	btnShowSurface.type(Button::Type::Toggle);
 
 	add(btnShowUnderground, {164, 10});
-	btnShowUnderground.size({75, 20});
+	btnShowUnderground.size(viewFilterButtonSize);
 	btnShowUnderground.type(Button::Type::Toggle);
 
 	add(btnShowActive, {10, 33});
-	btnShowActive.size({75, 20});
+	btnShowActive.size(viewFilterButtonSize);
 	btnShowActive.type(Button::Type::Toggle);
 
 	add(btnShowIdle, {87, 33});
-	btnShowIdle.size({75, 20});
+	btnShowIdle.size(viewFilterButtonSize);
 	btnShowIdle.type(Button::Type::Toggle);
 
 	add(btnShowDisabled, {164, 33});
-	btnShowDisabled.size({75, 20});
+	btnShowDisabled.size(viewFilterButtonSize);
 	btnShowDisabled.type(Button::Type::Toggle);
 
 	int position_x = Utility<Renderer>::get().size().x - 110;

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -60,12 +60,12 @@ FactoryReport::FactoryReport() :
 	factorySeed{imageCache.load("ui/interface/factory_seed.png")},
 	factoryAboveGround{imageCache.load("ui/interface/factory_ag.png")},
 	factoryUnderGround{imageCache.load("ui/interface/factory_ug.png")},
-	btnShowAll{"All", {this, &FactoryReport::onShowAll}},
-	btnShowSurface{"Surface", {this, &FactoryReport::onShowSurface}},
-	btnShowUnderground{"Underground", {this, &FactoryReport::onShowUnderground}},
-	btnShowActive{"Active", {this, &FactoryReport::onShowActive}},
-	btnShowIdle{"Idle", {this, &FactoryReport::onShowIdle}},
-	btnShowDisabled{"Disabled", {this, &FactoryReport::onShowDisabled}},
+	btnShowAll{"All", viewFilterButtonSize, {this, &FactoryReport::onShowAll}},
+	btnShowSurface{"Surface", viewFilterButtonSize, {this, &FactoryReport::onShowSurface}},
+	btnShowUnderground{"Underground", viewFilterButtonSize, {this, &FactoryReport::onShowUnderground}},
+	btnShowActive{"Active", viewFilterButtonSize, {this, &FactoryReport::onShowActive}},
+	btnShowIdle{"Idle", viewFilterButtonSize, {this, &FactoryReport::onShowIdle}},
+	btnShowDisabled{"Disabled", viewFilterButtonSize, {this, &FactoryReport::onShowDisabled}},
 	btnIdle{"Idle", {this, &FactoryReport::onIdle}},
 	btnClearProduction{"Clear Production", {this, &FactoryReport::onClearProduction}},
 	btnTakeMeThere{constants::TakeMeThere, {this, &FactoryReport::onTakeMeThere}},
@@ -75,28 +75,22 @@ FactoryReport::FactoryReport() :
 	lstFactoryList.selectionChanged().connect({this, &FactoryReport::onListSelectionChange});
 
 	add(btnShowAll, {10, 10});
-	btnShowAll.size(viewFilterButtonSize);
 	btnShowAll.type(Button::Type::Toggle);
 	btnShowAll.toggle(true);
 
 	add(btnShowSurface, {87, 10});
-	btnShowSurface.size(viewFilterButtonSize);
 	btnShowSurface.type(Button::Type::Toggle);
 
 	add(btnShowUnderground, {164, 10});
-	btnShowUnderground.size(viewFilterButtonSize);
 	btnShowUnderground.type(Button::Type::Toggle);
 
 	add(btnShowActive, {10, 33});
-	btnShowActive.size(viewFilterButtonSize);
 	btnShowActive.type(Button::Type::Toggle);
 
 	add(btnShowIdle, {87, 33});
-	btnShowIdle.size(viewFilterButtonSize);
 	btnShowIdle.type(Button::Type::Toggle);
 
 	add(btnShowDisabled, {164, 33});
-	btnShowDisabled.size(viewFilterButtonSize);
 	btnShowDisabled.type(Button::Type::Toggle);
 
 	int position_x = Utility<Renderer>::get().size().x - 110;

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -27,8 +27,8 @@ using namespace NAS2D;
 
 namespace
 {
-	const auto viewFilterButtonSize = NAS2D::Vector{75, 20};
-	const auto mainButtonSize = NAS2D::Vector{140, 30};
+	constexpr auto viewFilterButtonSize = NAS2D::Vector{75, 20};
+	constexpr auto mainButtonSize = NAS2D::Vector{140, 30};
 
 	bool productTypeInRange(ProductType productType)
 	{


### PR DESCRIPTION
Extract constants for common `Button` sizes. Use `Button` constructors to set sizes.

Related:
- Issue #1548
