### PR TITLE
Position `mPopulationPanel` so it stays on screen

### DIFF
--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -78,7 +78,8 @@ void MapViewState::initUi()
 	mFileIoDialog.anchored(true);
 	mFileIoDialog.hide();
 
-	mPopulationPanel.position({675, constants::ResourceIconSize + 4 + constants::MarginTight});
+	const auto populationPanelX = std::min(675, renderer.size().x - mPopulationPanel.size().x);
+	mPopulationPanel.position({populationPanelX, constants::ResourceIconSize + 4 + constants::MarginTight});
 
 	mResourceBreakdownPanel.position({0, 22});
 	mResourceBreakdownPanel.playerResources(&mResourcesCount);
@@ -185,6 +186,9 @@ void MapViewState::initUi()
 
 void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 {
+	const auto populationPanelX = std::min(675, size.x - mPopulationPanel.size().x);
+	mPopulationPanel.position({populationPanelX, constants::ResourceIconSize + 4 + constants::MarginTight});
+
 	// Bottom UI Area
 	mBottomUiRect = {{0, size.y - constants::BottomUiHeight}, {size.x, constants::BottomUiHeight}};
 


### PR DESCRIPTION
For larger font sizes, the window can enlarge. Potentially it's position can allow it to extend beyond the space available to the main window, causing the contents to be clipped. This can happen when the main window is set near the minimum size, and the font sizes are increased by 4 points. This change detects such an overflow and repositions the population panel so it remains fully on screen.

----

Update with font size +4 points:

![image](https://github.com/user-attachments/assets/f9d454d8-f648-4dad-89b5-3601e81f1292)

Note the right edge of the population panel is placed against the right edge of the window. The left edge has moved left so it no longer lines up with the population panel pin.

----

Related:
- Issue #1548
