### PR TITLE
Fix `WarehouseReport` right pane visibility

### DIFF
--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -231,6 +231,12 @@ void WarehouseReport::onResize()
 }
 
 
+void WarehouseReport::onVisibilityChange(bool /*visible*/)
+{
+	btnTakeMeThere.visible(selectedWarehouse() != nullptr);
+}
+
+
 void WarehouseReport::filterButtonClicked()
 {
 	btnShowAll.toggle(false);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -239,7 +239,9 @@ void WarehouseReport::onVisibilityChange(bool /*visible*/)
 
 void WarehouseReport::setVisibility()
 {
-	btnTakeMeThere.visible(lstStructures.isItemSelected());
+	const auto isWarehouseSelected = lstStructures.isItemSelected();
+	btnTakeMeThere.visible(isWarehouseSelected);
+	lstProducts.visible(isWarehouseSelected);
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -233,6 +233,12 @@ void WarehouseReport::onResize()
 
 void WarehouseReport::onVisibilityChange(bool /*visible*/)
 {
+	setVisibility();
+}
+
+
+void WarehouseReport::setVisibility()
+{
 	btnTakeMeThere.visible(lstStructures.isItemSelected());
 }
 
@@ -301,13 +307,11 @@ void WarehouseReport::onTakeMeThere()
 void WarehouseReport::onStructureSelectionChange()
 {
 	const auto* warehouse = selectedWarehouse();
-
 	if (warehouse != nullptr)
 	{
 		lstProducts.productPool(warehouse->products());
 	}
-
-	btnTakeMeThere.visible(warehouse != nullptr);
+	setVisibility();
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -233,7 +233,7 @@ void WarehouseReport::onResize()
 
 void WarehouseReport::onVisibilityChange(bool /*visible*/)
 {
-	btnTakeMeThere.visible(selectedWarehouse() != nullptr);
+	btnTakeMeThere.visible(lstStructures.isItemSelected());
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -43,6 +43,7 @@ private:
 	void fillListFromStructureList(const std::vector<Warehouse*>&);
 
 	void onResize() override;
+	void onVisibilityChange(bool visible) override;
 
 	void onShowAll();
 	void onFull();

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -44,6 +44,7 @@ private:
 
 	void onResize() override;
 	void onVisibilityChange(bool visible) override;
+	void setVisibility();
 
 	void onShowAll();
 	void onFull();


### PR DESCRIPTION
Fix visibility of "Take me there" and `ProductListBox` visibility in `WarehouseReport`.

Sometimes the "Take me there" button could be visible even though no warehouse was selected. This happened when right-clicking the structure list to unselect any warehouse, and switching tab views to another report and returning. The "Take me there" button was visible again, even though no warehouse was selected. Additionally the `ProductListBox` was always visible, even when no warehouse was selected. When no warehouse was selected it would contain the items for the first warehouse.

Noticed this during recent `WarehouseReport` refactoring in PR #1706.

Related:
- PR #1706
- Issue #479
