### PR TITLE
Remove `Factory::initFactory` method

### DIFF
--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -24,7 +24,6 @@ namespace
 			}
 		}
 	}
-}
 
 
 /**
@@ -49,6 +48,7 @@ const std::map<ProductType, ProductionCost> ProductionCostTable =
 	{ProductType::PRODUCT_CLOTHING, ProductionCost{1, {0, 1, 0, 0}}},
 	{ProductType::PRODUCT_MEDICINE, ProductionCost{1, {0, 2, 0, 1}}},
 };
+}
 
 
 const ProductionCost& productCost(ProductType productType)

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -9,6 +9,24 @@
 #include <stdexcept>
 
 
+namespace
+{
+	void assertNoDuplicates(const std::vector<ProductType>& products)
+	{
+		for (std::size_t i = 0; i < products.size(); ++i)
+		{
+			for (std::size_t j = i + 1; j < products.size(); ++j)
+			{
+				if (products[i] == products[j])
+				{
+					throw std::runtime_error("Duplicate product added to factory list: " + std::to_string(products[j]));
+				}
+			}
+		}
+	}
+}
+
+
 /**
  * Table with production information for each product that factories can produce.
  *
@@ -39,9 +57,12 @@ const ProductionCost& productCost(ProductType productType)
 }
 
 
-Factory::Factory(StructureID id) :
-	Structure(StructureClass::Factory, id)
-{}
+Factory::Factory(StructureID id, std::vector<ProductType> products) :
+	Structure(StructureClass::Factory, id),
+	mAvailableProducts{std::move(products)}
+{
+	assertNoDuplicates(mAvailableProducts);
+}
 
 
 void Factory::productType(ProductType type)

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -26,28 +26,28 @@ namespace
 	}
 
 
-/**
- * Table with production information for each product that factories can produce.
- *
- * \note	This table defines parameters for -all- products that any factory can
- *			produce. It is up to the individual factory to determine what they are
- *			allowed to build.
- */
-const std::map<ProductType, ProductionCost> ProductionCostTable =
-{
-	{ProductType::PRODUCT_NONE, ProductionCost{}},
+	/**
+	 * Table with production information for each product that factories can produce.
+	 *
+	 * \note	This table defines parameters for -all- products that any factory can
+	 *			produce. It is up to the individual factory to determine what they are
+	 *			allowed to build.
+	 */
+	const std::map<ProductType, ProductionCost> ProductionCostTable =
+	{
+		{ProductType::PRODUCT_NONE, ProductionCost{}},
 
-	{ProductType::PRODUCT_DIGGER, ProductionCost{5, {3, 1, 1, 0}}},
-	{ProductType::PRODUCT_DOZER, ProductionCost{5, {3, 1, 1, 0}}},
-	{ProductType::PRODUCT_EXPLORER, ProductionCost{5, {5, 2, 1, 1}}},
-	{ProductType::PRODUCT_MINER, ProductionCost{5, {3, 2, 1, 1}}},
-	{ProductType::PRODUCT_TRUCK, ProductionCost{3, {2, 1, 1, 0}}},
+		{ProductType::PRODUCT_DIGGER, ProductionCost{5, {3, 1, 1, 0}}},
+		{ProductType::PRODUCT_DOZER, ProductionCost{5, {3, 1, 1, 0}}},
+		{ProductType::PRODUCT_EXPLORER, ProductionCost{5, {5, 2, 1, 1}}},
+		{ProductType::PRODUCT_MINER, ProductionCost{5, {3, 2, 1, 1}}},
+		{ProductType::PRODUCT_TRUCK, ProductionCost{3, {2, 1, 1, 0}}},
 
-	{ProductType::PRODUCT_MAINTENANCE_PARTS, ProductionCost{2, {2, 2, 1, 1}}},
+		{ProductType::PRODUCT_MAINTENANCE_PARTS, ProductionCost{2, {2, 2, 1, 1}}},
 
-	{ProductType::PRODUCT_CLOTHING, ProductionCost{1, {0, 1, 0, 0}}},
-	{ProductType::PRODUCT_MEDICINE, ProductionCost{1, {0, 2, 0, 1}}},
-};
+		{ProductType::PRODUCT_CLOTHING, ProductionCost{1, {0, 1, 0, 0}}},
+		{ProductType::PRODUCT_MEDICINE, ProductionCost{1, {0, 2, 0, 1}}},
+	};
 }
 
 

--- a/appOPHD/MapObjects/Structures/Factory.h
+++ b/appOPHD/MapObjects/Structures/Factory.h
@@ -32,7 +32,7 @@ public:
 	using ProductionTypeList = std::vector<ProductType>;
 
 public:
-	Factory(StructureID id);
+	Factory(StructureID id, std::vector<ProductType> products = {});
 
 	virtual void updateProduction();
 

--- a/appOPHD/MapObjects/Structures/Factory.h
+++ b/appOPHD/MapObjects/Structures/Factory.h
@@ -53,8 +53,6 @@ public:
 
 	const ProductionTypeList& productList() const { return mAvailableProducts; }
 
-	virtual void initFactory() = 0;
-
 	ProductionSignal::Source& productionComplete() { return mProductionComplete; }
 
 	NAS2D::Dictionary getDataDict() const override;

