### PR TITLE
Convert `MainReportsUiState` to use `Delegate`

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -34,7 +34,7 @@ NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wra
 
 GameState::GameState(const std::string& savedGameFilename) :
 	mSaveGameDocument{saveGameDocument(savedGameFilename)},
-	mMainReportsState{},
+	mMainReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onHideReports}},
 	mMapViewState{*this, mSaveGameDocument},
 	mColonyShip{colonyShipDataFromSave(mSaveGameDocument)},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
@@ -42,7 +42,7 @@ GameState::GameState(const std::string& savedGameFilename) :
 
 
 GameState::GameState(const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty) :
-	mMainReportsState{},
+	mMainReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onHideReports}},
 	mMapViewState{*this, planetAttributes, selectedDifficulty},
 	mColonyShip{},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
@@ -64,8 +64,6 @@ GameState::~GameState()
 void GameState::initializeGameState()
 {
 	mMainReportsState.initialize();
-	mMainReportsState.takeMeThere().connect({this, &GameState::onTakeMeThere});
-	mMainReportsState.hideReports().connect({this, &GameState::onHideReports});
 
 	mMapViewState.initialize();
 	initializeMapViewState();

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -64,12 +64,8 @@ GameState::~GameState()
 void GameState::initializeGameState()
 {
 	mMainReportsState.initialize();
+	mMainReportsState.takeMeThere().connect({this, &GameState::onTakeMeThere});
 	mMainReportsState.hideReports().connect({this, &GameState::onHideReports});
-
-	for (auto takeMeThere : mMainReportsState.takeMeThere())
-	{
-		takeMeThere->connect({this, &GameState::onTakeMeThere});
-	}
 
 	mMapViewState.initialize();
 	initializeMapViewState();

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -282,7 +282,7 @@ void MainReportsUiState::exit()
 		}
 	}
 
-	mReportsUiSignal();
+	mHideReportsSignal();
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -188,6 +188,14 @@ MainReportsUiState::~MainReportsUiState()
 void MainReportsUiState::initialize()
 {
 	initializePanels();
+	for (auto& panel : panels)
+	{
+		if (panel.report)
+		{
+			panel.report->takeMeThereSignal().connect({this, &MainReportsUiState::onTakeMeThere});
+		}
+	}
+
 	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();
 	onWindowResized(size);
 }
@@ -232,6 +240,12 @@ void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 			panel.report->area({{0, 48}, NAS2D::Vector{newSize.x, newSize.y - 48}});
 		}
 	}
+}
+
+
+void MainReportsUiState::onTakeMeThere(const Structure* structure)
+{
+	mTakeMeThereSignal(structure);
 }
 
 
@@ -354,26 +368,6 @@ void MainReportsUiState::clearLists()
 			panel.report->fillLists();
 		}
 	}
-}
-
-
-/**
- * Gets a list of TakeMeThere signal pointers.
- *
- * Acts as a pass-through for GameState.
- */
-MainReportsUiState::TakeMeThereSignalSourceList MainReportsUiState::takeMeThere()
-{
-	TakeMeThereSignalSourceList takeMeThereList;
-	for (auto& panel : panels)
-	{
-		if (panel.report)
-		{
-			takeMeThereList.push_back(&panel.report->takeMeThereSignal());
-		}
-	}
-
-	return takeMeThereList;
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -222,6 +222,19 @@ void MainReportsUiState::onDeactivate()
 }
 
 
+void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
+{
+	onResizeTabBar(newSize.x, fontMain);
+	for (Panel& panel : panels)
+	{
+		if (panel.report)
+		{
+			panel.report->area({{0, 48}, NAS2D::Vector{newSize.x, newSize.y - 48}});
+		}
+	}
+}
+
+
 void MainReportsUiState::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	if (!active())
@@ -283,19 +296,6 @@ void MainReportsUiState::onExit()
 	}
 
 	mHideReportsSignal();
-}
-
-
-void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
-{
-	onResizeTabBar(newSize.x, fontMain);
-	for (Panel& panel : panels)
-	{
-		if (panel.report)
-		{
-			panel.report->area({{0, 48}, NAS2D::Vector{newSize.x, newSize.y - 48}});
-		}
-	}
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -161,9 +161,12 @@ namespace
 }
 
 
