### PR TITLE
Dynamic size `FileIo` window

### DIFF
--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -27,7 +27,7 @@ FileIo::FileIo() : Window{"File I/O"}
 	size({700, 350});
 
 	mOpenSaveFolder.size({std::max(105, mOpenSaveFolder.size().x + constants::Margin), 20});
-	add(mOpenSaveFolder, {area().size.x - mOpenSaveFolder.size().x - 5, 22});
+	add(mOpenSaveFolder, {5 + 690 - mOpenSaveFolder.size().x, sWindowTitleBarHeight + 2});
 
 	mListBox.size({690, 253});
 	mListBox.visible(true);

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -32,7 +32,7 @@ FileIo::FileIo() : Window{"File I/O"}
 	mListBox.selectionChanged().connect({this, &FileIo::onFileSelect});
 	add(mListBox, {5, 45});
 
-	mFileName.size({mListBox.size().x, 18});
+	mFileName.size({mListBox.size().x, std::max(18, mFileName.size().y)});
 	mFileName.maxCharacters(50);
 	mFileName.textChanged().connect({this, &FileIo::onFileNameChange});
 	add(mFileName, mListBox.area().crossYPoint() - NAS2D::Point{0, 0} + NAS2D::Vector{0, 4});

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -29,6 +29,16 @@ FileIo::FileIo() : Window{"File I/O"}
 	mOpenSaveFolder.size({std::max(105, mOpenSaveFolder.size().x + constants::Margin), 20});
 	add(mOpenSaveFolder, {area().size.x - mOpenSaveFolder.size().x - 5, 22});
 
+	mListBox.size({690, 253});
+	mListBox.visible(true);
+	mListBox.selectionChanged().connect({this, &FileIo::onFileSelect});
+	add(mListBox, {5, 45});
+
+	mFileName.size({690, 18});
+	mFileName.maxCharacters(50);
+	mFileName.textChanged().connect({this, &FileIo::onFileNameChange});
+	add(mFileName, {5, 302});
+
 	mFileOperation.size({50, 20});
 	mFileOperation.enabled(false);
 	add(mFileOperation, {area().size.x - mFileOperation.size().x - 5, 325});
@@ -39,16 +49,6 @@ FileIo::FileIo() : Window{"File I/O"}
 
 	mClose.size({std::max(50, mClose.size().x + constants::Margin), 20});
 	add(mClose, {mFileOperation.position().x - mClose.size().x - 5, 325});
-
-	mFileName.size({690, 18});
-	mFileName.maxCharacters(50);
-	mFileName.textChanged().connect({this, &FileIo::onFileNameChange});
-	add(mFileName, {5, 302});
-
-	mListBox.size({690, 253});
-	mListBox.visible(true);
-	mListBox.selectionChanged().connect({this, &FileIo::onFileSelect});
-	add(mListBox, {5, 45});
 }
 
 

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -26,18 +26,18 @@ FileIo::FileIo() : Window{"File I/O"}
 
 	size({700, 350});
 
-	mOpenSaveFolder.size({105, 20});
+	mOpenSaveFolder.size({std::max(105, mOpenSaveFolder.size().x + constants::Margin), 20});
 	add(mOpenSaveFolder, {area().size.x - mOpenSaveFolder.size().x - 5, 22});
 
 	mFileOperation.size({50, 20});
 	mFileOperation.enabled(false);
 	add(mFileOperation, {area().size.x - mFileOperation.size().x - 5, 325});
 
-	mDeleteFile.size({50, 20});
+	mDeleteFile.size({std::max(50, mDeleteFile.size().x + constants::Margin), 20});
 	mDeleteFile.enabled(false);
 	add(mDeleteFile, {5, 325});
 
-	mClose.size({50, 20});
+	mClose.size({std::max(50, mClose.size().x + constants::Margin), 20});
 	add(mClose, {mFileOperation.position().x - mClose.size().x - 5, 325});
 
 	mFileName.size({690, 18});

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -34,10 +34,10 @@ FileIo::FileIo() : Window{"File I/O"}
 	mListBox.selectionChanged().connect({this, &FileIo::onFileSelect});
 	add(mListBox, {5, 45});
 
-	mFileName.size({690, 18});
+	mFileName.size({mListBox.size().x, 18});
 	mFileName.maxCharacters(50);
 	mFileName.textChanged().connect({this, &FileIo::onFileNameChange});
-	add(mFileName, {5, 302});
+	add(mFileName, mListBox.area().crossYPoint() - NAS2D::Point{0, 0} + NAS2D::Vector{0, 4});
 
 	mFileOperation.size({50, 20});
 	mFileOperation.enabled(false);

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -27,18 +27,18 @@ FileIo::FileIo() : Window{"File I/O"}
 	size({700, 350});
 
 	mOpenSaveFolder.size({105, 20});
