### PR TITLE
Dynamic sizing factory product pane

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -505,16 +505,13 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);
 
-	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
-	{
-		const auto progressBarPosition = buildingProductNamePosition + NAS2D::Vector{0, 20};
-		const auto progressBarSize = NAS2D::Vector{mRect.size.x - originRight.x - 10, 30};
-		drawProgressBar(
-			selectedFactory->productionTurnsCompleted(),
-			selectedFactory->productionTurnsToComplete(),
-			{progressBarPosition, progressBarSize}
-		);
-	}
+	const auto progressBarPosition = buildingProductNamePosition + NAS2D::Vector{0, 20};
+	const auto progressBarSize = NAS2D::Vector{mRect.size.x - originRight.x - 10, 30};
+	drawProgressBar(
+		selectedFactory->productionTurnsCompleted(),
+		selectedFactory->productionTurnsToComplete(),
+		{progressBarPosition, progressBarSize}
+	);
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
 	const auto turnsTitlePosition = buildingProductNamePosition + NAS2D::Vector{0, 56};

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -485,34 +485,43 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 
 void FactoryReport::drawProductPane(Renderer& renderer)
 {
-	renderer.drawText(fontBigBold, "Production", NAS2D::Point{detailPanelRect.position.x, detailPanelRect.position.y + 180}, constants::PrimaryTextColor);
+	const auto origin = NAS2D::Point{detailPanelRect.position.x, detailPanelRect.position.y + 180};
+	renderer.drawText(fontBigBold, "Production", origin, constants::PrimaryTextColor);
 
 	int positionX = detailPanelRect.position.x + lstProducts.size().x + 20;
 
 	if (selectedProductType != ProductType::PRODUCT_NONE)
 	{
-		renderer.drawText(fontBigBold, ProductCatalogue::get(selectedProductType).Name, NAS2D::Point{positionX, detailPanelRect.position.y + 180}, constants::PrimaryTextColor);
-		renderer.drawImage(productImage(selectedProductType), NAS2D::Point{positionX, lstProducts.position().y});
+		const auto productNamePosition = NAS2D::Point{positionX, detailPanelRect.position.y + 180};
+		const auto productImagePosition = NAS2D::Point{positionX, lstProducts.position().y};
+		renderer.drawText(fontBigBold, ProductCatalogue::get(selectedProductType).Name, productNamePosition, constants::PrimaryTextColor);
+		renderer.drawImage(productImage(selectedProductType), productImagePosition);
 		mTxtProductDescription.update();
 	}
 
 	if (selectedFactory->productType() == ProductType::PRODUCT_NONE) { return; }
 
-	renderer.drawText(fontBigBold, "Progress", NAS2D::Point{positionX, detailPanelRect.position.y + 358}, constants::PrimaryTextColor);
-	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, NAS2D::Point{positionX, detailPanelRect.position.y + 393}, constants::PrimaryTextColor);
+	const auto progressTextPosition = NAS2D::Point{positionX, detailPanelRect.position.y + 358};
+	const auto buildingProductNamePosition = NAS2D::Point{positionX, detailPanelRect.position.y + 393};
+	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);
 
 	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
 	{
+		const auto progressBarPosition = NAS2D::Point{positionX, detailPanelRect.position.y + 413};
+		const auto progressBarSize = NAS2D::Vector{mRect.size.x - positionX - 10, 30};
 		drawProgressBar(
 			selectedFactory->productionTurnsCompleted(),
 			selectedFactory->productionTurnsToComplete(),
-			{{positionX, detailPanelRect.position.y + 413}, {mRect.size.x - positionX - 10, 30}}
+			{progressBarPosition, progressBarSize}
 		);
 	}
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
-	renderer.drawText(fontMediumBold, "Turns", NAS2D::Point{positionX, detailPanelRect.position.y + 449}, constants::PrimaryTextColor);
-	renderer.drawText(fontMedium, text, NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, detailPanelRect.position.y + 449}, constants::PrimaryTextColor);
+	const auto turnsTitlePosition = NAS2D::Point{positionX, detailPanelRect.position.y + 449};
+	const auto turnsTextPosition = NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, detailPanelRect.position.y + 449};
+	renderer.drawText(fontMediumBold, "Turns", turnsTitlePosition, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, text, turnsTextPosition, constants::PrimaryTextColor);
 }
 
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -485,31 +485,30 @@ void FactoryReport::drawDetailPane(Renderer& renderer)
 
 void FactoryReport::drawProductPane(Renderer& renderer)
 {
-	const auto origin = NAS2D::Point{detailPanelRect.position.x, detailPanelRect.position.y + 180};
-	renderer.drawText(fontBigBold, "Production", origin, constants::PrimaryTextColor);
+	const auto originLeft = detailPanelRect.position + NAS2D::Vector{0, 180};
+	renderer.drawText(fontBigBold, "Production", originLeft, constants::PrimaryTextColor);
 
-	int positionX = detailPanelRect.position.x + lstProducts.size().x + 20;
+	const auto originRight = originLeft + NAS2D::Vector{lstProducts.size().x + 20, 0};
 
 	if (selectedProductType != ProductType::PRODUCT_NONE)
 	{
-		const auto productNamePosition = NAS2D::Point{positionX, detailPanelRect.position.y + 180};
-		const auto productImagePosition = NAS2D::Point{positionX, lstProducts.position().y};
-		renderer.drawText(fontBigBold, ProductCatalogue::get(selectedProductType).Name, productNamePosition, constants::PrimaryTextColor);
+		const auto productImagePosition = NAS2D::Point{originRight.x, lstProducts.position().y};
+		renderer.drawText(fontBigBold, ProductCatalogue::get(selectedProductType).Name, originRight, constants::PrimaryTextColor);
 		renderer.drawImage(productImage(selectedProductType), productImagePosition);
 		mTxtProductDescription.update();
 	}
 
 	if (selectedFactory->productType() == ProductType::PRODUCT_NONE) { return; }
 
-	const auto progressTextPosition = NAS2D::Point{positionX, detailPanelRect.position.y + 358};
-	const auto buildingProductNamePosition = NAS2D::Point{positionX, detailPanelRect.position.y + 393};
+	const auto progressTextPosition = originRight + NAS2D::Vector{0, 178};
+	const auto buildingProductNamePosition = originRight + NAS2D::Vector{0, 213};
 	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);
 
 	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
 	{
-		const auto progressBarPosition = NAS2D::Point{positionX, detailPanelRect.position.y + 413};
-		const auto progressBarSize = NAS2D::Vector{mRect.size.x - positionX - 10, 30};
+		const auto progressBarPosition = originRight + NAS2D::Vector{0, 233};
+		const auto progressBarSize = NAS2D::Vector{mRect.size.x - originRight.x - 10, 30};
 		drawProgressBar(
 			selectedFactory->productionTurnsCompleted(),
 			selectedFactory->productionTurnsToComplete(),
@@ -518,8 +517,8 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	}
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
-	const auto turnsTitlePosition = NAS2D::Point{positionX, detailPanelRect.position.y + 449};
-	const auto turnsTextPosition = NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, detailPanelRect.position.y + 449};
+	const auto turnsTitlePosition = originRight + NAS2D::Vector{0, 269};
+	const auto turnsTextPosition = NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, originRight.y + 269};
 	renderer.drawText(fontMediumBold, "Turns", turnsTitlePosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, text, turnsTextPosition, constants::PrimaryTextColor);
 }

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -501,13 +501,13 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	if (selectedFactory->productType() == ProductType::PRODUCT_NONE) { return; }
 
 	const auto progressTextPosition = originRight + NAS2D::Vector{0, 178};
