### PR TITLE
Update `FactoryReport` control sizes

### DIFF
--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -73,7 +73,7 @@ namespace constants
 	const std::string Robodozer = "Robodozer";
 	const std::string Roboexplorer = "Roboexplorer";
 	const std::string Robominer = "Robominer";
-	const std::string MaintenanceSupplies = "Maintenance Supplies";
+	const std::string MaintenanceSupplies = "Maintenance";
 	const std::string Truck = "Truck";
 
 	const std::string Clothing = "Clothing";

--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -73,7 +73,7 @@ namespace constants
 	const std::string Robodozer = "Robodozer";
 	const std::string Roboexplorer = "Roboexplorer";
 	const std::string Robominer = "Robominer";
-	const std::string MaintenanceSupplies = "Maintenance";
+	const std::string Maintenance = "Maintenance";
 	const std::string Truck = "Truck";
 
 	const std::string Clothing = "Clothing";

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -107,8 +107,8 @@ FactoryReport::FactoryReport() :
 
 	add(btnApply, {0, 0});
 
-	add(cboFilterByProduct, {280, 33});
-	cboFilterByProduct.size({170, 20});
+	add(cboFilterByProduct, {330, 33});
+	cboFilterByProduct.size({120, 20});
 
 	cboFilterByProduct.addItem(constants::None, ProductType::PRODUCT_NONE);
 	cboFilterByProduct.addItem(constants::Clothing, ProductType::PRODUCT_CLOTHING);

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -112,7 +112,7 @@ FactoryReport::FactoryReport() :
 
 	cboFilterByProduct.addItem(constants::None, ProductType::PRODUCT_NONE);
 	cboFilterByProduct.addItem(constants::Clothing, ProductType::PRODUCT_CLOTHING);
-	cboFilterByProduct.addItem(constants::MaintenanceSupplies, ProductType::PRODUCT_MAINTENANCE_PARTS);
+	cboFilterByProduct.addItem(constants::Maintenance, ProductType::PRODUCT_MAINTENANCE_PARTS);
 	cboFilterByProduct.addItem(constants::Medicine, ProductType::PRODUCT_MEDICINE);
 	cboFilterByProduct.addItem(constants::Robodigger, ProductType::PRODUCT_DIGGER);
 	cboFilterByProduct.addItem(constants::Robodozer, ProductType::PRODUCT_DOZER);

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -27,7 +27,7 @@ using namespace NAS2D;
 
 namespace
 {
-	constexpr auto viewFilterButtonSize = NAS2D::Vector{85, 20};
+	constexpr auto viewFilterButtonSize = NAS2D::Vector{104, 20};
 	constexpr auto viewFilterSpacing = NAS2D::Vector{viewFilterButtonSize.x + constants::MarginTight, 0};
 	constexpr auto viewFilterOriginRow1 = NAS2D::Vector{10, 10};
 	constexpr auto viewFilterOriginRow2 = NAS2D::Vector{10, 33};


### PR DESCRIPTION
Decrease the combo box size, and increase size of filter buttons. This allows for better layout at increased font sizes.

To decrease the combo box size, the "Maintenance Supplies" entry was shortened to "Maintenance".

Original:
![image](https://github.com/user-attachments/assets/2acb80e7-6ae3-4371-a0c3-ac7de69d1e2a)

Updated:
![image](https://github.com/user-attachments/assets/abad7b61-2e14-4841-9981-7b8379ee137e)

----

Related:
- Issue #1548
