### PR TITLE
Use `dynamic_cast` for downcasting

### DIFF
--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -85,7 +85,7 @@ void CrimeExecution::executeCrimes(const std::vector<Structure*>& structuresComm
 		switch (structure->structureId())
 		{
 		case StructureID::SID_AGRIDOME:
-			stealFood(static_cast<FoodProduction&>(*structure));
+			stealFood(dynamic_cast<FoodProduction&>(*structure));
 			break;
 		case StructureID::SID_SMELTER:
 			stealRawResources(*structure);

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -356,7 +356,7 @@ void MainReportsUiState::selectMinePanel(Structure* structure)
 void MainReportsUiState::injectTechnology(TechnologyCatalog& catalog, ResearchTracker& tracker)
 {
 	auto researchPanel = Panels[static_cast<size_t>(NavigationPanel::Research)].UiPanel;
-	static_cast<ResearchReport*>(researchPanel)->injectTechReferences(catalog, tracker);
+	dynamic_cast<ResearchReport*>(researchPanel)->injectTechReferences(catalog, tracker);
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -355,8 +355,8 @@ void MainReportsUiState::selectMinePanel(Structure* structure)
 
 void MainReportsUiState::injectTechnology(TechnologyCatalog& catalog, ResearchTracker& tracker)
 {
-	auto researchPanel = Panels[static_cast<size_t>(NavigationPanel::Research)].UiPanel;
-	dynamic_cast<ResearchReport*>(researchPanel)->injectTechReferences(catalog, tracker);
+	auto* researchPanel = Panels[static_cast<size_t>(NavigationPanel::Research)].UiPanel;
+	dynamic_cast<ResearchReport&>(*researchPanel).injectTechReferences(catalog, tracker);
 }
 
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1035,7 +1035,8 @@ void MapViewState::placeRobodozer(Tile& tile)
 
 		if (structure->isWarehouse())
 		{
-			if (simulateMoveProducts(dynamic_cast<Warehouse*>(structure))) { moveProducts(dynamic_cast<Warehouse*>(structure)); }
+			auto* warehouse = dynamic_cast<Warehouse*>(structure);
+			if (simulateMoveProducts(warehouse)) { moveProducts(warehouse); }
 			else { return; }
 		}
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -658,19 +658,19 @@ void MapViewState::onInspectStructure(Structure& structure, bool inspectModifier
 
 	if (structure.isFactory() && preferStructureSpecificView)
 	{
-		mFactoryProduction.factory(&static_cast<Factory&>(structure));
+		mFactoryProduction.factory(&dynamic_cast<Factory&>(structure));
 		mFactoryProduction.show();
 		mWindowStack.bringToFront(&mFactoryProduction);
 	}
 	else if (structure.isWarehouse() && preferStructureSpecificView)
 	{
-		mWarehouseInspector.warehouse(&static_cast<Warehouse&>(structure));
+		mWarehouseInspector.warehouse(&dynamic_cast<Warehouse&>(structure));
 		mWarehouseInspector.show();
 		mWindowStack.bringToFront(&mWarehouseInspector);
 	}
 	else if (structure.isMineFacility() && preferStructureSpecificView)
 	{
-		mMineOperationsWindow.mineFacility(&static_cast<MineFacility&>(structure));
+		mMineOperationsWindow.mineFacility(&dynamic_cast<MineFacility&>(structure));
 		mMineOperationsWindow.show();
 		mWindowStack.bringToFront(&mMineOperationsWindow);
 	}
@@ -921,14 +921,14 @@ void MapViewState::placeStructure(Tile& tile)
 
 		if (structure.isFactory())
 		{
-			auto& factory = static_cast<Factory&>(structure);
+			auto& factory = dynamic_cast<Factory&>(structure);
 			factory.productionComplete().connect({this, &MapViewState::onFactoryProductionComplete});
 			factory.resourcePool(&mResourcesCount);
 		}
 
 		if (structure.structureId() == StructureID::SID_MAINTENANCE_FACILITY)
 		{
-			static_cast<MaintenanceFacility&>(structure).resources(mResourcesCount);
+			dynamic_cast<MaintenanceFacility&>(structure).resources(mResourcesCount);
 		}
 
 		auto cost = StructureCatalogue::costToBuild(mCurrentStructure);
@@ -1028,14 +1028,14 @@ void MapViewState::placeRobodozer(Tile& tile)
 			}
 		}
 
-		if (structure->isFactory() && static_cast<Factory*>(structure) == mFactoryProduction.factory())
+		if (structure->isFactory() && dynamic_cast<Factory*>(structure) == mFactoryProduction.factory())
 		{
 			mFactoryProduction.hide();
 		}
 
 		if (structure->isWarehouse())
 		{
-			if (simulateMoveProducts(static_cast<Warehouse*>(structure))) { moveProducts(static_cast<Warehouse*>(structure)); }
+			if (simulateMoveProducts(dynamic_cast<Warehouse*>(structure))) { moveProducts(dynamic_cast<Warehouse*>(structure)); }
 			else { return; }
 		}
 

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -190,7 +190,7 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
 		throw std::runtime_error("Digger defines a depth that exceeds the maximum digging depth!");
 	}
 
-	const auto dir = dynamic_cast<Robodigger*>(&robot)->direction(); // fugly
+	const auto dir = dynamic_cast<Robodigger&>(robot).direction(); // fugly
 	auto newPosition = position.translate(dir);
 
 	if (dir == Direction::Down)
@@ -234,7 +234,7 @@ void MapViewState::onMinerTaskComplete(Robot& robot)
 	if (mRobotList.find(&robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::onMinerTaskComplete() called with a Robot not in the Robot List!"); }
 
 	auto& robotTile = *mRobotList[&robot];
-	auto& miner = *dynamic_cast<Robominer*>(&robot);
+	auto& miner = dynamic_cast<Robominer&>(robot);
 
 	auto& mineFacility = miner.buildMine(*mTileMap, robotTile.xyz());
 	mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -151,7 +151,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 		structures.push_back(structure);
 	}
 
-	auto& seedFactory = *static_cast<SeedFactory*>(structures[2]);
+	auto& seedFactory = *dynamic_cast<SeedFactory*>(structures[2]);
 	seedFactory.resourcePool(&mResourcesCount);
 	seedFactory.productionComplete().connect({this, &MapViewState::onFactoryProductionComplete});
 
@@ -190,7 +190,7 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
 		throw std::runtime_error("Digger defines a depth that exceeds the maximum digging depth!");
 	}
 
-	const auto dir = static_cast<Robodigger*>(&robot)->direction(); // fugly
+	const auto dir = dynamic_cast<Robodigger*>(&robot)->direction(); // fugly
 	auto newPosition = position.translate(dir);
 
 	if (dir == Direction::Down)
@@ -234,7 +234,7 @@ void MapViewState::onMinerTaskComplete(Robot& robot)
 	if (mRobotList.find(&robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::onMinerTaskComplete() called with a Robot not in the Robot List!"); }
 
 	auto& robotTile = *mRobotList[&robot];
-	auto& miner = *static_cast<Robominer*>(&robot);
+	auto& miner = *dynamic_cast<Robominer*>(&robot);
 
 	auto& mineFacility = miner.buildMine(*mTileMap, robotTile.xyz());
 	mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -411,12 +411,12 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structureId == StructureID::SID_COLONIST_LANDER)
 		{
-			dynamic_cast<ColonistLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployColonistLander});
+			dynamic_cast<ColonistLander&>(structure).deploySignal().connect({this, &MapViewState::onDeployColonistLander});
 		}
 
 		if (structureId == StructureID::SID_CARGO_LANDER)
 		{
-			dynamic_cast<CargoLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployCargoLander});
+			dynamic_cast<CargoLander&>(structure).deploySignal().connect({this, &MapViewState::onDeployCargoLander});
 		}
 
 		if (structureId == StructureID::SID_MINE_FACILITY)
