### PR TITLE
Rename method `Robot::processTurn`

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -75,7 +75,7 @@ NAS2D::Dictionary Robot::getDataDict() const
 }
 
 
-void Robot::processTurn(TileMap& /*tileMap*/)
+void Robot::processTurn(TileMap& tileMap)
 {
 	if (mSelfDestruct)
 	{
@@ -93,6 +93,7 @@ void Robot::processTurn(TileMap& /*tileMap*/)
 
 	if (mTurnsToCompleteTask == 0)
 	{
+		onTaskComplete(tileMap);
 		mTaskCompleteSignal(*this);
 	}
 
@@ -102,4 +103,9 @@ void Robot::processTurn(TileMap& /*tileMap*/)
 	{
 		die();
 	}
+}
+
+
+void Robot::onTaskComplete(TileMap& /*tileMap*/)
+{
 }

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -75,7 +75,7 @@ NAS2D::Dictionary Robot::getDataDict() const
 }
 
 
-void Robot::update()
+void Robot::processTurn()
 {
 	if (mSelfDestruct)
 	{

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -104,8 +104,3 @@ void Robot::processTurn(TileMap& tileMap)
 		die();
 	}
 }
-
-
-void Robot::onTaskComplete(TileMap& /*tileMap*/)
-{
-}

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -75,7 +75,7 @@ NAS2D::Dictionary Robot::getDataDict() const
 }
 
 
-void Robot::processTurn()
+void Robot::processTurn(TileMap& /*tileMap*/)
 {
 	if (mSelfDestruct)
 	{

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -7,6 +7,7 @@
 
 
 class Tile;
+class TileMap;
 
 
 class Robot : public MapObject
@@ -32,7 +33,7 @@ public:
 	bool isDead() const;
 	virtual void die();
 
-	virtual void processTurn();
+	virtual void processTurn(TileMap& tileMap);
 
 	virtual void startTask(Tile& tile);
 	void startTask(int turns);

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -32,7 +32,7 @@ public:
 	bool isDead() const;
 	virtual void die();
 
-	void update() override;
+	void processTurn() override;
 
 	virtual void startTask(Tile& tile);
 	void startTask(int turns);

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -59,7 +59,7 @@ public:
 	virtual NAS2D::Dictionary getDataDict() const;
 
 protected:
-	virtual void onTaskComplete(TileMap& tileMap);
+	virtual void onTaskComplete(TileMap& tileMap) = 0;
 
 	void incrementFuelCellAge() { mFuelCellAge++; }
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -59,6 +59,8 @@ public:
 	virtual NAS2D::Dictionary getDataDict() const;
 
 protected:
+	virtual void onTaskComplete(TileMap& tileMap);
+
 	void incrementFuelCellAge() { mFuelCellAge++; }
 
 private:

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -32,7 +32,7 @@ public:
 	bool isDead() const;
 	virtual void die();
 
-	void processTurn() override;
+	virtual void processTurn();
 
 	virtual void startTask(Tile& tile);
 	void startTask(int turns);

--- a/appOPHD/MapObjects/Robots/Robodigger.cpp
+++ b/appOPHD/MapObjects/Robots/Robodigger.cpp
@@ -30,3 +30,8 @@ NAS2D::Dictionary Robodigger::getDataDict() const
 	dictionary.set("direction", static_cast<int>(mDirection));
 	return dictionary;
 }
+
+
+void Robodigger::onTaskComplete(TileMap& /*tileMap*/)
+{
+}

--- a/appOPHD/MapObjects/Robots/Robodigger.h
+++ b/appOPHD/MapObjects/Robots/Robodigger.h
@@ -16,6 +16,9 @@ public:
 
 	NAS2D::Dictionary getDataDict() const override;
 
+protected:
+	void onTaskComplete(TileMap& tileMap) override;
+
 private:
 	Direction mDirection;
 };

