### PR TITLE
Refactor load save game

### DIFF
--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -2,6 +2,47 @@
 
 #include "appOPHD/Constants/Strings.h"
 
+#include <NAS2D/ParserHelper.h>
+
+namespace
+{
+	void setLanders(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
+	{
+		if (element)
+		{
+			const auto dictionary = NAS2D::attributesToDictionary(*element);
+			colonyShipData.colonistLanders = dictionary.get<int>("colonist_landers");
+			colonyShipData.cargoLanders = dictionary.get<int>("cargo_landers");
+		}
+	}
+
+
+	void setManeuveringFuel(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
+	{
+		if (element)
+		{
+			auto turnCount = NAS2D::attributesToDictionary(*element).get<int>("count");
+
+			colonyShipData.turnsOfManeuveringFuel = turnCount > constants::ColonyShipOrbitTime ? 0 : constants::ColonyShipOrbitTime - turnCount + 1;
+		}
+	}
+}
+
+
+ColonyShipData colonyShipDataFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
+{
+	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
+	if (root)
+	{
+		ColonyShipData colonyShipData;
+		setLanders(colonyShipData, root->firstChildElement("population"));
+		setManeuveringFuel(colonyShipData, root->firstChildElement("turns"));
+		return colonyShipData;
+	}
+	throw std::runtime_error("Invalid save game root element.");
+}
+
+
 ColonyShip::ColonyShip()
 {}
 

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -3,6 +3,17 @@
 #include "appOPHD/Constants/Numbers.h"
 
 #include <optional>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlDocument;
+	}
+}
+class GameState;
+
 struct ColonyShipData
 {
 	int colonistLanders = 0;
@@ -10,7 +21,7 @@ struct ColonyShipData
 	int turnsOfManeuveringFuel = 0;
 };
 
