### PR TITLE
Landers use Robot Comm Range

### DIFF
--- a/appOPHD/Constants/Numbers.h
+++ b/appOPHD/Constants/Numbers.h
@@ -40,8 +40,6 @@ namespace constants
 
 	inline constexpr auto MinimumWindowSize{NAS2D::Vector{1000, 700}};
 
-	inline constexpr int LanderCommRange{5};
-
 	inline constexpr int RoadIntegrityChange{80};
 
 	inline constexpr float RouteBaseCost{0.5f};

--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -267,7 +267,7 @@ namespace constants
 
 	const std::string AlertLanderTileObstructed = "Cannot place Lander because there is an object on the selected tile.";
 	const std::string AlertLanderTerrain = "Landers cannot be placed on Impassable Terrain.";
-	const std::string AlertLanderCommRange = "Landers must be placed within 5 tiles of the Command Center.";
+	const std::string AlertLanderCommRange = "Landers must be placed within communications range.";
 
 	const std::string AlertStructureOutOfRange = "Cannot build structures outside of Command Center communications range.";
 	const std::string AlertStructureTileObstructed = "The selected tile already has a structure on it. You must bulldoze the existing structure in order to build here.";

--- a/appOPHD/MapObjects/Structures/SeedLander.h
+++ b/appOPHD/MapObjects/Structures/SeedLander.h
@@ -27,6 +27,11 @@ public:
 		mPosition = position;
 	}
 
+	int getRange() const
+	{
+		return commRange();
+	}
+
 	Signal::Source& deploySignal() { return mDeploy; }
 
 protected:

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -827,7 +827,7 @@ void MapViewState::placeStructure(Tile& tile)
 {
 	if (mCurrentStructure == StructureID::SID_NONE) { throw std::runtime_error("MapViewState::placeStructure() called but mCurrentStructure == STRUCTURE_NONE"); }
 
-	if (!selfSustained(mCurrentStructure) && !isPointInCcRange(tile.xy()))
+	if (!selfSustained(mCurrentStructure) && !isInCcRange(tile.xy()))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOutOfRange);
 		return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -944,7 +944,7 @@ void MapViewState::placeRobot(Tile& tile)
 	if (!tile.excavated()) { return; }
 	if (!mRobotPool.isControlCapacityAvailable()) { return; }
 
-	if (!inCommRange(tile.xy()))
+	if (!isInCommRange(tile.xy()))
 	{
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertOutOfCommRange);
 		return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1383,6 +1383,7 @@ void MapViewState::updateCommRangeOverlay()
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	fillOverlay(*mTileMap, mCommRangeOverlay, structureManager.getStructures<CommandCenter>());
 	fillOverlay(*mTileMap, mCommRangeOverlay, structureManager.getStructures<CommTower>());
+	fillOverlay(*mTileMap, mCommRangeOverlay, structureManager.getStructures<SeedLander>());
 }
 
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -35,6 +35,17 @@ constexpr std::array AllDirections4{
 };
 
 
+CommandCenter& firstCc()
+{
+	const auto& ccList = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
+	if (ccList.empty())
+	{
+		throw std::runtime_error("firstCc() called with no active CommandCenter");
+	}
+	return *ccList.at(0);
+}
+
+
 bool isCcPlaced()
 {
 	const auto& ccList = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
@@ -56,17 +67,6 @@ bool isPointInCcRange(NAS2D::Point<int> position)
 		}
 	}
 	return false;
-}
-
-
-CommandCenter& firstCc()
-{
-	const auto& ccList = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
-	if (ccList.empty())
-	{
-		throw std::runtime_error("firstCc() called with no active CommandCenter");
-	}
-	return *ccList.at(0);
 }
 
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -160,7 +160,7 @@ bool validLanderSite(Tile& tile)
 		return false;
 	}
 
