### PR TITLE
Have `MainReportsUiState` determine which report to show

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -34,7 +34,7 @@ NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wra
 
 GameState::GameState(const std::string& savedGameFilename) :
 	mSaveGameDocument{saveGameDocument(savedGameFilename)},
-	mMainReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onHideReports}},
+	mMainReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onShowReports}, {this, &GameState::onHideReports}},
 	mMapViewState{*this, mSaveGameDocument},
 	mColonyShip{colonyShipDataFromSave(mSaveGameDocument)},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
@@ -42,7 +42,7 @@ GameState::GameState(const std::string& savedGameFilename) :
 
 
 GameState::GameState(const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty) :
-	mMainReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onHideReports}},
+	mMainReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onShowReports}, {this, &GameState::onHideReports}},
 	mMapViewState{*this, planetAttributes, selectedDifficulty},
 	mColonyShip{},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -82,7 +82,6 @@ void GameState::initializeMapViewState()
 
 	mMapViewState.quitHandler({this, &GameState::onQuit});
 	mMapViewState.mapChangedHandler({this, &GameState::onMapChange});
-	mMapViewState.showReportsHandler({this, &GameState::onShowReports});
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -318,6 +318,12 @@ void MainReportsUiState::deselectAllPanels()
 }
 
 
+void MainReportsUiState::showReport()
+{
+	if (mShowReportsHandler) { mShowReportsHandler(); }
+}
+
+
 void MainReportsUiState::showReport(Structure* structure)
 {
 	if (structure->isFactory())

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cache.h"
 #include "../Constants/UiConstants.h"
+#include "../MapObjects/Structure.h"
 
 #include "../UI/Reports/ReportInterface.h"
 
@@ -314,6 +315,30 @@ void MainReportsUiState::deselectAllPanels()
 	{
 		panel.selected(false);
 	}
+}
+
+
+void MainReportsUiState::showReport(Structure* structure)
+{
+	if (structure->isFactory())
+	{
+		selectFactoryPanel(structure);
+	}
+	else if (structure->isWarehouse())
+	{
+		selectWarehousePanel(structure);
+	}
+	else if (structure->isMineFacility() || structure->isSmelter())
+	{
+		selectMinePanel(structure);
+	}
+	else
+	{
+		// avoids showing the full-screen UI on unhandled structures.
+		return;
+	}
+
+	if (mShowReportsHandler) { mShowReportsHandler(); }
 }
 
 

--- a/appOPHD/States/MainReportsUiState.cpp
+++ b/appOPHD/States/MainReportsUiState.cpp
@@ -161,9 +161,10 @@ namespace
 }
 
 
-MainReportsUiState::MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, HideReportsDelegate hideReportsHandler) :
+MainReportsUiState::MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, ShowReportsDelegate showReportsHandler, HideReportsDelegate hideReportsHandler) :
 	fontMain{fontCache.load(constants::FontPrimaryBold, 16)},
 	mTakeMeThereHandler{takeMeThereHandler},
+	mShowReportsHandler{showReportsHandler},
 	mHideReportsHandler{hideReportsHandler}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -30,6 +30,7 @@ public:
 
 	~MainReportsUiState() override;
 
+	void showReport(Structure* structure);
 	void selectFactoryPanel(Structure*);
 	void selectWarehousePanel(Structure*);
 	void selectMinePanel(Structure*);

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -32,9 +32,6 @@ public:
 
 	void showReport();
 	void showReport(Structure* structure);
-	void selectFactoryPanel(Structure*);
-	void selectWarehousePanel(Structure*);
-	void selectMinePanel(Structure*);
 
 	void injectTechnology(TechnologyCatalog&, ResearchTracker&);
 
@@ -54,6 +51,9 @@ protected:
 	void onExit();
 
 	void deselectAllPanels();
+	void selectFactoryPanel(Structure*);
+	void selectWarehousePanel(Structure*);
+	void selectMinePanel(Structure*);
 
 private:
 	const NAS2D::Font& fontMain;

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -30,6 +30,7 @@ public:
 
 	~MainReportsUiState() override;
 
+	void showReport();
 	void showReport(Structure* structure);
 	void selectFactoryPanel(Structure*);
 	void selectWarehousePanel(Structure*);

--- a/appOPHD/States/MainReportsUiState.h
+++ b/appOPHD/States/MainReportsUiState.h
@@ -22,10 +22,11 @@ class MainReportsUiState : public Wrapper
 {
 public:
 	using TakeMeThereDelegate = NAS2D::Delegate<void(const Structure*)>;
+	using ShowReportsDelegate = NAS2D::Delegate<void()>;
 	using HideReportsDelegate = NAS2D::Delegate<void()>;
 
 public:
-	MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, HideReportsDelegate hideReportsHandler);
+	MainReportsUiState(TakeMeThereDelegate takeMeThereHandler, ShowReportsDelegate showReportsHandler, HideReportsDelegate hideReportsHandler);
 
 	~MainReportsUiState() override;
 
@@ -56,5 +57,6 @@ private:
 	const NAS2D::Font& fontMain;
 
 	TakeMeThereDelegate mTakeMeThereHandler;
+	ShowReportsDelegate mShowReportsHandler;
 	HideReportsDelegate mHideReportsHandler;
 };

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -423,7 +423,7 @@ void MapViewState::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*
 
 	if (key == NAS2D::KeyCode::F1)
 	{
-		if (mShowReportsHandler) { mShowReportsHandler(); }
+		mMainReportsState.showReport();
 		return;
 	}
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -589,27 +589,7 @@ void MapViewState::onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<in
 		auto& tile = mTileMap->getTile(tilePosition);
 		if (tile.hasStructure())
 		{
-			Structure* structure = tile.structure();
-
-			if (structure->isFactory())
-			{
-				mMainReportsState.selectFactoryPanel(structure);
-			}
-			else if (structure->isWarehouse())
-			{
-				mMainReportsState.selectWarehousePanel(structure);
-			}
-			else if (structure->isMineFacility() || structure->isSmelter())
-			{
-				mMainReportsState.selectMinePanel(structure);
-			}
-			else
-			{
-				// avoids showing the full-screen UI on unhandled structures.
-				return;
-			}
-
-			if (mShowReportsHandler) { mShowReportsHandler(); }
+			mMainReportsState.showReport(tile.structure());
 		}
 	}
 }

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -115,7 +115,6 @@ public:
 
 	void quitHandler(EventDelegate newQuitHandler) { mQuitHandler = newQuitHandler; }
 	void mapChangedHandler(EventDelegate newMapChangedHandler) { mMapChangedHandler = newMapChangedHandler; }
-	void showReportsHandler(EventDelegate newShowReportsHandler) { mShowReportsHandler = newShowReportsHandler; }
 
 	void focusOnStructure(const Structure* s);
 
@@ -381,7 +380,6 @@ private:
 	// SIGNALS
 	EventDelegate mQuitHandler;
 	EventDelegate mMapChangedHandler;
-	EventDelegate mShowReportsHandler;
 
 	std::vector<Tile*> mConnectednessOverlay;
 	std::vector<Tile*> mCommRangeOverlay;


### PR DESCRIPTION
Rather than have `MapViewState` decide which report to show, and communicate showing of reports to `GameState`, have `MainReportsUiState` determine which report to show for a given `Structure`, and communicate it directly to `GameState`.

Related:
- Issue #1608
- Issue #650
- Issue #875
- PR #1793
- PR #1794
