### PR TITLE
Convert `ReportInterface` to use `Delegate`

### DIFF
--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -91,7 +91,7 @@ namespace
 	static std::array<Panel, 7> panels;
 
 
-	void initializePanels(ReportInterface::TakeMeThereDelegate takeMeThereHandler)
+	void initializePanels(MainReportsUiState::TakeMeThereDelegate takeMeThereHandler)
 	{
 		/* NOTE: Matches the order in enum NavigationPanel */
 		panels = std::array<Panel, 7>{

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -91,16 +91,16 @@ namespace
 	static std::array<Panel, 7> panels;
 
 
-	void initializePanels()
+	void initializePanels(ReportInterface::TakeMeThereDelegate takeMeThereHandler)
 	{
 		/* NOTE: Matches the order in enum NavigationPanel */
 		panels = std::array<Panel, 7>{
-			Panel{new ResearchReport(), "Research", &imageCache.load("ui/icons/research.png")},
-			Panel{new FactoryReport(), "Factories", &imageCache.load("ui/icons/production.png")},
-			Panel{new WarehouseReport(), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
-			Panel{new MineReport(), "Mines", &imageCache.load("ui/icons/mine.png")},
-			Panel{new SatellitesReport(), "Satellites", &imageCache.load("ui/icons/satellite.png")},
-			Panel{new SpaceportsReport(), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
+			Panel{new ResearchReport(takeMeThereHandler), "Research", &imageCache.load("ui/icons/research.png")},
+			Panel{new FactoryReport(takeMeThereHandler), "Factories", &imageCache.load("ui/icons/production.png")},
+			Panel{new WarehouseReport(takeMeThereHandler), "Warehouses", &imageCache.load("ui/icons/warehouse.png")},
+			Panel{new MineReport(takeMeThereHandler), "Mines", &imageCache.load("ui/icons/mine.png")},
+			Panel{new SatellitesReport(takeMeThereHandler), "Satellites", &imageCache.load("ui/icons/satellite.png")},
+			Panel{new SpaceportsReport(takeMeThereHandler), "Space Ports", &imageCache.load("ui/icons/spaceport.png")},
 			Panel{nullptr, "", &imageCache.load("ui/icons/exit.png")}
 		};
 
@@ -189,15 +189,7 @@ MainReportsUiState::~MainReportsUiState()
 
 void MainReportsUiState::initialize()
 {
-	initializePanels();
-	for (auto& panel : panels)
-	{
-		if (panel.report)
-		{
-			panel.report->takeMeThereSignal().connect({this, &MainReportsUiState::onTakeMeThere});
-		}
-	}
-
+	initializePanels({this, &MainReportsUiState::onTakeMeThere});
 	const auto size = NAS2D::Utility<NAS2D::Renderer>::get().size().to<int>();
 	onWindowResized(size);
 }

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -57,7 +57,8 @@ namespace
 }
 
 
-FactoryReport::FactoryReport() :
+FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
+	ReportInterface{takeMeThereHandler},
 	font{Control::getDefaultFont()},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -58,7 +58,7 @@ namespace
 
 
 FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
-	ReportInterface{takeMeThereHandler},
+	mTakeMeThereHandler{takeMeThereHandler},
 	font{Control::getDefaultFont()},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -379,7 +379,7 @@ void FactoryReport::onClearProduction()
 
 void FactoryReport::onTakeMeThere()
 {
-	mTakeMeThereSignal(selectedFactory);
+	if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedFactory); }
 }
 
 

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -26,7 +26,7 @@ class Factory;
 class FactoryReport : public ReportInterface
 {
 public:
-	FactoryReport(TakeMeThereDelegate takeMeThereHandler = {});
+	FactoryReport(TakeMeThereDelegate takeMeThereHandler);
 
 	void selectStructure(Structure*) override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -11,6 +11,7 @@
 #include <libControls/TextArea.h>
 
 #include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Signal/Delegate.h>
 
 
 namespace NAS2D
@@ -26,6 +27,8 @@ class Factory;
 class FactoryReport : public ReportInterface
 {
 public:
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+
 	FactoryReport(TakeMeThereDelegate takeMeThereHandler);
 
 	void selectStructure(Structure*) override;

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -26,7 +26,7 @@ class Factory;
 class FactoryReport : public ReportInterface
 {
 public:
-	FactoryReport();
+	FactoryReport(TakeMeThereDelegate takeMeThereHandler = {});
 
 	void selectStructure(Structure*) override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -69,6 +69,8 @@ private:
 
 	void onVisibilityChange(bool visible) override;
 
+private:
+	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& font;
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -73,7 +73,8 @@ namespace
 }
 
 
-MineReport::MineReport() :
+MineReport::MineReport(TakeMeThereDelegate takeMeThereHandler) :
+	ReportInterface{takeMeThereHandler},
 	font{Control::getDefaultFont()},
 	fontBold{Control::getDefaultFontBold()},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -312,7 +312,7 @@ void MineReport::onDigNewLevel()
 
 void MineReport::onTakeMeThere()
 {
-	mTakeMeThereSignal(mSelectedFacility);
+	if (mTakeMeThereHandler) { mTakeMeThereHandler(mSelectedFacility); }
 }
 
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -74,7 +74,7 @@ namespace
 
 
 MineReport::MineReport(TakeMeThereDelegate takeMeThereHandler) :
-	ReportInterface{takeMeThereHandler},
+	mTakeMeThereHandler{takeMeThereHandler},
 	font{Control::getDefaultFont()},
 	fontBold{Control::getDefaultFontBold()},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -24,7 +24,7 @@ class MineFacility;
 class MineReport : public ReportInterface
 {
 public:
-	MineReport(TakeMeThereDelegate takeMeThereHandler = {});
+	MineReport(TakeMeThereDelegate takeMeThereHandler);
 
 	void selectStructure(Structure* structure) override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -65,6 +65,7 @@ protected:
 	void drawOreProductionPane(const NAS2D::Point<int>& origin);
 
 private:
+	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& font;
 	const NAS2D::Font& fontBold;
 	const NAS2D::Font& fontMedium;

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -24,7 +24,7 @@ class MineFacility;
 class MineReport : public ReportInterface
 {
 public:
-	MineReport();
+	MineReport(TakeMeThereDelegate takeMeThereHandler = {});
 
 	void selectStructure(Structure* structure) override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -8,6 +8,7 @@
 #include <libControls/CheckBox.h>
 
 #include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Signal/Delegate.h>
 
 #include <array>
 
@@ -24,6 +25,8 @@ class MineFacility;
 class MineReport : public ReportInterface
 {
 public:
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+
 	MineReport(TakeMeThereDelegate takeMeThereHandler);
 
 	void selectStructure(Structure* structure) override;

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -3,6 +3,7 @@
 #include <libControls/ControlContainer.h>
 
 #include <NAS2D/Signal/Signal.h>
+#include <NAS2D/Signal/Delegate.h>
 
 
 class Structure;
@@ -21,8 +22,13 @@ public:
 	 * the map view on a given structure.
 	 */
 	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
 
-	ReportInterface() {}
+
+	ReportInterface(TakeMeThereDelegate takeMeThereHandler = {})
+	{
+		if (takeMeThereHandler) { mTakeMeThereSignal.connect(takeMeThereHandler); }
+	}
 
 	using ControlContainer::update;
 

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -2,8 +2,6 @@
 
 #include <libControls/ControlContainer.h>
 
-#include <NAS2D/Signal/Delegate.h>
-
 
 class Structure;
 
@@ -16,13 +14,6 @@ class Structure;
 class ReportInterface : public ControlContainer
 {
 public:
-	/**
-	 * Delegate used to handle clicks of a "Take Me There" button to center
-	 * the map view on a given structure.
-	 */
-	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
-
-
 	using ControlContainer::update;
 
 	/**

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -25,7 +25,7 @@ public:
 	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
 
 
-	ReportInterface(TakeMeThereDelegate takeMeThereHandler = {})
+	ReportInterface(TakeMeThereDelegate takeMeThereHandler)
 	{
 		if (takeMeThereHandler) { mTakeMeThereSignal.connect(takeMeThereHandler); }
 	}

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -58,8 +58,6 @@ public:
 	 */
 	virtual void selectStructure(Structure*) = 0;
 
-	TakeMeThereSignal::Source& takeMeThereSignal() { return mTakeMeThereSignal; }
-
 protected:
 	TakeMeThereSignal mTakeMeThereSignal;
 };

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -2,7 +2,6 @@
 
 #include <libControls/ControlContainer.h>
 
-#include <NAS2D/Signal/Signal.h>
 #include <NAS2D/Signal/Delegate.h>
 
 
@@ -18,16 +17,15 @@ class ReportInterface : public ControlContainer
 {
 public:
 	/**
-	 * Signal used to handle clicks of a "Take Me There" button to center
+	 * Delegate used to handle clicks of a "Take Me There" button to center
 	 * the map view on a given structure.
 	 */
-	using TakeMeThereSignal = NAS2D::Signal<const Structure*>;
 	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
 
 
-	ReportInterface(TakeMeThereDelegate takeMeThereHandler)
+	ReportInterface(TakeMeThereDelegate takeMeThereHandler) :
+		mTakeMeThereHandler{takeMeThereHandler}
 	{
-		if (takeMeThereHandler) { mTakeMeThereSignal.connect(takeMeThereHandler); }
 	}
 
 	using ControlContainer::update;
@@ -59,5 +57,11 @@ public:
 	virtual void selectStructure(Structure*) = 0;
 
 protected:
-	TakeMeThereSignal mTakeMeThereSignal;
+	void mTakeMeThereSignal(const Structure* structure)
+	{
+		if (mTakeMeThereHandler) { mTakeMeThereHandler(structure); }
+	}
+
+protected:
+	TakeMeThereDelegate mTakeMeThereHandler;
 };

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -23,11 +23,6 @@ public:
 	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
 
 
-	ReportInterface(TakeMeThereDelegate takeMeThereHandler) :
-		mTakeMeThereHandler{takeMeThereHandler}
-	{
-	}
-
 	using ControlContainer::update;
 
 	/**
@@ -55,7 +50,4 @@ public:
 	 *			downcasted to a more derived type (take advantage of dynamic_cast)
 	 */
 	virtual void selectStructure(Structure*) = 0;
-
-protected:
-	TakeMeThereDelegate mTakeMeThereHandler;
 };

--- a/appOPHD/UI/Reports/ReportInterface.h
+++ b/appOPHD/UI/Reports/ReportInterface.h
@@ -57,11 +57,5 @@ public:
 	virtual void selectStructure(Structure*) = 0;
 
 protected:
-	void mTakeMeThereSignal(const Structure* structure)
-	{
-		if (mTakeMeThereHandler) { mTakeMeThereHandler(structure); }
-	}
-
-protected:
 	TakeMeThereDelegate mTakeMeThereHandler;
 };

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -86,7 +86,7 @@ namespace
 
 
 ResearchReport::ResearchReport(TakeMeThereDelegate takeMeThereHandler) :
-	ReportInterface{takeMeThereHandler},
+	mTakeMeThereHandler{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -85,7 +85,8 @@ namespace
 }
 
 
-ResearchReport::ResearchReport() :
+ResearchReport::ResearchReport(TakeMeThereDelegate takeMeThereHandler) :
+	ReportInterface{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -27,7 +27,7 @@ class Structure;
 class ResearchReport : public ReportInterface
 {
 public:
-	ResearchReport();
+	ResearchReport(TakeMeThereDelegate takeMeThereHandler = {});
 	~ResearchReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -11,6 +11,7 @@
 
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Rectangle.h>
+#include <NAS2D/Signal/Delegate.h>
 
 #include <vector>
 
@@ -27,6 +28,8 @@ class Structure;
 class ResearchReport : public ReportInterface
 {
 public:
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+
 	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -27,7 +27,7 @@ class Structure;
 class ResearchReport : public ReportInterface
 {
 public:
-	ResearchReport(TakeMeThereDelegate takeMeThereHandler = {});
+	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -90,6 +90,7 @@ private:
 	};
 
 private:
+	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;
 	const NAS2D::Font& fontBigBold;

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -10,7 +10,8 @@
 using namespace NAS2D;
 
 
-SatellitesReport::SatellitesReport() :
+SatellitesReport::SatellitesReport(TakeMeThereDelegate takeMeThereHandler) :
+	ReportInterface{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -11,7 +11,7 @@ using namespace NAS2D;
 
 
 SatellitesReport::SatellitesReport(TakeMeThereDelegate takeMeThereHandler) :
-	ReportInterface{takeMeThereHandler},
+	mTakeMeThereHandler{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -13,7 +13,7 @@ namespace NAS2D
 class SatellitesReport : public ReportInterface
 {
 public:
-	SatellitesReport();
+	SatellitesReport(TakeMeThereDelegate takeMeThereHandler = {});
 	~SatellitesReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -13,7 +13,7 @@ namespace NAS2D
 class SatellitesReport : public ReportInterface
 {
 public:
-	SatellitesReport(TakeMeThereDelegate takeMeThereHandler = {});
+	SatellitesReport(TakeMeThereDelegate takeMeThereHandler);
 	~SatellitesReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -30,6 +30,7 @@ private:
 
 	void draw() const override;
 
+	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;
 	const NAS2D::Font& fontBigBold;

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -2,6 +2,8 @@
 
 #include "ReportInterface.h"
 
+#include <NAS2D/Signal/Delegate.h>
+
 
 namespace NAS2D
 {
@@ -13,6 +15,8 @@ namespace NAS2D
 class SatellitesReport : public ReportInterface
 {
 public:
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+
 	SatellitesReport(TakeMeThereDelegate takeMeThereHandler);
 	~SatellitesReport() override;
 

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -8,7 +8,8 @@
 
 using namespace NAS2D;
 
-SpaceportsReport::SpaceportsReport() :
+SpaceportsReport::SpaceportsReport(TakeMeThereDelegate takeMeThereHandler) :
+	ReportInterface{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -9,7 +9,7 @@
 using namespace NAS2D;
 
 SpaceportsReport::SpaceportsReport(TakeMeThereDelegate takeMeThereHandler) :
-	ReportInterface{takeMeThereHandler},
+	mTakeMeThereHandler{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -30,6 +30,7 @@ private:
 
 	void draw() const override;
 
+	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;
 	const NAS2D::Font& fontBigBold;

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -13,7 +13,7 @@ namespace NAS2D
 class SpaceportsReport : public ReportInterface
 {
 public:
-	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler = {});
+	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler);
 	~SpaceportsReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -13,7 +13,7 @@ namespace NAS2D
 class SpaceportsReport : public ReportInterface
 {
 public:
-	SpaceportsReport();
+	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler = {});
 	~SpaceportsReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -2,6 +2,8 @@
 
 #include "ReportInterface.h"
 
+#include <NAS2D/Signal/Delegate.h>
+
 
 namespace NAS2D
 {
@@ -13,6 +15,8 @@ namespace NAS2D
 class SpaceportsReport : public ReportInterface
 {
 public:
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+
 	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler);
 	~SpaceportsReport() override;
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -196,7 +196,7 @@ void WarehouseReport::onDoubleClick(MouseButton button, NAS2D::Point<int> positi
 
 	if (lstStructures.area().contains(position) && selectedWarehouse())
 	{
-		mTakeMeThereSignal(selectedWarehouse());
+		if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedWarehouse()); }
 	}
 }
 
@@ -302,7 +302,7 @@ void WarehouseReport::onDisabled()
 
 void WarehouseReport::onTakeMeThere()
 {
-	mTakeMeThereSignal(selectedWarehouse());
+	if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedWarehouse()); }
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -51,7 +51,8 @@ namespace
 }
 
 
-WarehouseReport::WarehouseReport() :
+WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
+	ReportInterface{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -52,7 +52,7 @@ namespace
 
 
 WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
-	ReportInterface{takeMeThereHandler},
+	mTakeMeThereHandler{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
 	fontMediumBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryMedium)},
 	fontBigBold{fontCache.load(constants::FontPrimaryBold, constants::FontPrimaryHuge)},

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -8,6 +8,7 @@
 #include <libControls/Button.h>
 
 #include <NAS2D/Math/Point.h>
+#include <NAS2D/Signal/Delegate.h>
 
 #include <vector>
 
@@ -25,6 +26,8 @@ class Structure;
 class WarehouseReport : public ReportInterface
 {
 public:
+	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+
 	WarehouseReport(TakeMeThereDelegate takeMeThereHandler);
 	~WarehouseReport() override;
 

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -25,7 +25,7 @@ class Structure;
 class WarehouseReport : public ReportInterface
 {
 public:
-	WarehouseReport();
+	WarehouseReport(TakeMeThereDelegate takeMeThereHandler = {});
 	~WarehouseReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -25,7 +25,7 @@ class Structure;
 class WarehouseReport : public ReportInterface
 {
 public:
-	WarehouseReport(TakeMeThereDelegate takeMeThereHandler = {});
+	WarehouseReport(TakeMeThereDelegate takeMeThereHandler);
 	~WarehouseReport() override;
 
 	void fillLists() override;

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -68,6 +68,7 @@ private:
 	void drawLeftPanel(NAS2D::Renderer&);
 	void drawRightPanel(NAS2D::Renderer&);
 
+	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& fontMedium;
 	const NAS2D::Font& fontMediumBold;
 	const NAS2D::Font& fontBigBold;


### PR DESCRIPTION
Move the use of `Delegate` down to sub-classes of `ReportInterface`.

Related:
- Issue #875
- PR #1793
