### PR TITLE
Update `routeTable` type to correct for `const` key

### DIFF
--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -44,13 +44,13 @@ namespace
 
 	bool hasRoute(MineFacility* mineFacility)
 	{
-		const auto& routeTable = NAS2D::Utility<std::map<MineFacility*, Route>>::get();
+		const auto& routeTable = NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
 		return routeTable.find(mineFacility) != routeTable.end();
 	}
 
 	float getRouteCost(MineFacility* mineFacility)
 	{
-		const auto& routeTable = NAS2D::Utility<std::map<MineFacility*, Route>>::get();
+		const auto& routeTable = NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
 		if (routeTable.find(mineFacility) == routeTable.end())
 		{
 			return FLT_MAX;


### PR DESCRIPTION
Because of the type change, the `const` difference meant `Utility` was creating and returning a new variable, rather than referencing the expected variable.

Due to these two uses not using the non-required `class` keyword, they were missed during the update in commit 346075f6685fe1dbb8dbf7abcbbe1d49227c93da.

----

Fix bug introduced in:
- PR #1701 (Commit 346075f6685fe1dbb8dbf7abcbbe1d49227c93da)
