### PR TITLE
Refactor map object selection

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1326,12 +1326,6 @@ void MapViewState::updateRobots()
  */
 void MapViewState::setStructureID(StructureID type, InsertMode mode)
 {
-	if (type == StructureID::SID_NONE)
-	{
-		clearMode();
-		return;
-	}
-
 	mCurrentStructure = type;
 
 	mInsertMode = mode;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -472,7 +472,6 @@ void MapViewState::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*
 			break;
 
 		case NAS2D::KeyCode::Escape:
-			clearMode();
 			resetUi();
 			break;
 
@@ -853,7 +852,6 @@ void MapViewState::placeStructure(Tile& tile)
 		mColonyShip.onDeployColonistLander();
 		if (mColonyShip.colonistLanders() == 0)
 		{
-			clearMode();
 			resetUi();
 			populateStructureMenu();
 		}
@@ -869,7 +867,6 @@ void MapViewState::placeStructure(Tile& tile)
 		mColonyShip.onDeployCargoLander();
 		if (mColonyShip.cargoLanders() == 0)
 		{
-			clearMode();
 			resetUi();
 			populateStructureMenu();
 		}
@@ -1223,7 +1220,6 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 		s.deploySignal().connect({this, &MapViewState::onDeploySeedLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(s, mTileMap->getTile({point, 0})); // Can only ever be placed on depth level 0
 
-		clearMode();
 		resetUi();
 
 		mStructures.clear();

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -667,7 +667,6 @@ void MapViewState::onInspectRobot(Robot& robot)
 
 void MapViewState::onInspectTile(Tile& tile)
 {
-	clearSelections();
 	mTileInspector.tile(tile);
 	mTileInspector.show();
 	mWindowStack.bringToFront(&mTileInspector);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -748,8 +748,6 @@ void MapViewState::clearMode()
 
 	mCurrentStructure = StructureID::SID_NONE;
 	mCurrentRobot = Robot::Type::None;
-
-	clearSelections();
 }
 
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1322,18 +1322,6 @@ void MapViewState::updateRobots()
 
 
 /**
- * Checks and sets the current structure mode.
- */
-void MapViewState::setStructureID(StructureID type, InsertMode mode)
-{
-	mCurrentStructure = type;
-
-	mInsertMode = mode;
-	setCursor(PointerType::PlaceTile);
-}
-
-
-/**
  * Checks the connectedness of all tiles surrounding
  * the Command Center.
  */

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -180,8 +180,6 @@ private:
 
 	Robot& addRobot(Robot::Type type);
 
-	void setStructureID(StructureID type, InsertMode mode);
-
 	// MISCELLANEOUS UTILITY FUNCTIONS
 	void updateFood();
 	void transferFoodToCommandCenter();

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -726,6 +726,7 @@ void MapViewState::nextTurn()
 	mMorale.closeJournal();
 
 	clearMode();
+	clearSelections();
 
 	mPopulationPool.clear();
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -528,7 +528,9 @@ void MapViewState::onStructuresSelectionChange(const IconGrid::Item* item)
 		return;
 	}
 
-	setStructureID(structureId, InsertMode::Structure);
+	mCurrentStructure = structureId;
+	mInsertMode = InsertMode::Structure;
+	setCursor(PointerType::PlaceTile);
 }
 
 
@@ -540,7 +542,9 @@ void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* /*item*/)
 	mRobots.clearSelection();
 	mStructures.clearSelection();
 
-	setStructureID(StructureID::SID_TUBE, InsertMode::Tube);
+	mCurrentStructure = StructureID::SID_TUBE;
+	mInsertMode = InsertMode::Tube;
+	setCursor(PointerType::PlaceTile);
 }
 
 
@@ -559,7 +563,6 @@ void MapViewState::onRobotsSelectionChange(const IconGrid::Item* item)
 	}
 
 	mCurrentRobot = static_cast<Robot::Type>(item->meta);
-
 	mInsertMode = InsertMode::Robot;
 	setCursor(PointerType::PlaceTile);
 }

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -513,7 +513,11 @@ void MapViewState::onNotificationClicked(const NotificationArea::Notification& n
 
 void MapViewState::onStructuresSelectionChange(const IconGrid::Item* item)
 {
-	if (!item) { return; }
+	if (!item)
+	{
+		clearMode();
+		return;
+	}
 
 	mConnections.clearSelection();
 	mRobots.clearSelection();
@@ -539,7 +543,11 @@ void MapViewState::onStructuresSelectionChange(const IconGrid::Item* item)
  */
 void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* item)
 {
-	if (!item) { return; }
+	if (!item)
+	{
+		clearMode();
+		return;
+	}
 
 	mRobots.clearSelection();
 	mStructures.clearSelection();

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -555,14 +555,14 @@ void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* item)
  */
 void MapViewState::onRobotsSelectionChange(const IconGrid::Item* item)
 {
-	mConnections.clearSelection();
-	mStructures.clearSelection();
-
 	if (!item)
 	{
 		clearMode();
 		return;
 	}
+
+	mConnections.clearSelection();
+	mStructures.clearSelection();
 
 	mCurrentRobot = static_cast<Robot::Type>(item->meta);
 	mInsertMode = InsertMode::Robot;

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -537,8 +537,10 @@ void MapViewState::onStructuresSelectionChange(const IconGrid::Item* item)
 /**
  * Handler for the Tubes Pallette dialog.
  */
-void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* /*item*/)
+void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* item)
 {
+	if (!item) { return; }
+
 	mRobots.clearSelection();
 	mStructures.clearSelection();
 


### PR DESCRIPTION
Refactor code that handles selecting and unselecting objects to place on the map.

Changes should make the code more robust to changes in `IconGrid` `selectionChanged` notifications, which might otherwise cause unintentional interactions in the event handler code. Without changes, potentially the callback handlers might mutually unselect objects leading to ignored selections, or cause infinite recursion leading to a stack overflow and crash.

There was a minor bug fix in the last commit where in prior code unselecting an item didn't always update the mouse cursor and action, leaving it to behave as it an object was still selected for placement.

Related:
- Issue #1721
