### PR TITLE
Refactor `Wrapper` name aliases

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -48,7 +48,7 @@ GameState::~GameState()
 
 void GameState::initializeGameState()
 {
-	mMainReportsState->_initialize();
+	mMainReportsState->initialize();
 	mMainReportsState->hideReports().connect({this, &GameState::onHideReports});
 
 	for (auto takeMeThere : mMainReportsState->takeMeThere())
@@ -56,7 +56,7 @@ void GameState::initializeGameState()
 		takeMeThere->connect({this, &GameState::onTakeMeThere});
 	}
 
-	mMapView->_initialize();
+	mMapView->initialize();
 	initializeMapViewState();
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
@@ -165,7 +165,7 @@ void GameState::onLoadGame(const std::string& saveGameName)
 			throw std::runtime_error("Save game file does not exist: " + saveGamePath);
 		}
 		auto newMapView = std::make_unique<MapViewState>(*mMainReportsState.get(), saveGamePath);
-		newMapView->_initialize();
+		newMapView->initialize();
 		mNewMapView = std::move(newMapView);
 	}
 	catch (const std::exception& e)

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -193,7 +193,7 @@ NAS2D::State* GameState::update()
 {
 	if (mActiveState)
 	{
-		mActiveState->_update();
+		mActiveState->update();
 	}
 
 	mFade.update();

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -208,7 +208,7 @@ void MainReportsUiState::initialize()
 }
 
 
