### PR TITLE
Refactor header includes

### DIFF
--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Numbers.h"
-
 #include <string>
 
 

--- a/appOPHD/Constants/UiConstants.h
+++ b/appOPHD/Constants/UiConstants.h
@@ -3,7 +3,6 @@
 #include <NAS2D/Duration.h>
 #include <NAS2D/Renderer/Color.h>
 
-#include <limits>
 #include <string>
 
 
@@ -22,8 +21,6 @@ namespace constants
 	inline constexpr int ResourceIconSize{16};
 
 	inline constexpr int ResourceBoxWidth{200};
-
-	inline constexpr auto NoSelection{std::numeric_limits<std::size_t>::max()};
 
 	inline constexpr unsigned int StructureIconSize{46};
 	inline constexpr unsigned int RobotIconSize{46};

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -28,6 +28,9 @@ namespace
 }
 
 
+std::size_t PlanetSelectState::NoSelection{std::numeric_limits<std::size_t>::max()};
+
+
 PlanetSelectState::PlanetSelectState() :
 	mFontBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	mTinyFont{Control::getDefaultFont()},
@@ -39,7 +42,7 @@ PlanetSelectState::PlanetSelectState() :
 	mHover{"sfx/menu4.ogg"},
 	mQuit{"Main Menu", {100, 20}, {this, &PlanetSelectState::onQuit}},
 	mPlanetDescription{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
-	mPlanetSelection{constants::NoSelection},
+	mPlanetSelection{NoSelection},
 	mReturnState{this},
 	mPlanets{attributesToPlanets(parsePlanetAttributes())}
 {
@@ -112,7 +115,7 @@ NAS2D::State* PlanetSelectState::update()
 	{
 		return this;
 	}
-	else if (mPlanetSelection != constants::NoSelection)
+	else if (mPlanetSelection != NoSelection)
 	{
 		return new GameState(mPlanets[mPlanetSelection].attributes(), Difficulty::Medium);
 	}

--- a/appOPHD/States/PlanetSelectState.cpp
+++ b/appOPHD/States/PlanetSelectState.cpp
@@ -28,7 +28,7 @@ namespace
 }
 
 
-std::size_t PlanetSelectState::NoSelection{std::numeric_limits<std::size_t>::max()};
+const std::size_t PlanetSelectState::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
 PlanetSelectState::PlanetSelectState() :

--- a/appOPHD/States/PlanetSelectState.h
+++ b/appOPHD/States/PlanetSelectState.h
@@ -20,6 +20,9 @@
 class PlanetSelectState : public NAS2D::State
 {
 public:
+	static std::size_t NoSelection;
+
+
 	PlanetSelectState();
 	~PlanetSelectState() override;
 

--- a/appOPHD/States/PlanetSelectState.h
+++ b/appOPHD/States/PlanetSelectState.h
@@ -20,7 +20,7 @@
 class PlanetSelectState : public NAS2D::State
 {
 public:
-	static std::size_t NoSelection;
+	static const std::size_t NoSelection;
 
 
 	PlanetSelectState();

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -11,9 +11,13 @@
 #include <algorithm>
 #include <stdexcept>
 #include <string>
+#include <limits>
 
 
 using namespace NAS2D;
+
+
+std::size_t IconGrid::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
 IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :
@@ -88,7 +92,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 
 	if (mSelectedIndex >= mIconItemList.size())
 	{
-		mSelectedIndex = constants::NoSelection;
+		mSelectedIndex = NoSelection;
 	}
 
 	if (previousIndex != mSelectedIndex)
@@ -105,7 +109,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 	auto startPoint = mRect.position;
 	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint, mGridSize * (mIconSize + mIconMargin)}.contains(position))
 	{
-		mHighlightIndex = constants::NoSelection;
+		mHighlightIndex = NoSelection;
 		return;
 	}
 
@@ -114,7 +118,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 
 	if (mHighlightIndex >= mIconItemList.size())
 	{
-		mHighlightIndex = constants::NoSelection;
+		mHighlightIndex = NoSelection;
 	}
 }
 
@@ -239,8 +243,8 @@ void IconGrid::clear()
  */
 void IconGrid::clearSelection()
 {
-	mHighlightIndex = constants::NoSelection;
-	mSelectedIndex = constants::NoSelection;
+	mHighlightIndex = NoSelection;
+	mSelectedIndex = NoSelection;
 }
 
 
@@ -249,7 +253,7 @@ void IconGrid::clearSelection()
  */
 void IconGrid::selection(std::size_t newSelection)
 {
-	mSelectedIndex = (newSelection < mIconItemList.size()) ? newSelection : constants::NoSelection;
+	mSelectedIndex = (newSelection < mIconItemList.size()) ? newSelection : NoSelection;
 }
 
 
