### PR TITLE
Refactor `GameState` construction

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -18,10 +18,6 @@
 NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wrapers. */
 
 
-// Explicit constructor needed in implementation file
-// If a default constructor was used instead, construction would happen in importing translation unit
-// The header uses forward declares for some types, so only incomplete types are available to importing code
-// Complete types are needed to construct the std::unique_ptr members
 GameState::GameState():
 	mMainReportsState{std::make_unique<MainReportsUiState>()}
 {

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -28,6 +28,11 @@ GameState::GameState():
 	{
 		takeMeThere->connect({this, &GameState::onTakeMeThere});
 	}
+
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().connect({this, &GameState::onMouseMove});
+
+	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect({this, &GameState::onMusicComplete});
 }
 
 
@@ -64,10 +69,6 @@ GameState::~GameState()
 
 void GameState::initialize()
 {
-	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseMotion().connect({this, &GameState::onMouseMove});
-
-	NAS2D::Utility<NAS2D::Mixer>::get().musicCompleteSignalSource().connect({this, &GameState::onMusicComplete});
 	mFade.fadeIn(constants::FadeSpeed);
 }
 

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -28,7 +28,15 @@ GameState::GameState():
 	{
 		takeMeThere->connect({this, &GameState::onTakeMeThere});
 	}
+}
 
+
+GameState::GameState(const std::string& savedGameFilename) : GameState()
+{
+	auto* mapView = new MapViewState(*mMainReportsState.get(), savedGameFilename);
+	mapView->_initialize();
+	mapView->activate();
+	mapviewstate(mapView);
 }
 
 

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -94,12 +94,6 @@ void GameState::mapviewstate(MapViewState* state)
 }
 
 
