### PR TITLE
Comm range data

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -263,6 +263,11 @@ int Structure::storageCapacity() const
 	return mStructureType.oreStorageCapacity;
 }
 
+int Structure::commRange() const
+{
+	return operational() ? mStructureType.commRange : 0;
+}
+
 bool Structure::hasCrime() const
 {
 	return mStructureType.isCrimeTarget;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -136,6 +136,7 @@ public:
 
 	int energyRequirement() const;
 	int storageCapacity() const;
+	int commRange() const;
 
 	bool hasCrime() const;
 	int crimeRate() const { return mCrimeRate; }

--- a/appOPHD/StructureCatalogue.cpp
+++ b/appOPHD/StructureCatalogue.cpp
@@ -71,7 +71,7 @@ namespace
 		const auto& structuresElement = *document.firstChildElement("Structures");
 
 		const auto requiredFields = std::vector<std::string>{"Name", "ImagePath", "TurnsToBuild", "MaxAge"};
-		const auto optionalFields = std::vector<std::string>{"RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "FoodProduced", "FoodStorageCapacity", "OreStorageCapacity", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
+		const auto optionalFields = std::vector<std::string>{"RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "FoodProduced", "FoodStorageCapacity", "OreStorageCapacity", "CommRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
 
 		std::vector<StructureType> structureTypes;
 		for (const auto* structureElement = structuresElement.firstChildElement(); structureElement; structureElement = structureElement->nextSiblingElement())
@@ -96,6 +96,7 @@ namespace
 				dictionary.get<int>("FoodProduced"),
 				dictionary.get<int>("FoodStorageCapacity"),
 				dictionary.get<int>("OreStorageCapacity"),
+				dictionary.get<int>("CommRange", 0),
 				dictionary.get<int>("IntegrityDecayRate"),
 				dictionary.get<bool>("IsSelfSustained"),
 				dictionary.get<bool>("IsRepairable"),

--- a/libOPHD/MapObjects/StructureType.h
+++ b/libOPHD/MapObjects/StructureType.h
@@ -22,6 +22,7 @@ struct StructureType
 	int foodProduced{0};
 	int foodStorageCapacity{0};
 	int oreStorageCapacity{0};
+	int commRange{0};
 	int integrityDecayRate{1};
 
 	bool isSelfSustained{false};


### PR DESCRIPTION
Allow loading `CommRange` data from `StructureTypes.xml`.

This is part 1 of a change to move `CommRange` data from hardcoded constants to an external data file. This allows the extra field to be loaded. Without this change, an update to the data file would cause errors due to a new unknown field. This change will be applied first, before the change to update the data file, and the change to use the new updated data file.

Related:
- Issue #1336
- Issue #1422
