### PR TITLE
Set `CheckBox` default size

### DIFF
--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -22,6 +22,15 @@
 #include <algorithm>
 
 
+namespace
+{
+	constexpr auto iconSize = NAS2D::Vector{13, 13};
+	constexpr auto uncheckedIconRect = NAS2D::Rectangle{{0, 0}, iconSize};
+	constexpr auto checkedIconRect = NAS2D::Rectangle{{13, 0}, iconSize};
+	constexpr auto textOffset = NAS2D::Vector{20, 0};
+}
+
+
 CheckBox::CheckBox(std::string newText) :
 	mFont{getDefaultFont()},
 	mSkin{getImage("ui/skin/checkbox.png")}
@@ -82,7 +91,7 @@ void CheckBox::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position
 void CheckBox::onTextChange()
 {
 	const auto textWidth = mFont.width(text());
-	width((textWidth > 0) ? 20 + textWidth : 13);
+	width((textWidth > 0) ? textOffset.x + textWidth : iconSize.x);
 }
 
 
@@ -91,7 +100,7 @@ void CheckBox::onTextChange()
  */
 void CheckBox::onResize()
 {
-	mRect.size = {std::max(mRect.size.x, 13), 13};
+	mRect.size = {std::max(mRect.size.x, iconSize.x), iconSize.y};
 }
 
 
@@ -105,10 +114,6 @@ void CheckBox::update()
 void CheckBox::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-
-	const auto uncheckedIconRect = NAS2D::Rectangle<int>{{0, 0}, {13, 13}};
-	const auto checkedIconRect = NAS2D::Rectangle<int>{{13, 0}, {13, 13}};
-
 	renderer.drawSubImage(mSkin, position(), (mChecked ? checkedIconRect : uncheckedIconRect));
-	renderer.drawText(mFont, text(), position() + NAS2D::Vector{20, 0}, NAS2D::Color::White);
+	renderer.drawText(mFont, text(), position() + textOffset, NAS2D::Color::White);
 }

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -96,11 +96,11 @@ void CheckBox::onTextChange()
 
 
 /**
- * Enforces minimum and maximum sizes.
+ * Enforces minimum sizes.
  */
 void CheckBox::onResize()
 {
-	mRect.size = {std::max(mRect.size.x, iconSize.x), iconSize.y};
+	mRect.size = {std::max(mRect.size.x, iconSize.x), std::max({mRect.size.y, iconSize.y, mFont.height()})};
 }
 
 

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -27,7 +27,8 @@ namespace
 	constexpr auto iconSize = NAS2D::Vector{13, 13};
 	constexpr auto uncheckedIconRect = NAS2D::Rectangle{{0, 0}, iconSize};
 	constexpr auto checkedIconRect = NAS2D::Rectangle{{13, 0}, iconSize};
-	constexpr auto textOffset = NAS2D::Vector{20, 0};
+	constexpr auto internalSpacing = 2;
+	constexpr auto textOffset = NAS2D::Vector{iconSize.x + internalSpacing, 0};
 }
 
 

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -115,6 +115,6 @@ void CheckBox::update()
 void CheckBox::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	renderer.drawSubImage(mSkin, position(), (mChecked ? checkedIconRect : uncheckedIconRect));
+	renderer.drawSubImage(mSkin, position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y + 1) / 2}, (mChecked ? checkedIconRect : uncheckedIconRect));
 	renderer.drawText(mFont, text(), position() + textOffset, NAS2D::Color::White);
 }

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -115,6 +115,7 @@ void CheckBox::update()
 void CheckBox::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	renderer.drawSubImage(mSkin, position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y + 1) / 2}, (mChecked ? checkedIconRect : uncheckedIconRect));
+	const auto iconPosition = position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y + 1) / 2};
+	renderer.drawSubImage(mSkin, iconPosition, (mChecked ? checkedIconRect : uncheckedIconRect));
 	renderer.drawText(mFont, text(), position() + textOffset, NAS2D::Color::White);
 }


### PR DESCRIPTION
Updates calculation to set minimum size for `CheckBox`.

Vertically center the checkbox icon. This becomes particularly important as the font size increases.

----

At +4 point font size:

Original:

![image](https://github.com/user-attachments/assets/4c5eab45-6dba-4046-8d49-abe03c461b79)

Updated:

![image](https://github.com/user-attachments/assets/956281dd-915e-4ae5-b5f1-13c9e7fb15fc)

----

At normal font size:

Original:

![image](https://github.com/user-attachments/assets/184763ec-749f-46c8-b645-19d189d23e0a)

Updated:

![image](https://github.com/user-attachments/assets/04231967-a366-450e-9494-4ace1683bc1d)

The difference is very subtle at the normal font size.

----

Related:
- Issue #1548
- Issue #896
