### PR TITLE
Add layout helper functions

### DIFF
--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -19,13 +19,14 @@
 #include "../../MapObjects/Mine.h"
 #include "../../MapObjects/Structures/MineFacility.h"
 
+#include <libControls/Layout.h>
+
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <array>
 #include <cfloat>
 #include <map>
-#include <ranges>
 
 
 using namespace NAS2D;
@@ -164,13 +165,10 @@ void MineReport::onResize()
 	btnAddTruck.position({buttonPositionX, renderer.size().y - 130});
 	btnRemoveTruck.position({buttonPositionX, renderer.size().y - 95});
 
-	const auto checkBoxWidths = std::views::transform(chkResources, [](const CheckBox& checkBox){ return checkBox.size().x; });
-	const auto maxCheckBoxWidth = std::ranges::max(checkBoxWidths);
-	const auto checkBoxPositionX = area().size.x - maxCheckBoxWidth - 10;
-	chkResources[0].position({checkBoxPositionX, chkResources[0].position().y});
-	chkResources[1].position({checkBoxPositionX, chkResources[1].position().y});
-	chkResources[2].position({checkBoxPositionX, chkResources[2].position().y});
-	chkResources[3].position({checkBoxPositionX, chkResources[3].position().y});
+	const auto checkBoxes = std::vector<Control*>{&chkResources[0], &chkResources[1], &chkResources[2], &chkResources[3]};
+	const auto maxCheckBoxSize = maxSize(checkBoxes);
+	const auto checkBoxPositionX = area().size.x - maxCheckBoxSize.x - 10;
+	setPositionX(checkBoxes, checkBoxPositionX);
 }
 
 

--- a/libControls/Layout.cpp
+++ b/libControls/Layout.cpp
@@ -16,3 +16,12 @@ NAS2D::Vector<int> maxSize(const std::vector<Control*>& controls)
 	}
 	return maxSize;
 }
+
+
+void setSize(const std::vector<Control*>& controls, NAS2D::Vector<int> newSize)
+{
+	for (auto* control : controls)
+	{
+		control->size(newSize);
+	}
+}

--- a/libControls/Layout.cpp
+++ b/libControls/Layout.cpp
@@ -25,3 +25,21 @@ void setSize(const std::vector<Control*>& controls, NAS2D::Vector<int> newSize)
 		control->size(newSize);
 	}
 }
+
+
+void setPositionX(const std::vector<Control*>& controls, int newX)
+{
+	for (auto* control : controls)
+	{
+		control->position({newX, control->position().y});
+	}
+}
+
+
+void setPositionY(const std::vector<Control*>& controls, int newY)
+{
+	for (auto* control : controls)
+	{
+		control->position({control->position().x, newY});
+	}
+}

--- a/libControls/Layout.cpp
+++ b/libControls/Layout.cpp
@@ -1,0 +1,18 @@
+#include "Layout.h"
+
+#include "Control.h"
+
+#include <algorithm>
+
+
+NAS2D::Vector<int> maxSize(const std::vector<Control*>& controls)
+{
+	NAS2D::Vector<int> maxSize{0, 0};
+	for (const auto* control : controls)
+	{
+		const auto controlSize = control->size();
+		maxSize.x = std::max(maxSize.x, controlSize.x);
+		maxSize.y = std::max(maxSize.y, controlSize.y);
+	}
+	return maxSize;
+}

--- a/libControls/Layout.h
+++ b/libControls/Layout.h
@@ -15,3 +15,6 @@ class Control;
 
 NAS2D::Vector<int> maxSize(const std::vector<Control*>& controls);
 void setSize(const std::vector<Control*>& controls, NAS2D::Vector<int> newSize);
+
+void setPositionX(const std::vector<Control*>& controls, int newX);
+void setPositionY(const std::vector<Control*>& controls, int newY);

--- a/libControls/Layout.h
+++ b/libControls/Layout.h
@@ -14,3 +14,4 @@ class Control;
 
 
 NAS2D::Vector<int> maxSize(const std::vector<Control*>& controls);
+void setSize(const std::vector<Control*>& controls, NAS2D::Vector<int> newSize);

--- a/libControls/Layout.h
+++ b/libControls/Layout.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <vector>
+
+
+namespace NAS2D
+{
+	template <typename BaseType> struct Point;
+	template <typename BaseType> struct Vector;
+}
+
+
+class Control;
+
+
+NAS2D::Vector<int> maxSize(const std::vector<Control*>& controls);

--- a/libControls/libControls.vcxproj
+++ b/libControls/libControls.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="ComboBox.cpp" />
     <ClCompile Include="Control.cpp" />
     <ClCompile Include="Label.cpp" />
+    <ClCompile Include="Layout.cpp" />
     <ClCompile Include="ListBox.cpp" />
     <ClCompile Include="ListBoxBase.cpp" />
     <ClCompile Include="RadioButton.cpp" />
@@ -169,6 +170,7 @@
     <ClInclude Include="ComboBox.h" />
     <ClInclude Include="Control.h" />
     <ClInclude Include="Label.h" />
+    <ClInclude Include="Layout.h" />
     <ClInclude Include="ListBox.h" />
     <ClInclude Include="ListBoxBase.h" />
     <ClInclude Include="RadioButtonGroup.h" />

--- a/libControls/libControls.vcxproj.filters
+++ b/libControls/libControls.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="Label.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Layout.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="ListBox.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -81,6 +84,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Label.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Layout.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ListBox.h">


### PR DESCRIPTION
Start adding a few helper functions for `Control` layout.

This helps clean up some code that failed to compile on older versions of Clang, such as is shipped with Ubuntu 22.04. The CI builds use Ubuntu 24.04, which has a newer version of Clang, with better support for the `ranges` library.

Related:
- Issue #896
- Issue #307
- Issue #1548
- Commit 63059032192abb4ffc02783008bcfe20a9ce96a6 (PR #1637)
