### PR TITLE
Move `die` method from `MapObject` to `Robot`

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -39,6 +39,19 @@ const std::string& Robot::name() const
 }
 
 
+void Robot::die()
+{
+	mIsDead = true;
+}
+
+
+/// Robot is dead and should be cleaned up.
+bool Robot::isDead() const
+{
+	return mIsDead;
+}
+
+
 void Robot::startTask(Tile& tile)
 {
 	startTask(getTaskTime(mType, tile));

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -29,6 +29,9 @@ public:
 
 	const std::string& name() const override;
 
+	bool isDead() const;
+	virtual void die();
+
 	void update() override;
 
 	virtual void startTask(Tile& tile);
@@ -62,6 +65,7 @@ private:
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
 
+	bool mIsDead = false;
 	bool mSelfDestruct = false;
 	bool mCancelTask{false};
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -431,29 +431,6 @@ void Structure::forced_state_change(StructureState structureState, DisabledReaso
 }
 
 
-/**
- * Special overriding of MapObject::die for Structure.
- *
- * There is no conceivable situation in which a Structure should be marked as 'dead' or have its
- * 'die' function be called. Such cases should be treated as bad logic and immediately and very
- * loudly fail.
- *
- * This function exists purely for debug purposes as it was noticed in StructureManager testing
- * for this flag when there should never be a need to do so.
- *
- * \note	This is for debug purposes only. Release modes will silently ignore this condition
- *			and simply act as a passthrough.
- *
- * \throws	Throws \c std::runtime_error
- */
-void Structure::die()
-{
-	MapObject::die();
-
-	throw std::runtime_error("MapObject::die() was called on a Structure!");
-}
-
-
 void Structure::crimeRate(int crimeRate)
 {
 	mCrimeRate = std::clamp(crimeRate, 0, 100);

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -202,7 +202,6 @@ private:
 
 	void incrementAge();
 	void updateIntegrityDecay();
-	void die() override;
 
 	/**
 	 * Provided so that structures that need to do something upon

--- a/libOPHD/MapObjects/MapObject.cpp
+++ b/libOPHD/MapObjects/MapObject.cpp
@@ -10,16 +10,3 @@ NAS2D::Sprite& MapObject::sprite()
 {
 	return mSprite;
 }
-
-
-void MapObject::die()
-{
-	mIsDead = true;
-}
-
-
-/// MapObject is dead and should be cleaned up.
-bool MapObject::isDead() const
-{
-	return mIsDead;
-}

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -23,10 +23,6 @@ public:
 	virtual void update() = 0;
 	NAS2D::Sprite& sprite();
 
-	bool isDead() const;
-	virtual void die();
-
 private:
 	NAS2D::Sprite mSprite;
-	bool mIsDead = false;
 };


### PR DESCRIPTION
The `die` method is only ever used with `Robot`. The `Structure` class had an override that throws an exception so it will fail loudly if it was ever used on a `Structure`. Even better than a runtime error, is a compile time error. By moving the function out of `MapObject`, and not providing such a method in `Structure`, any attempt to reference the name on a `Structure`, or rather on a non-`Robot` will fail at compile time.

Noticed this while looking at `MapObject` to add a `MapCoordinate` field to it.

Related:
- Issue #1795
- PR #1796