--- a/appOPHD/MapObjects/Structures/SeedFactory.h
+++ b/appOPHD/MapObjects/Structures/SeedFactory.h
@@ -9,12 +9,6 @@ public:
 	SeedFactory() : Factory(
 		StructureID::SID_SEED_FACTORY)
 	{
-		initFactory();
-	}
-
-protected:
-	void initFactory()
-	{
 		addProduct(ProductType::PRODUCT_DIGGER);
 		addProduct(ProductType::PRODUCT_DOZER);
 		addProduct(ProductType::PRODUCT_MINER);

--- a/appOPHD/MapObjects/Structures/SeedFactory.h
+++ b/appOPHD/MapObjects/Structures/SeedFactory.h
@@ -6,12 +6,16 @@
 class SeedFactory : public Factory
 {
 public:
-	SeedFactory() : Factory(
-		StructureID::SID_SEED_FACTORY)
+	SeedFactory() :
+	Factory(
+		StructureID::SID_SEED_FACTORY,
+		{
+			ProductType::PRODUCT_DIGGER,
+			ProductType::PRODUCT_DOZER,
+			ProductType::PRODUCT_MINER,
+			ProductType::PRODUCT_TRUCK,
+		}
+	)
 	{
-		addProduct(ProductType::PRODUCT_DIGGER);
-		addProduct(ProductType::PRODUCT_DOZER);
-		addProduct(ProductType::PRODUCT_MINER);
-		addProduct(ProductType::PRODUCT_TRUCK);
 	}
 };

--- a/appOPHD/MapObjects/Structures/SeedFactory.h
+++ b/appOPHD/MapObjects/Structures/SeedFactory.h
@@ -13,7 +13,7 @@ public:
 	}
 
 protected:
-	void initFactory() override
+	void initFactory()
 	{
 		addProduct(ProductType::PRODUCT_DIGGER);
 		addProduct(ProductType::PRODUCT_DOZER);

--- a/appOPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/appOPHD/MapObjects/Structures/SurfaceFactory.h
@@ -14,7 +14,7 @@ public:
 
 protected:
 
-	void initFactory() override
+	void initFactory()
 	{
 		addProduct(ProductType::PRODUCT_DIGGER);
 		addProduct(ProductType::PRODUCT_DOZER);

--- a/appOPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/appOPHD/MapObjects/Structures/SurfaceFactory.h
@@ -9,13 +9,6 @@ public:
 	SurfaceFactory() : Factory(
 		StructureID::SID_SURFACE_FACTORY)
 	{
-		initFactory();
-	}
-
-protected:
-
-	void initFactory()
-	{
 		addProduct(ProductType::PRODUCT_DIGGER);
 		addProduct(ProductType::PRODUCT_DOZER);
 		addProduct(ProductType::PRODUCT_MINER);

--- a/appOPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/appOPHD/MapObjects/Structures/SurfaceFactory.h
@@ -6,12 +6,16 @@
 class SurfaceFactory : public Factory
 {
 public:
-	SurfaceFactory() : Factory(
-		StructureID::SID_SURFACE_FACTORY)
+	SurfaceFactory() :
+	Factory(
+		StructureID::SID_SURFACE_FACTORY,
+		{
+			ProductType::PRODUCT_DIGGER,
+			ProductType::PRODUCT_DOZER,
+			ProductType::PRODUCT_MINER,
+			ProductType::PRODUCT_TRUCK,
+		}
+	)
 	{
-		addProduct(ProductType::PRODUCT_DIGGER);
-		addProduct(ProductType::PRODUCT_DOZER);
-		addProduct(ProductType::PRODUCT_MINER);
-		addProduct(ProductType::PRODUCT_TRUCK);
 	}
 };

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -9,13 +9,6 @@ public:
 	UndergroundFactory() : Factory(
 		StructureID::SID_UNDERGROUND_FACTORY)
 	{
-		initFactory();
-	}
-
-protected:
-
-	void initFactory()
-	{
 		// Need to be replaced by non robot/surface goods
 		// Produces luxuries, clothing, or medicine
 		addProduct(ProductType::PRODUCT_CLOTHING);

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -6,12 +6,16 @@
 class UndergroundFactory : public Factory
 {
 public:
-	UndergroundFactory() : Factory(
-		StructureID::SID_UNDERGROUND_FACTORY)
+	UndergroundFactory() :
+	Factory(
+		StructureID::SID_UNDERGROUND_FACTORY,
+		{
+			// Need to be replaced by non robot/surface goods
+			// Produces luxuries, clothing, or medicine
+			ProductType::PRODUCT_CLOTHING,
+			ProductType::PRODUCT_MEDICINE,
+		}
+	)
 	{
-		// Need to be replaced by non robot/surface goods
-		// Produces luxuries, clothing, or medicine
-		addProduct(ProductType::PRODUCT_CLOTHING);
-		addProduct(ProductType::PRODUCT_MEDICINE);
 	}
 };

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -14,7 +14,7 @@ public:
 
 protected:
 
-	void initFactory() override
+	void initFactory()
 	{
 		// Robot digger for now. Need to be replaced by non robot/surface goods
 		// Produces luxuries, clothing, or medicine

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -16,7 +16,7 @@ protected:
 
 	void initFactory()
 	{
-		// Robot digger for now. Need to be replaced by non robot/surface goods
+		// Need to be replaced by non robot/surface goods
 		// Produces luxuries, clothing, or medicine
 		addProduct(ProductType::PRODUCT_CLOTHING);
 		addProduct(ProductType::PRODUCT_MEDICINE);


### PR DESCRIPTION
Remove the `virtual` method `Factory::initFactory`.

Visual Studio Code was showing a number of warnings, such as:
> Call to virtual method 'UndergroundFactory::initFactory' during construction bypasses virtual dispatch

The method in question was declared `virtual`, but was used in a way that made virtual dispatch impossible. Of course initialization should be done in constructors, rather than in separate init methods, so an easy solution was to move initialization into the constructor and get rid of `initFactory`.

Related:
- Issue #307
