### PR TITLE
Mark `Control::draw` as `protected`

### DIFF
--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -151,12 +151,6 @@ void Button::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relati
 }
 
 
-void Button::update()
-{
-	draw();
-}
-
-
 void Button::draw() const
 {
 	if (!visible()) { return; }

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -50,8 +50,6 @@ public:
 
 	ClickSignal::Source& click() { return mSignal; }
 
-	void update() override;
-
 protected:
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -51,11 +51,11 @@ public:
 	ClickSignal::Source& click() { return mSignal; }
 
 protected:
+	void draw() const override;
+
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
-
-	void draw() const override;
 
 private:
 	const ButtonSkin mButtonSkin;

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -97,15 +97,9 @@ void CheckBox::onResize()
 }
 
 
-void CheckBox::update()
-{
-	if (!visible()) { return; }
-	draw();
-}
-
-
 void CheckBox::draw() const
 {
+	if (!visible()) { return; }
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto iconPosition = position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y + 1) / 2};
 	renderer.drawSubImage(mSkin, iconPosition, (mChecked ? checkedIconRect : uncheckedIconRect));

--- a/libControls/CheckBox.h
+++ b/libControls/CheckBox.h
@@ -27,7 +27,6 @@ public:
 	void checked(bool toggle);
 	bool checked() const;
 
-	void update() override;
 	void draw() const override;
 
 protected:

--- a/libControls/CheckBox.h
+++ b/libControls/CheckBox.h
@@ -27,9 +27,9 @@ public:
 	void checked(bool toggle);
 	bool checked() const;
 
+protected:
 	void draw() const override;
 
-protected:
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 
 	void onResize() override;

--- a/libControls/Control.h
+++ b/libControls/Control.h
@@ -78,6 +78,8 @@ public:
 	virtual void update() { draw(); }
 
 protected:
+	virtual void draw() const {}
+
 	virtual void onMove(NAS2D::Vector<int> /*displacement*/) {}
 	virtual void onResize() {}
 	virtual void onVisibilityChange(bool /*visible*/) {}
@@ -90,7 +92,4 @@ protected:
 	bool mEnabled = true; /**< Flag indicating whether or not the Control is enabled. */
 	bool mHasFocus = false; /**< Flag indicating that the Control has input focus. */
 	bool mHighlight = false; /**< Flag indicating that this Control is highlighted. */
-
-private:
-	virtual void draw() const {}
 };

--- a/libControls/Control.h
+++ b/libControls/Control.h
@@ -75,7 +75,7 @@ public:
 	virtual void hasFocus(bool focus);
 	bool hasFocus() const;
 
-	virtual void update() {}
+	virtual void update() { draw(); }
 
 protected:
 	virtual void onMove(NAS2D::Vector<int> /*displacement*/) {}

--- a/libControls/Label.cpp
+++ b/libControls/Label.cpp
@@ -40,12 +40,6 @@ void Label::color(const NAS2D::Color& color)
 }
 
 
-void Label::update()
-{
-	draw();
-}
-
-
 void Label::draw() const
 {
 	if (!visible()) { return; }

--- a/libControls/Label.h
+++ b/libControls/Label.h
@@ -34,7 +34,6 @@ public:
 	void font(const NAS2D::Font* font);
 	void color(const NAS2D::Color& color);
 
-	void update() override;
 	void draw() const override;
 
 protected:

--- a/libControls/Label.h
+++ b/libControls/Label.h
@@ -34,9 +34,8 @@ public:
 	void font(const NAS2D::Font* font);
 	void color(const NAS2D::Color& color);
 
-	void draw() const override;
-
 protected:
+	void draw() const override;
 	void autoSize();
 
 private:

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -186,6 +186,7 @@ public:
 	}
 
 
+protected:
 	void draw() const override
 	{
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -221,7 +222,6 @@ public:
 	}
 
 
-protected:
 	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 	{
 		if (!visible() || mHighlightIndex == NoSelection || mHighlightIndex >= mItems.size() || !mClientRect.contains(position))

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -42,9 +42,10 @@ public:
 	void clearSelected();
 
 	void update() override;
-	void draw() const override;
 
 protected:
+	void draw() const override;
+
 	void clear();
 	void updateScrollLayout();
 

--- a/libControls/RadioButtonGroup.cpp
+++ b/libControls/RadioButtonGroup.cpp
@@ -23,7 +23,7 @@ RadioButtonGroup::RadioButtonGroup(std::vector<std::string> options, SelectDeleg
 
 		auto &button = mRadioButtons.emplace_back(*this, std::move(option));
 		button.visible(visible());
-		button.position(mRect.position + offset);
+		add(button, offset);
 	}
 }
 
