### PR TITLE
Fix `IconGrid` draw offset

### DIFF
--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -241,28 +241,23 @@ void IconGrid::update()
 	mSkin.draw(renderer, mRect);
 
 	if (mGridSizeInIcons.x == 0) { return; }
-	const auto indexToGridPosition = [gridSize = mGridSizeInIcons, startPoint = mRect.position, spacing = mIconSize + mIconMargin](Index index) {
-		const auto linearOffset = static_cast<int>(index);
-		const auto offset = NAS2D::Vector{linearOffset % gridSize.x, linearOffset / gridSize.x};
-		return startPoint + offset * spacing;
-	};
 
 	for (Index i = 0; i < mIconItemList.size(); ++i)
 	{
-		const auto position = indexToGridPosition(i) + NAS2D::Vector{mIconMargin, mIconMargin};
+		const auto position = indexToPosition(i);
 		const auto highlightColor = mIconItemList[i].available ? NAS2D::Color::White : NAS2D::Color::Red;
 		renderer.drawSubImage(mIconSheet, position, NAS2D::Rectangle<int>{{mIconItemList[i].pos.x, mIconItemList[i].pos.y}, {mIconSize, mIconSize}}, highlightColor);
 	}
 
 	if (mSelectedIndex != NoSelection)
 	{
-		const auto position = indexToGridPosition(mSelectedIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
+		const auto position = indexToPosition(mSelectedIndex);
 		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 100, 255});
 	}
 
 	if (mHighlightIndex != NoSelection)
 	{
-		const auto position = indexToGridPosition(mHighlightIndex) + NAS2D::Vector{mIconMargin, mIconMargin};
+		const auto position = indexToPosition(mHighlightIndex);
 		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 180, 0});
 
 		// Name Tooltip
@@ -321,4 +316,14 @@ IconGrid::Index IconGrid::positionToIndex(NAS2D::Point<int> position) const
 	const auto gridOffset = (relativeOffset / (mIconSize + mIconMargin)).to<Index>();
 	const auto index = gridOffset.x + (static_cast<Index>(mGridSizeInIcons.x) * gridOffset.y);
 	return (index >= mIconItemList.size()) ? NoSelection : index;
+}
+
+
+NAS2D::Point<int> IconGrid::indexToPosition(Index index) const
+{
+	// Assume a width of a least one grid icon, so we avoid division by 0
+	const auto divisor = std::max(mGridSizeInIcons.x, 1);
+	const auto linearOffset = static_cast<int>(index);
+	const auto offset = NAS2D::Vector{linearOffset % divisor, linearOffset / divisor};
+	return mRect.position + NAS2D::Vector{mIconMargin, mIconMargin} + offset * (mIconSize + mIconMargin);
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -264,11 +264,13 @@ void IconGrid::update()
 		if (mShowTooltip)
 		{
 			const auto& highlightedName = mIconItemList[mHighlightIndex].name;
-			const auto& position = iconArea.position;
-			const auto tooltipRect = NAS2D::Rectangle<int>{{position.x, position.y - 15}, {mFont.width(highlightedName) + 4, mFont.height()}};
+			const auto textMargin = NAS2D::Vector{2, 0};
+			const auto textBoxSize = mFont.size(highlightedName) + textMargin * 2;
+			const auto textBoxOffset = NAS2D::Vector{0, -15};
+			const auto tooltipRect = NAS2D::Rectangle{iconArea.position + textBoxOffset, textBoxSize};
 			renderer.drawBoxFilled(tooltipRect, NAS2D::Color{245, 245, 245});
 			renderer.drawBox(tooltipRect, NAS2D::Color{175, 175, 175});
-			renderer.drawText(mFont, highlightedName, position + NAS2D::Vector{2, -15}, NAS2D::Color::Black);
+			renderer.drawText(mFont, highlightedName, tooltipRect.position + textMargin, NAS2D::Color::Black);
 		}
 	}
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -249,7 +249,7 @@ void IconGrid::update()
 
 	for (Index i = 0; i < mIconItemList.size(); ++i)
 	{
-		const auto position = indexToGridPosition(i);
+		const auto position = indexToGridPosition(i) + NAS2D::Vector{mIconMargin, mIconMargin};
 		const auto highlightColor = mIconItemList[i].available ? NAS2D::Color::White : NAS2D::Color::Red;
 		renderer.drawSubImage(mIconSheet, position, NAS2D::Rectangle<int>{{mIconItemList[i].pos.x, mIconItemList[i].pos.y}, {mIconSize, mIconSize}}, highlightColor);
 	}

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -266,7 +266,7 @@ void IconGrid::update()
 			const auto& highlightedName = mIconItemList[mHighlightIndex].name;
 			const auto textMargin = NAS2D::Vector{2, 0};
 			const auto textBoxSize = mFont.size(highlightedName) + textMargin * 2;