@@ -427,7 +427,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 				throw std::runtime_error("Mine Facility is located on a Tile with no Ore Deposit.");
 			}
 
-			auto& mineFacility = *dynamic_cast<MineFacility*>(&structure);
+			auto& mineFacility = dynamic_cast<MineFacility&>(structure);
 			mineFacility.oreDeposit(oreDeposit);
 			mineFacility.maxDepth(mTileMap->maxDepth());
 			mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});
@@ -447,18 +447,18 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structureId == StructureID::SID_AIR_SHAFT && mapCoordinate.z != 0)
 		{
-			dynamic_cast<AirShaft*>(&structure)->ug(); // force underground state
+			dynamic_cast<AirShaft&>(structure).ug(); // force underground state
 		}
 
 		if (structureId == StructureID::SID_SEED_LANDER)
 		{
-			dynamic_cast<SeedLander*>(&structure)->position(mapCoordinate.xy);
+			dynamic_cast<SeedLander&>(structure).position(mapCoordinate.xy);
 		}
 
 		if (structureId == StructureID::SID_AGRIDOME ||
 			structureId == StructureID::SID_COMMAND_CENTER)
 		{
-			auto& foodProduction = *dynamic_cast<FoodProduction*>(&structure);
+			auto& foodProduction = dynamic_cast<FoodProduction&>(structure);
 
 			auto foodStorage = structureElement->firstChildElement("food");
 			if (foodStorage == nullptr)
@@ -494,7 +494,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			auto personnel = structureElement->firstChildElement("personnel");
 			if (personnel)
 			{
-				auto& maintenanceFacility = *dynamic_cast<MaintenanceFacility*>(&structure);
+				auto& maintenanceFacility = dynamic_cast<MaintenanceFacility&>(structure);
 				maintenanceFacility.personnel(NAS2D::attributesToDictionary(*personnel).get<int>("assigned", 0));
 				maintenanceFacility.resources(mResourcesCount);
 			}
@@ -502,7 +502,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structure.isWarehouse())
 		{
-			auto& warehouse = *dynamic_cast<Warehouse*>(&structure);
+			auto& warehouse = dynamic_cast<Warehouse&>(structure);
 			warehouse.products().deserialize(NAS2D::attributesToDictionary(
 				*structureElement->firstChildElement("warehouse_products")
 			));
@@ -510,7 +510,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structure.isFactory())
 		{
-			auto& factory = *dynamic_cast<Factory*>(&structure);
+			auto& factory = dynamic_cast<Factory&>(structure);
 			factory.productType(static_cast<ProductType>(production_type));
 			factory.productionTurnsCompleted(production_completed);
 			factory.resourcePool(&mResourcesCount);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -349,7 +349,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		auto& robot = addRobot(robotType);
 		if (robotType == Robot::Type::Digger)
 		{
-			static_cast<Robodigger&>(robot).direction(static_cast<Direction>(direction));
+			dynamic_cast<Robodigger&>(robot).direction(static_cast<Direction>(direction));
 		}
 
 		robot.fuelCellAge(age);
@@ -411,12 +411,12 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structureId == StructureID::SID_COLONIST_LANDER)
 		{
-			static_cast<ColonistLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployColonistLander});
+			dynamic_cast<ColonistLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployColonistLander});
 		}
 
 		if (structureId == StructureID::SID_CARGO_LANDER)
 		{
-			static_cast<CargoLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployCargoLander});
+			dynamic_cast<CargoLander*>(&structure)->deploySignal().connect({this, &MapViewState::onDeployCargoLander});
 		}
 
 		if (structureId == StructureID::SID_MINE_FACILITY)
