### PR TITLE
Add method `StructureManager::create`

### DIFF
--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -25,8 +25,8 @@ MineFacility& Robominer::buildMine(TileMap& tileMap, const MapCoordinate& positi
 	// Surface structure
 	auto& robotTile = tileMap.getTile(position);
 	auto& mineFacility = *new MineFacility(&robotTile);
-	mineFacility.maxDepth(tileMap.maxDepth());
 	structureManager.addStructure(mineFacility, robotTile);
+	mineFacility.maxDepth(tileMap.maxDepth());
 
 	// Tile immediately underneath facility.
 	auto& tileBelow = tileMap.getTile(position.translate(MapOffsetDown));

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -24,13 +24,12 @@ MineFacility& Robominer::buildMine(TileMap& tileMap, const MapCoordinate& positi
 
 	// Surface structure
 	auto& robotTile = tileMap.getTile(position);
-	auto& mineFacility = *new MineFacility(&robotTile);
-	structureManager.addStructure(mineFacility, robotTile);
+	auto& mineFacility = structureManager.create<MineFacility>(robotTile);
 	mineFacility.maxDepth(tileMap.maxDepth());
 
 	// Tile immediately underneath facility.
 	auto& tileBelow = tileMap.getTile(position.translate(MapOffsetDown));
-	structureManager.addStructure(*new MineShaft(), tileBelow);
+	structureManager.create<MineShaft>(tileBelow);
 
 	robotTile.index(TerrainType::Dozed);
 	tileBelow.index(TerrainType::Dozed);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -878,8 +878,8 @@ void MapViewState::placeStructure(Tile& tile)
 		if (!validLanderSite(tile)) { return; }
 
 		auto& s = *new ColonistLander(&tile);
-		s.deploySignal().connect({this, &MapViewState::onDeployColonistLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
+		s.deploySignal().connect({this, &MapViewState::onDeployColonistLander});
 
 		mColonyShip.onDeployColonistLander();
 		if (mColonyShip.colonistLanders() == 0)
@@ -893,8 +893,8 @@ void MapViewState::placeStructure(Tile& tile)
 		if (!validLanderSite(tile)) { return; }
 
 		auto& cargoLander = *new CargoLander(&tile);
-		cargoLander.deploySignal().connect({this, &MapViewState::onDeployCargoLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(cargoLander, tile);
+		cargoLander.deploySignal().connect({this, &MapViewState::onDeployCargoLander});
 
 		mColonyShip.onDeployCargoLander();
 		if (mColonyShip.cargoLanders() == 0)
@@ -1249,8 +1249,8 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 
 		auto& tile = mTileMap->getTile({point, 0}); // Can only ever be placed on depth level 0
 		auto& s = *new SeedLander(&tile);
-		s.deploySignal().connect({this, &MapViewState::onDeploySeedLander});
 		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
+		s.deploySignal().connect({this, &MapViewState::onDeploySeedLander});
 
 		resetUi();
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -918,8 +918,7 @@ void MapViewState::placeStructure(Tile& tile)
 			return;
 		}
 
-		auto& structure = *StructureCatalogue::create(mCurrentStructure);
-		NAS2D::Utility<StructureManager>::get().addStructure(structure, tile);
+		auto& structure = NAS2D::Utility<StructureManager>::get().create(mCurrentStructure, tile);
 
 		if (structure.isFactory())
 		{

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -877,8 +877,7 @@ void MapViewState::placeStructure(Tile& tile)
 	{
 		if (!validLanderSite(tile)) { return; }
 
-		auto& s = *new ColonistLander(&tile);
-		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
+		auto& s = NAS2D::Utility<StructureManager>::get().create<ColonistLander>(tile);
 		s.deploySignal().connect({this, &MapViewState::onDeployColonistLander});
 
 		mColonyShip.onDeployColonistLander();
@@ -892,8 +891,7 @@ void MapViewState::placeStructure(Tile& tile)
 	{
 		if (!validLanderSite(tile)) { return; }
 
-		auto& cargoLander = *new CargoLander(&tile);
-		NAS2D::Utility<StructureManager>::get().addStructure(cargoLander, tile);
+		auto& cargoLander = NAS2D::Utility<StructureManager>::get().create<CargoLander>(tile);
 		cargoLander.deploySignal().connect({this, &MapViewState::onDeployCargoLander});
 
 		mColonyShip.onDeployCargoLander();
@@ -1248,8 +1246,7 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
 		}
 
 		auto& tile = mTileMap->getTile({point, 0}); // Can only ever be placed on depth level 0
-		auto& s = *new SeedLander(&tile);
-		NAS2D::Utility<StructureManager>::get().addStructure(s, tile);
+		auto& s = NAS2D::Utility<StructureManager>::get().create<SeedLander>(tile);
 		s.deploySignal().connect({this, &MapViewState::onDeploySeedLander});
 
 		resetUi();

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -254,7 +254,7 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	auto& mineFacilityTile = structureManager.tileFromStructure(mineFacility);
 	auto& mineDepthTile = mTileMap->getTile({mineFacilityTile.xy(), mineFacility->oreDeposit().depth()});
-	structureManager.addStructure(*new MineShaft(), mineDepthTile);
+	structureManager.create<MineShaft>(mineDepthTile);
 	mineDepthTile.index(TerrainType::Dozed);
 	mineDepthTile.excavated(true);
 }

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -201,12 +201,12 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
 		auto& airShaftTop = *new AirShaft();
-		if (position.z > 0) { airShaftTop.underground(); }
 		structureManager.addStructure(airShaftTop, tile);
+		if (position.z > 0) { airShaftTop.underground(); }
 
 		auto& airShaftBottom = *new AirShaft();
-		airShaftBottom.underground();
 		structureManager.addStructure(airShaftBottom, tileMap.getTile(newPosition));
+		airShaftBottom.underground();
 
 		tileMap.getTile(position).index(TerrainType::Dozed);
 		tileMap.getTile(newPosition).index(TerrainType::Dozed);

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -200,12 +200,10 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
 	{
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-		auto& airShaftTop = *new AirShaft();
-		structureManager.addStructure(airShaftTop, tile);
+		auto& airShaftTop = structureManager.create<AirShaft>(tile);
 		if (position.z > 0) { airShaftTop.underground(); }
 
-		auto& airShaftBottom = *new AirShaft();
-		structureManager.addStructure(airShaftBottom, tileMap.getTile(newPosition));
+		auto& airShaftBottom = structureManager.create<AirShaft>(tileMap.getTile(newPosition));
 		airShaftBottom.underground();
 
 		tileMap.getTile(position).index(TerrainType::Dozed);

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -1,6 +1,7 @@
 #include "StructureManager.h"
 
 #include "Constants/Numbers.h"
+#include "StructureCatalogue.h"
 #include "ProductPool.h"
 #include "IOHelper.h"
 #include "Map/Tile.h"
@@ -136,6 +137,14 @@ namespace
 StructureManager::StructureManager() :
 	mStructureLists{populateKeys()}
 {
+}
+
+
+Structure& StructureManager::create(StructureID structureId, Tile& tile)
+{
+	auto& structure = *StructureCatalogue::create(structureId);
+	addStructure(structure, tile);
+	return structure;
 }
 
 

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <vector>
+#include <concepts>
 
 
 namespace NAS2D
@@ -69,6 +70,24 @@ class StructureManager
 {
 public:
 	StructureManager();
+
+	template <typename StructureType>
+	requires std::derived_from<StructureType, Structure> && std::constructible_from<StructureType, Tile*>
+	StructureType& create(Tile& tile)
+	{
+		auto& structure = *new StructureType(&tile);
+		addStructure(structure, tile);
+		return structure;
+	}
+
+	template <typename StructureType>
+	requires std::derived_from<StructureType, Structure> && std::constructible_from<StructureType>
+	StructureType& create(Tile& tile)
+	{
+		auto& structure = *new StructureType();
+		addStructure(structure, tile);
+		return structure;
+	}
 
 	Structure& create(StructureID structureId, Tile& tile);
 

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -70,6 +70,8 @@ class StructureManager
 public:
 	StructureManager();
 
+	Structure& create(StructureID structureId, Tile& tile);
+
 	void addStructure(Structure& structure, Tile& tile);
 	void removeStructure(Structure& structure);
 


### PR DESCRIPTION
Add method to create arbitrary `Structure` derived types, initialize them with a `Tile*` for those with a constructor that takes one, and adding the structure to the structures list. Structures can be created either with a type name (via a template) or with a `StructureID` value.

----

Documentation:
- https://en.cppreference.com/w/cpp/concepts.html
- https://en.cppreference.com/w/cpp/concepts/derived_from.html
- https://en.cppreference.com/w/cpp/concepts/constructible_from

----

Related:
- Issue #1665
- Issue #480
- Issue #1804