@@ -47,22 +47,6 @@ void RadioButtonGroup::select(RadioButtonGroup::RadioButton& button)
 {
 	auto index = static_cast<std::size_t>(std::distance(mRadioButtons.data(), &button));
 	select(index);
-}
-
-
-void RadioButtonGroup::update()
-{
-	if (!visible()) { return; }
-	draw();
-}
-
-
-void RadioButtonGroup::draw() const
-{
-	for (auto &control : mRadioButtons)
-	{
-		control.draw();
-	}
 }
 
 

--- a/libControls/RadioButtonGroup.h
+++ b/libControls/RadioButtonGroup.h
@@ -35,9 +35,9 @@ private:
 		void text(const std::string& text);
 		const std::string& text() const;
 
+	protected:
 		void draw() const override;
 
-	protected:
 		void onResize() override;
 		void onTextChange();
 		void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);

--- a/libControls/RadioButtonGroup.h
+++ b/libControls/RadioButtonGroup.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Control.h"
+#include "ControlContainer.h"
 #include "Label.h"
 
 #include <NAS2D/Signal/Delegate.h>
@@ -16,7 +16,7 @@ namespace NAS2D
 }
 
 
-class RadioButtonGroup : public Control
+class RadioButtonGroup : public ControlContainer
 {
 private:
 	class RadioButton : public Control
@@ -61,9 +61,6 @@ public:
 	void clear();
 	void select(std::size_t index);
 	void select(RadioButtonGroup::RadioButton& button);
-
-	void update() override;
-	void draw() const override;
 
 protected:
 	void onMove(NAS2D::Vector<int> displacement) override;

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -41,11 +41,11 @@ public:
 	void max(ValueType newMax);
 
 	void update() override;
-	void draw() const override;
-
 	ValueChangeSignal::Source& change() { return mSignal; }
 
 protected:
+	void draw() const override;
+
 	void onButtonClick(bool& buttonFlag, ValueType value);
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -32,12 +32,6 @@ void TextArea::onTextChange()
 }
 
 
-void TextArea::update()
-{
-	draw();
-}
-
-
 void TextArea::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();

--- a/libControls/TextArea.h
+++ b/libControls/TextArea.h
@@ -15,10 +15,11 @@ public:
 	TextArea(const NAS2D::Font& font, NAS2D::Color textColor = NAS2D::Color::White);
 
 protected:
+	void draw() const override;
+
 	void onResize() override;
 	void onTextChange() override;
 
-	void draw() const override;
 	void processString();
 
 private:

--- a/libControls/TextArea.h
+++ b/libControls/TextArea.h
@@ -14,8 +14,6 @@ public:
 	TextArea(NAS2D::Color textColor = NAS2D::Color::White);
 	TextArea(const NAS2D::Font& font, NAS2D::Color textColor = NAS2D::Color::White);
 
-	void update() override;
-
 protected:
 	void onResize() override;
 	void onTextChange() override;

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -58,9 +58,10 @@ public:
 	void maxCharacters(std::size_t count);
 
 	void update() override;
-	void draw() const override;
 
 protected:
+	void draw() const override;
+
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onTextInput(const std::string& newTextInput);

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -20,6 +20,8 @@ public:
 	void add(Control&, const std::string&);
 
 	void update() override;
+
+protected:
 	void draw() const override;
 
 private:

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -71,8 +71,6 @@ void Window::show()
 
 void Window::update()
 {
-	if (!visible()) { return; }
-
 	draw();
 
 	ControlContainer::update();
@@ -81,6 +79,8 @@ void Window::update()
 
 void Window::draw() const
 {
+	if (!visible()) { return; }
+
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	renderer.drawImage(mTitleBarLeft, mRect.position);

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -22,7 +22,6 @@ public:
 	void show() override;
 
 	void update() override;
-	void draw() const override;
 
 	using TitleChangeSignal = NAS2D::Signal<Window*>;
 
@@ -33,6 +32,8 @@ public:
 	virtual void onTitleChanged() { mTitleChanged(this); }
 
 protected:
+	void draw() const override;
+
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);


### PR DESCRIPTION
Mark `Control::draw` as `protected`, and set a default implementation of `update()` that calls `draw()`.

Most controls will override `update` with a custom drawing implementation. Though some will use an `update` method similar to the default added here and override `draw` for the drawing implementation. This solidifies that pattern until we are ready to decouple `update` from `draw`.

Make `RadioButtonGroup` derive from `ControlContainer`, and use that to dispatch drawing to the contained `RadioButton` objects.

Related:
- Issue #1756
- Issue #896
