### PR TITLE
Update `WarehouseReport` buttons

### DIFF
--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -174,7 +174,7 @@ namespace constants
 	// =====================================
 	const std::string WarehouseEmpty = "Empty";
 	const std::string WarehouseFull = "At Capacity";
-	const std::string WarehouseSpaceAvailable = "Space Available";
+	const std::string WarehouseVacancy = "Space Available";
 
 	const std::string ResearchReportTopicDetails = "Research Topic Details";
 

--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -174,7 +174,7 @@ namespace constants
 	// =====================================
 	const std::string WarehouseEmpty = "Empty";
 	const std::string WarehouseFull = "At Capacity";
-	const std::string WarehouseVacancy = "Space Available";
+	const std::string WarehouseVacancy = "Vacancy";
 
 	const std::string ResearchReportTopicDetails = "Research Topic Details";
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -57,7 +57,7 @@ WarehouseReport::WarehouseReport() :
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All", {this, &WarehouseReport::onShowAll}},
-	btnSpaceAvailable{"Space Available", {this, &WarehouseReport::onSpaceAvailable}},
+	btnSpaceAvailable{"Vacancy", {this, &WarehouseReport::onSpaceAvailable}},
 	btnFull{"Full", {this, &WarehouseReport::onFull}},
 	btnEmpty{"Empty", {this, &WarehouseReport::onEmpty}},
 	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -44,7 +44,7 @@ namespace
 		if (warehouse.state() != StructureState::Operational) { return warehouse.stateDescription(); }
 		else if (productPool.empty()) { return constants::WarehouseEmpty; }
 		else if (productPool.atCapacity()) { return constants::WarehouseFull; }
-		else if (!productPool.empty() && !productPool.atCapacity()) { return constants::WarehouseSpaceAvailable; }
+		else if (!productPool.empty() && !productPool.atCapacity()) { return constants::WarehouseVacancy; }
 
 		return std::string{};
 	}

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -63,7 +63,7 @@ WarehouseReport::WarehouseReport() :
 	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}}
 {
-	const auto buttons = std::array{&btnShowAll, &btnVacancy, &btnFull, &btnEmpty, &btnDisabled};
+	const auto buttons = std::array{&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled};
 	for (auto button : buttons)
 	{
 		button->size({89, 20});

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -57,7 +57,7 @@ WarehouseReport::WarehouseReport() :
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All", {this, &WarehouseReport::onShowAll}},
-	btnVacancy{"Vacancy", {this, &WarehouseReport::onSpaceAvailable}},
+	btnVacancy{"Vacancy", {this, &WarehouseReport::onVacancy}},
 	btnFull{"Full", {this, &WarehouseReport::onFull}},
 	btnEmpty{"Empty", {this, &WarehouseReport::onEmpty}},
 	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},
@@ -146,7 +146,7 @@ void WarehouseReport::fillLists()
 }
 
 
-void WarehouseReport::fillListSpaceAvailable()
+void WarehouseReport::fillListVacancy()
 {
 	const auto predicate = [](Warehouse* wh) {
 		return !wh->products().atCapacity() && !wh->products().empty() && (wh->operational() || wh->isIdle());
@@ -250,12 +250,12 @@ void WarehouseReport::onShowAll()
 }
 
 
-void WarehouseReport::onSpaceAvailable()
+void WarehouseReport::onVacancy()
 {
 	filterButtonClicked();
 	btnVacancy.toggle(true);
 
-	fillListSpaceAvailable();
+	fillListVacancy();
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -67,7 +67,7 @@ WarehouseReport::WarehouseReport() :
 	const auto buttons = std::array{&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled};
 	for (auto button : buttons)
 	{
-		button->size({89, 20});
+		button->size({94, 20});
 		button->type(Button::Type::Toggle);
 		button->toggle(false);
 		add(*button, buttonOffset);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -57,13 +57,13 @@ WarehouseReport::WarehouseReport() :
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All", {this, &WarehouseReport::onShowAll}},
-	btnSpaceAvailable{"Vacancy", {this, &WarehouseReport::onSpaceAvailable}},
+	btnVacancy{"Vacancy", {this, &WarehouseReport::onSpaceAvailable}},
 	btnFull{"Full", {this, &WarehouseReport::onFull}},
 	btnEmpty{"Empty", {this, &WarehouseReport::onEmpty}},
 	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}}
 {
-	const auto buttons = std::array{&btnShowAll, &btnSpaceAvailable, &btnFull, &btnEmpty, &btnDisabled};
+	const auto buttons = std::array{&btnShowAll, &btnVacancy, &btnFull, &btnEmpty, &btnDisabled};
 	for (auto button : buttons)
 	{
 		button->size({89, 20});
@@ -72,7 +72,7 @@ WarehouseReport::WarehouseReport() :
 	}
 
 	btnShowAll.toggle(true);
-	btnSpaceAvailable.size({100, 20});
+	btnVacancy.size({100, 20});
 
 	btnTakeMeThere.size({140, 30});
 
@@ -234,7 +234,7 @@ void WarehouseReport::onResize()
 void WarehouseReport::filterButtonClicked()
 {
 	btnShowAll.toggle(false);
-	btnSpaceAvailable.toggle(false);
+	btnVacancy.toggle(false);
 	btnFull.toggle(false);
 	btnEmpty.toggle(false);
 	btnDisabled.toggle(false);
@@ -253,7 +253,7 @@ void WarehouseReport::onShowAll()
 void WarehouseReport::onSpaceAvailable()
 {
 	filterButtonClicked();
-	btnSpaceAvailable.toggle(true);
+	btnVacancy.toggle(true);
 
 	fillListSpaceAvailable();
 }

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -57,8 +57,8 @@ WarehouseReport::WarehouseReport() :
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},
 	imageWarehouse{imageCache.load("ui/interface/warehouse.png")},
 	btnShowAll{"All", {this, &WarehouseReport::onShowAll}},
-	btnVacancy{"Vacancy", {this, &WarehouseReport::onVacancy}},
 	btnFull{"Full", {this, &WarehouseReport::onFull}},
+	btnVacancy{"Vacancy", {this, &WarehouseReport::onVacancy}},
 	btnEmpty{"Empty", {this, &WarehouseReport::onEmpty}},
 	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}}
