### PR TITLE
Remove unused `Structure` header includes

### DIFF
--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -1,8 +1,5 @@
 #include "Agridome.h"
 
-
-#include "../../Constants/Strings.h"
-
 #include <algorithm>
 
 

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -1,7 +1,6 @@
 #include "ColonistLander.h"
 
 
-#include "../../Constants/Strings.h"
 #include "../../Map/Tile.h"
 
 

--- a/appOPHD/MapObjects/Structures/CommandCenter.cpp
+++ b/appOPHD/MapObjects/Structures/CommandCenter.cpp
@@ -1,9 +1,6 @@
 #include "CommandCenter.h"
 
 
-#include "../../Constants/Numbers.h"
-
-
 CommandCenter::CommandCenter() : FoodProduction(
 	StructureClass::Command,
 	StructureID::SID_COMMAND_CENTER)

--- a/appOPHD/MapObjects/Structures/CommandCenter.h
+++ b/appOPHD/MapObjects/Structures/CommandCenter.h
@@ -3,9 +3,6 @@
 #include "FoodProduction.h"
 
 
-/**
- * Implements the Command Center structure.
- */
 class CommandCenter : public FoodProduction
 {
 public:

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -3,9 +3,6 @@
 #include "../Structure.h"
 
 
-/**
- * Implements a Tube Structure.
- */
 class Tube : public Structure
 {
 public:


### PR DESCRIPTION
Some of the recent refactoring made these header includes no longer necessary.

Related:
- Issue #1723