@@ -427,7 +427,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 				throw std::runtime_error("Mine Facility is located on a Tile with no Ore Deposit.");
 			}
 
-			auto& mineFacility = *static_cast<MineFacility*>(&structure);
+			auto& mineFacility = *dynamic_cast<MineFacility*>(&structure);
 			mineFacility.oreDeposit(oreDeposit);
 			mineFacility.maxDepth(mTileMap->maxDepth());
 			mineFacility.extensionComplete().connect({this, &MapViewState::onMineFacilityExtend});
@@ -447,18 +447,18 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structureId == StructureID::SID_AIR_SHAFT && mapCoordinate.z != 0)
 		{
-			static_cast<AirShaft*>(&structure)->ug(); // force underground state
+			dynamic_cast<AirShaft*>(&structure)->ug(); // force underground state
 		}
 
 		if (structureId == StructureID::SID_SEED_LANDER)
 		{
-			static_cast<SeedLander*>(&structure)->position(mapCoordinate.xy);
+			dynamic_cast<SeedLander*>(&structure)->position(mapCoordinate.xy);
 		}
 
 		if (structureId == StructureID::SID_AGRIDOME ||
 			structureId == StructureID::SID_COMMAND_CENTER)
 		{
-			auto& foodProduction = *static_cast<FoodProduction*>(&structure);
+			auto& foodProduction = *dynamic_cast<FoodProduction*>(&structure);
 
 			auto foodStorage = structureElement->firstChildElement("food");
 			if (foodStorage == nullptr)
@@ -494,7 +494,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			auto personnel = structureElement->firstChildElement("personnel");
 			if (personnel)
 			{
-				auto& maintenanceFacility = *static_cast<MaintenanceFacility*>(&structure);
+				auto& maintenanceFacility = *dynamic_cast<MaintenanceFacility*>(&structure);
 				maintenanceFacility.personnel(NAS2D::attributesToDictionary(*personnel).get<int>("assigned", 0));
 				maintenanceFacility.resources(mResourcesCount);
 			}
@@ -502,7 +502,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structure.isWarehouse())
 		{
-			auto& warehouse = *static_cast<Warehouse*>(&structure);
+			auto& warehouse = *dynamic_cast<Warehouse*>(&structure);
 			warehouse.products().deserialize(NAS2D::attributesToDictionary(
 				*structureElement->firstChildElement("warehouse_products")
 			));
@@ -510,7 +510,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structure.isFactory())
 		{
-			auto& factory = *static_cast<Factory*>(&structure);
+			auto& factory = *dynamic_cast<Factory*>(&structure);
 			factory.productType(static_cast<ProductType>(production_type));
 			factory.productionTurnsCompleted(production_completed);
 			factory.resourcePool(&mResourcesCount);

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -365,8 +365,8 @@ void MapViewState::transportOreFromMines()
 		if (routeIt != routeTable.end())
 		{
 			const auto& route = routeIt->second;
-			auto& smelter = *dynamic_cast<OreRefining*>(static_cast<Tile*>(route.path.back())->structure());
-			auto& mineFacility = *dynamic_cast<MineFacility*>(static_cast<Tile*>(route.path.front())->structure());
+			auto& smelter = dynamic_cast<OreRefining&>(*static_cast<Tile*>(route.path.back())->structure());
+			auto& mineFacility = dynamic_cast<MineFacility&>(*static_cast<Tile*>(route.path.front())->structure());
 
 			if (!smelter.operational()) { break; }
 
@@ -524,8 +524,8 @@ void MapViewState::updateBiowasteRecycling()
 				return; // No more residences, so don't waste time iterating over remaining recycling facilities
 			}
 
-			Residence* residence = dynamic_cast<Residence*>(*residenceIterator);
-			residence->pullWaste(recycling->wasteProcessingCapacity());
+			auto& residence = dynamic_cast<Residence&>(**residenceIterator);
+			residence.pullWaste(recycling->wasteProcessingCapacity());
 			++residenceIterator;
 		}
 	}

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -365,8 +365,8 @@ void MapViewState::transportOreFromMines()
 		if (routeIt != routeTable.end())
 		{
 			const auto& route = routeIt->second;
-			auto& smelter = *static_cast<OreRefining*>(static_cast<Tile*>(route.path.back())->structure());
-			auto& mineFacility = *static_cast<MineFacility*>(static_cast<Tile*>(route.path.front())->structure());
+			auto& smelter = *dynamic_cast<OreRefining*>(static_cast<Tile*>(route.path.back())->structure());
+			auto& mineFacility = *dynamic_cast<MineFacility*>(static_cast<Tile*>(route.path.front())->structure());
 
 			if (!smelter.operational()) { break; }
 
@@ -524,7 +524,7 @@ void MapViewState::updateBiowasteRecycling()
 				return; // No more residences, so don't waste time iterating over remaining recycling facilities
 			}
 
