### PR TITLE
Set default `Button` size

### DIFF
--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -5,6 +5,12 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
+namespace
+{
+	constexpr auto internalPadding = NAS2D::Vector{2, 2};
+}
+
+
 Button::Button(std::string newText) :
 	mButtonSkin{
 		{
@@ -49,6 +55,7 @@ Button::Button(std::string newText) :
 
 	mFont = &getDefaultFont();
 	text(newText);
+	size(mFont->size(text()) + internalPadding * 2);
 }
 
 

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -42,14 +42,13 @@ Button::Button(std::string newText) :
 		}
 	}
 {
-	text(newText);
-
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &Button::onMouseDown});
 	eventHandler.mouseButtonUp().connect({this, &Button::onMouseUp});
 	eventHandler.mouseMotion().connect({this, &Button::onMouseMove});
 
 	mFont = &getDefaultFont();
+	text(newText);
 }
 
 


### PR DESCRIPTION
Set default `Button` size based on `text`.

All buttons are currently manually sized, so there is no graphical change. This should allow us to start removing some of the manual sizing though.

Related:
- Issue #1548
- Issue #896
