### PR TITLE
Fix `FactoryReport` product description clipping

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -501,7 +501,7 @@ void FactoryReport::drawProductPane(Renderer& renderer)
 
 	if (selectedFactory->productType() == ProductType::PRODUCT_NONE) { return; }
 
-	const auto progressTextPosition = originRight + NAS2D::Vector{0, 178};
+	const auto progressTextPosition = originRight + NAS2D::Vector{0, mRect.size.y - originRight.y - 115};
 	const auto buildingProductNamePosition = progressTextPosition + NAS2D::Vector{0, 35};
 	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
 	renderer.drawText(fontMedium, "Building " + ProductCatalogue::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -278,7 +278,7 @@ void FactoryReport::onResize()
 	lstProducts.selectionChanged().connect({this, &FactoryReport::onProductSelectionChange});
 
 	mTxtProductDescription.position(lstProducts.area().crossXPoint() + NAS2D::Vector{158, 0});
-	mTxtProductDescription.width(mRect.size.x - mTxtProductDescription.position().x - 30);
+	mTxtProductDescription.width(mRect.size.x - mTxtProductDescription.position().x - 10);
 }
 
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -125,7 +125,7 @@ FactoryReport::FactoryReport() :
 
 	add(lstProducts, {cboFilterByProduct.area().position.x + cboFilterByProduct.area().size.x + 20, mRect.position.y + 230});
 
-	mTxtProductDescription.height(128);
+	mTxtProductDescription.height(260);
 	mTxtProductDescription.textColor(constants::PrimaryTextColor);
 
 	fillLists();


### PR DESCRIPTION
Expand product description text area to reduce text clipping.

There is still some clipping at small window sizes, though the amount of clipping is reduced. Additionally, the full text can be made to fit at a smaller window size than previously.

----

Original:
![image](https://github.com/user-attachments/assets/d26951a8-f53b-4f71-b875-7d92763117ee)

Updated:
![image](https://github.com/user-attachments/assets/529e80a1-c58c-40f7-91b6-f5c7acc4cbd3)

Updated, with window resized to fit full text:
![image](https://github.com/user-attachments/assets/f460a340-cc65-40ff-b695-ec3f65ef2940)

----

Related:
- Issue #1548
