### PR TITLE
Convert console message to exception in `ProductCatalogue.cpp`

### DIFF
--- a/appOPHD/ProductCatalogue.cpp
+++ b/appOPHD/ProductCatalogue.cpp
@@ -4,7 +4,7 @@
 
 #include <NAS2D/ParserHelper.h>
 
-#include <iostream>
+#include <stdexcept>
 
 
 namespace
@@ -49,7 +49,7 @@ void ProductCatalogue::init(const std::string& filename)
 
 		if (mProductTable.find(productId) != mProductTable.end())
 		{
-			std::cout << "ProductID (" << product.Id << ") already found in table: " << mProductTable[productId].Name << ". Previous entry will be overwritten with new entry '" << product.Name << "'" << std::endl;
+			throw std::runtime_error("Duplicate ProductID in data file: ID = " + std::to_string(product.Id) + ", Name = " + product.Name + ", filename = " + filename);
 		}
 
 		mProductTable[productId] = product;


### PR DESCRIPTION
In general, we should prefer using exceptions to report errors rather than rely on console messages.

In this particular case, we are reporting an issue with a static data asset shipped with the game. If that's wrong, we should fail loudly. This type of error should be caught and fixed before shipping a release.

----

This removes the only use of `std::cout` outside of `main`.

----

Related:
- Issue #848
