### PR TITLE
Add `RadioButtonGroup` to `libDemoControls`

### DIFF
--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -7,7 +7,12 @@
 MainWindow::MainWindow() :
 	Window{"Main Window"},
 	button{"Button", {this, &MainWindow::onButtonClick}},
-	label{"Label: Waiting for button"}
+	label{"Label: Waiting for button"},
+	radioButtonGroup{{
+		{"Option 1", {this, &MainWindow::onRadioButtonClick}},
+		{"Option 2", {this, &MainWindow::onRadioButtonClick}},
+		{"Option 3", {this, &MainWindow::onRadioButtonClick}},
+	}}
 {
 	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	size(renderer.size());
@@ -15,10 +20,17 @@ MainWindow::MainWindow() :
 	button.size(button.size() + NAS2D::Vector{8, 2});
 	add(button, {10, 30});
 	add(label, {70, 30});
+	add(radioButtonGroup, {10, 60});
 }
 
 
 void MainWindow::onButtonClick()
 {
 	label.text("Label: Button was clicked");
+}
+
+
+void MainWindow::onRadioButtonClick()
+{
+	label.text("Label: RadioButton was clicked");
 }

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -4,6 +4,7 @@
 
 #include <libControls/Button.h>
 #include <libControls/Label.h>
+#include <libControls/RadioButtonGroup.h>
 
 
 class MainWindow : public Window
@@ -13,8 +14,10 @@ public:
 
 protected:
 	void onButtonClick();
+	void onRadioButtonClick();
 
 private:
 	Button button;
 	Label label;
+	RadioButtonGroup radioButtonGroup;
 };


### PR DESCRIPTION
It should be noted that `RadioButtonGroup` is not currently used anywhere else.

From the demo here it's clear there are some graphical alignment issues.

There is no real way to get which `RadioButton` was selected other than to have separate callback handlers. That seems like a bit of a gap in the current API. We should probably add a method to get the index of the current selection, if any. Actually it's not obvious if having separate callback handlers for each `RadioButton` is really the best way to go here. Maybe just one callback on the `RadioButtonGroup` that receives a selected index, rather than a handler on every `RadioButton`. It would be relatively easy to go from a selected index to any given button specific data.

Related:
- Issue #1743
- PR #822