-			Residence* residence = static_cast<Residence*>(*residenceIterator);
+			Residence* residence = dynamic_cast<Residence*>(*residenceIterator);
 			residence->pullWaste(recycling->wasteProcessingCapacity());
 			++residenceIterator;
 		}
@@ -565,7 +565,7 @@ void MapViewState::transferFoodToCommandCenter()
 
 		while (foodProducerIterator != foodProducers.end())
 		{
-			auto foodProducer = static_cast<FoodProduction*>(*foodProducerIterator);
+			auto foodProducer = dynamic_cast<FoodProduction*>(*foodProducerIterator);
 			const int foodMoved = std::clamp(foodToMove, 0, foodProducer->foodLevel());
 			foodProducer->foodLevel(foodProducer->foodLevel() - foodMoved);
 			commandCenter->foodLevel(commandCenter->foodLevel() + foodMoved);

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -72,7 +72,7 @@ namespace
 		{
 			structureElement->linkEndChild(NAS2D::dictionaryToAttributes(
 				"warehouse_products",
-				static_cast<const Warehouse&>(structure).products().serialize()
+				dynamic_cast<const Warehouse&>(structure).products().serialize()
 			));
 		}
 
@@ -81,7 +81,7 @@ namespace
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
 					"food",
-					{{{"level", static_cast<const FoodProduction&>(structure).foodLevel()}}}
+					{{{"level", dynamic_cast<const FoodProduction&>(structure).foodLevel()}}}
 				)
 			);
 		}
