### PR TITLE
Refactor `MineOperationsWindow` table drawing

### DIFF
--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -215,14 +215,14 @@ void MineOperationsWindow::update()
 	renderer.drawText(mFontBold, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
 	const auto tableOrigin = origin + NAS2D::Vector{10, 180};
-	const auto width = mRect.size.x;
-	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, {width - 20, 40}});
+	const auto tableWidth = mRect.size.x - 20;
+	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, {tableWidth, 40}});
 
 	renderer.drawLine(tableOrigin + NAS2D::Vector{88, 0}, tableOrigin + NAS2D::Vector{88, 39}, NAS2D::Color{22, 22, 22});
 	renderer.drawLine(tableOrigin + NAS2D::Vector{177, 0}, tableOrigin + NAS2D::Vector{177, 39}, NAS2D::Color{22, 22, 22});
 	renderer.drawLine(tableOrigin + NAS2D::Vector{265, 0}, tableOrigin + NAS2D::Vector{265, 39}, NAS2D::Color{22, 22, 22});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{width - 21, 20}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{tableWidth - 1, 20}, NAS2D::Color{22, 22, 22});
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -219,11 +219,13 @@ void MineOperationsWindow::update()
 	const auto cellSize = NAS2D::Vector{(tableSize.x + 1) / 4, tableSize.y / 2};
 	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, tableSize});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, tableSize.y - 1}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, tableSize.y - 1}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, tableSize.y - 1}, NAS2D::Color{22, 22, 22});
+	const auto dividerLineColor = NAS2D::Color{22, 22, 22};
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{1, cellSize.y}, tableOrigin + NAS2D::Vector{tableSize.x - 1, cellSize.y}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, tableSize.y - 1}, dividerLineColor);
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, tableSize.y - 1}, dividerLineColor);
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, tableSize.y - 1}, dividerLineColor);
+
+	renderer.drawLine(tableOrigin + NAS2D::Vector{1, cellSize.y}, tableOrigin + NAS2D::Vector{tableSize.x - 1, cellSize.y}, dividerLineColor);
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -212,9 +212,9 @@ void MineOperationsWindow::update()
 	drawLabelAndValue(origin + NAS2D::Vector{260, 95}, "Available: ", std::to_string(mAvailableTrucks));
 
 	// REMAINING ORE PANEL
-	const auto width = mRect.size.x;
 	renderer.drawText(mFontBold, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
+	const auto width = mRect.size.x;
 	mPanel.draw(renderer, NAS2D::Rectangle{origin + NAS2D::Vector{10, 180}, {width - 20, 40}});
 
 	renderer.drawLine(origin + NAS2D::Vector{98, 180}, origin + NAS2D::Vector{98, 219}, NAS2D::Color{22, 22, 22});

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -214,29 +214,30 @@ void MineOperationsWindow::update()
 	// REMAINING ORE PANEL
 	renderer.drawText(mFontBold, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
+	const auto tableOrigin = origin + NAS2D::Vector{10, 180};
 	const auto width = mRect.size.x;
-	mPanel.draw(renderer, NAS2D::Rectangle{origin + NAS2D::Vector{10, 180}, {width - 20, 40}});
+	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, {width - 20, 40}});
 
-	renderer.drawLine(origin + NAS2D::Vector{98, 180}, origin + NAS2D::Vector{98, 219}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(origin + NAS2D::Vector{187, 180}, origin + NAS2D::Vector{187, 219}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(origin + NAS2D::Vector{275, 180}, origin + NAS2D::Vector{275, 219}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{88, 0}, tableOrigin + NAS2D::Vector{88, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{177, 0}, tableOrigin + NAS2D::Vector{177, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{265, 0}, tableOrigin + NAS2D::Vector{265, 39}, NAS2D::Color{22, 22, 22});
 
-	renderer.drawLine(origin + NAS2D::Vector{11, 200}, origin + NAS2D::Vector{width - 11, 200}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{width - 21, 20}, NAS2D::Color{22, 22, 22});
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources
 	{
-		std::tuple{46,  ResourceImageRectsOre[0], availableResources.resources[0]},
-		std::tuple{135, ResourceImageRectsOre[1], availableResources.resources[1]},
-		std::tuple{224, ResourceImageRectsOre[2], availableResources.resources[2]},
-		std::tuple{313, ResourceImageRectsOre[3], availableResources.resources[3]}
+		std::tuple{36,  ResourceImageRectsOre[0], availableResources.resources[0]},
+		std::tuple{125, ResourceImageRectsOre[1], availableResources.resources[1]},
+		std::tuple{214, ResourceImageRectsOre[2], availableResources.resources[2]},
+		std::tuple{303, ResourceImageRectsOre[3], availableResources.resources[3]}
 	};
 
 	for (const auto& [offsetX, iconRect, resourceCount] : resources)
 	{
 		const auto resourceCountString = std::to_string(resourceCount);
 		const auto textOffsetX = offsetX - (mFont.width(resourceCountString) / 2) + 8;
-		renderer.drawSubImage(mIcons, origin + NAS2D::Vector{offsetX, 183}, iconRect);
-		renderer.drawText(mFont, resourceCountString, origin + NAS2D::Vector{textOffsetX, 202}, NAS2D::Color::White);
+		renderer.drawSubImage(mIcons, tableOrigin + NAS2D::Vector{offsetX, 3}, iconRect);
+		renderer.drawText(mFont, resourceCountString, tableOrigin + NAS2D::Vector{textOffsetX, 22}, NAS2D::Color::White);
 	}
 }

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -216,14 +216,14 @@ void MineOperationsWindow::update()
 
 	const auto tableOrigin = origin + NAS2D::Vector{10, 180};
 	const auto tableSize = NAS2D::Vector{mRect.size.x - 20, 40};
-	const auto cellSize = NAS2D::Vector{(tableSize.x + 1) / 4, 20};
+	const auto cellSize = NAS2D::Vector{(tableSize.x + 1) / 4, tableSize.y / 2};
 	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, tableSize});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, 39}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 39}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, tableSize.y - 1}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, tableSize.y - 1}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, tableSize.y - 1}, NAS2D::Color{22, 22, 22});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{tableSize.x - 1, 20}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{1, cellSize.y}, tableOrigin + NAS2D::Vector{tableSize.x - 1, cellSize.y}, NAS2D::Color{22, 22, 22});
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -215,15 +215,15 @@ void MineOperationsWindow::update()
 	renderer.drawText(mFontBold, "Remaining Resources", origin + NAS2D::Vector{10, 164}, NAS2D::Color::White);
 
 	const auto tableOrigin = origin + NAS2D::Vector{10, 180};
