### PR TITLE
Fix `drawProgressBar` showing no progress

### DIFF
--- a/appOPHD/UI/ProgressBar.cpp
+++ b/appOPHD/UI/ProgressBar.cpp
@@ -17,7 +17,7 @@ void drawProgressBar(int value, int max, NAS2D::Rectangle<int> rect, int padding
 	if (max > 0)
 	{
 		auto innerRect = rect.inset(padding);
-		innerRect.size.x *= clippedValue / max;
+		innerRect.size.x = innerRect.size.x * clippedValue / max;
 		renderer.drawBoxFilled(innerRect, NAS2D::Color{0, 100, 0});
 	}
 }


### PR DESCRIPTION
There was an order of operations issue, where the division was being done before the multiplication. That caused the division to round values to 0, which when multiplied meant no progress was ever shown.

Noticed this while working on:
- PR #1635
- PR #1634
- Issue #1548
