### PR TITLE
Bug fix/text input disabled

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -240,8 +240,6 @@ MapViewState::~MapViewState()
 	eventHandler.mouseWheel().disconnect({this, &MapViewState::onMouseWheel});
 	eventHandler.windowResized().disconnect({this, &MapViewState::onWindowResized});
 
-	eventHandler.textInputMode(false);
-
 	NAS2D::Utility<std::map<class MineFacility*, Route>>::get().clear();
 }
 


### PR DESCRIPTION
In rearranging the calls to initialize `~MapViewState` no longer leaves the status of `SDL_TextInput` off. This had the side effect of causing the `NAS2D::Utility<StructureManager>::get().dropAllStructures();` in `MapViewState::load` where  `StructureManager` was still populated with pointers from objects from the now deleted `MapViewState`.  

Edit:
New strategy. I do not see any advantage of disabling `SDL_TextInput` by `~MapViewState`.  