### PR TITLE
Rename `thing` to `mapObject` in `Tile`

### DIFF
--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -105,7 +105,7 @@ void walkGraph(const MapCoordinate& position, TileMap& tileMap)
 		if (!tileMap.isValidPosition(nextPosition)) { continue; }
 
 		auto& tile = tileMap.getTile(nextPosition);
-		if (!tile.thingIsStructure() || tile.structure()->connected()) { continue; }
+		if (!tile.hasStructure() || tile.structure()->connected()) { continue; }
 
 		if (validConnection(thisTile.structure(), tile.structure(), direction))
 		{

--- a/appOPHD/Map/Connections.cpp
+++ b/appOPHD/Map/Connections.cpp
@@ -48,7 +48,7 @@ namespace
 			const auto surfacePosition = MapCoordinate{tileToInspect, 0};
 			if (!tileMap.isValidPosition(surfacePosition)) { continue; }
 			const auto& tile = tileMap.getTile(surfacePosition);
-			if (!tile.thingIsStructure()) { continue; }
+			if (!tile.hasStructure()) { continue; }
 
 			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
 		}

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -60,7 +60,7 @@ bool routeObstructed(Route& route)
 
 		// \note	Tile being occupied by a robot is not an obstruction for the
 		//			purposes of routing/pathing.
-		if (tile.thingIsStructure() && !tile.structure()->isRoad()) { return true; }
+		if (tile.hasStructure() && !tile.structure()->isRoad()) { return true; }
 		if (tile.index() == TerrainType::Impassable) { return true; }
 	}
 

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -127,7 +127,7 @@ float Tile::movementCost() const
 		return FLT_MAX;
 	}
 
-	if (!empty() && thingIsStructure() && structure()->isRoad())
+	if (!empty() && hasStructure() && structure()->isRoad())
 	{
 		Structure& road = *structure();
 
@@ -145,7 +145,7 @@ float Tile::movementCost() const
 		}
 	}
 
-	if (!empty() && (!thingIsStructure() || (!structure()->isMineFacility() && !structure()->isSmelter())))
+	if (!empty() && (!hasStructure() || (!structure()->isMineFacility() && !structure()->isSmelter())))
 	{
 		return FLT_MAX;
 	}

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -63,7 +63,7 @@ bool Tile::isSurface()
  *
  * \param	mapObject		Pointer to a MapObject.
  */
