### PR TITLE
Update NAS2D submodule for new `Duration` type

### DIFF
--- a/appOPHD/Constants/UiConstants.h
+++ b/appOPHD/Constants/UiConstants.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <NAS2D/Duration.h>
 #include <NAS2D/Renderer/Color.h>
 
-#include <chrono>
 #include <limits>
 #include <string>
 
 
 namespace constants
 {
-	inline constexpr std::chrono::milliseconds FadeSpeed{300};
+	inline constexpr Duration FadeSpeed{300};
 
 	inline constexpr int BottomUiHeight{162};
 

--- a/appOPHD/States/SplashState.cpp
+++ b/appOPHD/States/SplashState.cpp
@@ -24,7 +24,7 @@ namespace
 
 	const int pauseTime = 5800;
 	unsigned int fadePauseTime = 5000;
-	const std::chrono::milliseconds fadeLength{800};
+	const Duration fadeLength{800};
 
 	NAS2D::Timer bylineTimer;
 


### PR DESCRIPTION
The new `Duration` type is a type safe time duration value in milliseconds, which doesn't require importing the whole `<chrono>` library just to specify a data type.

The internal type was chosen to be consistent with SDL, which is where the source of time values comes from. The `<chrono>` library used a larger type.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1233
- Issue #1573
