### PR TITLE
Convert `CheckBox` to `Delegate`

### DIFF
--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -32,18 +32,13 @@ namespace
 }
 
 
-CheckBox::CheckBox(std::string newText) :
+CheckBox::CheckBox(std::string newText, ClickDelegate clickHandler) :
 	mFont{getDefaultFont()},
-	mSkin{getImage("ui/skin/checkbox.png")}
+	mSkin{getImage("ui/skin/checkbox.png")},
+	mClickHandler{clickHandler}
 {
 	text(newText);
 	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &CheckBox::onMouseDown});
-}
-
-
-CheckBox::CheckBox(std::string newText, ClickSignal::DelegateType clickHandler) : CheckBox(newText)
-{
-	mSignal.connect({clickHandler});
 }
 
 
@@ -78,7 +73,10 @@ void CheckBox::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position
 	if (button == NAS2D::MouseButton::Left && mRect.contains(position))
 	{
 		mChecked = !mChecked;
-		mSignal();
+		if (mClickHandler)
+		{
+			mClickHandler();
+		}
 	}
 }
 

--- a/libControls/CheckBox.h
+++ b/libControls/CheckBox.h
@@ -2,7 +2,7 @@
 
 #include "TextControl.h"
 
-#include <NAS2D/Signal/Signal.h>
+#include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>
 
@@ -19,10 +19,9 @@ namespace NAS2D
 class CheckBox : public TextControl
 {
 public:
-	using ClickSignal = NAS2D::Signal<>;
+	using ClickDelegate = NAS2D::Delegate<void()>;
 
-	CheckBox(std::string newText = "");
-	CheckBox(std::string newText, ClickSignal::DelegateType clickHandler);
+	CheckBox(std::string newText = "", ClickDelegate clickHandler = {});
 	~CheckBox() override;
 
 	void checked(bool toggle);
@@ -41,7 +40,7 @@ private:
 	const NAS2D::Font& mFont;
 	const NAS2D::Image& mSkin;
 
-	ClickSignal mSignal; /**< Object to notify when the Button is activated. */
+	ClickDelegate mClickHandler;
 
 	bool mChecked = false;
 };


### PR DESCRIPTION
Use `Delegate` instead of `Signal` in `CheckBox`.

Related:
- Issue #875
