### PR TITLE
Refactor `MapObject` handling of `Sprite`

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -151,8 +151,8 @@ const std::string& Structure::name() const
  */
 void Structure::disable(DisabledReason reason)
 {
-	sprite().pause();
-	sprite().color(NAS2D::Color{255, 0, 0, 185});
+	mSprite.pause();
+	mSprite.color(NAS2D::Color{255, 0, 0, 185});
 	state(StructureState::Disabled);
 	mDisabledReason = reason;
 	mIdleReason = IdleReason::None;
@@ -171,8 +171,8 @@ void Structure::enable()
 		return;
 	}
 
-	sprite().resume();
-	sprite().color(NAS2D::Color::White);
+	mSprite.resume();
+	mSprite.color(NAS2D::Color::White);
 	state(StructureState::Operational);
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = IdleReason::None;
@@ -189,8 +189,8 @@ void Structure::idle(IdleReason reason)
 		return;
 	}
 
-	sprite().pause();
-	sprite().color(NAS2D::Color{255, 255, 255, 185});
+	mSprite.pause();
+	mSprite.color(NAS2D::Color{255, 255, 255, 185});
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = reason;
 	state(StructureState::Idle);
@@ -323,7 +323,7 @@ bool Structure::repairable() const
  */
 void Structure::activate()
 {
-	sprite().play(constants::StructureStateOperational);
+	mSprite.play(constants::StructureStateOperational);
 	enable();
 
 	activated();
@@ -332,7 +332,7 @@ void Structure::activate()
 
 void Structure::rebuild()
 {
-	sprite().play(constants::StructureStateConstruction);
+	mSprite.play(constants::StructureStateConstruction);
 	state(StructureState::UnderConstruction);
 
 	age(1);
@@ -407,7 +407,7 @@ void Structure::updateIntegrityDecay()
 */
 void Structure::destroy()
 {
-	sprite().play(constants::StructureStateDestroyed);
+	mSprite.play(constants::StructureStateDestroyed);
 	state(StructureState::Destroyed);
 }
 
@@ -419,7 +419,7 @@ void Structure::forced_state_change(StructureState structureState, DisabledReaso
 {
 	if (age() >= turnsToBuild())
 	{
-		sprite().play(constants::StructureStateOperational);
+		mSprite.play(constants::StructureStateOperational);
 		//enable();
 	}
 

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -17,7 +17,7 @@ AirShaft::AirShaft() : Structure(
 
 void AirShaft::ug()
 {
-	sprite().play(constants::StructureStateOperationalUg);
+	mSprite.play(constants::StructureStateOperationalUg);
 	mIsUnderground = true;
 }
 

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -29,7 +29,7 @@ MineFacility::MineFacility(OreDeposit* oreDeposit) :
 	),
 	mOreDeposit(oreDeposit)
 {
-	sprite().play(constants::StructureStateConstruction);
+	mSprite.play(constants::StructureStateConstruction);
 }
 
 

--- a/appOPHD/MapObjects/Structures/Road.cpp
+++ b/appOPHD/MapObjects/Structures/Road.cpp
@@ -1,0 +1,12 @@
+#include "Road.h"
+
+#include "../../Map/Connections.h"
+
+
+void Road::updateConnections(const TileMap& tileMap)
+{
+	if (operational())
+	{
+		mSprite.play(roadAnimationName(*this, tileMap));
+	}
+}

--- a/appOPHD/MapObjects/Structures/Road.h
+++ b/appOPHD/MapObjects/Structures/Road.h
@@ -3,6 +3,9 @@
 #include "../Structure.h"
 
 
+class TileMap;
+
+
 class Road : public Structure
 {
 public:
@@ -11,4 +14,7 @@ public:
 		StructureID::SID_ROAD)
 	{
 	}
+
+
+	void updateConnections(const TileMap& tileMap);
 };

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -487,8 +487,7 @@ void MapViewState::updateRoads()
 
 	for (auto* road : roads)
 	{
-		if (!road->operational()) { continue; }
-		road->sprite().play(roadAnimationName(*road, *mTileMap));
+		road->updateConnections(*mTileMap);
 	}
 }
 

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -123,7 +123,7 @@ void DetailMap::update()
 
 		if (tile.thing())
 		{
-			tile.thing()->sprite().update();
+			tile.thing()->updateAnimation();
 		}
 	}
 }
@@ -161,7 +161,7 @@ void DetailMap::draw() const
 			// Tell an occupying thing to update itself.
 			if (tile.thing())
 			{
-				tile.thing()->sprite().draw(position);
+				tile.thing()->draw(position);
 			}
 		}
 	}

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -211,6 +211,7 @@
     <ClCompile Include="MapObjects\Structures\Recycling.cpp" />
     <ClCompile Include="MapObjects\Structures\ResearchFacility.cpp" />
     <ClCompile Include="MapObjects\Structures\Residence.cpp" />
+    <ClCompile Include="MapObjects\Structures\Road.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp" />
     <ClCompile Include="MapObjects\Structures\SolarPlant.cpp" />
     <ClCompile Include="MapObjects\Structures\StorageTanks.cpp" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="MapObjects\Structures\Residence.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\Structures\Road.cpp">
+      <Filter>Source Files\MapObjects\Structures</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\SolarPanelArray.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>

--- a/libOPHD/MapObjects/MapObject.cpp
+++ b/libOPHD/MapObjects/MapObject.cpp
@@ -16,9 +16,3 @@ void MapObject::draw(NAS2D::Point<int> position) const
 {
 	mSprite.draw(position);
 }
-
-
-NAS2D::Sprite& MapObject::sprite()
-{
-	return mSprite;
-}

--- a/libOPHD/MapObjects/MapObject.cpp
+++ b/libOPHD/MapObjects/MapObject.cpp
@@ -6,6 +6,18 @@ MapObject::MapObject(const std::string& spritePath, const std::string& initialAc
 {}
 
 
+void MapObject::updateAnimation()
+{
+	mSprite.update();
+}
+
+
+void MapObject::draw(NAS2D::Point<int> position) const
+{
+	mSprite.draw(position);
+}
+
+
 NAS2D::Sprite& MapObject::sprite()
 {
 	return mSprite;

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -24,7 +24,6 @@ public:
 
 	virtual void updateAnimation();
 	virtual void draw(NAS2D::Point<int> position) const;
-	NAS2D::Sprite& sprite();
 
 protected:
 	NAS2D::Sprite mSprite;

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -23,6 +23,6 @@ public:
 	virtual void update() = 0;
 	NAS2D::Sprite& sprite();
 
-private:
+protected:
 	NAS2D::Sprite mSprite;
 };

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -21,6 +21,9 @@ public:
 
 	virtual const std::string& name() const = 0;
 	virtual void update() = 0;
+
+	virtual void updateAnimation();
+	virtual void draw(NAS2D::Point<int> position) const;
 	NAS2D::Sprite& sprite();
 
 protected:


### PR DESCRIPTION
Remove public accessor for `Sprite` member field, and instead provide `updateAnimation` and `draw` methods.

Certain operations on `Sprite` should be protected from outside access, such as changing the animation.

Noticed this while looking at `MapObject` to add a `MapCoordinate` field.

Related:
- Issue #1795
- PR #1796
- PR #1797
