### PR TITLE
Update NAS2D submodule for `Fade` race condition fix

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1423,5 +1423,5 @@ void MapViewState::scrubRobotList()
 
 bool MapViewState::hasGameEnded()
 {
-	return mFade.isFaded() && mGameOver;
+	return mFade.isFaded();
 }

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -285,7 +285,6 @@ private:
 	void onTakeMeThere(const MapCoordinate& position);
 
 private:
-	bool mGameOver = false;
 	Difficulty mDifficulty = Difficulty::Medium;
 	std::unique_ptr<TileMap> mTileMap;
 	CrimeRateUpdate mCrimeRateUpdate;

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -641,7 +641,6 @@ void MapViewState::onReturnToGame()
  */
 void MapViewState::onGameOver()
 {
-	mGameOver = true;
 	mFade.fadeOut(constants::FadeSpeed);
 	mQuitSignal();
 }


### PR DESCRIPTION
Upstream fix for `Fade::isFaded()` means we no longer need the `mGameOver` check.

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/1202
- PR #1539