-void MainReportsUiState::_activate()
+void MainReportsUiState::onActivate()
 {
 	for (auto& panel : Panels)
 	{

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -222,7 +222,7 @@ void MainReportsUiState::_activate()
 }
 
 
-void MainReportsUiState::_deactivate()
+void MainReportsUiState::onDeactivate()
 {
 	for (auto& panel : Panels)
 	{

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -41,7 +41,6 @@ public:
 	ReportsUiSignal::Source& hideReports() { return mReportsUiSignal; }
 	TakeMeThereSignalSourceList takeMeThere();
 
-protected:
 	void initialize() override;
 	State* update() override;
 

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -45,7 +45,7 @@ public:
 	State* update() override;
 
 private:
-	void _deactivate() override;
+	void onDeactivate() override;
 	void _activate() override;
 
 private:

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -46,7 +46,7 @@ public:
 
 private:
 	void onDeactivate() override;
-	void _activate() override;
+	void onActivate() override;
 
 private:
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -304,7 +304,7 @@ void MapViewState::_activate()
 }
 
 
-void MapViewState::_deactivate()
+void MapViewState::onDeactivate()
 {
 	mGameOverDialog.enabled(false);
 	mGameOptionsDialog.enabled(false);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -298,7 +298,7 @@ void MapViewState::initialize()
 }
 
 
-void MapViewState::_activate()
+void MapViewState::onActivate()
 {
 	unhideUi();
 }

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -130,7 +130,7 @@ public:
 	State* update() override;
 
 private:
-	void _deactivate() override;
+	void onDeactivate() override;
 	void _activate() override;
 
 	// EVENT HANDLERS

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -131,7 +131,7 @@ public:
 
 private:
 	void onDeactivate() override;
-	void _activate() override;
+	void onActivate() override;
 
 	// EVENT HANDLERS
 	void onActivate(bool newActiveValue);

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -126,7 +126,6 @@ public:
 
 	bool hasGameEnded();
 
-protected:
 	void initialize() override;
 	State* update() override;
 

--- a/appOPHD/States/Wrapper.h
+++ b/appOPHD/States/Wrapper.h
@@ -25,9 +25,8 @@ class Wrapper : public NAS2D::State
 public:
 	Wrapper() : mIsActive(false) {}
 
+	using NAS2D::State::initialize;
 	using NAS2D::State::update;
-
-	void _initialize() { initialize(); }
 
 	void deactivate() { mIsActive = false; _deactivate(); }
 	void activate() { mIsActive = true; _activate(); }

--- a/appOPHD/States/Wrapper.h
+++ b/appOPHD/States/Wrapper.h
@@ -28,7 +28,7 @@ public:
 	using NAS2D::State::initialize;
 	using NAS2D::State::update;
 
-	void deactivate() { mIsActive = false; _deactivate(); }
+	void deactivate() { mIsActive = false; onDeactivate(); }
 	void activate() { mIsActive = true; _activate(); }
 	bool active() const { return mIsActive; }
 
@@ -39,7 +39,7 @@ private:
 	 *
 	 * \note	This is the place to unhook event handlers.
 	 */
-	virtual void _deactivate() = 0;
+	virtual void onDeactivate() = 0;
 
 	/**
 	 * Called when the state is being reactivated and being set as the active state.

--- a/appOPHD/States/Wrapper.h
+++ b/appOPHD/States/Wrapper.h
@@ -25,7 +25,7 @@ class Wrapper : public NAS2D::State
 public:
 	Wrapper() : mIsActive(false) {}
 
-	State* _update() { return update(); }
+	using NAS2D::State::update;
 
 	void _initialize() { initialize(); }
 

--- a/appOPHD/States/Wrapper.h
+++ b/appOPHD/States/Wrapper.h
@@ -29,7 +29,7 @@ public:
 	using NAS2D::State::update;
 
 	void deactivate() { mIsActive = false; onDeactivate(); }
-	void activate() { mIsActive = true; _activate(); }
+	void activate() { mIsActive = true; onActivate(); }
 	bool active() const { return mIsActive; }
 
 private:
@@ -47,7 +47,7 @@ private:
 	 * \note	This function is called whenever the Wrapper is pushed onto the top
 	 *			of the stack. This is the place to rehook event handlers.
 	 */
-	virtual void _activate() = 0;
+	virtual void onActivate() = 0;
 
 
 private:

--- a/appOPHD/States/Wrapper.h
+++ b/appOPHD/States/Wrapper.h
@@ -8,15 +8,13 @@
  * to allow calls to State::update() and State::initialize() from non
  * StateManager objects.
  *
- * This class is provided as a simple means to implement a State Stack
+ * This class is provided as a simple means to provide access
  * without having to modify NAS2D states and state managers.
  *
- * \note	To prevent Wrappers and their UIs not on the top of the stack from
+ * \note	To prevent Wrappers and their UIs not currently active from
  *			reacting to events, Wrappers should test if they are active in their
- *			event handler functions. If the Wrapper is returning a nullptr, it
- *			should hide its UI elements (and show them again when the reset()
- *			function is called).
- *
+ *			event handler functions. If the Wrapper is deactivated, it
+ *			should hide its UI elements (and show them again when activated).
  */
 class Wrapper : public NAS2D::State
 {
@@ -42,8 +40,7 @@ private:
 	/**
 	 * Called when the state is being reactivated and being set as the active state.
 	 *
-	 * \note	This function is called whenever the Wrapper is pushed onto the top
-	 *			of the stack. This is the place to rehook event handlers.
+	 * \note	This is the place to rehook event handlers.
 	 */
 	virtual void onActivate() = 0;
 

--- a/appOPHD/States/Wrapper.h
+++ b/appOPHD/States/Wrapper.h
@@ -2,8 +2,6 @@
 
 #include <NAS2D/State.h>
 
-#include <stack>
-
 
 /**
  * Implements a simple wrapper interface around the NAS2D::State object
@@ -53,6 +51,3 @@ private:
 private:
 	bool mIsActive;
 };
-
-
-using WrapperStack = std::stack<Wrapper*>;


### PR DESCRIPTION
Remove the `_` prefixed name aliases.

Either update access to existing methods from `protected` to `public`, or give the method a proper event name, such as `onActivate` and `onDeactivate`.

Related:
- PR #1623
- PR #1622
- Issue #775
