### PR TITLE
Use lowerCamelCase for Report panel names

### DIFF
--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -50,9 +50,9 @@ namespace
 		void selected(bool isSelected)
 		{
 			mIsSelected = isSelected;
-			if (UiPanel)
+			if (report)
 			{
-				UiPanel->enabled(isSelected);
+				report->enabled(isSelected);
 			}
 		}
 
@@ -65,7 +65,7 @@ namespace
 		{
 			icon = panelInfo.image;
 			name = panelInfo.name;
-			UiPanel = panelInfo.report;
+			report = panelInfo.report;
 		}
 
 	public:
@@ -78,7 +78,7 @@ namespace
 
 		NAS2D::Rectangle<int> Rect;
 
-		ReportInterface* UiPanel = nullptr;
+		ReportInterface* report = nullptr;
 
 	private:
 		bool mIsSelected = false;
@@ -124,9 +124,9 @@ namespace
 		{
 			renderer.drawBoxFilled(panel.Rect, constants::PrimaryColorVariant);
 
-			if (panel.UiPanel)
+			if (panel.report)
 			{
-				panel.UiPanel->update();
+				panel.report->update();
 			}
 		}
 
@@ -138,9 +138,9 @@ namespace
 	void selectPanel(Panel& panel, Structure* structure)
 	{
 		panel.selected(true);
-		panel.UiPanel->visible(true);
-		panel.UiPanel->refresh();
-		panel.UiPanel->selectStructure(structure);
+		panel.report->visible(true);
+		panel.report->refresh();
+		panel.report->selectStructure(structure);
 	}
 
 
@@ -175,7 +175,7 @@ MainReportsUiState::~MainReportsUiState()
 
 	for (Panel& panel : Panels)
 	{
-		delete panel.UiPanel;
+		delete panel.report;
 	}
 }
 
@@ -201,7 +201,7 @@ void MainReportsUiState::initialize()
 	{
 		auto& panel = Panels[i];
 		panel.setMeta(panelInfo[i]);
-		setReportValues(panel.UiPanel, size);
+		setReportValues(panel.report, size);
 	}
 
 	setPanelRects(size.x, fontMain);
@@ -212,11 +212,11 @@ void MainReportsUiState::onActivate()
 {
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel)
+		if (panel.report)
 		{
-			panel.UiPanel->fillLists();
-			panel.UiPanel->refresh();
-			panel.UiPanel->show();
+			panel.report->fillLists();
+			panel.report->refresh();
+			panel.report->show();
 		}
 	}
 }
@@ -226,10 +226,10 @@ void MainReportsUiState::onDeactivate()
 {
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel)
+		if (panel.report)
 		{
-			panel.UiPanel->hide();
-			panel.UiPanel->clearSelected();
+			panel.report->hide();
+			panel.report->clearSelected();
 		}
 
 		panel.selected(false);
@@ -271,9 +271,9 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 			bool selected = panel.Rect.contains(MOUSE_COORDS);
 			panel.selected(selected);
 
-			if (panel.UiPanel)
+			if (panel.report)
 			{
-				panel.UiPanel->visible(selected);
+				panel.report->visible(selected);
 			}
 		}
 	}
@@ -291,9 +291,9 @@ void MainReportsUiState::exit()
 
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel)
+		if (panel.report)
 		{
-			panel.UiPanel->clearSelected();
+			panel.report->clearSelected();
 		}
 	}
 
@@ -306,9 +306,9 @@ void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 	setPanelRects(newSize.x, fontMain);
 	for (Panel& panel : Panels)
 	{
-		if (panel.UiPanel)
+		if (panel.report)
 		{
-			panel.UiPanel->size(NAS2D::Vector{newSize.x, newSize.y - 48});
+			panel.report->size(NAS2D::Vector{newSize.x, newSize.y - 48});
 		}
 	}
 }
@@ -355,7 +355,7 @@ void MainReportsUiState::selectMinePanel(Structure* structure)
 
 void MainReportsUiState::injectTechnology(TechnologyCatalog& catalog, ResearchTracker& tracker)
 {
-	auto* researchPanel = Panels[static_cast<size_t>(NavigationPanel::Research)].UiPanel;
+	auto* researchPanel = Panels[static_cast<size_t>(NavigationPanel::Research)].report;
 	dynamic_cast<ResearchReport&>(*researchPanel).injectTechReferences(catalog, tracker);
 }
 
