### PR TITLE
Update `IconGrid` for missed cases of selection changed event

### DIFF
--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -265,11 +265,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	if (!enabled() || !visible() || !mRect.contains(position)) { return; }
 	if (button != MouseButton::Left) { return; }
 
-	const auto iconIndex = positionToIndex(position);
-	if (mSelectedIndex != iconIndex)
-	{
-		setSelectionInternal(iconIndex);
-	}
+	setSelectionInternal(positionToIndex(position));
 }
 
 

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -176,10 +176,7 @@ void IconGrid::incrementSelection()
 {
 	if (mSelectedIndex == NoSelection) { return; }
 
-	const auto nextIndex = (mSelectedIndex + 1 >= mIconItemList.size()) ? 0 : mSelectedIndex + 1;
-	mSelectedIndex = nextIndex;
-
-	raiseChangedEvent();
+	setSelectionInternal((mSelectedIndex + 1 >= mIconItemList.size()) ? 0 : mSelectedIndex + 1);
 }
 
 
@@ -187,10 +184,7 @@ void IconGrid::decrementSelection()
 {
 	if (mSelectedIndex == NoSelection) { return; }
 
-	const auto nextIndex = ((mSelectedIndex == 0) ? mIconItemList.size() : mSelectedIndex) - 1;
-	mSelectedIndex = nextIndex;
-
-	raiseChangedEvent();
+	setSelectionInternal(((mSelectedIndex == 0) ? mIconItemList.size() : mSelectedIndex) - 1);
 }
 
 

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -308,12 +308,6 @@ void IconGrid::setSelectionInternal(Index newSelection)
 
 void IconGrid::raiseChangedEvent() const
 {
-	if (mSelectedIndex != NoSelection)
-	{
-		mSelectionChangedDelegate(&mIconItemList[mSelectedIndex]);
-	}
-	else
-	{
-		mSelectionChangedDelegate(nullptr);
-	}
+	const auto* item = (mSelectedIndex == NoSelection) ? nullptr : &mIconItemList[mSelectedIndex];
+	mSelectionChangedDelegate(item);
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -144,7 +144,7 @@ void IconGrid::setSelection(Index newSelection)
 	{
 		throw std::runtime_error("IconGrid selection is out of bounds: " + std::to_string(newSelection));
 	}
-	mSelectedIndex = newSelection;
+	setSelectionInternal(newSelection);
 }
 
 
@@ -165,7 +165,7 @@ void IconGrid::setSelectionByMeta(int selectionMetaValue)
 	{
 		if (mIconItemList[i].meta == selectionMetaValue)
 		{
-			mSelectedIndex = i;
+			setSelectionInternal(i);
 			return;
 		}
 	}

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -140,7 +140,11 @@ void IconGrid::clearSelection()
 
 void IconGrid::setSelection(Index newSelection)
 {
-	mSelectedIndex = (newSelection < mIconItemList.size()) ? newSelection : NoSelection;
+	if (newSelection >= mIconItemList.size())
+	{
+		throw std::runtime_error("IconGrid selection is out of bounds: " + std::to_string(newSelection));
+	}
+	mSelectedIndex = newSelection;
 }
 
 

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -134,7 +134,7 @@ void IconGrid::itemAvailable(const std::string& itemName, bool isItemAvailable)
 void IconGrid::clearSelection()
 {
 	mHighlightIndex = NoSelection;
-	mSelectedIndex = NoSelection;
+	setSelectionInternal(NoSelection);
 }
 
 

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -188,19 +188,6 @@ void IconGrid::decrementSelection()
 }
 
 
-void IconGrid::raiseChangedEvent() const
-{
-	if (mSelectedIndex != NoSelection)
-	{
-		mSelectionChangedDelegate(&mIconItemList[mSelectedIndex]);
-	}
-	else
-	{
-		mSelectionChangedDelegate(nullptr);
-	}
-}
-
-
 void IconGrid::hide()
 {
 	Control::hide();
@@ -315,5 +302,18 @@ void IconGrid::setSelectionInternal(Index newSelection)
 	{
 		mSelectedIndex = newSelection;
 		raiseChangedEvent();
+	}
+}
+
+
+void IconGrid::raiseChangedEvent() const
+{
+	if (mSelectedIndex != NoSelection)
+	{
+		mSelectionChangedDelegate(&mIconItemList[mSelectedIndex]);
+	}
+	else
+	{
+		mSelectionChangedDelegate(nullptr);
 	}
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -301,13 +301,7 @@ void IconGrid::setSelectionInternal(Index newSelection)
 	if (mSelectedIndex != newSelection)
 	{
 		mSelectedIndex = newSelection;
-		raiseChangedEvent();
+		const auto* item = (mSelectedIndex == NoSelection) ? nullptr : &mIconItemList[mSelectedIndex];
+		mSelectionChangedDelegate(item);
 	}
-}
-
-
-void IconGrid::raiseChangedEvent() const
-{
-	const auto* item = (mSelectedIndex == NoSelection) ? nullptr : &mIconItemList[mSelectedIndex];
-	mSelectionChangedDelegate(item);
 }

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -314,3 +314,13 @@ NAS2D::Rectangle<int> IconGrid::indexToArea(Index index) const
 {
 	return NAS2D::Rectangle{indexToPosition(index), {mIconSize, mIconSize}};
 }
+
+
+void IconGrid::setSelectionInternal(Index newSelection)
+{
+	if (mSelectedIndex != newSelection)
+	{
+		mSelectedIndex = newSelection;
+		raiseChangedEvent();
+	}
+}

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -268,8 +268,7 @@ void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
 	const auto iconIndex = positionToIndex(position);
 	if (mSelectedIndex != iconIndex)
 	{
-		mSelectedIndex = iconIndex;
-		raiseChangedEvent();
+		setSelectionInternal(iconIndex);
 	}
 }
 

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -72,6 +72,7 @@ protected:
 	NAS2D::Point<int> indexToPosition(Index index) const;
 	NAS2D::Rectangle<int> indexToArea(Index index) const;
 
+	void setSelectionInternal(Index newSelection);
 	void raiseChangedEvent() const;
 
 private:

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -73,7 +73,6 @@ protected:
 	NAS2D::Rectangle<int> indexToArea(Index index) const;
 
 	void setSelectionInternal(Index newSelection);
-	void raiseChangedEvent() const;
 
 private:
 	const NAS2D::RectangleSkin mSkin;


### PR DESCRIPTION
Ensure `IconGrid` raises the selection changed event whenever the selection changes.

These changes needed refactoring of map object placement (PR #1737) to ensure there was no unintended interactions between the callback handlers, such as mutual clearing of selections, and infinite recursion.

Related:
- Issue #1721
- PR #1737
