### PR TITLE
Use concepts `requires`

### DIFF
--- a/libOPHD/RandomNumberGenerator.h
+++ b/libOPHD/RandomNumberGenerator.h
@@ -11,8 +11,8 @@ public:
 	RandomNumberGenerator() : generator(randomDevice()) {}
 
 	template <typename T>
-	std::enable_if_t<std::is_arithmetic_v<T>, T>
-	generate(T min, T max)
+	requires std::is_arithmetic_v<T>
+	T generate(T min, T max)
 	{
 		if (min > max)
 		{

--- a/testLibOPHD/RandomNumberGenerator.test.cpp
+++ b/testLibOPHD/RandomNumberGenerator.test.cpp
@@ -15,10 +15,3 @@ TEST(RandomNumberGenerator, FloatType)
 	EXPECT_EQ(0.0f, randomNumber.generate(0.0f, 0.0f));
 	EXPECT_EQ(1.0f, randomNumber.generate(1.0f, 1.0f));
 }
-
-
-TEST(RandomNumberGenerator, NonNumericType)
-{
-	struct NonNumeric {};
-	EXPECT_EQ(0, randomNumber.generate(NonNumeric{}, NonNumeric{}));
-}

--- a/testLibOPHD/RandomNumberGenerator.test.cpp
+++ b/testLibOPHD/RandomNumberGenerator.test.cpp
@@ -15,3 +15,10 @@ TEST(RandomNumberGenerator, FloatType)
 	EXPECT_EQ(0.0f, randomNumber.generate(0.0f, 0.0f));
 	EXPECT_EQ(1.0f, randomNumber.generate(1.0f, 1.0f));
 }
+
+
+TEST(RandomNumberGenerator, NonNumericType)
+{
+	struct NonNumeric {};
+	EXPECT_EQ(0, randomNumber.generate<NonNumeric>(0, 0));
+}

--- a/testLibOPHD/RandomNumberGenerator.test.cpp
+++ b/testLibOPHD/RandomNumberGenerator.test.cpp
@@ -20,5 +20,5 @@ TEST(RandomNumberGenerator, FloatType)
 TEST(RandomNumberGenerator, NonNumericType)
 {
 	struct NonNumeric {};
-	EXPECT_EQ(0, randomNumber.generate<NonNumeric>(0, 0));
+	EXPECT_EQ(0, randomNumber.generate(NonNumeric{}, NonNumeric{}));
 }


### PR DESCRIPTION
Use the `requires` keyword from the Constraints and concepts addition to C++20 to replace `std::enable_if` in `RandomNumberGenerator`.

The syntax used is a slight variation of that discussed in the related Issue:
- Issue #1812
