### PR TITLE
Minor layout changes to prepare for larger fonts

### DIFF
--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -49,7 +49,7 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck{"Add Truck", {this, &MineOperationsWindow::onAssignTruck}},
 	btnUnassignTruck{"Remove Truck", {this, &MineOperationsWindow::onUnassignTruck}}
 {
-	size({420, 290});
+	size({420, 300});
 
 	// Set up GUI Layout
 	btnIdle.type(Button::Type::Toggle);

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -129,7 +129,7 @@ MineReport::MineReport() :
 	add(btnAddTruck, {0, 145});
 	add(btnRemoveTruck, {0, 180});
 
-	const auto checkBoxOriginY = 230 + fontMediumBold.height() + 10 + 10;
+	const auto checkBoxOriginY = 260 + fontMediumBold.height() + 10 + 10;
 	const auto resourceNameHeight = std::max({ResourceImageRectsOre[0].size.y, fontBold.height(), chkResources[0].size().y});
 	const auto resourceProgressBarHeight = std::max(25, fontBold.height() + constants::MarginTight * 2);
 	const auto checkBoxSpacingY = resourceNameHeight + resourceProgressBarHeight + constants::Margin + 23;
@@ -527,7 +527,7 @@ void MineReport::update()
 	if (mSelectedFacility)
 	{
 		drawMineFacilityPane(startPoint + NAS2D::Vector{10, 30});
-		drawOreProductionPane(startPoint + NAS2D::Vector{10, 230});
+		drawOreProductionPane(startPoint + NAS2D::Vector{10, 260});
 	}
 
 	UIContainer::update();


### PR DESCRIPTION
Some minor layout changes to make more room for larger fonts, without things looking too cramped.

There are probably a few more places where some additional space could be useful, though these seem to be the only places where the alignment looked off because things were too cramped.

----

Related:
- Issue #1548
