### PR TITLE
Add `policeRange` data to `StructureTypes.xml`

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -278,6 +278,11 @@ int Structure::commRange() const
 	return operational() ? mStructureType.commRange : 0;
 }
 
+int Structure::policeRange() const
+{
+	return operational() ? mStructureType.policeRange : 0;
+}
+
 bool Structure::hasCrime() const
 {
 	return mStructureType.isCrimeTarget;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -139,6 +139,7 @@ public:
 	int foodStorageCapacity() const;
 	int storageCapacity() const;
 	int commRange() const;
+	int policeRange() const;
 
 	bool hasCrime() const;
 	int crimeRate() const { return mCrimeRate; }

--- a/appOPHD/MapObjects/Structures/SurfacePolice.h
+++ b/appOPHD/MapObjects/Structures/SurfacePolice.h
@@ -14,6 +14,6 @@ public:
 
 	int getRange() const
 	{
-		return 5;
+		return policeRange();
 	}
 };

--- a/appOPHD/MapObjects/Structures/UndergroundPolice.h
+++ b/appOPHD/MapObjects/Structures/UndergroundPolice.h
@@ -14,6 +14,6 @@ public:
 
 	int getRange() const
 	{
-		return 5;
+		return policeRange();
 	}
 };

--- a/appOPHD/StructureCatalogue.cpp
+++ b/appOPHD/StructureCatalogue.cpp
@@ -71,7 +71,7 @@ namespace
 		const auto& structuresElement = *document.firstChildElement("Structures");
 
 		const auto requiredFields = std::vector<std::string>{"Name", "ImagePath", "TurnsToBuild", "MaxAge"};
-		const auto optionalFields = std::vector<std::string>{"RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "FoodProduced", "FoodStorageCapacity", "OreStorageCapacity", "CommRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
+		const auto optionalFields = std::vector<std::string>{"RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "FoodProduced", "FoodStorageCapacity", "OreStorageCapacity", "CommRange", "PoliceRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
 
 		std::vector<StructureType> structureTypes;
 		for (const auto* structureElement = structuresElement.firstChildElement(); structureElement; structureElement = structureElement->nextSiblingElement())
@@ -97,6 +97,7 @@ namespace
 				dictionary.get<int>("FoodStorageCapacity"),
 				dictionary.get<int>("OreStorageCapacity"),
 				dictionary.get<int>("CommRange", 0),
+				dictionary.get<int>("PoliceRange", 0),
 				dictionary.get<int>("IntegrityDecayRate"),
 				dictionary.get<bool>("IsSelfSustained"),
 				dictionary.get<bool>("IsRepairable"),

--- a/libOPHD/MapObjects/StructureType.h
+++ b/libOPHD/MapObjects/StructureType.h
@@ -23,6 +23,7 @@ struct StructureType
 	int foodStorageCapacity{0};
 	int oreStorageCapacity{0};
 	int commRange{0};
+	int policeRange{0};
 	int integrityDecayRate{1};
 
 	bool isSelfSustained{false};


### PR DESCRIPTION
As part of this update, the police coverage range can now go to `0` when the building is disabled.

Related:
- Issue #1723
