### PR TITLE
Remove unused method `incrementFuelCellAge`

### DIFF
--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -61,8 +61,6 @@ public:
 protected:
 	virtual void onTaskComplete(TileMap& tileMap) = 0;
 
-	void incrementFuelCellAge() { mFuelCellAge++; }
-
 private:
 	const std::string& mName;
 	int mFuelCellAge = 0;


### PR DESCRIPTION
Within the class, it's easier to update the field directly.

Noticed this while doing some recent refactoring.

Related:
- Issue #1795
- PR #1800