@@ -364,9 +364,9 @@ void MainReportsUiState::clearLists()
 {
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel)
+		if (panel.report)
 		{
-			panel.UiPanel->fillLists();
+			panel.report->fillLists();
 		}
 	}
 }
@@ -382,9 +382,9 @@ MainReportsUiState::TakeMeThereSignalSourceList MainReportsUiState::takeMeThere(
 	TakeMeThereSignalSourceList takeMeThereList;
 	for (auto& panel : Panels)
 	{
-		if (panel.UiPanel)
+		if (panel.report)
 		{
-			takeMeThereList.push_back(&panel.UiPanel->takeMeThereSignal());
+			takeMeThereList.push_back(&panel.report->takeMeThereSignal());
 		}
 	}
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -63,7 +63,7 @@ namespace
 
 		void setMeta(const PanelInfo& panelInfo)
 		{
-			Img = panelInfo.image;
+			icon = panelInfo.image;
 			name = panelInfo.name;
 			UiPanel = panelInfo.report;
 		}
@@ -71,7 +71,7 @@ namespace
 	public:
 		std::string name;
 
-		const NAS2D::Image* Img = nullptr;
+		const NAS2D::Image* icon = nullptr;
 
 		NAS2D::Point<int> TextPosition;
 		NAS2D::Point<int> IconPosition;
@@ -131,7 +131,7 @@ namespace
 		}
 
 		renderer.drawText(font, panel.name, panel.TextPosition, drawColor);
-		renderer.drawImage(*panel.Img, panel.IconPosition, 1.0f, drawColor);
+		renderer.drawImage(*panel.icon, panel.IconPosition, 1.0f, drawColor);
 	}
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -64,12 +64,12 @@ namespace
 		void setMeta(const PanelInfo& panelInfo)
 		{
 			Img = panelInfo.image;
-			Name = panelInfo.name;
+			name = panelInfo.name;
 			UiPanel = panelInfo.report;
 		}
 
 	public:
-		std::string Name;
+		std::string name;
 
 		const NAS2D::Image* Img = nullptr;
 
@@ -104,7 +104,7 @@ namespace
 		{
 			auto& panel = Panels[i];
 			panel.Rect = NAS2D::Rectangle{panelPosition, panelSize};
-			panel.TextPosition = panelPosition + (panelSize - font.size(panel.Name)) / 2 + NAS2D::Vector{20, 0};
+			panel.TextPosition = panelPosition + (panelSize - font.size(panel.name)) / 2 + NAS2D::Vector{20, 0};
 			panel.IconPosition = {panel.TextPosition.x - 40, 8};
 			panelPosition.x += panelSize.x;
 		}
@@ -130,7 +130,7 @@ namespace
 			}
 		}
 
-		renderer.drawText(font, panel.Name, panel.TextPosition, drawColor);
+		renderer.drawText(font, panel.name, panel.TextPosition, drawColor);
 		renderer.drawImage(*panel.Img, panel.IconPosition, 1.0f, drawColor);
 	}
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -85,14 +85,14 @@ namespace
 	};
 
 
