### PR TITLE
Split `Road` connections from `MapViewState`

### DIFF
--- a/appOPHD/Map/Connections.cpp
+++ b/appOPHD/Map/Connections.cpp
@@ -1,0 +1,76 @@
+#include "Connections.h"
+
+#include "TileMap.h"
+#include "../StructureManager.h"
+#include "../Constants/Numbers.h"
+
+#include <libOPHD/DirectionOffset.h>
+#include <libOPHD/Map/MapCoordinate.h>
+
+#include <NAS2D/Utility.h>
+#include <NAS2D/Math/Point.h>
+
+
+namespace
+{
+	const std::map<std::array<bool, 4>, std::string> IntersectionPatternTable =
+	{
+		{{true, false, true, false}, "left"},
+		{{true, false, false, false}, "left"},
+		{{false, false, true, false}, "left"},
+
+		{{false, true, false, true}, "right"},
+		{{false, true, false, false}, "right"},
+		{{false, false, false, true}, "right"},
+
+		{{false, false, false, false}, "intersection"},
+		{{true, true, false, false}, "intersection"},
+		{{false, false, true, true}, "intersection"},
+		{{false, true, true, true}, "intersection"},
+		{{true, true, true, false}, "intersection"},
+		{{true, true, true, true}, "intersection"},
+		{{true, false, false, true}, "intersection"},
+		{{false, true, true, false}, "intersection"},
+
+		{{false, true, true, true}, "intersection"},
+		{{true, false, true, true}, "intersection"},
+		{{true, true, false, true}, "intersection"},
+		{{true, true, true, false}, "intersection"}
+	};
+
+
+	auto getSurroundingRoads(const TileMap& tileMap, const NAS2D::Point<int>& tileLocation)
+	{
+		std::array<bool, 4> surroundingTiles{false, false, false, false};
+		for (size_t i = 0; i < 4; ++i)
+		{
+			const auto tileToInspect = tileLocation + DirectionClockwise4[i];
+			const auto surfacePosition = MapCoordinate{tileToInspect, 0};
+			if (!tileMap.isValidPosition(surfacePosition)) { continue; }
+			const auto& tile = tileMap.getTile(surfacePosition);
+			if (!tile.thingIsStructure()) { continue; }
+
+			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
+		}
+		return surroundingTiles;
+	}
+
+
+	std::string roadAnimationName(int integrity, const std::array<bool, 4>& surroundingTiles)
+	{
+		std::string tag = "";
+
+		if (integrity == 0) { tag = "-destroyed"; }
+		else if (integrity < constants::RoadIntegrityChange) { tag = "-decayed"; }
+
+		return IntersectionPatternTable.at(surroundingTiles) + tag;
+	}
+}
+
+
+std::string roadAnimationName(const Road& road, const TileMap& tileMap)
+{
+	const auto tileLocation = NAS2D::Utility<StructureManager>::get().tileFromStructure(&road).xy();
+	const auto surroundingTiles = getSurroundingRoads(tileMap, tileLocation);
+	return roadAnimationName(road.integrity(), surroundingTiles);
+}

--- a/appOPHD/Map/Connections.h
+++ b/appOPHD/Map/Connections.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+
+class TileMap;
+class Road;
+
+
+std::string roadAnimationName(const Road& road, const TileMap& tileMap);

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -8,6 +8,7 @@
 
 #include "Route.h"
 
+#include "../Map/Connections.h"
 #include "../Map/TileMap.h"
 
 #include "../Cache.h"
@@ -32,68 +33,6 @@ namespace
 		{"SID_FUSION_REACTOR", {constants::FusionReactor, 21, SID_FUSION_REACTOR}},
 		{"SID_SOLAR_PLANT", {constants::SolarPlant, 10, StructureID::SID_SOLAR_PLANT}}
 	};
