### PR TITLE
Only attempt to install `vcpkg` packages when no cache restored

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,8 @@ jobs:
         path: vcpkg_installed
         key: ${{ env.cacheKeyVcpkg }}
 
-    - name: Pre-install vcpkg dependencies - OPHD
+    - name: Install vcpkg dependencies - OPHD
+      if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
       env:
         VcpkgManifestInstall: true
       run: |
@@ -81,7 +82,8 @@ jobs:
       run: |
         xcopy vcpkg_installed nas2d-core\vcpkg_installed\ /s /e
 
-    - name: Pre-install vcpkg dependencies - NAS2D
+    - name: Install vcpkg dependencies - NAS2D
+      if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
       working-directory: nas2d-core
       env:
         VcpkgManifestInstall: true


### PR DESCRIPTION
Hopefully the `vcpkg` install step should only run when the cache expires, or is invalidated, and otherwise leave us with a valid cache from a previous run, which can be used during the build.

This is in response to the recent removal of the `x-gha` caching backend:
> (VcpkgInstallManifestDependencies target) -> 
>   %VCPKG_BINARY_SOURCES% : warning : The 'x-gha' binary caching backend has been removed. Consider using a NuGet-based binary caching provider instead, see extended documentation at https://learn.microsoft.com/vcpkg/users/binarycaching?WT.mc_id=vcpkg_inproduct_cli. [D:\a\OPHD\OPHD\appOPHD\appOPHD.vcxproj]

----

We probably should have done this earlier. The `vcpkg` install step often tries to update things even when they should be version locked. We don't really want those spurious updates. It's especially a problem when a later step uses a cache that depends on an earlier step after an earlier step is modified after restoring the cache. That leads to the `error LNK4020` problem (Issue #1553), and mention of the PDB file being corrupted. Basically, if we need to invalidate a cache and rebuild a step, we should invalidate all caches for future steps, and rebuild all of them. We're not quite there yet with this change, since we don't invalidate future caches, though if they are built together, they should generally expire pretty close together, so there should be a fairly small window where a cache for an earlier step expires, while a cache for a later step is still used.

----

Related:
- Issue #1553
