### PR TITLE
Refactor Report panel initialization

### DIFF
--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -53,6 +53,14 @@ namespace
 	class Panel
 	{
 	public:
+		void select(Structure* structure)
+		{
+			selected(true);
+			report->visible(true);
+			report->refresh();
+			report->selectStructure(structure);
+		}
+
 		void selected(bool isSelected)
 		{
 			mIsSelected = isSelected;
@@ -133,15 +141,6 @@ namespace
 
 		renderer.drawText(font, panel.name, panel.textPosition, drawColor);
 		renderer.drawImage(*panel.icon, panel.iconPosition, 1.0f, drawColor);
-	}
-
-
-	void selectPanel(Panel& panel, Structure* structure)
-	{
-		panel.selected(true);
-		panel.report->visible(true);
-		panel.report->refresh();
-		panel.report->selectStructure(structure);
 	}
 }
 
@@ -324,7 +323,7 @@ void MainReportsUiState::deselectAllPanels()
 void MainReportsUiState::selectFactoryPanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(panels[ProductionPanelIndex], structure);
+	panels[ProductionPanelIndex].select(structure);
 }
 
 
@@ -334,7 +333,7 @@ void MainReportsUiState::selectFactoryPanel(Structure* structure)
 void MainReportsUiState::selectWarehousePanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(panels[WarehousePanelIndex], structure);
+	panels[WarehousePanelIndex].select(structure);
 }
 
 
@@ -344,7 +343,7 @@ void MainReportsUiState::selectWarehousePanel(Structure* structure)
 void MainReportsUiState::selectMinePanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(panels[MinesPanelIndex], structure);
+	panels[MinesPanelIndex].select(structure);
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -43,6 +43,10 @@ namespace
 		Exit
 	};
 
+	constexpr auto ResearchPanelIndex = static_cast<size_t>(NavigationPanel::Research);
+	constexpr auto ProductionPanelIndex = static_cast<size_t>(NavigationPanel::Production);
+	constexpr auto WarehousePanelIndex = static_cast<size_t>(NavigationPanel::Warehouse);
+	constexpr auto MinesPanelIndex = static_cast<size_t>(NavigationPanel::Mines);
 	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
 
 
@@ -328,7 +332,7 @@ void MainReportsUiState::deselectAllPanels()
 void MainReportsUiState::selectFactoryPanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(panels[static_cast<size_t>(NavigationPanel::Production)], structure);
+	selectPanel(panels[ProductionPanelIndex], structure);
 }
 
 
@@ -338,7 +342,7 @@ void MainReportsUiState::selectFactoryPanel(Structure* structure)
 void MainReportsUiState::selectWarehousePanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(panels[static_cast<size_t>(NavigationPanel::Warehouse)], structure);
+	selectPanel(panels[WarehousePanelIndex], structure);
 }
 
 
@@ -348,13 +352,13 @@ void MainReportsUiState::selectWarehousePanel(Structure* structure)
 void MainReportsUiState::selectMinePanel(Structure* structure)
 {
 	deselectAllPanels();
-	selectPanel(panels[static_cast<size_t>(NavigationPanel::Mines)], structure);
+	selectPanel(panels[MinesPanelIndex], structure);
 }
 
 
 void MainReportsUiState::injectTechnology(TechnologyCatalog& catalog, ResearchTracker& tracker)
 {
-	auto* researchPanel = panels[static_cast<size_t>(NavigationPanel::Research)].report;
+	auto* researchPanel = panels[ResearchPanelIndex].report;
 	dynamic_cast<ResearchReport&>(*researchPanel).injectTechReferences(catalog, tracker);
 }
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -42,17 +42,16 @@ namespace
 	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
 
 
