### PR TITLE
Fix warnings `-Wdangling-reference`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.6
     environment:
       Toolchain: "gcc"
-      WARN_EXTRA: "-Wno-dangling-reference  -Wno-useless-cast -Wno-effc++"
+      WARN_EXTRA: "-Wno-useless-cast -Wno-effc++"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
@@ -53,7 +53,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.13
     environment:
       Toolchain: "mingw"
-      WARN_EXTRA: "-Wno-dangling-reference  -Wno-useless-cast -Wno-effc++"
+      WARN_EXTRA: "-Wno-useless-cast -Wno-effc++"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/libControls/Control.h
+++ b/libControls/Control.h
@@ -31,7 +31,15 @@ public:
 
 	static const NAS2D::Font& getDefaultFont();
 	static const NAS2D::Font& getDefaultFontBold();
+
+	#if __GNUC__ >= 13
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wdangling-reference"
+	#endif
 	static const NAS2D::Image& getImage(const std::string& filename);
+	#if __GNUC__ >= 13
+		#pragma GCC diagnostic pop
+	#endif
 
 
 	Control() = default;

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ TARGET_OS ?= $(CURRENT_OS)
 Toolchain ?=
 
 PkgConfig := pkg-config
-WarnFlags := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wsign-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wno-unknown-pragmas -Wmissing-format-attribute -Wredundant-decls -Wformat=2
+WarnFlags := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wsign-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wunknown-pragmas -Wmissing-format-attribute -Wredundant-decls -Wformat=2
 
 gccCXX := g++
 gccWarnFlags := $(WarnFlags) -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Weffc++


### PR DESCRIPTION
Disable new buggy warning flag `-Wdangling-reference` added in GCC 13+. This flag was included as part of `-Wextra`.

Allow warning for `-Wunknown-pragmas`. Any warnings generated by unknown pragmas have long been fixed.

Related:
- Issue #307
