### PR TITLE
Use `std::to_string` instead of `NAS2D::stringFrom`

### DIFF
--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -4,8 +4,6 @@
 
 #include "../../UI/StringTable.h"
 
-#include <NAS2D/StringFrom.h>
-
 
 namespace
 {
@@ -45,10 +43,10 @@ StringTable Recycling::createInspectorViewTable()
 	StringTable stringTable(2, 2);
 
 	stringTable[{0, 0}].text = "Max Residents Supported:";
-	stringTable[{1, 0}].text = NAS2D::stringFrom(residentialSupportCount());
+	stringTable[{1, 0}].text = std::to_string(residentialSupportCount());
 
 	stringTable[{0, 1}].text = "Max Waste Processing Capacity:";
-	stringTable[{1, 1}].text = NAS2D::stringFrom(wasteProcessingCapacity());
+	stringTable[{1, 1}].text = std::to_string(wasteProcessingCapacity());
 
 	if (!operational()) {
 		stringTable[{1, 0}].textColor = constants::WarningTextColor;

--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -7,7 +7,6 @@
 #include <libOPHD/EnumDifficulty.h>
 #include <libOPHD/RandomNumberGenerator.h>
 
-#include <NAS2D/StringFrom.h>
 #include <NAS2D/Utility.h>
 
 
@@ -113,7 +112,7 @@ void CrimeExecution::stealFood(FoodProduction& structure)
 
 		mCrimeEventSignal.emit(
 			"Food Stolen",
-			NAS2D::stringFrom(foodStolen) + " units of food was pilfered from a " + structure.name() + ". " + getReasonForStealing() + ".",
+			std::to_string(foodStolen) + " units of food was pilfered from a " + structure.name() + ". " + getReasonForStealing() + ".",
 			structure
 		);
 	}
@@ -148,7 +147,7 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 
 	mCrimeEventSignal.emit(
 		"Resources Stolen",
-		NAS2D::stringFrom(amountStolen) + " units of " + resourceNames[indexToStealFrom] + " were stolen from a " + structure.name() + ". " + getReasonForStealing() + ".",
+		std::to_string(amountStolen) + " units of " + resourceNames[indexToStealFrom] + " were stolen from a " + structure.name() + ". " + getReasonForStealing() + ".",
 		structure
 	);
 }


### PR DESCRIPTION
These are simple cases of converting an `int` to a `std::string` and the `<string>` header has already been implicitly included. There is no need for an additional include or for the additional generality of `stringFrom`.

Related:
- Issue #1573
