### PR TITLE
Split `Music` to separate cache file

### DIFF
--- a/appOPHD/Cache.h
+++ b/appOPHD/Cache.h
@@ -2,13 +2,8 @@
 
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Resource/Image.h>
-#include <NAS2D/Resource/Music.h>
 #include <NAS2D/Resource/ResourceCache.h>
-
-#include <memory>
 
 
 inline NAS2D::ResourceCache<NAS2D::Font, std::string, unsigned int> fontCache;
 inline NAS2D::ResourceCache<NAS2D::Image, std::string> imageCache;
-
-inline std::unique_ptr<NAS2D::Music> trackMars;

--- a/appOPHD/CacheMusic.h
+++ b/appOPHD/CacheMusic.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <NAS2D/Resource/Music.h>
+
+#include <memory>
+
+
+inline std::unique_ptr<NAS2D::Music> trackMars;

--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -3,6 +3,7 @@
 #include "PlanetSelectState.h"
 
 #include "../Cache.h"
+#include "../CacheMusic.h"
 #include "../OpenSaveGame.h"
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -286,6 +286,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h" />
+    <ClInclude Include="CacheMusic.h" />
     <ClInclude Include="Constants\Numbers.h" />
     <ClInclude Include="Constants\Strings.h" />
     <ClInclude Include="Constants\UiConstants.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -377,6 +377,9 @@
     <ClInclude Include="Cache.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CacheMusic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Constants\Numbers.h">
       <Filter>Header Files\Constants</Filter>
     </ClInclude>

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -1,4 +1,5 @@
 #include "Cache.h"
+#include "CacheMusic.h"
 #include "Constants/Strings.h"
 #include "Constants/Numbers.h"
 #include "Constants/UiConstants.h"


### PR DESCRIPTION
The `<memory>` header can be a bit of an expensive include in terms of compile time. Couple that with how frequently `Cache.h` is included, and how few of those includes need the entry that makes use of `<memory>`, and it becomes a good candidate to split to a separate file. Additionally there is a NAS2D issue that may require substantially increasing the transitive includes from `Music.h` to include `<SDL.h>`, and there's even more incentive to split that off.

Related:
- Issue #1573
- Issue https://github.com/lairworks/nas2d-core/issues/1242