-	const auto tableWidth = mRect.size.x - 20;
-	const auto cellSize = NAS2D::Vector{(tableWidth + 1) / 4, 20};
-	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, {tableWidth, 40}});
+	const auto tableSize = NAS2D::Vector{mRect.size.x - 20, 40};
+	const auto cellSize = NAS2D::Vector{(tableSize.x + 1) / 4, 20};
+	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, tableSize});
 
 	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, 39}, NAS2D::Color{22, 22, 22});
 	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 39}, NAS2D::Color{22, 22, 22});
 	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 39}, NAS2D::Color{22, 22, 22});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{tableWidth - 1, 20}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{tableSize.x - 1, 20}, NAS2D::Color{22, 22, 22});
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -219,9 +219,9 @@ void MineOperationsWindow::update()
 	const auto cellSize = NAS2D::Vector{(tableWidth + 1) / 4, 20};
 	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, {tableWidth, 40}});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 0}, tableOrigin + NAS2D::Vector{cellSize.x - 1, 39}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 0}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 39}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 0}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 39}, NAS2D::Color{22, 22, 22});
 
 	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{tableWidth - 1, 20}, NAS2D::Color{22, 22, 22});
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -216,28 +216,30 @@ void MineOperationsWindow::update()
 
 	const auto tableOrigin = origin + NAS2D::Vector{10, 180};
 	const auto tableWidth = mRect.size.x - 20;
+	const auto cellSize = NAS2D::Vector{(tableWidth + 1) / 4, 20};
 	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, {tableWidth, 40}});
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{88, 0}, tableOrigin + NAS2D::Vector{88, 39}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{177, 0}, tableOrigin + NAS2D::Vector{177, 39}, NAS2D::Color{22, 22, 22});
-	renderer.drawLine(tableOrigin + NAS2D::Vector{265, 0}, tableOrigin + NAS2D::Vector{265, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 0}, tableOrigin + NAS2D::Vector{cellSize.x - 1, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 0}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 39}, NAS2D::Color{22, 22, 22});
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 0}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 39}, NAS2D::Color{22, 22, 22});
 
 	renderer.drawLine(tableOrigin + NAS2D::Vector{1, 20}, tableOrigin + NAS2D::Vector{tableWidth - 1, 20}, NAS2D::Color{22, 22, 22});
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources
 	{
-		std::tuple{36,  ResourceImageRectsOre[0], availableResources.resources[0]},
-		std::tuple{125, ResourceImageRectsOre[1], availableResources.resources[1]},
-		std::tuple{214, ResourceImageRectsOre[2], availableResources.resources[2]},
-		std::tuple{303, ResourceImageRectsOre[3], availableResources.resources[3]}
+		std::tuple{ResourceImageRectsOre[0], availableResources.resources[0]},
+		std::tuple{ResourceImageRectsOre[1], availableResources.resources[1]},
+		std::tuple{ResourceImageRectsOre[2], availableResources.resources[2]},
+		std::tuple{ResourceImageRectsOre[3], availableResources.resources[3]}
 	};
 
-	for (const auto& [offsetX, iconRect, resourceCount] : resources)
+	auto columnOrigin = tableOrigin;
+	for (const auto& [iconRect, resourceCount] : resources)
 	{
 		const auto resourceCountString = std::to_string(resourceCount);
-		const auto textOffsetX = offsetX - (mFont.width(resourceCountString) / 2) + 8;
-		renderer.drawSubImage(mIcons, tableOrigin + NAS2D::Vector{offsetX, 3}, iconRect);
-		renderer.drawText(mFont, resourceCountString, tableOrigin + NAS2D::Vector{textOffsetX, 22}, NAS2D::Color::White);
+		renderer.drawSubImage(mIcons, columnOrigin + (cellSize - iconRect.size) / 2 + NAS2D::Vector{0, 1}, iconRect);
+		renderer.drawText(mFont, resourceCountString, columnOrigin + (cellSize - mFont.size(resourceCountString)) / 2 + NAS2D::Vector{0, cellSize.y + 1}, NAS2D::Color::White);
+		columnOrigin.x += cellSize.x;
 	}
 }


### PR DESCRIPTION
Refactor table drawing code in `MineOperationsWindow`.

Previously, many values were hardcoded manually set offsets and sizes. This makes drawing relative to a `tableOrigin`, and dynamic based on `cellSize`. This allows for easier updates if the table needs to be re-positioned or re-sized, which will be needed if font sizes are adjusted.

Related:
- Issue #1548