-void Tile::pushMapObject(MapObject* mapObject)
+void Tile::mapObject(MapObject* mapObject)
 {
 	if (mMapObject)
 	{

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -69,7 +69,7 @@ void Tile::pushMapObject(MapObject* mapObject)
 	{
 		if (mMapObject == mapObject)
 		{
-			throw std::runtime_error("Attempting to pushMapObject on a tile where it's already set");
+			throw std::runtime_error("Attempting to set MapObject on a tile where it's already set");
 		}
 		deleteMapObject();
 	}

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -110,13 +110,13 @@ void Tile::placeOreDeposit(OreDeposit* oreDeposit)
 
 Structure* Tile::structure() const
 {
-	return dynamic_cast<Structure*>(thing());
+	return dynamic_cast<Structure*>(mapObject());
 }
 
 
 Robot* Tile::robot() const
 {
-	return dynamic_cast<Robot*>(thing());
+	return dynamic_cast<Robot*>(mapObject());
 }
 
 

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -59,12 +59,11 @@ public:
 	bool empty() const { return mMapObject == nullptr; }
 
 	bool hasOreDeposit() const { return mOreDeposit != nullptr; }
+	bool hasStructure() const { return structure() != nullptr; }
+	bool hasRobot() const { return robot() != nullptr; }
 
 	Structure* structure() const;
 	Robot* robot() const;
-
-	bool hasStructure() const { return structure() != nullptr; }
-	bool hasRobot() const { return robot() != nullptr; }
 
 	const OreDeposit* oreDeposit() const { return mOreDeposit; }
 	OreDeposit* oreDeposit() { return mOreDeposit; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -50,7 +50,11 @@ public:
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }
 
+	void mapObject(MapObject*);
 	MapObject* mapObject() const { return mMapObject; }
+
+	void deleteMapObject();
+	void removeMapObject();
 
 	bool empty() const { return mMapObject == nullptr; }
 
@@ -61,11 +65,6 @@ public:
 
 	bool hasStructure() const { return structure() != nullptr; }
 	bool hasRobot() const { return robot() != nullptr; }
-
-	void mapObject(MapObject*);
-	void deleteMapObject();
-
-	void removeMapObject();
 
 	const OreDeposit* oreDeposit() const { return mOreDeposit; }
 	OreDeposit* oreDeposit() { return mOreDeposit; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -60,7 +60,7 @@ public:
 	Robot* robot() const;
 
 	bool hasStructure() const { return structure() != nullptr; }
-	bool thingIsRobot() const { return robot() != nullptr; }
+	bool hasRobot() const { return robot() != nullptr; }
 
 	void pushMapObject(MapObject*);
 	void deleteMapObject();

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -59,7 +59,7 @@ public:
 	Structure* structure() const;
 	Robot* robot() const;
 
-	bool thingIsStructure() const { return structure() != nullptr; }
+	bool hasStructure() const { return structure() != nullptr; }
 	bool thingIsRobot() const { return robot() != nullptr; }
 
 	void pushMapObject(MapObject*);

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -62,7 +62,7 @@ public:
 	bool hasStructure() const { return structure() != nullptr; }
 	bool hasRobot() const { return robot() != nullptr; }
 
-	void pushMapObject(MapObject*);
+	void mapObject(MapObject*);
 	void deleteMapObject();
 
 	void removeMapObject();

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -50,7 +50,7 @@ public:
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }
 
-	MapObject* thing() const { return mMapObject; }
+	MapObject* mapObject() const { return mMapObject; }
 
 	bool empty() const { return mMapObject == nullptr; }
 

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -226,7 +226,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 
 void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 {
-	// ORE DEPOSITS (MINES)
+	// Ore deposits
 	for (auto* oreDepositElement = element->firstChildElement("mines")->firstChildElement("mine"); oreDepositElement; oreDepositElement = oreDepositElement->nextSiblingElement())
 	{
 		const auto oreDepositDictionary = NAS2D::attributesToDictionary(*oreDepositElement);
@@ -244,7 +244,7 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 		mOreDepositLocations.push_back(Point{x, y});
 	}
 
-	// TILES AT INDEX 0 WITH NO THINGS
+	// Tiles indexes
 	for (auto* tileElement = element->firstChildElement("tiles")->firstChildElement("tile"); tileElement; tileElement = tileElement->nextSiblingElement())
 	{
 		const auto tileDictionary = NAS2D::attributesToDictionary(*tileElement);

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -271,7 +271,7 @@ void RobotPool::insertRobotIntoTable(RobotTileTable& robotMap, Robot& robot, Til
 	if (it != robotMap.end()) { throw std::runtime_error("MapViewState::insertRobot(): Attempting to add a duplicate Robot* pointer."); }
 
 	robotMap[&robot] = &tile;
-	tile.pushMapObject(&robot);
+	tile.mapObject(&robot);
 
 	++mRobotControlCount;
 }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -587,7 +587,7 @@ void MapViewState::onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<in
 		if (!mTileMap->isValidPosition(tilePosition)) { return; }
 
 		auto& tile = mTileMap->getTile(tilePosition);
-		if (tile.thingIsStructure())
+		if (tile.hasStructure())
 		{
 			Structure* structure = tile.structure();
 
@@ -651,7 +651,7 @@ void MapViewState::onInspect(const MapCoordinate& tilePosition, bool inspectModi
 	{
 		onInspectRobot(*tile.robot());
 	}
-	else if (tile.thingIsStructure())
+	else if (tile.hasStructure())
 	{
 		onInspectStructure(*tile.structure(), inspectModifier);
 	}
@@ -845,7 +845,7 @@ void MapViewState::placeStructure(Tile& tile)
 
 	if (tile.mapObject())
 	{
-		if (tile.thingIsStructure())
+		if (tile.hasStructure())
 		{
 			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTileObstructed);
 		}
@@ -971,11 +971,11 @@ void MapViewState::placeRobot(Tile& tile)
 
 void MapViewState::placeRobodozer(Tile& tile)
 {
-	if (tile.mapObject() && !tile.thingIsStructure())
+	if (tile.mapObject() && !tile.hasStructure())
 	{
 		return;
 	}
-	else if (tile.index() == TerrainType::Dozed && !tile.thingIsStructure())
+	else if (tile.index() == TerrainType::Dozed && !tile.hasStructure())
 	{
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertTileBulldozed);
 		return;
@@ -998,7 +998,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 			NAS2D::Utility<StructureManager>::get().removeStructure(*mineShaftTile.structure());
 		}
 	}
-	else if (tile.thingIsStructure())
+	else if (tile.hasStructure())
 	{
 		if (mStructureInspector.structure() == tile.structure()) { mStructureInspector.hide(); }
 
@@ -1117,12 +1117,12 @@ void MapViewState::placeRobodigger(Tile& tile)
 	{
 		if (!tile.isSurface())
 		{
-			if (tile.thingIsStructure() && tile.structure()->connectorDirection() != ConnectorDir::CONNECTOR_VERTICAL) // Air shaft
+			if (tile.hasStructure() && tile.structure()->connectorDirection() != ConnectorDir::CONNECTOR_VERTICAL) // Air shaft
 			{
 				doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertStructureInWay);
 				return;
 			}
-			else if (tile.thingIsStructure() && tile.structure()->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL && tile.depth() == mTileMap->maxDepth())
+			else if (tile.hasStructure() && tile.structure()->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL && tile.depth() == mTileMap->maxDepth())
 			{
 				doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMaxDigDepth);
 				return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -647,7 +647,7 @@ void MapViewState::onInspect(const MapCoordinate& tilePosition, bool inspectModi
 	{
 		onInspectTile(tile);
 	}
-	else if (tile.thingIsRobot())
+	else if (tile.hasRobot())
 	{
 		onInspectRobot(*tile.robot());
 	}

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -803,7 +803,7 @@ void MapViewState::placeTubes(Tile& tile)
 		return;
 	}
 
-	if (tile.thing() || tile.oreDeposit() || !tile.excavated()) { return; }
+	if (tile.mapObject() || tile.oreDeposit() || !tile.excavated()) { return; }
 
 	/** FIXME: This is a kludge that only works because all of the tube structures are listed alphabetically.
 	 * Should instead take advantage of the updated meta data in the IconGrid::Item.
@@ -843,7 +843,7 @@ void MapViewState::placeStructure(Tile& tile)
 		return;
 	}
 
-	if (tile.thing())
+	if (tile.mapObject())
 	{
 		if (tile.thingIsStructure())
 		{
@@ -971,7 +971,7 @@ void MapViewState::placeRobot(Tile& tile)
 
 void MapViewState::placeRobodozer(Tile& tile)
 {
-	if (tile.thing() && !tile.thingIsStructure())
+	if (tile.mapObject() && !tile.thingIsStructure())
 	{
 		return;
 	}
@@ -1135,7 +1135,7 @@ void MapViewState::placeRobodigger(Tile& tile)
 		}
 	}
 
-	if (!tile.thing() && mMapView->currentDepth() > 0) { mDiggerDirection.cardinalOnlyEnabled(); }
+	if (!tile.mapObject() && mMapView->currentDepth() > 0) { mDiggerDirection.cardinalOnlyEnabled(); }
 	else { mDiggerDirection.downOnlyEnabled(); }
 
 	mDiggerDirection.setParameters(tile);
@@ -1165,7 +1165,7 @@ void MapViewState::placeRobodigger(Tile& tile)
 
 void MapViewState::placeRobominer(Tile& tile)
 {
-	if (tile.thing())
+	if (tile.mapObject())
 	{
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMinerTileObstructed);
 		return;
@@ -1299,7 +1299,7 @@ void MapViewState::updateRobots()
 				robot->abortTask(*tile);
 			}
 
-			if (tile->thing() == robot)
+			if (tile->mapObject() == robot)
 			{
 				tile->removeMapObject();
 			}
@@ -1311,7 +1311,7 @@ void MapViewState::updateRobots()
 		}
 		else if (robot->idle())
 		{
-			if (tile->thing() == robot)
+			if (tile->mapObject() == robot)
 			{
 				tile->removeMapObject();
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -102,7 +102,7 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir)
 {
-	if (tile.oreDeposit() || !tile.bulldozed() || !tile.excavated() || !tile.thingIsStructure())
+	if (tile.oreDeposit() || !tile.bulldozed() || !tile.excavated() || !tile.hasStructure())
 	{
 		return false;
 	}
@@ -136,7 +136,7 @@ bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnector
 bool checkStructurePlacement(Tile& tile, Direction dir)
 {
 	Structure* structure = tile.structure();
-	if (tile.oreDeposit() || !tile.bulldozed() || !tile.excavated() || !tile.thingIsStructure() || !structure->connected() || !structure->isConnector())
+	if (tile.oreDeposit() || !tile.bulldozed() || !tile.excavated() || !tile.hasStructure() || !structure->connected() || !structure->isConnector())
 	{
 		return false;
 	}

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -223,7 +223,7 @@ bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position)
 			doAlertMessage(constants::AlertLanderLocation, constants::AlertSeedOreDeposit);
 			return false;
 		}
-		else if (tile.thing())
+		else if (tile.mapObject())
 		{
 			// This is a case that should never happen. If it does, blow up loudly.
 			throw std::runtime_error("Tile obstructed by a MapObject other than a Mine.");

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -199,8 +199,8 @@ bool validLanderSite(Tile& tile)
 
 
 /**
- * Check landing site for obstructions such as mining beacons, things
- * and impassable terrain.
+ * Check landing site for obstructions such as mining beacons, structures,
+ * robots, and impassable terrain.
  *
  * This is used for the SEED Lander only.
  *

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -149,7 +149,6 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
 		throw std::runtime_error("StructureManager::addStructure(): Attempting to add a Structure that is already managed!");
 	}
 
-	// Remove things from tile only if we know we're adding a structure.
 	if (!tile.empty())
 	{
 		tile.removeMapObject();

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -157,7 +157,7 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
 	mStructureTileTable[&structure] = &tile;
 
 	mStructureLists[structure.structureClass()].push_back(&structure);
-	tile.pushMapObject(&structure);
+	tile.mapObject(&structure);
 }
 
 

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -121,9 +121,9 @@ void DetailMap::update()
 	{
 		auto& tile = mTileMap.getTile({tilePosition, mMapView.currentDepth()});
 
-		if (tile.thing())
+		if (tile.mapObject())
 		{
-			tile.thing()->updateAnimation();
+			tile.mapObject()->updateAnimation();
 		}
 	}
 }
@@ -149,7 +149,7 @@ void DetailMap::draw() const
 			renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
 
 			// Draw a beacon on an unoccupied tile with a mine
-			if (mTileMap.isTileBlockedByOreDeposit(tile) && !tile.thing())
+			if (mTileMap.isTileBlockedByOreDeposit(tile) && !tile.mapObject())
 			{
 				constexpr NAS2D::Vector<int> beaconOffsetInTile{0, -64};
 				constexpr NAS2D::Vector<int> beaconLightOffsetInTile{59, 15};
@@ -159,9 +159,9 @@ void DetailMap::draw() const
 			}
 
 			// Tell an occupying thing to update itself.
-			if (tile.thing())
+			if (tile.mapObject())
 			{
-				tile.thing()->draw(position);
+				tile.mapObject()->draw(position);
 			}
 		}
 	}

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -158,7 +158,6 @@ void DetailMap::draw() const
 				renderer.drawSubImage(mMineBeacon, position + beaconLightOffsetInTile, beaconLightSubImageRect, glowColor());
 			}
 
-			// Tell an occupying thing to update itself.
 			if (tile.mapObject())
 			{
 				tile.mapObject()->draw(position);

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -15,8 +15,8 @@ class MapObject
 {
 public:
 	MapObject(const std::string& spritePath, const std::string& initialAction);
-	MapObject(const MapObject& thing) = delete;
-	MapObject& operator=(const MapObject& thing) = delete;
+	MapObject(const MapObject& mapObject) = delete;
+	MapObject& operator=(const MapObject& mapObject) = delete;
 	virtual ~MapObject() = default;
 
 	virtual const std::string& name() const = 0;


### PR DESCRIPTION
Noticed this while looking at the `MapObject` code to add a `MapCoordinate` field.

Related:
- Issue #1795
- PR #1798
- PR #1797
- PR #1796