@@ -146,6 +146,16 @@ void WarehouseReport::fillLists()
 }
 
 
+void WarehouseReport::fillListFull()
+{
+	const auto predicate = [](Warehouse* wh) {
+		return wh->products().atCapacity() && (wh->operational() || wh->isIdle());
+	};
+
+	fillListFromStructureList(selectWarehouses(predicate));
+}
+
+
 void WarehouseReport::fillListVacancy()
 {
 	const auto predicate = [](Warehouse* wh) {
@@ -155,16 +165,6 @@ void WarehouseReport::fillListVacancy()
 	fillListFromStructureList(selectWarehouses(predicate));
 }
 
-
-
-void WarehouseReport::fillListFull()
-{
-	const auto predicate = [](Warehouse* wh) {
-		return wh->products().atCapacity() && (wh->operational() || wh->isIdle());
-	};
-
-	fillListFromStructureList(selectWarehouses(predicate));
-}
 
 
 void WarehouseReport::fillListEmpty()
@@ -250,21 +250,21 @@ void WarehouseReport::onShowAll()
 }
 
 
-void WarehouseReport::onVacancy()
-{
-	filterButtonClicked();
-	btnVacancy.toggle(true);
-
-	fillListVacancy();
-}
-
-
 void WarehouseReport::onFull()
 {
 	filterButtonClicked();
 	btnFull.toggle(true);
 
 	fillListFull();
+}
+
+
+void WarehouseReport::onVacancy()
+{
+	filterButtonClicked();
+	btnVacancy.toggle(true);
+
+	fillListVacancy();
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -72,7 +72,6 @@ WarehouseReport::WarehouseReport() :
 	}
 
 	btnShowAll.toggle(true);
-	btnVacancy.size({100, 20});
 
 	btnTakeMeThere.size({140, 30});
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -71,7 +71,7 @@ WarehouseReport::WarehouseReport() :
 		button->type(Button::Type::Toggle);
 		button->toggle(false);
 		add(*button, buttonOffset);
-		buttonOffset.x += button->size().x + constants::Margin;
+		buttonOffset.x += button->size().x + constants::MarginTight;
 	}
 
 	btnShowAll.toggle(true);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -63,12 +63,15 @@ WarehouseReport::WarehouseReport() :
 	btnDisabled{"Disabled", {this, &WarehouseReport::onDisabled}},
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}}
 {
+	auto buttonOffset = NAS2D::Vector{10, 10};
 	const auto buttons = std::array{&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled};
 	for (auto button : buttons)
 	{
 		button->size({89, 20});
 		button->type(Button::Type::Toggle);
 		button->toggle(false);
+		add(*button, buttonOffset);
+		buttonOffset.x += button->size().x + constants::Margin;
 	}
 
 	btnShowAll.toggle(true);
@@ -81,12 +84,6 @@ WarehouseReport::WarehouseReport() :
 
 	fillLists();
 
-	auto buttonOffset = NAS2D::Vector{10, 10};
-	for (auto button : buttons)
-	{
-		add(*button, buttonOffset);
-		buttonOffset.x += button->size().x + constants::Margin;
-	}
 	add(btnTakeMeThere, {10, 10});
 	add(lstStructures, {10, 115});
 	add(lstProducts, {Utility<Renderer>::get().center().x + 10, 173});

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -44,14 +44,14 @@ private:
 	void onResize() override;
 
 	void onShowAll();
-	void onSpaceAvailable();
+	void onVacancy();
 	void onFull();
 	void onEmpty();
 	void onDisabled();
 
 	void onTakeMeThere();
 
-	void fillListSpaceAvailable();
+	void fillListVacancy();
 	void fillListFull();
 	void fillListEmpty();
 	void fillListDisabled();

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -44,15 +44,15 @@ private:
 	void onResize() override;
 
 	void onShowAll();
-	void onVacancy();
 	void onFull();
+	void onVacancy();
 	void onEmpty();
 	void onDisabled();
 
 	void onTakeMeThere();
 
-	void fillListVacancy();
 	void fillListFull();
+	void fillListVacancy();
 	void fillListEmpty();
 	void fillListDisabled();
 
@@ -73,8 +73,8 @@ private:
 	const Warehouse* selectedWarehouse = nullptr;
 
 	Button btnShowAll;
-	Button btnVacancy;
 	Button btnFull;
+	Button btnVacancy;
 	Button btnEmpty;
 	Button btnDisabled;
 

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -73,7 +73,7 @@ private:
 	const Warehouse* selectedWarehouse = nullptr;
 
 	Button btnShowAll;
-	Button btnSpaceAvailable;
+	Button btnVacancy;
 	Button btnFull;
 	Button btnEmpty;
 	Button btnDisabled;


### PR DESCRIPTION
Change button text from "Space Available" to "Vacancy". Swap order of "Full" and "Vacancy" buttons. Adjust margin between buttons and button sizes, so they are consistent with other report views, and fill the available space.

Original:
![image](https://github.com/user-attachments/assets/4c50da3e-a5b1-4219-bf7e-2b4714cf61ae)

Updated:
![image](https://github.com/user-attachments/assets/87ceec8e-3f61-46bb-8795-260598b99706)

----

Related:
- Issue #1548