-	add(mOpenSaveFolder, {590, 22});
+	add(mOpenSaveFolder, {area().size.x - mOpenSaveFolder.size().x - 5, 22});
 
 	mFileOperation.size({50, 20});
 	mFileOperation.enabled(false);
-	add(mFileOperation, {645, 325});
+	add(mFileOperation, {area().size.x - mFileOperation.size().x - 5, 325});
 
 	mDeleteFile.size({50, 20});
 	mDeleteFile.enabled(false);
 	add(mDeleteFile, {5, 325});
 
 	mClose.size({50, 20});
-	add(mClose, {590, 325});
+	add(mClose, {mFileOperation.position().x - mClose.size().x - 5, 325});
 
 	mFileName.size({690, 18});
 	mFileName.maxCharacters(50);

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -24,8 +24,6 @@ FileIo::FileIo() : Window{"File I/O"}
 	eventHandler.mouseDoubleClick().connect({this, &FileIo::onDoubleClick});
 	eventHandler.keyDown().connect({this, &FileIo::onKeyDown});
 
-	size({700, 350});
-
 	mOpenSaveFolder.size({std::max(105, mOpenSaveFolder.size().x + constants::Margin), 20});
 	add(mOpenSaveFolder, {5 + 690 - mOpenSaveFolder.size().x, sWindowTitleBarHeight + 2});
 
@@ -51,6 +49,8 @@ FileIo::FileIo() : Window{"File I/O"}
 
 	mClose.size({std::max(50, mClose.size().x + constants::Margin), 20});
 	add(mClose, {mFileOperation.position().x - mClose.size().x - 5, bottomButtonArea.position.y});
+
+	size(bottomButtonArea.endPoint() - NAS2D::Point{0, 0} + NAS2D::Vector{5, 5});
 }
 
 

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -26,29 +26,29 @@ FileIo::FileIo() : Window{"File I/O"}
 
 	size({700, 350});
 
-	add(mOpenSaveFolder, {590, 22});
 	mOpenSaveFolder.size({105, 20});
+	add(mOpenSaveFolder, {590, 22});
 
-	add(mFileOperation, {645, 325});
 	mFileOperation.size({50, 20});
 	mFileOperation.enabled(false);
+	add(mFileOperation, {645, 325});
 
-	add(mDeleteFile, {5, 325});
 	mDeleteFile.size({50, 20});
 	mDeleteFile.enabled(false);
+	add(mDeleteFile, {5, 325});
 
-	add(mClose, {590, 325});
 	mClose.size({50, 20});
+	add(mClose, {590, 325});
 
-	add(mFileName, {5, 302});
 	mFileName.size({690, 18});
 	mFileName.maxCharacters(50);
 	mFileName.textChanged().connect({this, &FileIo::onFileNameChange});
+	add(mFileName, {5, 302});
 
-	add(mListBox, {5, 45});
 	mListBox.size({690, 253});
 	mListBox.visible(true);
 	mListBox.selectionChanged().connect({this, &FileIo::onFileSelect});
+	add(mListBox, {5, 45});
 }
 
 

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -39,16 +39,18 @@ FileIo::FileIo() : Window{"File I/O"}
 	mFileName.textChanged().connect({this, &FileIo::onFileNameChange});
 	add(mFileName, mListBox.area().crossYPoint() - NAS2D::Point{0, 0} + NAS2D::Vector{0, 4});
 
+	const auto bottomButtonArea = NAS2D::Rectangle{mFileName.area().crossYPoint() + NAS2D::Vector{0, 5}, {mFileName.size().x, 20}};
+
 	mFileOperation.size({50, 20});
 	mFileOperation.enabled(false);
-	add(mFileOperation, {area().size.x - mFileOperation.size().x - 5, 325});
+	add(mFileOperation, {bottomButtonArea.endPoint().x - mFileOperation.size().x, bottomButtonArea.position.y});
 
 	mDeleteFile.size({std::max(50, mDeleteFile.size().x + constants::Margin), 20});
 	mDeleteFile.enabled(false);
-	add(mDeleteFile, {5, 325});
+	add(mDeleteFile, {bottomButtonArea.position.x, bottomButtonArea.position.y});
 
 	mClose.size({std::max(50, mClose.size().x + constants::Margin), 20});
-	add(mClose, {mFileOperation.position().x - mClose.size().x - 5, 325});
+	add(mClose, {mFileOperation.position().x - mClose.size().x - 5, bottomButtonArea.position.y});
 }
 
 


### PR DESCRIPTION
Dynamically size `FileIo` window so it will be responsive to `Font` size changes.

Changes were done so as to not move or resize anything under the current font size.

Related:
- Issue #1548