--- a/appOPHD/MapObjects/Robots/Robodozer.cpp
+++ b/appOPHD/MapObjects/Robots/Robodozer.cpp
@@ -23,3 +23,8 @@ void Robodozer::abortTask(Tile& tile)
 {
 	tile.index(static_cast<TerrainType>(mTileIndex));
 }
+
+
+void Robodozer::onTaskComplete(TileMap& /*tileMap*/)
+{
+}

--- a/appOPHD/MapObjects/Robots/Robodozer.h
+++ b/appOPHD/MapObjects/Robots/Robodozer.h
@@ -13,6 +13,9 @@ public:
 	void startTask(Tile& tile) override;
 	void abortTask(Tile& tile) override;
 
+protected:
+	void onTaskComplete(TileMap& tileMap) override;
+
 private:
 	std::size_t mTileIndex = 0;
 };

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -40,3 +40,8 @@ MineFacility& Robominer::buildMine(TileMap& tileMap, const MapCoordinate& positi
 
 	return mineFacility;
 }
+
+
+void Robominer::onTaskComplete(TileMap& /*tileMap*/)
+{
+}

--- a/appOPHD/MapObjects/Robots/Robominer.h
+++ b/appOPHD/MapObjects/Robots/Robominer.h
@@ -14,4 +14,7 @@ public:
 	Robominer();
 
 	MineFacility& buildMine(TileMap& tileMap, const MapCoordinate& position);
+
+protected:
+	void onTaskComplete(TileMap& tileMap) override;
 };

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -339,7 +339,7 @@ void Structure::rebuild()
 }
 
 
-void Structure::update()
+void Structure::processTurn()
 {
 	if (destroyed()) { return; }
 	incrementAge();

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -178,7 +178,7 @@ public:
 
 	void rebuild();
 
-	void update() override;
+	void processTurn() override;
 	virtual void think() {}
 
 	/**

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -178,7 +178,7 @@ public:
 
 	void rebuild();
 
-	void processTurn() override;
+	virtual void processTurn();
 	virtual void think() {}
 
 	/**

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1275,7 +1275,7 @@ void MapViewState::updateRobots()
 		auto robot = robot_it->first;
 		auto tile = robot_it->second;
 
-		robot->update();
+		robot->processTurn();
 
 		const auto& position = tile->xyz();
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1275,7 +1275,7 @@ void MapViewState::updateRobots()
 		auto robot = robot_it->first;
 		auto tile = robot_it->second;
 
-		robot->processTurn();
+		robot->processTurn(*mTileMap);
 
 		const auto& position = tile->xyz();
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -516,7 +516,7 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 	for (std::size_t i = 0; i < structures.size(); ++i)
 	{
 		structure = structures[i];
-		structure->update();
+		structure->processTurn();
 
 		if (structure->ages() && (structure->age() >= structure->maxAge() - 10))
 		{

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -20,7 +20,6 @@ public:
 	virtual ~MapObject() = default;
 
 	virtual const std::string& name() const = 0;
-	virtual void processTurn() = 0;
 
 	virtual void updateAnimation();
 	virtual void draw(NAS2D::Point<int> position) const;

--- a/libOPHD/MapObjects/MapObject.h
+++ b/libOPHD/MapObjects/MapObject.h
@@ -20,7 +20,7 @@ public:
 	virtual ~MapObject() = default;
 
 	virtual const std::string& name() const = 0;
-	virtual void update() = 0;
+	virtual void processTurn() = 0;
 
 	virtual void updateAnimation();
 	virtual void draw(NAS2D::Point<int> position) const;


### PR DESCRIPTION
Rename `Robot::update` to `Robot::processTurn`, and create new `virtual` method `Robot::onTaskComplete`.

The `Robot` classes should be able to modify the `TileMap` themselves to complete their actions once they have access to the `TileMap` and a `MapCoordinate` for their own location.

Related:
- Issue #1795
