### PR TITLE
Refactor `Button` click handling

### DIFF
--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -170,9 +170,6 @@ void Button::update()
 }
 
 
-/**
- * Draws the button.
- */
 void Button::draw() const
 {
 	if (!visible()) { return; }


### PR DESCRIPTION
Mostly the refactoring here is to make it easier to log debug info, and confirm that two buttons from two different report views are both calling the click handler at the same time.

When logging on the first line of the `Button::onMouseDown` method, there is more than a screen full of `Button` objects that process each click. By moving the logging after any early exits, that can be reduced substantially. For the investigation of the report view buttons, there are two active buttons responding to the clicks.

Example debug line:
```cpp
std::cout << "Button::onMouseDown: this = " << this << " " << mText << std::endl;
```

Related:
- Issue #1608
