### PR TITLE
Reduce `FileIo` includes

### DIFF
--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -9,9 +9,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/EventHandler.h>
-#include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/EnumKeyCode.h>
-#include <NAS2D/EnumKeyModifier.h>
 
 #include <string>
 #include <vector>

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -9,6 +9,9 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/EnumMouseButton.h>
+#include <NAS2D/EnumKeyCode.h>
+#include <NAS2D/EnumKeyModifier.h>
 
 #include <string>
 #include <vector>

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -12,7 +12,6 @@
 #include <NAS2D/EnumKeyCode.h>
 
 #include <string>
-#include <vector>
 #include <algorithm>
 
 

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -6,9 +6,9 @@
 
 #include "MessageBox.h"
 
-#include <NAS2D/EnumKeyCode.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
+#include <NAS2D/EventHandler.h>
 
 #include <string>
 #include <vector>

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -7,10 +7,15 @@
 #include <libControls/Label.h>
 
 #include <NAS2D/Signal/Delegate.h>
-#include <NAS2D/EnumMouseButton.h>
-#include <NAS2D/EnumKeyCode.h>
-#include <NAS2D/EnumKeyModifier.h>
 #include <NAS2D/Math/Point.h>
+
+
+namespace NAS2D
+{
+	enum class KeyModifier : uint16_t;
+	enum class KeyCode : uint32_t;
+	enum class MouseButton;
+}
 
 
 class FileIo : public Window

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -7,7 +7,9 @@
 #include <libControls/Label.h>
 
 #include <NAS2D/Signal/Delegate.h>
-#include <NAS2D/EventHandler.h>
+#include <NAS2D/EnumMouseButton.h>
+#include <NAS2D/EnumKeyCode.h>
+#include <NAS2D/EnumKeyModifier.h>
 #include <NAS2D/Math/Point.h>
 
 

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -6,7 +6,6 @@
 #include <libControls/ListBox.h>
 #include <libControls/Label.h>
 
-#include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -2,6 +2,8 @@
 
 #include <libControls/ControlContainer.h>
 
+#include <NAS2D/Signal/Signal.h>
+
 
 class Structure;
 

--- a/libControls/ControlContainer.cpp
+++ b/libControls/ControlContainer.cpp
@@ -2,6 +2,8 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <algorithm>
 #include <stdexcept>

--- a/libControls/ControlContainer.cpp
+++ b/libControls/ControlContainer.cpp
@@ -1,6 +1,7 @@
 #include "ControlContainer.h"
 
 #include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
 
 #include <algorithm>
 #include <stdexcept>

--- a/libControls/ControlContainer.h
+++ b/libControls/ControlContainer.h
@@ -2,11 +2,16 @@
 
 #include "Control.h"
 
-#include <NAS2D/Math/Point.h>
-#include <NAS2D/Math/Vector.h>
-#include <NAS2D/EnumMouseButton.h>
-
 #include <vector>
+
+
+namespace NAS2D
+{
+	enum class MouseButton;
+
+	template <typename BaseType> struct Point;
+	template <typename BaseType> struct Vector;
+}
 
 
 /**

--- a/libControls/ControlContainer.h
+++ b/libControls/ControlContainer.h
@@ -4,7 +4,7 @@
 
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
-#include <NAS2D/EventHandler.h>
+#include <NAS2D/EnumMouseButton.h>
 
 #include <vector>
 

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -4,6 +4,7 @@
 
 #include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -7,7 +7,6 @@
 #include <NAS2D/Renderer/RectangleSkin.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
-#include <NAS2D/Signal/Signal.h>
 
 #include <string>
 
@@ -24,13 +23,10 @@ public:
 
 	void update() override;
 
-	using TitleChangeSignal = NAS2D::Signal<Window*>;
-
 	void title(const std::string& title);
 	const std::string& title() const { return mTitle; }
-	TitleChangeSignal::Source& titleChanged() { return mTitleChanged; }
 
-	virtual void onTitleChanged() { mTitleChanged(this); }
+	virtual void onTitleChanged() {}
 
 protected:
 	void draw() const override;
@@ -47,8 +43,6 @@ private:
 	const NAS2D::Image& mTitleBarCenter;
 	const NAS2D::Image& mTitleBarRight;
 	NAS2D::RectangleSkin mBody;
-
-	TitleChangeSignal mTitleChanged;
 
 	std::string mTitle;
 

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -7,6 +7,7 @@
 #include <NAS2D/Renderer/RectangleSkin.h>
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
+#include <NAS2D/Signal/Signal.h>
 
 #include <string>
 


### PR DESCRIPTION
There was an unused include for `Signal.h` that was removed, which led to a cascade of related changes to minimize header includes.

The unused `TitleChangeSignal` in `Window` was removed.

Related:
- Issue #875
- Issue #1573
