### PR TITLE
Refactor constants - sort UI to `UiConstants.h`

### DIFF
--- a/appOPHD/Constants/Numbers.h
+++ b/appOPHD/Constants/Numbers.h
@@ -1,15 +1,11 @@
 #pragma once
 
-#include <NAS2D/Math/Vector.h>
-
 
 /**
  * Numeric constants
  */
 namespace constants
 {
-	inline constexpr int PlanetAnimationSpeed{35};
-
 	inline constexpr int SmeltingMinimumResourcesCount{20};
 
 	inline constexpr int BaseStorageCapacity{250};
@@ -37,8 +33,6 @@ namespace constants
 	inline constexpr int CommandCenterPopulationCapacity{10};
 
 	inline constexpr int RobotCommandCapacity{10};
-
-	inline constexpr auto MinimumWindowSize{NAS2D::Vector{1000, 700}};
 
 	inline constexpr int RoadIntegrityChange{80};
 

--- a/appOPHD/Constants/UiConstants.h
+++ b/appOPHD/Constants/UiConstants.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <NAS2D/Duration.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Color.h>
 
 #include <string>
@@ -9,6 +10,10 @@
 namespace constants
 {
 	inline constexpr Duration FadeSpeed{300};
+
+	inline constexpr int PlanetAnimationSpeed{35};
+
+	inline constexpr auto MinimumWindowSize{NAS2D::Vector{1000, 700}};
 
 	inline constexpr int BottomUiHeight{162};
 

--- a/appOPHD/Constants/UiConstants.h
+++ b/appOPHD/Constants/UiConstants.h
@@ -11,7 +11,7 @@ namespace constants
 {
 	inline constexpr Duration FadeSpeed{300};
 
-	inline constexpr int PlanetAnimationSpeed{35};
+	inline constexpr Duration PlanetAnimationSpeed{35};
 
 	inline constexpr auto MinimumWindowSize{NAS2D::Vector{1000, 700}};
 

--- a/appOPHD/States/Planet.cpp
+++ b/appOPHD/States/Planet.cpp
@@ -59,7 +59,7 @@ void Planet::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relati
 
 void Planet::update()
 {
-	if (mMouseInArea && mTimer.elapsedTicks() >= constants::PlanetAnimationSpeed)
+	if (mMouseInArea && mTimer.elapsedTicks() >= constants::PlanetAnimationSpeed.milliseconds)
 	{
 		mTimer.reset(); // don't care about frame skips.
 		++mTick;

--- a/appOPHD/States/Planet.cpp
+++ b/appOPHD/States/Planet.cpp
@@ -1,6 +1,6 @@
 #include "Planet.h"
 
-#include "../Constants/Numbers.h"
+#include "../Constants/UiConstants.h"
 
 #include <libOPHD/XmlSerializer.h>
 

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -1,7 +1,6 @@
 #include "Cache.h"
 #include "CacheMusic.h"
 #include "Constants/Strings.h"
-#include "Constants/Numbers.h"
 #include "Constants/UiConstants.h"
 #include "WindowEventWrapper.h"
 #include "PointerType.h"


### PR DESCRIPTION
With fewer game relates constants in `Numbers.h` it becomes more obvious when UI related constants are misplaced.

Related:
- Issue #1723