-class GameState;
+ColonyShipData colonyShipDataFromSave(NAS2D::Xml::XmlDocument&);
 
 class ColonyShip
 {

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -36,7 +36,7 @@ NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wra
 GameState::GameState(const std::string& savedGameFilename) :
 	mSaveGameDocument{saveGameDocument(savedGameFilename)},
 	mMainReportsState{},
-	mMapViewState{*this, savedGameFilename},
+	mMapViewState{*this, mSaveGameDocument},
 	mColonyShip{colonyShipDataFromSave(mSaveGameDocument)},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
 {}

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -15,46 +15,18 @@
 #include <NAS2D/Mixer/Mixer.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Filesystem.h>
-#include <NAS2D/ParserHelper.h>
 
 namespace
 {
-	void setLanders(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
+	NAS2D::Xml::XmlDocument saveGameDocument(const std::string& filePath)
 	{
-		if (element)
+		if (!NAS2D::Utility<NAS2D::Filesystem>::get().exists(filePath))
 		{
-			const auto dictionary = NAS2D::attributesToDictionary(*element);
-			colonyShipData.colonistLanders = dictionary.get<int>("colonist_landers");
-			colonyShipData.cargoLanders = dictionary.get<int>("cargo_landers");
+			throw std::runtime_error("File '" + filePath + "' was not found.");
 		}
+		auto xmlDocument = openSavegame(filePath);
+		return xmlDocument;
 	}
-
-	void setManeuveringFuel(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
-	{
-		if (element)
-		{
-			auto turnCount = NAS2D::attributesToDictionary(*element).get<int>("count");
-
-			colonyShipData.turnsOfManeuveringFuel = turnCount > constants::ColonyShipOrbitTime ? 0 : constants::ColonyShipOrbitTime - turnCount + 1;
-		}
-	}
-}
-
-
-ColonyShipData colonyShipDataFromFile(const std::string& filePath)
-{
-	if (!NAS2D::Utility<NAS2D::Filesystem>::get().exists(filePath))
-	{
-		throw std::runtime_error("File '" + filePath + "' was not found.");
-	}
-	auto xmlDocument = openSavegame(filePath);
-	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
-
-	ColonyShipData colonyShipData;
-	setLanders(colonyShipData, root->firstChildElement("population"));
-	setManeuveringFuel(colonyShipData, root->firstChildElement("turns"));
-
-	return colonyShipData;
 }
 
 
@@ -62,9 +34,10 @@ NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wra
 
 
 GameState::GameState(const std::string& savedGameFilename) :
+	mSaveGameDocument{saveGameDocument(savedGameFilename)},
 	mMainReportsState{},
 	mMapViewState{*this, savedGameFilename},
-	mColonyShip{colonyShipDataFromFile(savedGameFilename)},
+	mColonyShip{colonyShipDataFromSave(mSaveGameDocument)},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
 {}
 

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -49,6 +49,7 @@ GameState::GameState(const Planet::Attributes& planetAttributes, Difficulty sele
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
 {}
 
+
 GameState::~GameState()
 {
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -184,8 +184,16 @@ void GameState::onLoadGame(const std::string& saveGameName)
 
 void GameState::onSaveGame(const std::string& saveGameName)
 {
-	mMapViewState.save(constants::SaveGamePath + saveGameName + ".xml");
 	mFileIoDialog.hide();
+	auto saveGamePath = constants::SaveGamePath + saveGameName + ".xml";
+	NAS2D::Xml::XmlDocument saveGameDocument;
+	mMapViewState.save(saveGameDocument);
+
+	// Write out the XML file.
+	NAS2D::Xml::XmlMemoryBuffer buff;
+	saveGameDocument.accept(&buff);
+
+	NAS2D::Utility<NAS2D::Filesystem>::get().writeFile(saveGamePath, buff.buffer());
 }
 
 

--- a/appOPHD/States/GameState.h
+++ b/appOPHD/States/GameState.h
@@ -11,11 +11,11 @@
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Fade.h>
+#include <NAS2D/ParserHelper.h>
 
 #include <string>
 #include <memory>
 
-ColonyShipData colonyShipDataFromFile(const std::string&);
 
 enum class Difficulty;
 
@@ -56,6 +56,7 @@ protected:
 	void onTakeMeThere(const Structure*);
 
 private:
+	NAS2D::Xml::XmlDocument mSaveGameDocument;
 	MainReportsUiState mMainReportsState;
 	MapViewState mMapViewState;
 	ColonyShip mColonyShip;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -181,12 +181,12 @@ const std::map<Difficulty, int> MapViewState::ColonyShipDeorbitMoraleLossMultipl
 };
 
 
-MapViewState::MapViewState(GameState& gameState, const std::string& savegame) :
+MapViewState::MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument) :
 	mCrimeRateUpdate{mDifficulty},
 	mCrimeExecution{mDifficulty, {this, &MapViewState::onCrimeEvent}},
 	mTechnologyReader{"tech0-1.xml"},
 	mLoadingExisting{true},
-	mExistingToLoad{savegame},
+	mExistingToLoad{&saveGameDocument},
 	mMainReportsState{gameState.mainReportsState()},
 	mStructures{"ui/structures.png", constants::StructureIconSize, constants::MarginTight},
 	mRobots{"ui/robots.png", constants::RobotIconSize, constants::MarginTight},

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -128,7 +128,7 @@ public:
 	void initialize() override;
 	State* update() override;
 
-	void save(const std::string& filePath);
+	void save(NAS2D::Xml::XmlDocument&);
 
 private:
 	void onDeactivate() override;

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -50,6 +50,7 @@
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/ParserHelper.h>
 #include <NAS2D/Renderer/Fade.h>
 
 #include <string>
@@ -109,7 +110,7 @@ public:
 	using MapChangedSignal = NAS2D::Signal<>;
 
 public:
-	MapViewState(GameState& gameState, const std::string& savegame);
+	MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument);
 	MapViewState(GameState& gameState, const Planet::Attributes& planetAttributes, Difficulty selectedDifficulty);
 	~MapViewState() override;
 
@@ -234,7 +235,7 @@ private:
 
 	void scrubRobotList();
 
-	void load(const std::string& filePath);
+	void load(NAS2D::Xml::XmlDocument*);
 	NAS2D::Xml::XmlElement* serializeProperties();
 
 	// UI MANAGEMENT FUNCTIONS
@@ -325,7 +326,7 @@ private:
 	std::unique_ptr<micropather::MicroPather> mPathSolver;
 
 	bool mLoadingExisting = false;
-	std::string mExistingToLoad; /**< Filename of the existing game to load. */
+	NAS2D::Xml::XmlDocument* mExistingToLoad = nullptr; 
 
 	MainReportsUiState& mMainReportsState;
 	std::unique_ptr<MapView> mMapView;

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -214,8 +214,12 @@ NAS2D::Xml::XmlElement* MapViewState::serializeProperties()
 }
 
 
-void MapViewState::load(const std::string& filePath)
+void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 {
+	if (!xmlDocument)
+	{
+		throw std::runtime_error("MapViewState::load(): Invalid XML document.");
+	}
 	resetUi();
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -231,11 +235,6 @@ void MapViewState::load(const std::string& filePath)
 	mBtnToggleHeightmap.toggle(false);
 	mMorale.closeJournal();
 
-	if (!NAS2D::Utility<NAS2D::Filesystem>::get().exists(filePath))
-	{
-		throw std::runtime_error("File '" + filePath + "' was not found.");
-	}
-
 	scrubRobotList();
 	NAS2D::Utility<StructureManager>::get().dropAllStructures();
 	ccLocation() = CcNotPlaced;
@@ -244,8 +243,7 @@ void MapViewState::load(const std::string& filePath)
 
 	mTileMap.reset();
 
-	auto xmlDocument = openSavegame(filePath);
-	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
+	auto* root = xmlDocument->firstChildElement(constants::SaveGameRootNode);
 
 	NAS2D::Xml::XmlElement* map = root->firstChildElement("properties");
 	const auto dictionary = NAS2D::attributesToDictionary(*map);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -138,7 +138,7 @@ namespace
 }
 
 
-void MapViewState::save(const std::string& filePath)
+void MapViewState::save(NAS2D::Xml::XmlDocument& saveGameDocument)
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.drawBoxFilled(NAS2D::Rectangle{{0, 0}, renderer.size()}, NAS2D::Color{0, 0, 0, 100});
@@ -146,13 +146,11 @@ void MapViewState::save(const std::string& filePath)
 	renderer.drawImage(*imageSaving, renderer.center() - imageSaving->size() / 2);
 	renderer.update();
 
-	NAS2D::Xml::XmlDocument doc;
-
 	auto* root = NAS2D::dictionaryToAttributes(
 		constants::SaveGameRootNode,
 		{{{"version", constants::SaveGameVersion}}}
 	);
-	doc.linkEndChild(root);
+	saveGameDocument.linkEndChild(root);
 
 	root->linkEndChild(serializeProperties());
 	mTileMap->serialize(root);
@@ -190,12 +188,6 @@ void MapViewState::save(const std::string& filePath)
 		));
 	}
 	root->linkEndChild(moraleChangeReasons);
-
-	// Write out the XML file.
-	NAS2D::Xml::XmlMemoryBuffer buff;
-	doc.accept(&buff);
-
-	NAS2D::Utility<NAS2D::Filesystem>::get().writeFile(filePath, buff.buffer());
 }
 
 


### PR DESCRIPTION
Moved colony ship related loading code to colony ship files. Game components of `GameState` now load and save to and from a common `XmlDocument` instead of making repeated file IO operations.