### PR TITLE
Refactor `MapObject` `name`

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -20,15 +20,23 @@ namespace
 
 
 Robot::Robot(const std::string& name, const std::string& spritePath, Type type) :
-	MapObject(name, spritePath, "running"),
+	MapObject(spritePath, "running"),
+	mName(name),
 	mType{type}
 {}
 
 
 Robot::Robot(const std::string& name, const std::string& spritePath, const std::string& initialAction, Type type) :
-	MapObject(name, spritePath, initialAction),
+	MapObject(spritePath, initialAction),
+	mName(name),
 	mType{type}
 {}
+
+
+const std::string& Robot::name() const
+{
+	return mName;
+}
 
 
 void Robot::startTask(Tile& tile)

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -27,6 +27,8 @@ public:
 	Robot(const std::string&, const std::string&, Type);
 	Robot(const std::string&, const std::string&, const std::string&, Type);
 
+	const std::string& name() const override;
+
 	void update() override;
 
 	virtual void startTask(Tile& tile);
@@ -56,6 +58,7 @@ protected:
 	void incrementFuelCellAge() { mFuelCellAge++; }
 
 private:
+	const std::string& mName;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -123,7 +123,7 @@ std::vector<Structure::StructureClass> allStructureClasses()
 
 
 Structure::Structure(StructureClass structureClass, StructureID id) :
-	MapObject(StructureName(id), StructureCatalogue::getType(id).spritePath, constants::StructureStateConstruction),
+	MapObject(StructureCatalogue::getType(id).spritePath, constants::StructureStateConstruction),
 	mStructureType(StructureCatalogue::getType(id)),
 	mStructureId(id),
 	mStructureClass(structureClass)
@@ -132,11 +132,17 @@ Structure::Structure(StructureClass structureClass, StructureID id) :
 
 
 Structure::Structure(const std::string& initialAction, StructureClass structureClass, StructureID id) :
-	MapObject(StructureName(id), StructureCatalogue::getType(id).spritePath, initialAction),
+	MapObject(StructureCatalogue::getType(id).spritePath, initialAction),
 	mStructureType(StructureCatalogue::getType(id)),
 	mStructureId(id),
 	mStructureClass(structureClass)
 {
+}
+
+
+const std::string& Structure::name() const
+{
+	return mStructureType.name;
 }
 
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -81,6 +81,8 @@ public:
 
 	~Structure() override = default;
 
+	const std::string& name() const override;
+
 	// STATES & STATE MANAGEMENT
 	StructureState state() const { return mStructureState; }
 

--- a/libOPHD/MapObjects/MapObject.cpp
+++ b/libOPHD/MapObjects/MapObject.cpp
@@ -1,16 +1,9 @@
 #include "MapObject.h"
 
 
-MapObject::MapObject(const std::string& name, const std::string& spritePath, const std::string& initialAction) :
-	mName(name),
+MapObject::MapObject(const std::string& spritePath, const std::string& initialAction) :
 	mSprite(spritePath, initialAction)
 {}
-
-
-const std::string& MapObject::name() const
-{
-	return mName;
-}
 
 
 NAS2D::Sprite& MapObject::sprite()

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -27,7 +27,7 @@ public:
 	virtual void die();
 
 private:
-	std::string mName;
+	const std::string& mName;
 	NAS2D::Sprite mSprite;
 	bool mIsDead = false;
 };

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -14,20 +14,19 @@
 class MapObject
 {
 public:
-	MapObject(const std::string& name, const std::string& spritePath, const std::string& initialAction);
+	MapObject(const std::string& spritePath, const std::string& initialAction);
 	MapObject(const MapObject& thing) = delete;
 	MapObject& operator=(const MapObject& thing) = delete;
 	virtual ~MapObject() = default;
 
+	virtual const std::string& name() const = 0;
 	virtual void update() = 0;
 	NAS2D::Sprite& sprite();
-	const std::string& name() const;
 
 	bool isDead() const;
 	virtual void die();
 
 private:
-	const std::string& mName;
 	NAS2D::Sprite mSprite;
 	bool mIsDead = false;
 };


### PR DESCRIPTION
Noticed we were making unnecessary string copies in `MapObject` when looking at adding a `MapCoordinate` field to them.

Could probably have pushed things down further in the `Robot` hierarchy, though I wanted to avoid data specific overrides of virtual functions. Plus, if `Robot` ever gets the equivalent of `StructureType`, it won't be necessary.

Related:
- Issue #1795