### PR TITLE
Set `CheatMenu` focus to `TextField`

### DIFF
--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -57,6 +57,8 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	add(btnOkay, {txtCheatCode.area().endPoint().x + 6, positionY});
 
 	size({btnOkay.area().endPoint().x + 10, positionY + txtCheatCode.size().y + 10});
+	// Transfer focus to text field
+	bringToFront(&txtCheatCode);
 }
 
 
@@ -65,7 +67,8 @@ void CheatMenu::onOkay()
 	if (mCheatHandler) { mCheatHandler(txtCheatCode.text()); }
 	txtCheatCode.clear();
 	hide();
-
+	// Transfer focus back to text field (from "Okay" button)
+	bringToFront(&txtCheatCode);
 }
 
 


### PR DESCRIPTION
Text focus broke a little worse during recent changes, where the text focus was not on the `TextField` even on the initial window display. This fixes that, so focus returns to the `TextField` every time it is displayed.

This does not address the issue of being able to press `Enter` to submit a cheat code. That may require a `TextField` update first, so it doesn't swallow `Enter` keys without any notice.

Related:
- Issue https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-2975090937
- PR #1773