-	if (!isPointInCcRange(tile.xy(), constants::LanderCommRange))
+	if (!inCommRange(tile.xy()))
 	{
 		doAlertMessage(constants::AlertLanderLocation, constants::AlertLanderCommRange);
 		return false;

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -71,6 +71,33 @@ bool isPointInCcRange(NAS2D::Point<int> position)
 
 
 /**
+ * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
+ */
+bool inCommRange(NAS2D::Point<int> position)
+{
+	auto& structureManager = NAS2D::Utility<StructureManager>::get();
+
+	const auto& structures = structureManager.allStructures();
+	for (const auto* structure : structures)
+	{
+		const auto commRange = structure->commRange();
+		if (commRange > 0 && isPointInRange(position, structureManager.tileFromStructure(structure).xy(), commRange))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance)
+{
+	return (point2 - point1).lengthSquared() <= distance * distance;
+}
+
+
+/**
  * Checks to see if a given tube connection is valid.
  */
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir)
@@ -222,33 +249,6 @@ bool structureIsLander(StructureID id)
 bool selfSustained(StructureID id)
 {
 	return StructureCatalogue::getType(id).isSelfSustained;
-}
-
-
-/**
- * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
- */
-bool inCommRange(NAS2D::Point<int> position)
-{
-	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-
-	const auto& structures = structureManager.allStructures();
-	for (const auto* structure : structures)
-	{
-		const auto commRange = structure->commRange();
-		if (commRange > 0 && isPointInRange(position, structureManager.tileFromStructure(structure).xy(), commRange))
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
-bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance)
-{
-	return (point2 - point1).lengthSquared() <= distance * distance;
 }
 
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -44,12 +44,7 @@ bool isCcPlaced()
 
 bool isPointInCcRange(NAS2D::Point<int> position)
 {
-	return isPointInCcRange(position, StructureCatalogue::getType(StructureID::SID_COMMAND_CENTER).commRange);
-}
-
-
-bool isPointInCcRange(NAS2D::Point<int> position, int range)
-{
+	const auto range = StructureCatalogue::getType(StructureID::SID_COMMAND_CENTER).commRange;
 	const auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	const auto& ccList = structureManager.getStructures<CommandCenter>();
 	for (const auto* commandCenter : ccList)

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -53,7 +53,7 @@ bool isCcPlaced()
 }
 
 
-bool isPointInCcRange(NAS2D::Point<int> position)
+bool isInCcRange(NAS2D::Point<int> position)
 {
 	const auto range = StructureCatalogue::getType(StructureID::SID_COMMAND_CENTER).commRange;
 	const auto& structureManager = NAS2D::Utility<StructureManager>::get();

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -73,7 +73,7 @@ bool isInCcRange(NAS2D::Point<int> position)
 /**
  * Indicates that a specified tile is out of communications range (out of range of a CC or Comm Tower).
  */
-bool inCommRange(NAS2D::Point<int> position)
+bool isInCommRange(NAS2D::Point<int> position)
 {
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
@@ -182,7 +182,7 @@ bool validLanderSite(Tile& tile)
 		return false;
 	}
 
-	if (!inCommRange(tile.xy()))
+	if (!isInCommRange(tile.xy()))
 	{
 		doAlertMessage(constants::AlertLanderLocation, constants::AlertLanderCommRange);
 		return false;

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -25,9 +25,9 @@ class Warehouse;
 struct StorableResources;
 enum class Direction;
 
+CommandCenter& firstCc();
 bool isCcPlaced();
 bool isPointInCcRange(NAS2D::Point<int> position);
-CommandCenter& firstCc();
 
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile& tile, Direction dir);

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -29,6 +29,9 @@ CommandCenter& firstCc();
 bool isCcPlaced();
 bool isPointInCcRange(NAS2D::Point<int> position);
 
+bool inCommRange(NAS2D::Point<int> position);
+bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);
+
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile& tile, Direction dir);
 bool validTubeConnection(TileMap& tilemap, MapCoordinate position, ConnectorDir dir);
@@ -36,8 +39,6 @@ bool validStructurePlacement(TileMap& tilemap, MapCoordinate position);
 bool validLanderSite(Tile& t);
 bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position);
 bool structureIsLander(StructureID id);
-bool inCommRange(NAS2D::Point<int> position);
-bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);
 bool selfSustained(StructureID id);
 
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count);

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -29,7 +29,7 @@ CommandCenter& firstCc();
 bool isCcPlaced();
 bool isInCcRange(NAS2D::Point<int> position);
 
-bool inCommRange(NAS2D::Point<int> position);
+bool isInCommRange(NAS2D::Point<int> position);
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);
 
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -27,7 +27,6 @@ enum class Direction;
 
 bool isCcPlaced();
 bool isPointInCcRange(NAS2D::Point<int> position);
-bool isPointInCcRange(NAS2D::Point<int> position, int range);
 CommandCenter& firstCc();
 
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -27,7 +27,7 @@ enum class Direction;
 
 CommandCenter& firstCc();
 bool isCcPlaced();
-bool isPointInCcRange(NAS2D::Point<int> position);
+bool isInCcRange(NAS2D::Point<int> position);
 
 bool inCommRange(NAS2D::Point<int> position);
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);


### PR DESCRIPTION
Make lander placement dependent on `CommRange` rather than an arbitrary distance to the Command Center (which might still be under construction).

This makes lander placement consistent with `Robot` placement.

Update the `CommRange` overlay to include the `SeedLander` `commRange`.

Related:
- PR #1714
- PR #1713
- Issue #1422
