### PR TITLE
Fix `CheatMenu` layout

### DIFF
--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -49,15 +49,13 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	txtCheatCode{maxCheatLength},
 	btnOkay{"Okay", {this, &CheatMenu::onOkay}}
 {
-	size({300, 88});
+	btnOkay.size(btnOkay.size() + NAS2D::Vector{6, 2});
 
-	mLabelCheatCode.size({30, 20});
-	btnOkay.size({40, 20});
-	txtCheatCode.size({150, 20});
+	add(mLabelCheatCode, {10, 34});
+	add(txtCheatCode, {mLabelCheatCode.area().endPoint().x + 6, 34});
+	add(btnOkay, {txtCheatCode.area().endPoint().x + 6, 34});
 
-	add(mLabelCheatCode, {5, 34});
-	add(btnOkay, {240, 34});
-	add(txtCheatCode, {40, 34});
+	size({btnOkay.area().endPoint().x + 10, 88});
 }
 
 

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -52,12 +52,11 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	size({300, 88});
 
 	mLabelCheatCode.size({30, 20});
-	add(mLabelCheatCode, {5, 34});
-
 	btnOkay.size({40, 20});
-	add(btnOkay, {240, 34});
-
 	txtCheatCode.size({150, 20});
+
+	add(mLabelCheatCode, {5, 34});
+	add(btnOkay, {240, 34});
 	add(txtCheatCode, {40, 34});
 }
 

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -51,11 +51,12 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 {
 	btnOkay.size(btnOkay.size() + NAS2D::Vector{6, 2});
 
-	add(mLabelCheatCode, {10, 34});
-	add(txtCheatCode, {mLabelCheatCode.area().endPoint().x + 6, 34});
-	add(btnOkay, {txtCheatCode.area().endPoint().x + 6, 34});
+	const auto positionY = sWindowTitleBarHeight + 10;
+	add(mLabelCheatCode, {10, positionY});
+	add(txtCheatCode, {mLabelCheatCode.area().endPoint().x + 6, positionY});
+	add(btnOkay, {txtCheatCode.area().endPoint().x + 6, positionY});
 
-	size({btnOkay.area().endPoint().x + 10, 88});
+	size({btnOkay.area().endPoint().x + 10, positionY + txtCheatCode.size().y + 10});
 }
 
 

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -2,6 +2,9 @@
 
 #include <libOPHD/XmlSerializer.h>
 
+#include <algorithm>
+#include <ranges>
+
 
 namespace
 {
@@ -34,6 +37,8 @@ namespace
 		{"dropretirees", CheatMenu::CheatCode::RemoveRetired},     // Remove ten retired colonists from the population
 		{"beepboop", CheatMenu::CheatCode::AddRobots}              // Add a RoboDigger, RoboMiner, and RoboDozer to the robot pool
 	};
+
+	static const auto maxCheatLength = std::ranges::max(std::views::transform(std::views::keys(cheatCodeTable), &std::string::size));
 }
 
 
@@ -52,7 +57,7 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	add(btnOkay, {240, 34});
 
 	txtCheatCode.size({150, 20});
-	txtCheatCode.maxCharacters(50);
+	txtCheatCode.maxCharacters(maxCheatLength);
 	add(txtCheatCode, {40, 34});
 }
 

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -46,6 +46,7 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	Window{"Cheating"},
 	mCheatHandler{cheatHandler},
 	mLabelCheatCode{"Code:"},
+	txtCheatCode{maxCheatLength},
 	btnOkay{"Okay", {this, &CheatMenu::onOkay}}
 {
 	size({300, 88});
@@ -57,7 +58,6 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	add(btnOkay, {240, 34});
 
 	txtCheatCode.size({150, 20});
-	txtCheatCode.maxCharacters(maxCheatLength);
 	add(txtCheatCode, {40, 34});
 }
 


### PR DESCRIPTION
The `CheatMenu` will now dynamically size and layout elements, and size window to match those elements.

The `TextField` size is dynamically adjusted to match the max length cheat code (currently calculated at 16 characters), and assumed worst case large character pixel size of "W".

Original:
![image](https://github.com/user-attachments/assets/e6028252-7853-4424-af1c-938ccb66cf4e)

Updated:
![image](https://github.com/user-attachments/assets/1c669919-3adc-47ea-a7c5-8775f80dcde8)

----

Related:
- https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-2975090937
- PR #1771
- PR #1772
- PR #1769