-
-
-	const std::map<std::array<bool, 4>, std::string> IntersectionPatternTable =
-	{
-		{{true, false, true, false}, "left"},
-		{{true, false, false, false}, "left"},
-		{{false, false, true, false}, "left"},
-
-		{{false, true, false, true}, "right"},
-		{{false, true, false, false}, "right"},
-		{{false, false, false, true}, "right"},
-
-		{{false, false, false, false}, "intersection"},
-		{{true, true, false, false}, "intersection"},
-		{{false, false, true, true}, "intersection"},
-		{{false, true, true, true}, "intersection"},
-		{{true, true, true, false}, "intersection"},
-		{{true, true, true, true}, "intersection"},
-		{{true, false, false, true}, "intersection"},
-		{{false, true, true, false}, "intersection"},
-
-		{{false, true, true, true}, "intersection"},
-		{{true, false, true, true}, "intersection"},
-		{{true, true, false, true}, "intersection"},
-		{{true, true, true, false}, "intersection"}
-	};
-
-
-	auto getSurroundingRoads(const TileMap& tileMap, const NAS2D::Point<int>& tileLocation)
-	{
-		std::array<bool, 4> surroundingTiles{false, false, false, false};
-		for (size_t i = 0; i < 4; ++i)
-		{
-			const auto tileToInspect = tileLocation + DirectionClockwise4[i];
-			const auto surfacePosition = MapCoordinate{tileToInspect, 0};
-			if (!tileMap.isValidPosition(surfacePosition)) { continue; }
-			const auto& tile = tileMap.getTile(surfacePosition);
-			if (!tile.thingIsStructure()) { continue; }
-
-			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
-		}
-		return surroundingTiles;
-	}
-
-
-	std::string roadAnimationName(int integrity, const std::array<bool, 4>& surroundingTiles)
-	{
-		std::string tag = "";
-
-		if (integrity == 0) { tag = "-destroyed"; }
-		else if (integrity < constants::RoadIntegrityChange) { tag = "-decayed"; }
-
-		return IntersectionPatternTable.at(surroundingTiles) + tag;
-	}
-
-
-	std::string roadAnimationName(const Road& road, const TileMap& tileMap)
-	{
-		const auto tileLocation = NAS2D::Utility<StructureManager>::get().tileFromStructure(&road).xy();
-		const auto surroundingTiles = getSurroundingRoads(tileMap, tileLocation);
-		return roadAnimationName(road.integrity(), surroundingTiles);
-	}
 
 
 	int consumeFood(FoodProduction& producer, int amountToConsume)

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -60,17 +60,6 @@ namespace
 	};
 
 
-	std::string roadAnimationName(int integrity, const std::array<bool, 4>& surroundingTiles)
-	{
-		std::string tag = "";
-
-		if (integrity == 0) { tag = "-destroyed"; }
-		else if (integrity < constants::RoadIntegrityChange) { tag = "-decayed"; }
-
-		return IntersectionPatternTable.at(surroundingTiles) + tag;
-	}
-
-
 	auto getSurroundingRoads(const TileMap& tileMap, const NAS2D::Point<int>& tileLocation)
 	{
 		std::array<bool, 4> surroundingTiles{false, false, false, false};
@@ -85,6 +74,17 @@ namespace
 			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
 		}
 		return surroundingTiles;
+	}
+
+
+	std::string roadAnimationName(int integrity, const std::array<bool, 4>& surroundingTiles)
+	{
+		std::string tag = "";
+
+		if (integrity == 0) { tag = "-destroyed"; }
+		else if (integrity < constants::RoadIntegrityChange) { tag = "-decayed"; }
+
+		return IntersectionPatternTable.at(surroundingTiles) + tag;
 	}
 
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -88,6 +88,14 @@ namespace
 	}
 
 
+	std::string roadAnimationName(const Road& road, const TileMap& tileMap)
+	{
+		const auto tileLocation = NAS2D::Utility<StructureManager>::get().tileFromStructure(&road).xy();
+		const auto surroundingTiles = getSurroundingRoads(tileMap, tileLocation);
+		return roadAnimationName(road.integrity(), surroundingTiles);
+	}
+
+
 	int consumeFood(FoodProduction& producer, int amountToConsume)
 	{
 		const auto foodLevel = producer.foodLevel();
@@ -590,11 +598,7 @@ void MapViewState::updateRoads()
 	for (auto* road : roads)
 	{
 		if (!road->operational()) { continue; }
-
-		const auto tileLocation = NAS2D::Utility<StructureManager>::get().tileFromStructure(road).xy();
-		const auto surroundingTiles = getSurroundingRoads(*mTileMap, tileLocation);
-
-		road->sprite().play(roadAnimationName(road->integrity(), surroundingTiles));
+		road->sprite().play(roadAnimationName(*road, *mTileMap));
 	}
 }
 

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="GraphWalker.cpp" />
     <ClCompile Include="IOHelper.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Map\Connections.cpp" />
     <ClCompile Include="Map\MapView.cpp" />
     <ClCompile Include="Map\Tile.cpp" />
     <ClCompile Include="Map\TileMap.cpp" />
@@ -288,6 +289,7 @@
     <ClInclude Include="Constants\UiConstants.h" />
     <ClInclude Include="GraphWalker.h" />
     <ClInclude Include="IOHelper.h" />
+    <ClInclude Include="Map\Connections.h" />
     <ClInclude Include="Map\MapView.h" />
     <ClInclude Include="Map\Tile.h" />
     <ClInclude Include="Map\TileMap.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Map\Connections.cpp">
+      <Filter>Source Files\Map</Filter>
+    </ClCompile>
     <ClCompile Include="Map\MapView.cpp">
       <Filter>Source Files\Map</Filter>
     </ClCompile>
@@ -382,6 +385,9 @@
     </ClInclude>
     <ClInclude Include="IOHelper.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Map\Connections.h">
+      <Filter>Header Files\Map</Filter>
     </ClInclude>
     <ClInclude Include="Map\MapView.h">
       <Filter>Header Files\Map</Filter>


### PR DESCRIPTION
Potentially we can re-purpose the auto `Road` connection code for `Tube` connections.

Related:
- Issue #1740
- Issue #650
