### PR TITLE
Refactor `IconGrid` mouse handling

### DIFF
--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -293,7 +293,7 @@ void IconGrid::onResize()
 
 void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 {
-	if (!enabled() || !visible()) { return; }
+	if (!enabled() || !visible() || !mRect.contains(position)) { return; }
 
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -305,7 +305,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	}
 
 	auto previousIndex = mSelectedIndex;
-	mSelectedIndex = translateCoordsToIndex(position - startPoint);
+	mSelectedIndex = translateCoordsToIndex(position);
 
 	if (previousIndex != mSelectedIndex)
 	{
@@ -326,12 +326,13 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 	}
 
 	// Assumes all coordinates are not negative.
-	mHighlightIndex = translateCoordsToIndex(position - startPoint);
+	mHighlightIndex = translateCoordsToIndex(position);
 }
 
 
-IconGrid::Index IconGrid::translateCoordsToIndex(NAS2D::Vector<int> relativeOffset) const
+IconGrid::Index IconGrid::translateCoordsToIndex(NAS2D::Point<int> position) const
 {
+	const auto relativeOffset = position - mRect.position;
 	const auto gridOffset = (relativeOffset / (mIconSize + mIconMargin)).to<Index>();
 	const auto index = gridOffset.x + (static_cast<Index>(mGridSizeInIcons.x) * gridOffset.y);
 	return (index >= mIconItemList.size()) ? NoSelection : index;

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -298,8 +298,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }
 
