### PR TITLE
Refactor `RoboDigger` placement

### DIFF
--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -577,7 +577,7 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
 	const auto directionOffset = directionEnumToOffset(direction);
-	if (directionOffset != DirectionCenter)
+	if (direction != Direction::Down)
 	{
 		mTileMap->getTile({tile.xy() + directionOffset, tile.depth()}).excavated(true);
 	}

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -576,9 +576,9 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
-	const auto directionOffset = directionEnumToOffset(direction);
 	if (direction != Direction::Down)
 	{
+		const auto directionOffset = directionEnumToOffset(direction);
 		mTileMap->getTile({tile.xy() + directionOffset, tile.depth()}).excavated(true);
 	}
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -578,8 +578,7 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 
 	if (direction != Direction::Down)
 	{
-		const auto directionOffset = directionEnumToOffset(direction);
-		mTileMap->getTile({tile.xy() + directionOffset, tile.depth()}).excavated(true);
+		mTileMap->getTile(tile.xyz().translate(direction)).excavated(true);
 	}
 
 	if (!mRobotPool.robotAvailable(Robot::Type::Digger))

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -572,10 +572,9 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 
 	// Assumes a digger is available.
 	Robodigger& robot = mRobotPool.getDigger();
+	robot.direction(direction);
 	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
-
-	robot.direction(direction);
 
 	const auto directionOffset = directionEnumToOffset(direction);
 	if (directionOffset != DirectionCenter)


### PR DESCRIPTION
Prepare to move code into `RoboDigger::onStartTask`, and simplify.

Once `RoboDigger` knows it's own location, we can potentially move this code into the `RoboDigger` class.

Related:
- Issue #1795