@@ -101,7 +101,7 @@ namespace
 
 		if (structure.isMineFacility())
 		{
-			const auto& facility = static_cast<const MineFacility&>(structure);
+			const auto& facility = dynamic_cast<const MineFacility&>(structure);
 
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
@@ -119,7 +119,7 @@ namespace
 
 		if (structure.structureClass() == Structure::StructureClass::Maintenance)
 		{
-			auto& maintenance = static_cast<const MaintenanceFacility&>(structure);
+			auto& maintenance = dynamic_cast<const MaintenanceFacility&>(structure);
 			structureElement->linkEndChild(
 				NAS2D::dictionaryToAttributes(
 					"personnel",
@@ -364,7 +364,7 @@ void StructureManager::updateEnergyProduction()
 
 	for (auto* structure : mStructureLists[Structure::StructureClass::EnergyProduction])
 	{
-		auto powerStructure = static_cast<PowerStructure*>(structure);
+		auto* powerStructure = dynamic_cast<PowerStructure*>(structure);
 		if (powerStructure->operational())
 		{
 			mTotalEnergyOutput += powerStructure->energyProduced();
@@ -414,7 +414,7 @@ void StructureManager::assignScientistsToResearchFacilities(PopulationPool& popu
 	int availableScientists = population.availableScientists();
 	for (auto* laboratory : mStructureLists[Structure::StructureClass::Laboratory])
 	{
-		ResearchFacility* lab = static_cast<ResearchFacility*>(laboratory);
+		auto* lab = dynamic_cast<ResearchFacility*>(laboratory);
 		lab->assignScientists(0);
 		if (lab->operational())
 		{


### PR DESCRIPTION
Use `dynamic_cast` rather than `static_cast` when converting a base class pointer/reference to a derived type.

Prefer reference syntax when we're not checking for cast failures with `nullptr`, as it will `throw` an exception rather than return `nullptr`.

Closes #1676
