### PR TITLE
Add `TextField` `maxCharacters` auto width

### DIFF
--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -24,10 +24,11 @@ namespace
 }
 
 
-TextField::TextField() :
+TextField::TextField(std::size_t maxCharacters) :
 	mFont{getDefaultFont()},
 	mSkinNormal{loadRectangleSkin("ui/skin/textbox_normal")},
-	mSkinFocus{loadRectangleSkin("ui/skin/textbox_highlight")}
+	mSkinFocus{loadRectangleSkin("ui/skin/textbox_highlight")},
+	mMaxCharacters{maxCharacters}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &TextField::onMouseDown});

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -111,7 +111,7 @@ void TextField::onTextInput(const std::string& newTextInput)
 {
 	if (!hasFocus() || !visible() || !editable() || newTextInput.empty()) { return; }
 
-	if (mMaxCharacters > 0 && text().length() == mMaxCharacters) { return; }
+	if (mMaxCharacters > 0 && text().length() >= mMaxCharacters) { return; }
 
 	auto prvLen = text().length();
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -35,7 +35,7 @@ TextField::TextField(std::size_t maxCharacters) :
 	eventHandler.keyDown().connect({this, &TextField::onKeyDown});
 	eventHandler.textInput().connect({this, &TextField::onTextInput});
 
-	height(mFont.height() + fieldPadding * 2);
+	size({mFont.width("W") * static_cast<int>(maxCharacters) + fieldPadding * 2, mFont.height() + fieldPadding * 2});
 }
 
 

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -42,7 +42,7 @@ public:
 	};
 
 public:
-	TextField();
+	TextField(std::size_t maxCharacters = 0);
 	~TextField() override;
 
 	void editable(bool editable);


### PR DESCRIPTION
Allow `TextField` to constructor to optionally accept `maxCharacters`, and use it to auto set the `width`.

Related:
- PR #1769
- Issue #1754