-	static std::array<Panel, 7> Panels;
+	static std::array<Panel, 7> panels;
 
 	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
 
 
 	void setPanelRects(int width, const NAS2D::Font& font)
 	{
-		auto& exitPanel = Panels[ExitPanelIndex];
+		auto& exitPanel = panels[ExitPanelIndex];
 		exitPanel.tabArea = {{width - 48, 0}, {48, 48}};
 		exitPanel.iconPosition = {width - 40, 8};
 
@@ -100,9 +100,9 @@ namespace
 		const auto panelSize = NAS2D::Vector{remaining_width / 6, 48};
 
 		auto panelPosition = NAS2D::Point{0, 0};
-		for (std::size_t i = 0; i < Panels.size() - 1; ++i)
+		for (std::size_t i = 0; i < panels.size() - 1; ++i)
 		{
-			auto& panel = Panels[i];
+			auto& panel = panels[i];
 			panel.tabArea = NAS2D::Rectangle{panelPosition, panelSize};
 			panel.textPosition = panelPosition + (panelSize - font.size(panel.name)) / 2 + NAS2D::Vector{20, 0};
 			panel.iconPosition = {panel.textPosition.x - 40, 8};
@@ -173,7 +173,7 @@ MainReportsUiState::~MainReportsUiState()
 	eventHandler.keyDown().disconnect({this, &MainReportsUiState::onKeyDown});
 	eventHandler.mouseButtonDown().disconnect({this, &MainReportsUiState::onMouseDown});
 
-	for (Panel& panel : Panels)
+	for (Panel& panel : panels)
 	{
 		delete panel.report;
 	}
@@ -199,7 +199,7 @@ void MainReportsUiState::initialize()
 
 	for (size_t i = 0; i < panelInfo.size(); i++)
 	{
-		auto& panel = Panels[i];
+		auto& panel = panels[i];
 		panel.setMeta(panelInfo[i]);
 		setReportValues(panel.report, size);
 	}
@@ -210,7 +210,7 @@ void MainReportsUiState::initialize()
 
 void MainReportsUiState::onActivate()
 {
-	for (auto& panel : Panels)
+	for (auto& panel : panels)
 	{
 		if (panel.report)
 		{
@@ -224,7 +224,7 @@ void MainReportsUiState::onActivate()
 
 void MainReportsUiState::onDeactivate()
 {
-	for (auto& panel : Panels)
+	for (auto& panel : panels)
 	{
 		if (panel.report)
 		{
@@ -266,7 +266,7 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 
 	if (button == NAS2D::MouseButton::Left)
 	{
-		for (Panel& panel : Panels)
+		for (Panel& panel : panels)
 		{
 			bool selected = panel.tabArea.contains(MOUSE_COORDS);
 			panel.selected(selected);
@@ -278,7 +278,7 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 		}
 	}
 
-	if (Panels[ExitPanelIndex].selected())
+	if (panels[ExitPanelIndex].selected())
 	{
 		exit();
 	}
@@ -289,7 +289,7 @@ void MainReportsUiState::exit()
 {
 	deselectAllPanels();
 
-	for (auto& panel : Panels)
+	for (auto& panel : panels)
 	{
 		if (panel.report)
 		{
@@ -304,7 +304,7 @@ void MainReportsUiState::exit()
 void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 {
 	setPanelRects(newSize.x, fontMain);
-	for (Panel& panel : Panels)
+	for (Panel& panel : panels)
 	{
 		if (panel.report)
 		{
@@ -316,7 +316,7 @@ void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 
 void MainReportsUiState::deselectAllPanels()
 {
-	for (auto& panel : Panels)
+	for (auto& panel : panels)
 	{
 		panel.selected(false);
 	}
@@ -329,7 +329,7 @@ void MainReportsUiState::deselectAllPanels()
 void MainReportsUiState::selectFactoryPanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(Panels[static_cast<size_t>(NavigationPanel::Production)], structure);
+	selectPanel(panels[static_cast<size_t>(NavigationPanel::Production)], structure);
 }
 
 
@@ -339,7 +339,7 @@ void MainReportsUiState::selectFactoryPanel(Structure* structure)
 void MainReportsUiState::selectWarehousePanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(Panels[static_cast<size_t>(NavigationPanel::Warehouse)], structure);
+	selectPanel(panels[static_cast<size_t>(NavigationPanel::Warehouse)], structure);
 }
 
 
@@ -349,20 +349,20 @@ void MainReportsUiState::selectWarehousePanel(Structure* structure)
 void MainReportsUiState::selectMinePanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(Panels[static_cast<size_t>(NavigationPanel::Mines)], structure);
+	selectPanel(panels[static_cast<size_t>(NavigationPanel::Mines)], structure);
 }
 
 
 void MainReportsUiState::injectTechnology(TechnologyCatalog& catalog, ResearchTracker& tracker)
 {
-	auto* researchPanel = Panels[static_cast<size_t>(NavigationPanel::Research)].report;
+	auto* researchPanel = panels[static_cast<size_t>(NavigationPanel::Research)].report;
 	dynamic_cast<ResearchReport&>(*researchPanel).injectTechReferences(catalog, tracker);
 }
 
 
 void MainReportsUiState::clearLists()
 {
-	for (auto& panel : Panels)
+	for (auto& panel : panels)
 	{
 		if (panel.report)
 		{
@@ -380,7 +380,7 @@ void MainReportsUiState::clearLists()
 MainReportsUiState::TakeMeThereSignalSourceList MainReportsUiState::takeMeThere()
 {
 	TakeMeThereSignalSourceList takeMeThereList;
-	for (auto& panel : Panels)
+	for (auto& panel : panels)
 	{
 		if (panel.report)
 		{
@@ -399,7 +399,7 @@ NAS2D::State* MainReportsUiState::update()
 	renderer.clearScreen(NAS2D::Color{35, 35, 35});
 	renderer.drawBoxFilled(NAS2D::Rectangle<int>{{0, 0}, {renderer.size().x, 48}}, NAS2D::Color::Black);
 
-	for (Panel& panel : Panels)
+	for (Panel& panel : panels)
 	{
 		drawPanel(renderer, panel, fontMain);
 	}

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -73,7 +73,7 @@ namespace
 
 		const NAS2D::Image* icon = nullptr;
 
-		NAS2D::Point<int> TextPosition;
+		NAS2D::Point<int> textPosition;
 		NAS2D::Point<int> IconPosition;
 
 		NAS2D::Rectangle<int> tabArea;
@@ -104,8 +104,8 @@ namespace
 		{
 			auto& panel = Panels[i];
 			panel.tabArea = NAS2D::Rectangle{panelPosition, panelSize};
-			panel.TextPosition = panelPosition + (panelSize - font.size(panel.name)) / 2 + NAS2D::Vector{20, 0};
-			panel.IconPosition = {panel.TextPosition.x - 40, 8};
+			panel.textPosition = panelPosition + (panelSize - font.size(panel.name)) / 2 + NAS2D::Vector{20, 0};
+			panel.IconPosition = {panel.textPosition.x - 40, 8};
 			panelPosition.x += panelSize.x;
 		}
 	}
@@ -130,7 +130,7 @@ namespace
 			}
 		}
 
-		renderer.drawText(font, panel.name, panel.TextPosition, drawColor);
+		renderer.drawText(font, panel.name, panel.textPosition, drawColor);
 		renderer.drawImage(*panel.icon, panel.IconPosition, 1.0f, drawColor);
 	}
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -74,7 +74,7 @@ namespace
 		const NAS2D::Image* icon = nullptr;
 
 		NAS2D::Point<int> textPosition;
-		NAS2D::Point<int> IconPosition;
+		NAS2D::Point<int> iconPosition;
 
 		NAS2D::Rectangle<int> tabArea;
 
@@ -94,7 +94,7 @@ namespace
 	{
 		auto& exitPanel = Panels[ExitPanelIndex];
 		exitPanel.tabArea = {{width - 48, 0}, {48, 48}};
-		exitPanel.IconPosition = {width - 40, 8};
+		exitPanel.iconPosition = {width - 40, 8};
 
 		int remaining_width = width - exitPanel.tabArea.size.x;
 		const auto panelSize = NAS2D::Vector{remaining_width / 6, 48};
@@ -105,7 +105,7 @@ namespace
 			auto& panel = Panels[i];
 			panel.tabArea = NAS2D::Rectangle{panelPosition, panelSize};
 			panel.textPosition = panelPosition + (panelSize - font.size(panel.name)) / 2 + NAS2D::Vector{20, 0};
-			panel.IconPosition = {panel.textPosition.x - 40, 8};
+			panel.iconPosition = {panel.textPosition.x - 40, 8};
 			panelPosition.x += panelSize.x;
 		}
 	}
@@ -131,7 +131,7 @@ namespace
 		}
 
 		renderer.drawText(font, panel.name, panel.textPosition, drawColor);
-		renderer.drawImage(*panel.icon, panel.IconPosition, 1.0f, drawColor);
+		renderer.drawImage(*panel.icon, panel.iconPosition, 1.0f, drawColor);
 	}
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -76,7 +76,7 @@ namespace
 		NAS2D::Point<int> TextPosition;
 		NAS2D::Point<int> IconPosition;
 
-		NAS2D::Rectangle<int> Rect;
+		NAS2D::Rectangle<int> tabArea;
 
 		ReportInterface* report = nullptr;
 
@@ -93,17 +93,17 @@ namespace
 	void setPanelRects(int width, const NAS2D::Font& font)
 	{
 		auto& exitPanel = Panels[ExitPanelIndex];
-		exitPanel.Rect = {{width - 48, 0}, {48, 48}};
+		exitPanel.tabArea = {{width - 48, 0}, {48, 48}};
 		exitPanel.IconPosition = {width - 40, 8};
 
-		int remaining_width = width - exitPanel.Rect.size.x;
+		int remaining_width = width - exitPanel.tabArea.size.x;
 		const auto panelSize = NAS2D::Vector{remaining_width / 6, 48};
 
 		auto panelPosition = NAS2D::Point{0, 0};
 		for (std::size_t i = 0; i < Panels.size() - 1; ++i)
 		{
 			auto& panel = Panels[i];
-			panel.Rect = NAS2D::Rectangle{panelPosition, panelSize};
+			panel.tabArea = NAS2D::Rectangle{panelPosition, panelSize};
 			panel.TextPosition = panelPosition + (panelSize - font.size(panel.name)) / 2 + NAS2D::Vector{20, 0};
 			panel.IconPosition = {panel.TextPosition.x - 40, 8};
 			panelPosition.x += panelSize.x;
@@ -113,16 +113,16 @@ namespace
 
 	void drawPanel(NAS2D::Renderer& renderer, Panel& panel, const NAS2D::Font& font)
 	{
-		if (panel.Rect.contains(MOUSE_COORDS))
+		if (panel.tabArea.contains(MOUSE_COORDS))
 		{
-			renderer.drawBoxFilled(panel.Rect, constants::HighlightColor);
+			renderer.drawBoxFilled(panel.tabArea, constants::HighlightColor);
 		}
 
 		auto drawColor = panel.selected() ? constants::PrimaryColor : constants::SecondaryColor;
 
 		if (panel.selected())
 		{
-			renderer.drawBoxFilled(panel.Rect, constants::PrimaryColorVariant);
+			renderer.drawBoxFilled(panel.tabArea, constants::PrimaryColorVariant);
 
 			if (panel.report)
 			{
@@ -268,7 +268,7 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 	{
 		for (Panel& panel : Panels)
 		{
-			bool selected = panel.Rect.contains(MOUSE_COORDS);
+			bool selected = panel.tabArea.contains(MOUSE_COORDS);
 			panel.selected(selected);
 
 			if (panel.report)

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -47,7 +47,7 @@ namespace
 	class Panel
 	{
 	public:
-		void Selected(bool isSelected)
+		void selected(bool isSelected)
 		{
 			mIsSelected = isSelected;
 			if (UiPanel)
@@ -56,7 +56,7 @@ namespace
 			}
 		}
 
-		bool Selected() const
+		bool selected() const
 		{
 			return mIsSelected;
 		}
@@ -118,9 +118,9 @@ namespace
 			renderer.drawBoxFilled(panel.Rect, constants::HighlightColor);
 		}
 
-		auto drawColor = panel.Selected() ? constants::PrimaryColor : constants::SecondaryColor;
+		auto drawColor = panel.selected() ? constants::PrimaryColor : constants::SecondaryColor;
 
-		if (panel.Selected())
+		if (panel.selected())
 		{
 			renderer.drawBoxFilled(panel.Rect, constants::PrimaryColorVariant);
 
@@ -137,7 +137,7 @@ namespace
 
 	void selectPanel(Panel& panel, Structure* structure)
 	{
-		panel.Selected(true);
+		panel.selected(true);
 		panel.UiPanel->visible(true);
 		panel.UiPanel->refresh();
 		panel.UiPanel->selectStructure(structure);
@@ -232,7 +232,7 @@ void MainReportsUiState::onDeactivate()
 			panel.UiPanel->clearSelected();
 		}
 
-		panel.Selected(false);
+		panel.selected(false);
 	}
 }
 
@@ -269,7 +269,7 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 		for (Panel& panel : Panels)
 		{
 			bool selected = panel.Rect.contains(MOUSE_COORDS);
-			panel.Selected(selected);
+			panel.selected(selected);
 
 			if (panel.UiPanel)
 			{
@@ -278,7 +278,7 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 		}
 	}
 
-	if (Panels[ExitPanelIndex].Selected())
+	if (Panels[ExitPanelIndex].selected())
 	{
 		exit();
 	}
@@ -318,7 +318,7 @@ void MainReportsUiState::deselectAllPanels()
 {
 	for (auto& panel : Panels)
 	{
-		panel.Selected(false);
+		panel.selected(false);
 	}
 }
 


### PR DESCRIPTION
Use lowerCamelCase names for consistency with the rest of the code base.

Some refactoring for `MainReportsUiState` before addressing the use of `Signal`.

Related:
- Issue #875
