### PR TITLE
Use `dynamic_cast` in `assignColonistsToResidences`

### DIFF
--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -400,8 +400,8 @@ void StructureManager::assignColonistsToResidences(PopulationPool& population)
 	int populationCount = population.size();
 	for (auto* structure : mStructureLists[Structure::StructureClass::Residence])
 	{
-		Residence* residence = static_cast<Residence*>(structure);
-		if (residence->operational())
+		Residence* residence = dynamic_cast<Residence*>(structure);
+		if (residence && residence->operational())
 		{
 			residence->assignColonists(populationCount);
 			populationCount -= residence->assignedColonists();


### PR DESCRIPTION
This likely fixes the crash from #905, though doesn't address other uses of `static_cast` in that file, at least one of which would affect writing Residence/RLD data fields to a saved game file.

Related:
- Issue #905