-MainReportsUiState& GameState::getMainReportsState()
-{
-	return *mMainReportsState;
-}
-
-
 void GameState::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 {
 	MOUSE_COORDS = position;

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -39,8 +39,6 @@ GameState::GameState():
 GameState::GameState(const std::string& savedGameFilename) : GameState()
 {
 	auto* mapView = new MapViewState(*mMainReportsState.get(), savedGameFilename);
-	mapView->_initialize();
-	mapView->activate();
 	initializeMapViewState(mapView);
 }
 
@@ -49,8 +47,6 @@ GameState::GameState(const Planet::Attributes& planetAttributes, Difficulty sele
 {
 	auto* mapView = new MapViewState(*mMainReportsState.get(), planetAttributes, selectedDifficulty);
 	mapView->setPopulationLevel(MapViewState::PopulationLevel::Large);
-	mapView->_initialize();
-	mapView->activate();
 	initializeMapViewState(mapView);
 }
 
@@ -87,6 +83,9 @@ void GameState::initializeMapViewState(MapViewState* state)
 {
 	mMapView.reset(state);
 	mActiveState = mMapView.get();
+
+	mMapView->_initialize();
+	mMapView->activate();
 
 	mMapView->quit().connect({this, &GameState::onQuit});
 	mMapView->showReportsUi().connect({this, &GameState::onShowReports});

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -38,16 +38,16 @@ GameState::GameState():
 
 GameState::GameState(const std::string& savedGameFilename) : GameState()
 {
-	auto* mapView = new MapViewState(*mMainReportsState.get(), savedGameFilename);
-	initializeMapViewState(mapView);
+	mMapView = std::make_unique<MapViewState>(*mMainReportsState.get(), savedGameFilename);
+	initializeMapViewState();
 }
 
 
 GameState::GameState(const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) : GameState()
 {
-	auto* mapView = new MapViewState(*mMainReportsState.get(), planetAttributes, selectedDifficulty);
-	mapView->setPopulationLevel(MapViewState::PopulationLevel::Large);
-	initializeMapViewState(mapView);
+	mMapView = std::make_unique<MapViewState>(*mMainReportsState.get(), planetAttributes, selectedDifficulty);
+	mMapView->setPopulationLevel(MapViewState::PopulationLevel::Large);
+	initializeMapViewState();
 }
 
 
@@ -69,19 +69,8 @@ void GameState::initialize()
 }
 
 
-/**
- * Sets a pointer for the MapViewState.
- *
- * Since the MapViewState is created outside of the GameState, this function
- * takes a pointer to an already instatiated MapViewState object.
- *
- * \param	state	Pointer to a MapViewState. Ownership is transfered to GameState.
- *
- * \note	GameState will handle correct destruction of the MapViewState object.
- */
-void GameState::initializeMapViewState(MapViewState* state)
+void GameState::initializeMapViewState()
 {
-	mMapView.reset(state);
 	mActiveState = mMapView.get();
 
 	mMapView->_initialize();

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -44,9 +44,6 @@ GameState::~GameState()
 }
 
 
-/**
- * Internal initializer function.
- */
 void GameState::initialize()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -41,7 +41,7 @@ GameState::GameState(const std::string& savedGameFilename) : GameState()
 	auto* mapView = new MapViewState(*mMainReportsState.get(), savedGameFilename);
 	mapView->_initialize();
 	mapView->activate();
-	mapviewstate(mapView);
+	initializeMapViewState(mapView);
 }
 
 
@@ -51,7 +51,7 @@ GameState::GameState(const Planet::Attributes& planetAttributes, Difficulty sele
 	mapView->setPopulationLevel(MapViewState::PopulationLevel::Large);
 	mapView->_initialize();
 	mapView->activate();
-	mapviewstate(mapView);
+	initializeMapViewState(mapView);
 }
 
 
@@ -83,7 +83,7 @@ void GameState::initialize()
  *
  * \note	GameState will handle correct destruction of the MapViewState object.
  */
-void GameState::mapviewstate(MapViewState* state)
+void GameState::initializeMapViewState(MapViewState* state)
 {
 	mMapView.reset(state);
 	mActiveState = mMapView.get();

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -40,6 +40,16 @@ GameState::GameState(const std::string& savedGameFilename) : GameState()
 }
 
 
+GameState::GameState(const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty) : GameState()
+{
+	auto* mapView = new MapViewState(*mMainReportsState.get(), planetAttributes, selectedDifficulty);
+	mapView->setPopulationLevel(MapViewState::PopulationLevel::Large);
+	mapView->_initialize();
+	mapView->activate();
+	mapviewstate(mapView);
+}
+
+
 GameState::~GameState()
 {
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -180,7 +180,7 @@ void GameState::onLoadGame(const std::string& saveGameName)
 		{
 			throw std::runtime_error("Save game file does not exist: " + saveGamePath);
 		}
-		mNewMapView = std::make_unique<MapViewState>(getMainReportsState(), saveGamePath);
+		mNewMapView = std::make_unique<MapViewState>(*mMainReportsState.get(), saveGamePath);
 	}
 	catch (const std::exception& e)
 	{

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -29,7 +29,7 @@ public:
 
 	State* update() override;
 
-private:
+protected:
 	GameState();
 	void mapviewstate(MapViewState*);
 	void initialize() override;

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -7,6 +7,7 @@
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Fade.h>
 
+#include <string>
 #include <memory>
 
 
@@ -20,6 +21,7 @@ class GameState : public NAS2D::State
 {
 public:
 	GameState();
+	GameState(const std::string& savedGameFilename);
 	~GameState() override;
 
 	void mapviewstate(MapViewState*);

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Planet.h"
 #include "../UI/FileIo.h"
 
 #include <NAS2D/State.h>
@@ -10,6 +11,8 @@
 #include <string>
 #include <memory>
 
+
+enum class Difficulty;
 
 class MainReportsUiState;
 class MapViewState;
@@ -22,6 +25,7 @@ class GameState : public NAS2D::State
 public:
 	GameState();
 	GameState(const std::string& savedGameFilename);
+	GameState(const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty);
 	~GameState() override;
 
 	void mapviewstate(MapViewState*);

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -43,10 +43,10 @@ private:
 	void onTakeMeThere(const Structure*);
 
 private:
-	NAS2D::State* mReturnState = this;
+	std::unique_ptr<MainReportsUiState> mMainReportsState;
 	std::unique_ptr<MapViewState> mMapView;
 	std::unique_ptr<MapViewState> mNewMapView;
 	Wrapper* mActiveState = nullptr;
-	std::unique_ptr<MainReportsUiState> mMainReportsState;
+	NAS2D::State* mReturnState = this;
 	NAS2D::Fade mFade;
 };

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -23,17 +23,17 @@ class Wrapper;
 class GameState : public NAS2D::State
 {
 public:
-	GameState();
 	GameState(const std::string& savedGameFilename);
 	GameState(const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty);
 	~GameState() override;
 
-	void mapviewstate(MapViewState*);
-
-	void initialize() override;
 	State* update() override;
 
 private:
+	GameState();
+	void mapviewstate(MapViewState*);
+	void initialize() override;
+
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void onFadeComplete();

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 	GameState();
-	void initializeMapViewState(MapViewState*);
+	void initializeMapViewState();
 	void initialize() override;
 
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -29,7 +29,6 @@ public:
 	~GameState() override;
 
 	void mapviewstate(MapViewState*);
-	MainReportsUiState& getMainReportsState();
 
 	void initialize() override;
 	State* update() override;

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 	GameState();
-	void mapviewstate(MapViewState*);
+	void initializeMapViewState(MapViewState*);
 	void initialize() override;
 
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);

--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -136,9 +136,7 @@ void MainMenuState::onLoadGame(const std::string& filePath)
 	try
 	{
 		checkSavegameVersion(filename);
-
-		GameState* gameState = new GameState(filename);
-		mReturnState = gameState;
+		mReturnState = new GameState(filename);
 
 		mFade.fadeOut(constants::FadeSpeed);
 		NAS2D::Utility<NAS2D::Mixer>::get().fadeOutMusic(constants::FadeSpeed);

--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -137,12 +137,7 @@ void MainMenuState::onLoadGame(const std::string& filePath)
 	{
 		checkSavegameVersion(filename);
 
-		GameState* gameState = new GameState();
-		MapViewState* mapview = new MapViewState(gameState->getMainReportsState(), filename);
-		mapview->_initialize();
-		mapview->activate();
-
-		gameState->mapviewstate(mapview);
+		GameState* gameState = new GameState(filename);
 		mReturnState = gameState;
 
 		mFade.fadeOut(constants::FadeSpeed);

--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -1,5 +1,4 @@
 #include "GameState.h"
-#include "MapViewState.h"
 #include "MainMenuState.h"
 #include "PlanetSelectState.h"
 

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -114,14 +114,7 @@ NAS2D::State* PlanetSelectState::update()
 	}
 	else if (mPlanetSelection != constants::NoSelection)
 	{
-		GameState* gameState = new GameState();
-		MapViewState* mapview = new MapViewState(gameState->getMainReportsState(), mPlanets[mPlanetSelection].attributes(), Difficulty::Medium);
-		mapview->setPopulationLevel(MapViewState::PopulationLevel::Large);
-		mapview->_initialize();
-		mapview->activate();
-
-		gameState->mapviewstate(mapview);
-
+		GameState* gameState = new GameState(mPlanets[mPlanetSelection].attributes(), Difficulty::Medium);
 		return gameState;
 	}
 

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -114,8 +114,7 @@ NAS2D::State* PlanetSelectState::update()
 	}
 	else if (mPlanetSelection != constants::NoSelection)
 	{
-		GameState* gameState = new GameState(mPlanets[mPlanetSelection].attributes(), Difficulty::Medium);
-		return gameState;
+		return new GameState(mPlanets[mPlanetSelection].attributes(), Difficulty::Medium);
 	}
 
 	return mReturnState;

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -1,13 +1,13 @@
 #include "PlanetSelectState.h"
 
 #include "GameState.h"
-#include "MapViewState.h"
 #include "MainMenuState.h"
 
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../Cache.h"
 
+#include <libOPHD/EnumDifficulty.h>
 #include <libOPHD/XmlSerializer.h>
 
 #include <NAS2D/Utility.h>

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -1,13 +1,13 @@
 #include "Cache.h"
 #include "Constants/Strings.h"
 #include "Constants/Numbers.h"
+#include "Constants/UiConstants.h"
 #include "WindowEventWrapper.h"
 #include "PointerType.h"
 
 #include "States/GameState.h"
 #include "States/SplashState.h"
 #include "States/MainMenuState.h"
-#include "States/MapViewState.h"
 #include "States/MainReportsUiState.h"
 
 #include "UI/MessageBox.h"

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -194,12 +194,7 @@ int main(int argc, char *argv[])
 
 			Utility<Mixer>::get().stopMusic();
 
-			GameState* gameState = new GameState();
-			MapViewState* mapview = new MapViewState(gameState->getMainReportsState(), filename);
-			mapview->_initialize();
-			mapview->activate();
-
-			gameState->mapviewstate(mapview);
+			GameState* gameState = new GameState(filename);
 			stateManager.setState(gameState);
 		}
 		else if (!options.get<bool>("skip-splash"))

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -194,8 +194,7 @@ int main(int argc, char *argv[])
 
 			Utility<Mixer>::get().stopMusic();
 
-			GameState* gameState = new GameState(filename);
-			stateManager.setState(gameState);
+			stateManager.setState(new GameState(filename));
 		}
 		else if (!options.get<bool>("skip-splash"))
 		{


### PR DESCRIPTION
While looking at ways to reduce imports of the `MapViewState` header file, I noticed with the recent saved game loading changes, some use of delegating constructors would allow us to finally solve the `GameState` construction order issue.

Closes #775

Related:
- Issue #775
- Issue #650
- Issue #830
- Issue #1573
- PR #1543
- PR #1585
