### PR TITLE
Add starter `demoLibControls` interface

### DIFF
--- a/demoLibControls/Cache.h
+++ b/demoLibControls/Cache.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <NAS2D/Resource/Font.h>
+#include <NAS2D/Resource/Image.h>
+#include <NAS2D/Resource/ResourceCache.h>
+
+
+inline NAS2D::ResourceCache<NAS2D::Font, std::string, unsigned int> fontCache;
+inline NAS2D::ResourceCache<NAS2D::Image, std::string> imageCache;

--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -6,10 +6,12 @@
 
 MainWindow::MainWindow() :
 	Window{"Main Window"},
-	button{"Button"}
+	button{"Button"},
+	label{"Label"}
 {
 	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	size(renderer.size());
 
 	add(button, {10, 30});
+	add(label, {70, 30});
 }

--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -1,0 +1,12 @@
+#include "MainWindow.h"
+
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+
+
+MainWindow::MainWindow() :
+	Window{"Main Window"}
+{
+	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	size(renderer.size());
+}

--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -7,11 +7,12 @@
 MainWindow::MainWindow() :
 	Window{"Main Window"},
 	button{"Button", {this, &MainWindow::onButtonClick}},
-	label{"Label"}
+	label{"Label: Waiting for button"}
 {
 	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	size(renderer.size());
 
+	button.size(button.size() + NAS2D::Vector{8, 2});
 	add(button, {10, 30});
 	add(label, {70, 30});
 }
@@ -19,5 +20,5 @@ MainWindow::MainWindow() :
 
 void MainWindow::onButtonClick()
 {
-	label.text("Button was clicked");
+	label.text("Label: Button was clicked");
 }

--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -6,7 +6,7 @@
 
 MainWindow::MainWindow() :
 	Window{"Main Window"},
-	button{"Button"},
+	button{"Button", {this, &MainWindow::onButtonClick}},
 	label{"Label"}
 {
 	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -14,4 +14,10 @@ MainWindow::MainWindow() :
 
 	add(button, {10, 30});
 	add(label, {70, 30});
+}
+
+
+void MainWindow::onButtonClick()
+{
+	label.text("Button was clicked");
 }

--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -5,8 +5,11 @@
 
 
 MainWindow::MainWindow() :
-	Window{"Main Window"}
+	Window{"Main Window"},
+	button{"Button"}
 {
 	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	size(renderer.size());
+
+	add(button, {10, 30});
 }

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -2,6 +2,8 @@
 
 #include <libControls/Window.h>
 
+#include <libControls/Button.h>
+
 
 class MainWindow : public Window
 {
@@ -9,5 +11,5 @@ public:
 	MainWindow();
 
 private:
-
+	Button button;
 };

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -3,6 +3,7 @@
 #include <libControls/Window.h>
 
 #include <libControls/Button.h>
+#include <libControls/Label.h>
 
 
 class MainWindow : public Window
@@ -12,4 +13,5 @@ public:
 
 private:
 	Button button;
+	Label label;
 };

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <libControls/Window.h>
+
+
+class MainWindow : public Window
+{
+public:
+	MainWindow();
+
+private:
+
+};

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -11,6 +11,9 @@ class MainWindow : public Window
 public:
 	MainWindow();
 
+protected:
+	void onButtonClick();
+
 private:
 	Button button;
 	Label label;

--- a/demoLibControls/MainWindowState.cpp
+++ b/demoLibControls/MainWindowState.cpp
@@ -1,0 +1,7 @@
+#include "MainWindowState.h"
+
+
+NAS2D::State* MainWindowState::update()
+{
+	return this;
+}

--- a/demoLibControls/MainWindowState.cpp
+++ b/demoLibControls/MainWindowState.cpp
@@ -3,5 +3,7 @@
 
 NAS2D::State* MainWindowState::update()
 {
+	mainWindow.update();
+
 	return this;
 }

