### PR TITLE
Remove code for the removed `vcpkg` `x-gha` binary cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       Platform: ${{ matrix.platform }}
       Configuration: Release
       VcpkgManifestInstall: false
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
     - uses: actions/checkout@v4
@@ -30,13 +29,6 @@ jobs:
       run: |
         vcpkg --version
         vcpkg integrate install
-
-    - name: Export GitHub Actions cache environment variables
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
     - name: Set SHA env vars
       shell: bash


### PR DESCRIPTION
For now we just cache the entire `vcpkg_installed` folder, with no binary caching for individual dependencies.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1306
- PR #1785
