### PR TITLE
Remove `Signal` from `RobotInspector`

### DIFF
--- a/appOPHD/UI/RobotInspector.h
+++ b/appOPHD/UI/RobotInspector.h
@@ -3,6 +3,8 @@
 #include <libControls/Button.h>
 #include <libControls/Window.h>
 
+#include <NAS2D/Signal/Signal.h>
+
 
 class Robot;
 

--- a/appOPHD/UI/RobotInspector.h
+++ b/appOPHD/UI/RobotInspector.h
@@ -3,8 +3,6 @@
 #include <libControls/Button.h>
 #include <libControls/Window.h>
 
-#include <NAS2D/Signal/Signal.h>
-
 
 class Robot;
 
@@ -30,8 +28,6 @@ private:
 	Button btnCancel;
 
 	NAS2D::Rectangle<int> mContentRect;
-
-	NAS2D::Signal<Robot*> mSignal;
 
 	Robot* mRobot{nullptr};
 };

--- a/appOPHD/UI/RobotInspector.h
+++ b/appOPHD/UI/RobotInspector.h
@@ -17,8 +17,6 @@ public:
 	void focusOnRobot(Robot*);
 	const Robot* focusedRobot() const { return mRobot; }
 
-	NAS2D::Signal<Robot*>& actionButtonClicked() { return mSignal; }
-
 	void update() override;
 
 private:


### PR DESCRIPTION
Remove unused `Signal` from `RobotInspector`.

Related:
- Issue #875
