### PR TITLE
Update `MineOperationsWindow` table - remove offsets

### DIFF
--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -50,7 +50,7 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck{"Add Truck", {this, &MineOperationsWindow::onAssignTruck}},
 	btnUnassignTruck{"Remove Truck", {this, &MineOperationsWindow::onUnassignTruck}}
 {
-	size({375, 270});
+	size({376, 270});
 
 	// Set up GUI Layout
 	btnIdle.type(Button::Type::Toggle);

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -221,9 +221,9 @@ void MineOperationsWindow::update()
 
 	const auto dividerLineColor = NAS2D::Color{22, 22, 22};
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x - 1, tableSize.y - 1}, dividerLineColor);
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2 - 1, tableSize.y - 1}, dividerLineColor);
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3 - 2, tableSize.y - 1}, dividerLineColor);
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x, 1}, tableOrigin + NAS2D::Vector{cellSize.x, tableSize.y - 1}, dividerLineColor);
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2, tableSize.y - 1}, dividerLineColor);
+	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3, tableSize.y - 1}, dividerLineColor);
 
 	renderer.drawLine(tableOrigin + NAS2D::Vector{1, cellSize.y}, tableOrigin + NAS2D::Vector{tableSize.x - 1, cellSize.y}, dividerLineColor);
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -221,14 +221,14 @@ void MineOperationsWindow::update()
 
 	const auto dividerLineColor = NAS2D::Color{22, 22, 22};
 
+	const auto rowOrigin = tableOrigin + NAS2D::Vector{1, cellSize.y};
+	renderer.drawLine(rowOrigin, rowOrigin + NAS2D::Vector{tableSize.x - 2, 0}, dividerLineColor);
+
 	for (int i = 1; i < 4; ++i)
 	{
 		const auto columnOrigin = tableOrigin + NAS2D::Vector{cellSize.x * i, 1};
 		renderer.drawLine(columnOrigin, columnOrigin + NAS2D::Vector{0, tableSize.y - 2}, dividerLineColor);
 	}
-
-	const auto rowOrigin = tableOrigin + NAS2D::Vector{1, cellSize.y};
-	renderer.drawLine(rowOrigin, rowOrigin + NAS2D::Vector{tableSize.x - 2, 0}, dividerLineColor);
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -221,9 +221,10 @@ void MineOperationsWindow::update()
 
 	const auto dividerLineColor = NAS2D::Color{22, 22, 22};
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x, 1}, tableOrigin + NAS2D::Vector{cellSize.x, tableSize.y - 1}, dividerLineColor);
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 2, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 2, tableSize.y - 1}, dividerLineColor);
-	renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * 3, 1}, tableOrigin + NAS2D::Vector{cellSize.x * 3, tableSize.y - 1}, dividerLineColor);
+	for (int i = 1; i < 4; ++i)
+	{
+		renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * i, 1}, tableOrigin + NAS2D::Vector{cellSize.x * i, tableSize.y - 1}, dividerLineColor);
+	}
 
 	renderer.drawLine(tableOrigin + NAS2D::Vector{1, cellSize.y}, tableOrigin + NAS2D::Vector{tableSize.x - 1, cellSize.y}, dividerLineColor);
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -236,12 +236,12 @@ void MineOperationsWindow::update()
 		std::tuple{ResourceImageRectsOre[3], availableResources.resources[3]}
 	};
 
-	auto columnOrigin = tableOrigin;
+	auto columnOrigin = tableOrigin + NAS2D::Vector{0, 1};
 	for (const auto& [iconRect, resourceCount] : resources)
 	{
 		const auto resourceCountString = std::to_string(resourceCount);
-		renderer.drawSubImage(mIcons, columnOrigin + (cellSize - iconRect.size) / 2 + NAS2D::Vector{0, 1}, iconRect);
-		renderer.drawText(mFont, resourceCountString, columnOrigin + (cellSize - mFont.size(resourceCountString)) / 2 + NAS2D::Vector{0, cellSize.y + 1}, NAS2D::Color::White);
+		renderer.drawSubImage(mIcons, columnOrigin + (cellSize - iconRect.size) / 2, iconRect);
+		renderer.drawText(mFont, resourceCountString, columnOrigin + (cellSize - mFont.size(resourceCountString)) / 2 + NAS2D::Vector{0, cellSize.y}, NAS2D::Color::White);
 		columnOrigin.x += cellSize.x;
 	}
 }

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -216,7 +216,7 @@ void MineOperationsWindow::update()
 
 	const auto tableOrigin = origin + NAS2D::Vector{10, 180};
 	const auto tableSize = NAS2D::Vector{mRect.size.x - 20, 40};
-	const auto cellSize = NAS2D::Vector{(tableSize.x + 1) / 4, tableSize.y / 2};
+	const auto cellSize = NAS2D::Vector{tableSize.x / 4, tableSize.y / 2};
 	mPanel.draw(renderer, NAS2D::Rectangle{tableOrigin, tableSize});
 
 	const auto dividerLineColor = NAS2D::Color{22, 22, 22};

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -223,10 +223,12 @@ void MineOperationsWindow::update()
 
 	for (int i = 1; i < 4; ++i)
 	{
-		renderer.drawLine(tableOrigin + NAS2D::Vector{cellSize.x * i, 1}, tableOrigin + NAS2D::Vector{cellSize.x * i, tableSize.y - 1}, dividerLineColor);
+		const auto columnOrigin = tableOrigin + NAS2D::Vector{cellSize.x * i, 1};
+		renderer.drawLine(columnOrigin, columnOrigin + NAS2D::Vector{0, tableSize.y - 2}, dividerLineColor);
 	}
 
-	renderer.drawLine(tableOrigin + NAS2D::Vector{1, cellSize.y}, tableOrigin + NAS2D::Vector{tableSize.x - 1, cellSize.y}, dividerLineColor);
+	const auto rowOrigin = tableOrigin + NAS2D::Vector{1, cellSize.y};
+	renderer.drawLine(rowOrigin, rowOrigin + NAS2D::Vector{tableSize.x - 2, 0}, dividerLineColor);
 
 	const auto availableResources = mFacility->oreDeposit().availableResources();
 	const std::array resources

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -244,7 +244,8 @@ void MineOperationsWindow::update()
 	{
 		const auto resourceCountString = std::to_string(resourceCount);
 		renderer.drawSubImage(mIcons, columnOrigin + (cellSize - iconRect.size) / 2, iconRect);
-		renderer.drawText(mFont, resourceCountString, columnOrigin + (cellSize - mFont.size(resourceCountString)) / 2 + NAS2D::Vector{0, cellSize.y}, NAS2D::Color::White);
+		const auto textPosition = columnOrigin + NAS2D::Vector{0, cellSize.y} + (cellSize - mFont.size(resourceCountString)) / 2;
+		renderer.drawText(mFont, resourceCountString, textPosition, NAS2D::Color::White);
 		columnOrigin.x += cellSize.x;
 	}
 }


### PR DESCRIPTION
Remove strange offsets in `MineOperationsWindow` table drawing, and improve dynamic drawing ability.

The strange offsets were likely unintended offsets from when things were manually placed. The changes are not pixel equivalent to the old display, though are so minor as to be hard to notice. The last column divider line may be the easiest to see.

----

Original:
![image](https://github.com/user-attachments/assets/3d34e19b-3669-424f-9997-0031ed9203d0)

Updated:
![image](https://github.com/user-attachments/assets/26503260-a01c-46ff-96c2-c0006d880fad)


----

Related:
- Issue #1548