-	auto startPoint = mRect.position;
-	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{mRect.position, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
 	{
 		return;
 	}
@@ -318,8 +317,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 {
 	if (!enabled() || !visible()) { return; }
 
-	auto startPoint = mRect.position;
-	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
+	if (mIconItemList.empty() || !NAS2D::Rectangle{mRect.position, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
 	{
 		mHighlightIndex = NoSelection;
 		return;

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -294,8 +294,6 @@ void IconGrid::onResize()
 void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible() || !mRect.contains(position)) { return; }
-
-	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }
 
 	const auto iconIndex = translateCoordsToIndex(position);

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -298,11 +298,10 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }
 
-	auto previousIndex = mSelectedIndex;
-	mSelectedIndex = translateCoordsToIndex(position);
-
-	if (previousIndex != mSelectedIndex)
+	const auto iconIndex = translateCoordsToIndex(position);
+	if (mSelectedIndex != iconIndex)
 	{
+		mSelectedIndex = iconIndex;
 		raiseChangedEvent();
 	}
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -298,11 +298,6 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }
 
-	if (!isInGridArea(position))
-	{
-		return;
-	}
-
 	auto previousIndex = mSelectedIndex;
 	mSelectedIndex = translateCoordsToIndex(position);
 

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -296,7 +296,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	if (!enabled() || !visible() || !mRect.contains(position)) { return; }
 	if (button != MouseButton::Left) { return; }
 
-	const auto iconIndex = translateCoordsToIndex(position);
+	const auto iconIndex = positionToIndex(position);
 	if (mSelectedIndex != iconIndex)
 	{
 		mSelectedIndex = iconIndex;
@@ -309,7 +309,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 {
 	if (!enabled() || !visible()) { return; }
 
-	mHighlightIndex = translateCoordsToIndex(position);
+	mHighlightIndex = positionToIndex(position);
 }
 
 
@@ -319,7 +319,7 @@ bool IconGrid::isInGridArea(NAS2D::Point<int> position) const
 }
 
 
-IconGrid::Index IconGrid::translateCoordsToIndex(NAS2D::Point<int> position) const
+IconGrid::Index IconGrid::positionToIndex(NAS2D::Point<int> position) const
 {
 	if (!isInGridArea(position)) { return NoSelection; }
 	const auto relativeOffset = position - mRect.position;

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -317,13 +317,6 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (!isInGridArea(position))
-	{
-		mHighlightIndex = NoSelection;
-		return;
-	}
-
-	// Assumes all coordinates are not negative.
 	mHighlightIndex = translateCoordsToIndex(position);
 }
 
@@ -336,6 +329,7 @@ bool IconGrid::isInGridArea(NAS2D::Point<int> position) const
 
 IconGrid::Index IconGrid::translateCoordsToIndex(NAS2D::Point<int> position) const
 {
+	if (!isInGridArea(position)) { return NoSelection; }
 	const auto relativeOffset = position - mRect.position;
 	const auto gridOffset = (relativeOffset / (mIconSize + mIconMargin)).to<Index>();
 	const auto index = gridOffset.x + (static_cast<Index>(mGridSizeInIcons.x) * gridOffset.y);

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -298,7 +298,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }
 
-	if (mIconItemList.empty() || !NAS2D::Rectangle{mRect.position, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
+	if (!isInGridArea(position))
 	{
 		return;
 	}
@@ -317,7 +317,7 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 {
 	if (!enabled() || !visible()) { return; }
 
-	if (mIconItemList.empty() || !NAS2D::Rectangle{mRect.position, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
+	if (!isInGridArea(position))
 	{
 		mHighlightIndex = NoSelection;
 		return;
@@ -325,6 +325,12 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 
 	// Assumes all coordinates are not negative.
 	mHighlightIndex = translateCoordsToIndex(position);
+}
+
+
+bool IconGrid::isInGridArea(NAS2D::Point<int> position) const
+{
+	return !mIconItemList.empty() && NAS2D::Rectangle{mRect.position, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position);
 }
 
 

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -307,11 +307,6 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	auto previousIndex = mSelectedIndex;
 	mSelectedIndex = translateCoordsToIndex(position - startPoint);
 
-	if (mSelectedIndex >= mIconItemList.size())
-	{
-		mSelectedIndex = NoSelection;
-	}
-
 	if (previousIndex != mSelectedIndex)
 	{
 		raiseChangedEvent();
@@ -332,16 +327,12 @@ void IconGrid::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*rela
 
 	// Assumes all coordinates are not negative.
 	mHighlightIndex = translateCoordsToIndex(position - startPoint);
-
-	if (mHighlightIndex >= mIconItemList.size())
-	{
-		mHighlightIndex = NoSelection;
-	}
 }
 
 
 IconGrid::Index IconGrid::translateCoordsToIndex(NAS2D::Vector<int> relativeOffset) const
 {
 	const auto gridOffset = (relativeOffset / (mIconSize + mIconMargin)).to<Index>();
-	return gridOffset.x + (static_cast<Index>(mGridSizeInIcons.x) * gridOffset.y);
+	const auto index = gridOffset.x + (static_cast<Index>(mGridSizeInIcons.x) * gridOffset.y);
+	return (index >= mIconItemList.size()) ? NoSelection : index;
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -298,11 +298,6 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	// Don't respond to anything unless it's the left mouse button.
 	if (button != MouseButton::Left) { return; }
 
-	if (!visible())
-	{
-		return;
-	}
-
 	auto startPoint = mRect.position;
 	if (mIconItemList.empty() || !NAS2D::Rectangle{startPoint, mGridSizeInIcons * (mIconSize + mIconMargin)}.contains(position))
 	{

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -70,6 +70,7 @@ protected:
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
+	bool isInGridArea(NAS2D::Point<int> position) const;
 	Index translateCoordsToIndex(NAS2D::Point<int> position) const;
 
 	void raiseChangedEvent() const;

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -70,7 +70,7 @@ protected:
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
-	Index translateCoordsToIndex(NAS2D::Vector<int> relativeOffset) const;
+	Index translateCoordsToIndex(NAS2D::Point<int> position) const;
 
 	void raiseChangedEvent() const;
 

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -71,7 +71,7 @@ protected:
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	bool isInGridArea(NAS2D::Point<int> position) const;
-	Index translateCoordsToIndex(NAS2D::Point<int> position) const;
+	Index positionToIndex(NAS2D::Point<int> position) const;
 
 	void raiseChangedEvent() const;
 


### PR DESCRIPTION
Refactor `IconGrid` mouse handling code.

Technically there is a slight behavior change, where clicks within the control but outside of the grid area will now be handled as making a `NoSelection` choice. Previously the click needed to be in the grid area and not on an icon to make a `NoSelection` choice. This might be considered a bug fix, as the behavior is now more consistent regarding clicks within the control and not on an icon.

Related:
- PR #1718
- Issue #1191
