### PR TITLE
Convert `ComboBox` to use `Delegate`

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -75,6 +75,7 @@ FactoryReport::FactoryReport() :
 	btnClearProduction{"Clear Production", mainButtonSize, {this, &FactoryReport::onClearProduction}},
 	btnTakeMeThere{constants::TakeMeThere, mainButtonSize, {this, &FactoryReport::onTakeMeThere}},
 	btnApply{"Apply", mainButtonSize, {this, &FactoryReport::onApply}},
+	cboFilterByProduct{{this, &FactoryReport::onProductFilterSelectionChange}},
 	mTxtProductDescription{constants::PrimaryTextColor}
 {
 	add(lstFactoryList, {10, 63});
@@ -121,8 +122,6 @@ FactoryReport::FactoryReport() :
 	cboFilterByProduct.addItem(constants::Roboexplorer, ProductType::PRODUCT_EXPLORER);
 	cboFilterByProduct.addItem(constants::Robominer, ProductType::PRODUCT_MINER);
 	cboFilterByProduct.addItem(constants::Truck, ProductType::PRODUCT_TRUCK);
-
-	cboFilterByProduct.selectionChanged().connect({this, &FactoryReport::onProductFilterSelectionChange});
 
 	add(lstProducts, {cboFilterByProduct.area().position.x + cboFilterByProduct.area().size.x + 20, mRect.position.y + 230});
 

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -15,7 +15,7 @@ namespace
 }
 
 
-ComboBox::ComboBox() :
+ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 	ControlContainer{{&btnDown, &txtField, &lstItems}},
 	mMaxDisplayItems{MinimumDisplayItems}
 {
@@ -30,6 +30,10 @@ ComboBox::ComboBox() :
 	lstItems.height(300);
 
 	lstItems.selectionChanged().connect({this, &ComboBox::onListSelectionChange});
+
+	if (selectionChangedHandler) {
+		mSelectionChanged.connect(selectionChangedHandler);
+	}
 }
 
 

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -17,6 +17,7 @@ namespace
 
 ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 	ControlContainer{{&btnDown, &txtField, &lstItems}},
+	mSelectionChangedHandler{selectionChangedHandler},
 	mMaxDisplayItems{MinimumDisplayItems}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
@@ -30,10 +31,6 @@ ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 	lstItems.height(300);
 
 	lstItems.selectionChanged().connect({this, &ComboBox::onListSelectionChange});
-
-	if (selectionChangedHandler) {
-		mSelectionChanged.connect(selectionChangedHandler);
-	}
 }
 
 
@@ -131,7 +128,7 @@ void ComboBox::onListSelectionChange()
 	txtField.text(selectionText());
 	lstItems.visible(false);
 	mRect = mBarRect;
-	mSelectionChanged();
+	if (mSelectionChangedHandler) { mSelectionChangedHandler(); }
 }
 
 
@@ -190,13 +187,13 @@ bool ComboBox::isItemSelected() const
 void ComboBox::setSelected(std::size_t index) {
 	lstItems.setSelected(index);
 	text(selectionText());
-	mSelectionChanged();
+	if (mSelectionChangedHandler) { mSelectionChangedHandler(); }
 }
 
 void ComboBox::text(const std::string& text) {
 	txtField.text(text);
 	lstItems.selectIf([target = NAS2D::toLowercase(txtField.text())](const auto& item){ return NAS2D::toLowercase(item.text) == target; });
-	mSelectionChanged();
+	if (mSelectionChangedHandler) { mSelectionChangedHandler(); }
 }
 
 const std::string& ComboBox::text() const {

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -30,8 +30,6 @@ public:
 
 	void clearSelected();
 
-	SelectionChangeSignal::Source& selectionChanged() { return mSelectionChanged; }
-
 	const std::string& selectionText() const;
 	int selectionUserData() const;
 

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -18,8 +18,9 @@ class ComboBox : public ControlContainer
 {
 public:
 	using SelectionChangeSignal = NAS2D::Signal<>;
+	using SelectionChangedDelegate = NAS2D::Delegate<void()>;
 
-	ComboBox();
+	ComboBox(SelectionChangedDelegate selectionChangedHandler = {});
 	~ComboBox() override;
 
 	void addItem(const std::string& item, int tag = 0);

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -5,7 +5,7 @@
 #include "ListBox.h"
 #include "TextField.h"
 
-#include <NAS2D/Signal/Signal.h>
+#include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
@@ -17,7 +17,6 @@
 class ComboBox : public ControlContainer
 {
 public:
-	using SelectionChangeSignal = NAS2D::Signal<>;
 	using SelectionChangedDelegate = NAS2D::Delegate<void()>;
 
 	ComboBox(SelectionChangedDelegate selectionChangedHandler = {});
@@ -54,7 +53,7 @@ private:
 
 	NAS2D::Rectangle<int> mBarRect;
 
-	SelectionChangeSignal mSelectionChanged;
+	SelectionChangedDelegate mSelectionChangedHandler;
 
 	std::size_t mMaxDisplayItems;
 };


### PR DESCRIPTION
Convert `ComboBox` to use `Delegate` rather than `Signal`.

Related:
- Issue #875