-	const auto buildingProductNamePosition = originRight + NAS2D::Vector{0, 213};
+	const auto buildingProductNamePosition = progressTextPosition + NAS2D::Vector{0, 35};
 	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);
 
 	if (selectedFactory->productType() != ProductType::PRODUCT_NONE)
 	{
-		const auto progressBarPosition = originRight + NAS2D::Vector{0, 233};
+		const auto progressBarPosition = buildingProductNamePosition + NAS2D::Vector{0, 20};
 		const auto progressBarSize = NAS2D::Vector{mRect.size.x - originRight.x - 10, 30};
 		drawProgressBar(
 			selectedFactory->productionTurnsCompleted(),
@@ -517,8 +517,8 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	}
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
-	const auto turnsTitlePosition = originRight + NAS2D::Vector{0, 269};
-	const auto turnsTextPosition = NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, originRight.y + 269};
+	const auto turnsTitlePosition = buildingProductNamePosition + NAS2D::Vector{0, 56};
+	const auto turnsTextPosition = NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, turnsTitlePosition.y};
 	renderer.drawText(fontMediumBold, "Turns", turnsTitlePosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, text, turnsTextPosition, constants::PrimaryTextColor);
 }

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -514,7 +514,7 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	);
 
 	const auto text = std::to_string(selectedFactory->productionTurnsCompleted()) + " / " + std::to_string(selectedFactory->productionTurnsToComplete());
-	const auto turnsTitlePosition = buildingProductNamePosition + NAS2D::Vector{0, 56};
+	const auto turnsTitlePosition = progressBarPosition + NAS2D::Vector{0, 36};
 	const auto turnsTextPosition = NAS2D::Point{mRect.size.x - fontMedium.width(text) - 10, turnsTitlePosition.y};
 	renderer.drawText(fontMediumBold, "Turns", turnsTitlePosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, text, turnsTextPosition, constants::PrimaryTextColor);

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -505,7 +505,7 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);
 
-	const auto progressBarPosition = buildingProductNamePosition + NAS2D::Vector{0, 20};
+	const auto progressBarPosition = buildingProductNamePosition + NAS2D::Vector{0, fontMedium.height()};
 	const auto progressBarSize = NAS2D::Vector{mRect.size.x - originRight.x - 10, 30};
 	drawProgressBar(
 		selectedFactory->productionTurnsCompleted(),


### PR DESCRIPTION
Modify `FactoryReport` product pane to calculate positions dynamically. Allow the progress bar to move based on font size of item above it.

Changes were designed to have no visual impact with current font. For a larger font there is a minor effect that prevents text from overlapping the progress bar.

Related:
- Issue #1548