-MainReportsUiState::MainReportsUiState() :
+MainReportsUiState::MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, HideReportsDelegate hideReportsHandler) :
 	fontMain{fontCache.load(constants::FontPrimaryBold, 16)}
 {
+	if (takeMeThereHandler) { mTakeMeThereSignal.connect(takeMeThereHandler); }
+	if (hideReportsHandler) { mHideReportsSignal.connect(hideReportsHandler); }
+
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.windowResized().connect({this, &MainReportsUiState::onWindowResized});
 	eventHandler.keyDown().connect({this, &MainReportsUiState::onKeyDown});

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -231,7 +231,7 @@ void MainReportsUiState::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier /*mod*
 
 	if (key == NAS2D::KeyCode::Escape)
 	{
-		exit();
+		onExit();
 	}
 }
 
@@ -265,12 +265,12 @@ void MainReportsUiState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int
 
 	if (panels[ExitPanelIndex].selected())
 	{
-		exit();
+		onExit();
 	}
 }
 
 
-void MainReportsUiState::exit()
+void MainReportsUiState::onExit()
 {
 	deselectAllPanels();
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -162,11 +162,10 @@ namespace
 
 
 MainReportsUiState::MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, HideReportsDelegate hideReportsHandler) :
-	fontMain{fontCache.load(constants::FontPrimaryBold, 16)}
+	fontMain{fontCache.load(constants::FontPrimaryBold, 16)},
+	mTakeMeThereHandler{takeMeThereHandler},
+	mHideReportsHandler{hideReportsHandler}
 {
-	if (takeMeThereHandler) { mTakeMeThereSignal.connect(takeMeThereHandler); }
-	if (hideReportsHandler) { mHideReportsSignal.connect(hideReportsHandler); }
-
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.windowResized().connect({this, &MainReportsUiState::onWindowResized});
 	eventHandler.keyDown().connect({this, &MainReportsUiState::onKeyDown});
@@ -248,7 +247,7 @@ void MainReportsUiState::onWindowResized(NAS2D::Vector<int> newSize)
 
 void MainReportsUiState::onTakeMeThere(const Structure* structure)
 {
-	mTakeMeThereSignal(structure);
+	if (mTakeMeThereHandler) { mTakeMeThereHandler(structure); }
 }
 
 
@@ -312,7 +311,7 @@ void MainReportsUiState::onExit()
 		}
 	}
 
-	mHideReportsSignal();
+	if (mHideReportsHandler) { mHideReportsHandler(); }
 }
 
 

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -21,9 +21,8 @@ namespace NAS2D
 class MainReportsUiState : public Wrapper
 {
 public:
+	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
 	using HideReportsSignal = NAS2D::Signal<>;
-	using TakeMeThereSignalSource = NAS2D::SignalSource<const Structure*>;
-	using TakeMeThereSignalSourceList = std::vector<TakeMeThereSignalSource*>;
 
 public:
 	MainReportsUiState();
@@ -38,8 +37,8 @@ public:
 
 	void clearLists();
 
+	TakeMeThereSignal::Source& takeMeThere() { return mTakeMeThereSignal; }
 	HideReportsSignal::Source& hideReports() { return mHideReportsSignal; }
-	TakeMeThereSignalSourceList takeMeThere();
 
 	void initialize() override;
 	State* update() override;
@@ -49,6 +48,7 @@ protected:
 	void onDeactivate() override;
 
 	void onWindowResized(NAS2D::Vector<int> newSize);
+	void onTakeMeThere(const Structure* structure);
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onExit();
@@ -58,5 +58,6 @@ protected:
 private:
 	const NAS2D::Font& fontMain;
 
+	TakeMeThereSignal mTakeMeThereSignal;
 	HideReportsSignal mHideReportsSignal;
 };

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -29,7 +29,7 @@ public:
 	using HideReportsDelegate = NAS2D::Delegate<void()>;
 
 public:
-	MainReportsUiState(TakeMeThereDelegate takeMeThereHandler = {}, HideReportsDelegate hideReportsHandler = {});
+	MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, HideReportsDelegate hideReportsHandler);
 
 	~MainReportsUiState() override;
 

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -41,9 +41,6 @@ public:
 
 	void clearLists();
 
-	TakeMeThereSignal::Source& takeMeThere() { return mTakeMeThereSignal; }
-	HideReportsSignal::Source& hideReports() { return mHideReportsSignal; }
-
 	void initialize() override;
 	State* update() override;
 

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -44,11 +44,10 @@ public:
 	void initialize() override;
 	State* update() override;
 
-private:
+protected:
 	void onDeactivate() override;
 	void onActivate() override;
 
-private:
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onWindowResized(NAS2D::Vector<int> newSize);

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -50,11 +50,10 @@ protected:
 
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
+	void onExit();
 	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void deselectAllPanels();
-
-	void exit();
 
 private:
 	const NAS2D::Font& fontMain;

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -48,10 +48,10 @@ protected:
 	void onDeactivate() override;
 	void onActivate() override;
 
+	void onWindowResized(NAS2D::Vector<int> newSize);
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onExit();
-	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void deselectAllPanels();
 

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -3,7 +3,6 @@
 #include "Wrapper.h"
 
 #include <NAS2D/Signal/Delegate.h>
-#include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>
 
@@ -22,9 +21,6 @@ namespace NAS2D
 class MainReportsUiState : public Wrapper
 {
 public:
-	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
-	using HideReportsSignal = NAS2D::Signal<>;
-
 	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
 	using HideReportsDelegate = NAS2D::Delegate<void()>;
 
@@ -59,6 +55,6 @@ protected:
 private:
 	const NAS2D::Font& fontMain;
 
-	TakeMeThereSignal mTakeMeThereSignal;
-	HideReportsSignal mHideReportsSignal;
+	TakeMeThereDelegate mTakeMeThereHandler;
+	HideReportsDelegate mHideReportsHandler;
 };

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -45,8 +45,8 @@ public:
 	State* update() override;
 
 protected:
-	void onDeactivate() override;
 	void onActivate() override;
+	void onDeactivate() override;
 
 	void onWindowResized(NAS2D::Vector<int> newSize);
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -21,7 +21,7 @@ namespace NAS2D
 class MainReportsUiState : public Wrapper
 {
 public:
-	using ReportsUiSignal = NAS2D::Signal<>;
+	using HideReportsSignal = NAS2D::Signal<>;
 	using TakeMeThereSignalSource = NAS2D::SignalSource<const Structure*>;
 	using TakeMeThereSignalSourceList = std::vector<TakeMeThereSignalSource*>;
 
@@ -38,7 +38,7 @@ public:
 
 	void clearLists();
 
-	ReportsUiSignal::Source& hideReports() { return mReportsUiSignal; }
+	HideReportsSignal::Source& hideReports() { return mHideReportsSignal; }
 	TakeMeThereSignalSourceList takeMeThere();
 
 	void initialize() override;
@@ -60,5 +60,5 @@ private:
 private:
 	const NAS2D::Font& fontMain;
 
-	ReportsUiSignal mReportsUiSignal;
+	HideReportsSignal mHideReportsSignal;
 };

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -2,6 +2,7 @@
 
 #include "Wrapper.h"
 
+#include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/Signal/Signal.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>
@@ -24,8 +25,11 @@ public:
 	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
 	using HideReportsSignal = NAS2D::Signal<>;
 
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+	using HideReportsDelegate = NAS2D::Delegate<void()>;
+
 public:
-	MainReportsUiState();
+	MainReportsUiState(TakeMeThereDelegate takeMeThereHandler = {}, HideReportsDelegate hideReportsHandler = {});
 
 	~MainReportsUiState() override;
 


### PR DESCRIPTION
To do this cleanly, there was a change to hide the detail about multiple reports being connected behind the `MainReportsUiState`.

The use of an intermediary method to hide the detail about multiple reports may also provide a place to hook in and fix bugs such as #1608, where views that are not visible still respond to events as if they were.

Related:
- Issue #875
- Issue #1608