--- a/demoLibControls/MainWindowState.h
+++ b/demoLibControls/MainWindowState.h
@@ -1,0 +1,11 @@
+#pragma once
+
+
+#include <NAS2D/State.h>
+
+
+class MainWindowState : public NAS2D::State
+{
+public:
+	State* update() override;
+};

--- a/demoLibControls/MainWindowState.h
+++ b/demoLibControls/MainWindowState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MainWindow.h"
 
 #include <NAS2D/State.h>
 
@@ -8,4 +9,7 @@ class MainWindowState : public NAS2D::State
 {
 public:
 	State* update() override;
+
+private:
+	MainWindow mainWindow;
 };

--- a/demoLibControls/demoLibControls.vcxproj
+++ b/demoLibControls/demoLibControls.vcxproj
@@ -159,6 +159,10 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="MainWindowState.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="MainWindowState.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libControls\libControls.vcxproj">

--- a/demoLibControls/demoLibControls.vcxproj
+++ b/demoLibControls/demoLibControls.vcxproj
@@ -162,6 +162,7 @@
     <ClCompile Include="MainWindowState.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Cache.h" />
     <ClInclude Include="MainWindowState.h" />
   </ItemGroup>
   <ItemGroup>

--- a/demoLibControls/demoLibControls.vcxproj
+++ b/demoLibControls/demoLibControls.vcxproj
@@ -159,10 +159,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="MainWindowState.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h" />
+    <ClInclude Include="MainWindow.h" />
     <ClInclude Include="MainWindowState.h" />
   </ItemGroup>
   <ItemGroup>

--- a/demoLibControls/demoLibControls.vcxproj.filters
+++ b/demoLibControls/demoLibControls.vcxproj.filters
@@ -18,12 +18,18 @@
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MainWindow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="MainWindowState.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Cache.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MainWindow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="MainWindowState.h">

--- a/demoLibControls/demoLibControls.vcxproj.filters
+++ b/demoLibControls/demoLibControls.vcxproj.filters
@@ -23,6 +23,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Cache.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="MainWindowState.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/demoLibControls/demoLibControls.vcxproj.filters
+++ b/demoLibControls/demoLibControls.vcxproj.filters
@@ -18,5 +18,13 @@
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MainWindowState.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="MainWindowState.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/demoLibControls/main.cpp
+++ b/demoLibControls/main.cpp
@@ -1,6 +1,10 @@
+#include "Cache.h"
 #include "MainWindowState.h"
 
+#include <libControls/Control.h>
+
 #include <NAS2D/Game.h>
+#include <NAS2D/Resource/ResourceCache.h>
 
 #include <iostream>
 
@@ -10,6 +14,11 @@ int main()
 	try
 	{
 		NAS2D::Game game{"Demo libControls", "DemoLibControls", "LairWorks"};
+
+		Control::setDefaultFont(fontCache.load("fonts/opensans.ttf", 14));
+		Control::setDefaultFontBold(fontCache.load("fonts/opensans-bold.ttf", 14));
+		Control::setImageCache(imageCache);
+
 		game.go(new MainWindowState);
 	}
 	catch (const std::exception& exception)

--- a/demoLibControls/main.cpp
+++ b/demoLibControls/main.cpp
@@ -1,5 +1,21 @@
+#include "MainWindowState.h"
+
+#include <NAS2D/Game.h>
+
+#include <iostream>
+
 
 int main()
 {
+	try
+	{
+		NAS2D::Game game{"Demo libControls", "DemoLibControls", "LairWorks"};
+		game.go(new MainWindowState);
+	}
+	catch (const std::exception& exception)
+	{
+		std::cerr << "\nException: " << exception.what() << std::endl;
+	}
+
 	return 0;
 }


### PR DESCRIPTION
Create initial user interface for `demoLibControls`.

For now it only contains a `Button` and a `Label` in the demo. It can be expanded as needed.

Related:
- Issue #1743