-			const auto textBoxOffset = NAS2D::Vector{0, -15};
+			const auto textBoxOffset = NAS2D::Vector{0, -textBoxSize.y};
 			const auto tooltipRect = NAS2D::Rectangle{iconArea.position + textBoxOffset, textBoxSize};
 			renderer.drawBoxFilled(tooltipRect, NAS2D::Color{245, 245, 245});
 			renderer.drawBox(tooltipRect, NAS2D::Color{175, 175, 175});

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -244,26 +244,27 @@ void IconGrid::update()
 
 	for (Index i = 0; i < mIconItemList.size(); ++i)
 	{
-		const auto position = indexToPosition(i);
+		const auto iconArea = indexToArea(i);
 		const auto highlightColor = mIconItemList[i].available ? NAS2D::Color::White : NAS2D::Color::Red;
-		renderer.drawSubImage(mIconSheet, position, NAS2D::Rectangle<int>{{mIconItemList[i].pos.x, mIconItemList[i].pos.y}, {mIconSize, mIconSize}}, highlightColor);
+		renderer.drawSubImage(mIconSheet, iconArea.position, NAS2D::Rectangle<int>{{mIconItemList[i].pos.x, mIconItemList[i].pos.y}, iconArea.size}, highlightColor);
 	}
 
 	if (mSelectedIndex != NoSelection)
 	{
-		const auto position = indexToPosition(mSelectedIndex);
-		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 100, 255});
+		const auto iconArea = indexToArea(mSelectedIndex);
+		renderer.drawBox(iconArea, NAS2D::Color{0, 100, 255});
 	}
 
 	if (mHighlightIndex != NoSelection)
 	{
-		const auto position = indexToPosition(mHighlightIndex);
-		renderer.drawBox(NAS2D::Rectangle{position, {mIconSize, mIconSize}}, NAS2D::Color{0, 180, 0});
+		const auto iconArea = indexToArea(mHighlightIndex);
+		renderer.drawBox(iconArea, NAS2D::Color{0, 180, 0});
 
 		// Name Tooltip
 		if (mShowTooltip)
 		{
 			const auto& highlightedName = mIconItemList[mHighlightIndex].name;
+			const auto& position = iconArea.position;
 			const auto tooltipRect = NAS2D::Rectangle<int>{{position.x, position.y - 15}, {mFont.width(highlightedName) + 4, mFont.height()}};
 			renderer.drawBoxFilled(tooltipRect, NAS2D::Color{245, 245, 245});
 			renderer.drawBox(tooltipRect, NAS2D::Color{175, 175, 175});
@@ -326,4 +327,10 @@ NAS2D::Point<int> IconGrid::indexToPosition(Index index) const
 	const auto linearOffset = static_cast<int>(index);
 	const auto offset = NAS2D::Vector{linearOffset % divisor, linearOffset / divisor};
 	return mRect.position + NAS2D::Vector{mIconMargin, mIconMargin} + offset * (mIconSize + mIconMargin);
+}
+
+
+NAS2D::Rectangle<int> IconGrid::indexToArea(Index index) const
+{
+	return NAS2D::Rectangle{indexToPosition(index), {mIconSize, mIconSize}};
 }

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -6,6 +6,7 @@
 #include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
+#include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Renderer/RectangleSkin.h>
 #include <NAS2D/Resource/Font.h>
 #include <NAS2D/Resource/Image.h>
@@ -69,6 +70,7 @@ protected:
 	bool isInGridArea(NAS2D::Point<int> position) const;
 	Index positionToIndex(NAS2D::Point<int> position) const;
 	NAS2D::Point<int> indexToPosition(Index index) const;
+	NAS2D::Rectangle<int> indexToArea(Index index) const;
 
 	void raiseChangedEvent() const;
 

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -68,6 +68,7 @@ protected:
 
 	bool isInGridArea(NAS2D::Point<int> position) const;
 	Index positionToIndex(NAS2D::Point<int> position) const;
+	NAS2D::Point<int> indexToPosition(Index index) const;
 
 	void raiseChangedEvent() const;
 


### PR DESCRIPTION
Fix drawing offsets in `IconGrid`, so icons are centered in highlight boxes, and tooltip text is offset far enough away to not overlap.

Original:
![image](https://github.com/user-attachments/assets/45e94df8-1a78-4bcd-ba66-f86c6fd87f74)

Updated:
![image](https://github.com/user-attachments/assets/1f4318f4-a04b-43bf-94c1-799d069cb0e4)

Related:
- Issue #1721