-	struct PanelInfo
-	{
-		ReportInterface* report{nullptr};
-		const std::string name{};
-		const NAS2D::Image* image{nullptr};
-	};
-
-
 	class Panel
 	{
 	public:
+		Panel() = default;
+		Panel(ReportInterface* newReport, std::string newName, const NAS2D::Image* newIcon) :
+			report{newReport},
+			name{newName},
+			icon{newIcon}
+		{}
+
 		void select(Structure* structure)
 		{
 			selected(true);
@@ -75,13 +74,6 @@ namespace
 			return mIsSelected;
 		}
 
-		void setMeta(const PanelInfo& panelInfo)
-		{
-			icon = panelInfo.image;
-			name = panelInfo.name;
-			report = panelInfo.report;
-		}
-
 	public:
 		ReportInterface* report = nullptr;
 		std::string name;
@@ -102,20 +94,18 @@ namespace
 	void initializePanels()
 	{
 		/* NOTE: Matches the order in enum NavigationPanel */
-		auto panelInfo = std::array<PanelInfo, 7>{
-			PanelInfo{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},
-			PanelInfo{new FactoryReport(), "Factories", &imageCache.load("ui/icons/production.png")},
-			PanelInfo{new WarehouseReport(), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
-			PanelInfo{new MineReport(), "Mines", &imageCache.load("ui/icons/mine.png")},
-			PanelInfo{new SatellitesReport(), "Satellites", &imageCache.load("ui/icons/satellite.png")},
-			PanelInfo{new SpaceportsReport(), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
-			PanelInfo{nullptr, "", &imageCache.load("ui/icons/exit.png")}
+		panels = std::array<Panel, 7>{
+			Panel{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},
+			Panel{new FactoryReport(), "Factories", &imageCache.load("ui/icons/production.png")},
+			Panel{new WarehouseReport(), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
+			Panel{new MineReport(), "Mines", &imageCache.load("ui/icons/mine.png")},
+			Panel{new SatellitesReport(), "Satellites", &imageCache.load("ui/icons/satellite.png")},
+			Panel{new SpaceportsReport(), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
+			Panel{nullptr, "", &imageCache.load("ui/icons/exit.png")}
 		};
 
-		for (size_t i = 0; i < panelInfo.size(); i++)
+		for (auto& panel : panels)
 		{
-			auto& panel = panels[i];
-			panel.setMeta(panelInfo[i]);
 			auto* report = panel.report;
 			if (report)
 			{

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -45,8 +45,8 @@ namespace
 	struct PanelInfo
 	{
 		ReportInterface* report{nullptr};
-		const NAS2D::Image* image{nullptr};
 		const std::string name{};
+		const NAS2D::Image* image{nullptr};
 	};
 
 
@@ -75,16 +75,13 @@ namespace
 		}
 
 	public:
+		ReportInterface* report = nullptr;
 		std::string name;
-
 		const NAS2D::Image* icon = nullptr;
 
+		NAS2D::Rectangle<int> tabArea;
 		NAS2D::Point<int> textPosition;
 		NAS2D::Point<int> iconPosition;
-
-		NAS2D::Rectangle<int> tabArea;
-
-		ReportInterface* report = nullptr;
 
 	private:
 		bool mIsSelected = false;
@@ -189,13 +186,13 @@ void MainReportsUiState::initialize()
 	// INIT UI REPORT PANELS
 	/* NOTE: Matches the order in enum NavigationPanel */
 	auto panelInfo = std::array<PanelInfo, 7>{
-		PanelInfo{new ResearchReport(), &imageCache.load("ui/icons/research.png"), "Research"},
-		PanelInfo{new FactoryReport(), &imageCache.load("ui/icons/production.png"), "Factories"},
-		PanelInfo{new WarehouseReport(), &imageCache.load("ui/icons/warehouse.png"), "Warehouses"},
-		PanelInfo{new MineReport(), &imageCache.load("ui/icons/mine.png"), "Mines"},
-		PanelInfo{new SatellitesReport(), &imageCache.load("ui/icons/satellite.png"), "Satellites"},
-		PanelInfo{new SpaceportsReport(), &imageCache.load("ui/icons/spaceport.png"), "Space Ports"},
-		PanelInfo{nullptr, &imageCache.load("ui/icons/exit.png"), ""}
+		PanelInfo{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},
+		PanelInfo{new FactoryReport(), "Factories", &imageCache.load("ui/icons/production.png")},
+		PanelInfo{new WarehouseReport(), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
+		PanelInfo{new MineReport(), "Mines", &imageCache.load("ui/icons/mine.png")},
+		PanelInfo{new SatellitesReport(), "Satellites", &imageCache.load("ui/icons/satellite.png")},
+		PanelInfo{new SpaceportsReport(), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
+		PanelInfo{nullptr, "", &imageCache.load("ui/icons/exit.png")}
 	};
 
 	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -101,7 +101,6 @@ namespace
 
 	void initializePanels()
 	{
-		// INIT UI REPORT PANELS
 		/* NOTE: Matches the order in enum NavigationPanel */
 		auto panelInfo = std::array<PanelInfo, 7>{
 			PanelInfo{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -115,7 +115,7 @@ namespace
 	}
 
 
-	void setPanelRects(int width, const NAS2D::Font& font)
+	void onResizeTabBar(int width, const NAS2D::Font& font)
 	{
 		auto& exitPanel = panels[ExitPanelIndex];
 		exitPanel.tabArea = {{width - 48, 0}, {48, 48}};
@@ -288,7 +288,7 @@ void MainReportsUiState::exit()
 
 void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 {
-	setPanelRects(newSize.x, fontMain);
+	onResizeTabBar(newSize.x, fontMain);
 	for (Panel& panel : panels)
 	{
 		if (panel.report)

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -43,6 +43,8 @@ namespace
 		Exit
 	};
 
+	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
+
 
 	class Panel
 	{
@@ -86,8 +88,6 @@ namespace
 
 
 	static std::array<Panel, 7> panels;
-
-	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
 
 
 	void setPanelRects(int width, const NAS2D::Font& font)

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -143,17 +143,6 @@ namespace
 		panel.report->refresh();
 		panel.report->selectStructure(structure);
 	}
-
-
-	void setReportValues(ReportInterface* report, const NAS2D::Vector<int>& size)
-	{
-		if (report)
-		{
-			report->position({0, 48});
-			report->size({size.x, size.y - 48});
-			report->hide();
-		}
-	}
 }
 
 
@@ -201,7 +190,13 @@ void MainReportsUiState::initialize()
 	{
 		auto& panel = panels[i];
 		panel.setMeta(panelInfo[i]);
-		setReportValues(panel.report, size);
+		auto* report = panel.report;
+		if (report)
+		{
+			report->position({0, 48});
+			report->size({size.x, size.y - 48});
+			report->hide();
+		}
 	}
 
 	setPanelRects(size.x, fontMain);

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -186,7 +186,7 @@ void MainReportsUiState::initialize()
 	const auto size = renderer.size().to<int>();
 
 	// INIT UI REPORT PANELS
-	/* NOTE: Matches the order in enum::NavigationPanel */
+	/* NOTE: Matches the order in enum NavigationPanel */
 	auto panelInfo = std::array<PanelInfo, 7>{
 		PanelInfo{new ResearchReport(), &imageCache.load("ui/icons/research.png"), "Research"},
 		PanelInfo{new FactoryReport(), &imageCache.load("ui/icons/production.png"), "Factories"},

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -183,8 +183,6 @@ void MainReportsUiState::initialize()
 		PanelInfo{nullptr, "", &imageCache.load("ui/icons/exit.png")}
 	};
 
-	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();
-
 	for (size_t i = 0; i < panelInfo.size(); i++)
 	{
 		auto& panel = panels[i];
@@ -192,13 +190,12 @@ void MainReportsUiState::initialize()
 		auto* report = panel.report;
 		if (report)
 		{
-			report->position({0, 48});
-			report->size({size.x, size.y - 48});
 			report->hide();
 		}
 	}
 
-	setPanelRects(size.x, fontMain);
+	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();
+	onWindowResized(size);
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -194,8 +194,7 @@ void MainReportsUiState::initialize()
 		PanelInfo{nullptr, &imageCache.load("ui/icons/exit.png"), ""}
 	};
 
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto size = renderer.size().to<int>();
+	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();
 
 	for (size_t i = 0; i < panelInfo.size(); i++)
 	{

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -24,14 +24,6 @@ extern NAS2D::Point<int> MOUSE_COORDS;
 
 namespace
 {
-	struct PanelInfo
-	{
-		ReportInterface* report{nullptr};
-		const NAS2D::Image* image{nullptr};
-		const std::string name{};
-	};
-
-
 	enum class NavigationPanel
 	{
 		Research,
@@ -48,6 +40,14 @@ namespace
 	constexpr auto WarehousePanelIndex = static_cast<size_t>(NavigationPanel::Warehouse);
 	constexpr auto MinesPanelIndex = static_cast<size_t>(NavigationPanel::Mines);
 	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
+
+
+	struct PanelInfo
+	{
+		ReportInterface* report{nullptr};
+		const NAS2D::Image* image{nullptr};
+		const std::string name{};
+	};
 
 
 	class Panel

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -182,9 +182,6 @@ MainReportsUiState::~MainReportsUiState()
 
 void MainReportsUiState::initialize()
 {
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto size = renderer.size().to<int>();
-
 	// INIT UI REPORT PANELS
 	/* NOTE: Matches the order in enum NavigationPanel */
 	auto panelInfo = std::array<PanelInfo, 7>{
@@ -196,6 +193,9 @@ void MainReportsUiState::initialize()
 		PanelInfo{new SpaceportsReport(), &imageCache.load("ui/icons/spaceport.png"), "Space Ports"},
 		PanelInfo{nullptr, &imageCache.load("ui/icons/exit.png"), ""}
 	};
+
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	const auto size = renderer.size().to<int>();
 
 	for (size_t i = 0; i < panelInfo.size(); i++)
 	{

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -302,7 +302,7 @@ void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 	{
 		if (panel.report)
 		{
-			panel.report->size(NAS2D::Vector{newSize.x, newSize.y - 48});
+			panel.report->area({{0, 48}, NAS2D::Vector{newSize.x, newSize.y - 48}});
 		}
 	}
 }

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -99,6 +99,33 @@ namespace
 	static std::array<Panel, 7> panels;
 
 
+	void initializePanels()
+	{
+		// INIT UI REPORT PANELS
+		/* NOTE: Matches the order in enum NavigationPanel */
+		auto panelInfo = std::array<PanelInfo, 7>{
+			PanelInfo{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},
+			PanelInfo{new FactoryReport(), "Factories", &imageCache.load("ui/icons/production.png")},
+			PanelInfo{new WarehouseReport(), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
+			PanelInfo{new MineReport(), "Mines", &imageCache.load("ui/icons/mine.png")},
+			PanelInfo{new SatellitesReport(), "Satellites", &imageCache.load("ui/icons/satellite.png")},
+			PanelInfo{new SpaceportsReport(), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
+			PanelInfo{nullptr, "", &imageCache.load("ui/icons/exit.png")}
+		};
+
+		for (size_t i = 0; i < panelInfo.size(); i++)
+		{
+			auto& panel = panels[i];
+			panel.setMeta(panelInfo[i]);
+			auto* report = panel.report;
+			if (report)
+			{
+				report->hide();
+			}
+		}
+	}
+
+
 	void setPanelRects(int width, const NAS2D::Font& font)
 	{
 		auto& exitPanel = panels[ExitPanelIndex];
@@ -171,29 +198,7 @@ MainReportsUiState::~MainReportsUiState()
 
 void MainReportsUiState::initialize()
 {
-	// INIT UI REPORT PANELS
-	/* NOTE: Matches the order in enum NavigationPanel */
-	auto panelInfo = std::array<PanelInfo, 7>{
-		PanelInfo{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},
-		PanelInfo{new FactoryReport(), "Factories", &imageCache.load("ui/icons/production.png")},
-		PanelInfo{new WarehouseReport(), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
-		PanelInfo{new MineReport(), "Mines", &imageCache.load("ui/icons/mine.png")},
-		PanelInfo{new SatellitesReport(), "Satellites", &imageCache.load("ui/icons/satellite.png")},
-		PanelInfo{new SpaceportsReport(), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
-		PanelInfo{nullptr, "", &imageCache.load("ui/icons/exit.png")}
-	};
-
-	for (size_t i = 0; i < panelInfo.size(); i++)
-	{
-		auto& panel = panels[i];
-		panel.setMeta(panelInfo[i]);
-		auto* report = panel.report;
-		if (report)
-		{
-			report->hide();
-		}
-	}
-
+	initializePanels();
 	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();
 	onWindowResized(size);
 }


### PR DESCRIPTION
Simplify initialization and layout of `Panel` array.

Some additional refactoring for `MainReportsUiState` before addressing the use of `Signal`.

Related:
- PR #1791
- Issue #875