@@ -287,7 +291,7 @@ void IconGrid::incrementSelection()
 
 	if (mIconItemList.empty())
 	{
-		mSelectedIndex = constants::NoSelection;
+		mSelectedIndex = NoSelection;
 	}
 
 	raiseChangedEvent();
@@ -304,7 +308,7 @@ void IconGrid::decrementSelection()
 
 	if (mIconItemList.empty())
 	{
-		mSelectedIndex = constants::NoSelection;
+		mSelectedIndex = NoSelection;
 	}
 
 	raiseChangedEvent();
@@ -313,7 +317,7 @@ void IconGrid::decrementSelection()
 
 void IconGrid::raiseChangedEvent()
 {
-	if (mSelectedIndex != constants::NoSelection)
+	if (mSelectedIndex != NoSelection)
 	{
 		mSignal(&mIconItemList[mSelectedIndex]);
 	}
@@ -358,13 +362,13 @@ void IconGrid::update()
 		renderer.drawSubImage(mIconSheet, position, NAS2D::Rectangle<int>{{mIconItemList[i].pos.x, mIconItemList[i].pos.y}, {mIconSize, mIconSize}}, highlightColor);
 	}
 
-	if (mSelectedIndex != constants::NoSelection)
+	if (mSelectedIndex != NoSelection)
 	{
 		const auto position = indexToGridPosition(mSelectedIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
 		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 100, 255});
 	}
 
-	if (mHighlightIndex != constants::NoSelection)
+	if (mHighlightIndex != NoSelection)
 	{
 		const auto position = indexToGridPosition(mHighlightIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
 		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 180, 0});

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -17,7 +17,7 @@
 using namespace NAS2D;
 
 
-std::size_t IconGrid::NoSelection{std::numeric_limits<std::size_t>::max()};
+const std::size_t IconGrid::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
 IconGrid::IconGrid(const std::string& filePath, int iconEdgeSize, int margin) :

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -36,6 +36,8 @@ public:
 
 	using Signal = NAS2D::Signal<const Item*>;
 
+	static std::size_t NoSelection;
+
 public:
 	IconGrid(const std::string& filePath, int iconSize, int margin);
 	~IconGrid() override;
@@ -92,8 +94,8 @@ private:
 
 	const NAS2D::Font& mFont;
 
-	Index mHighlightIndex = constants::NoSelection; /**< Current highlight index. */
-	Index mSelectedIndex = constants::NoSelection; /**< Currently selected item index. */
+	Index mHighlightIndex = NoSelection; /**< Current highlight index. */
+	Index mSelectedIndex = NoSelection; /**< Currently selected item index. */
 
 	int mIconSize = 1; /**< Size of the icons. */
 	int mIconMargin = 0; /**< Spacing between icons and edges of the IconGrid. */

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -36,7 +36,7 @@ public:
 
 	using Signal = NAS2D::Signal<const Item*>;
 
-	static std::size_t NoSelection;
+	static const std::size_t NoSelection;
 
 public:
 	IconGrid(const std::string& filePath, int iconSize, int margin);

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Resources.h"
+#include "../Constants/Numbers.h"
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../States/MapViewStateHelper.h"

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -9,7 +9,7 @@
 #include <limits>
 
 
-std::size_t ListBoxBase::NoSelection{std::numeric_limits<std::size_t>::max()};
+const std::size_t ListBoxBase::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
 ListBoxBase::ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold) :

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -26,7 +26,7 @@ class ListBoxBase : public Control
 public:
 	using SelectionChangeSignal = NAS2D::Signal<>;
 
-	static std::size_t NoSelection;
+	static const std::size_t NoSelection;
 
 
 	ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold);

--- a/libControls/RadioButtonGroup.cpp
+++ b/libControls/RadioButtonGroup.cpp
@@ -4,6 +4,10 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <algorithm>
+#include <limits>
+
+
+const std::size_t RadioButtonGroup::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
 RadioButtonGroup::RadioButtonGroup(std::vector<ButtonInfo> buttonInfos)

--- a/libControls/RadioButtonGroup.h
+++ b/libControls/RadioButtonGroup.h
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <string>
-#include <limits>
 
 
 class RadioButtonGroup : public Control
@@ -57,7 +56,7 @@ public:
 		NAS2D::Delegate<void()> delegate;
 	};
 
-	static inline constexpr auto NoSelection{std::numeric_limits<std::size_t>::max()};
+	static const std::size_t NoSelection;
 
 
 	RadioButtonGroup() = default;


### PR DESCRIPTION
Refactor header includes to reduce transitive inclusion.

Define `NoSelection` constant in each class that needs the concept. There's no reason the `NoSelection` for one class should relate to the `NoSelection` for another class. Potentially they could be made to be different types, so there would be no chance of confusing the two. Plus defining them separately means each class becomes more standalone. That makes it easier to move source files around, or sort them into different sub-projects.

Related:
- Issue #1422
