### PR TITLE
Re-order `Report` methods

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -153,15 +153,6 @@ void FactoryReport::clearSelected()
 
 
 /**
- * Pass-through function to simulate clicking on the Show All button.
- */
-void FactoryReport::refresh()
-{
-	onShowAll();
-}
-
-
-/**
  * Fills the factory list with all available factories.
  */
 void FactoryReport::fillLists()
@@ -173,6 +164,15 @@ void FactoryReport::fillLists()
 		lstFactoryList.addItem(factory);
 	}
 	checkFactoryActionControls();
+}
+
+
+/**
+ * Pass-through function to simulate clicking on the Show All button.
+ */
+void FactoryReport::refresh()
+{
+	onShowAll();
 }
 
 

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -32,10 +32,9 @@ public:
 	FactoryReport(TakeMeThereDelegate takeMeThereHandler);
 
 	void selectStructure(Structure*) override;
-	void refresh() override;
-
-	void fillLists() override;
 	void clearSelected() override;
+	void fillLists() override;
+	void refresh() override;
 
 	void update() override;
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -156,12 +156,6 @@ void MineReport::clearSelected()
 }
 
 
-void MineReport::refresh()
-{
-	onShowAll();
-}
-
-
 void MineReport::fillLists()
 {
 	lstMineFacilities.clear();
@@ -174,6 +168,12 @@ void MineReport::fillLists()
 
 	lstMineFacilities.setSelected(mSelectedFacility);
 	mAvailableTrucks = getTruckAvailability();
+}
+
+
+void MineReport::refresh()
+{
+	onShowAll();
 }
 
 

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -30,10 +30,9 @@ public:
 	MineReport(TakeMeThereDelegate takeMeThereHandler);
 
 	void selectStructure(Structure* structure) override;
-	void refresh() override;
-
-	void fillLists() override;
 	void clearSelected() override;
+	void fillLists() override;
+	void refresh() override;
 
 	void update() override;
 

--- a/appOPHD/UI/Reports/Report.h
+++ b/appOPHD/UI/Reports/Report.h
@@ -14,7 +14,14 @@ class Structure;
 class Report : public ControlContainer
 {
 public:
-	using ControlContainer::update;
+	/**
+	 * Instructs a Report to set its primary selection to a specified Structure.
+	 *
+	 * \note	Casting may be necessary depending on implementation of inheriting
+	 *			classes. Be mindful to pass pointers to objects that can be safely
+	 *			downcasted to a more derived type (take advantage of dynamic_cast)
+	 */
+	virtual void selectStructure(Structure*) = 0;
 
 	/**
 	 * Instructs the Report to clear any selections it may have.
@@ -33,12 +40,5 @@ public:
 	 */
 	virtual void refresh() = 0;
 
-	/**
-	 * Instructs a Report to set its primary selection to a specified Structure.
-	 *
-	 * \note	Casting may be necessary depending on implementation of inheriting
-	 *			classes. Be mindful to pass pointers to objects that can be safely
-	 *			downcasted to a more derived type (take advantage of dynamic_cast)
-	 */
-	virtual void selectStructure(Structure*) = 0;
+	using ControlContainer::update;
 };

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -111,7 +111,7 @@ ResearchReport::~ResearchReport()
 }
 
 
-void ResearchReport::fillLists()
+void ResearchReport::clearSelected()
 {
 	resetCategorySelection();
 	resetResearchDetails();
@@ -119,7 +119,7 @@ void ResearchReport::fillLists()
 }
 
 
-void ResearchReport::clearSelected()
+void ResearchReport::fillLists()
 {
 	resetCategorySelection();
 	resetResearchDetails();
@@ -151,19 +151,19 @@ void ResearchReport::refresh()
 }
 
 
+void ResearchReport::update()
+{
+	draw();
+	ControlContainer::update();
+}
+
+
 void ResearchReport::injectTechReferences(TechnologyCatalog& catalog, ResearchTracker& tracker)
 {
 	mTechCatalog = &catalog;
 	mResearchTracker = &tracker;
 
 	processCategories();
-}
-
-
-void ResearchReport::update()
-{
-	draw();
-	ControlContainer::update();
 }
 
 

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -111,6 +111,11 @@ ResearchReport::~ResearchReport()
 }
 
 
+void ResearchReport::selectStructure(Structure*)
+{
+}
+
+
 void ResearchReport::clearSelected()
 {
 	resetCategorySelection();

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -33,7 +33,7 @@ public:
 	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 
-	void selectStructure(Structure*) override {}
+	void selectStructure(Structure*) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -33,16 +33,14 @@ public:
 	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 
-	void fillLists() override;
+	void selectStructure(Structure*) override {}
 	void clearSelected() override;
-
+	void fillLists() override;
 	void refresh() override;
 
-	void selectStructure(Structure*) override {}
+	void update() override;
 
 	void injectTechReferences(TechnologyCatalog&, ResearchTracker&);
-
-	void update() override;
 
 private:
 	void onResize() override;

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -25,7 +25,7 @@ SatellitesReport::~SatellitesReport()
 }
 
 
-void SatellitesReport::fillLists()
+void SatellitesReport::selectStructure(Structure*)
 {
 }
 
@@ -35,12 +35,12 @@ void SatellitesReport::clearSelected()
 }
 
 
-void SatellitesReport::refresh()
+void SatellitesReport::fillLists()
 {
 }
 
 
-void SatellitesReport::selectStructure(Structure*)
+void SatellitesReport::refresh()
 {
 }
 

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -20,11 +20,10 @@ public:
 	SatellitesReport(TakeMeThereDelegate takeMeThereHandler);
 	~SatellitesReport() override;
 
-	void fillLists() override;
-	void clearSelected() override;
-
-	void refresh() override;
 	void selectStructure(Structure*) override;
+	void clearSelected() override;
+	void fillLists() override;
+	void refresh() override;
 
 	void update() override;
 

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -23,7 +23,7 @@ SpaceportsReport::~SpaceportsReport()
 }
 
 
-void SpaceportsReport::fillLists()
+void SpaceportsReport::selectStructure(Structure*)
 {
 }
 
@@ -33,12 +33,12 @@ void SpaceportsReport::clearSelected()
 }
 
 
-void SpaceportsReport::refresh()
+void SpaceportsReport::fillLists()
 {
 }
 
 
-void SpaceportsReport::selectStructure(Structure*)
+void SpaceportsReport::refresh()
 {
 }
 

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -20,11 +20,10 @@ public:
 	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler);
 	~SpaceportsReport() override;
 
-	void fillLists() override;
-	void clearSelected() override;
-
-	void refresh() override;
 	void selectStructure(Structure*) override;
+	void clearSelected() override;
+	void fillLists() override;
+	void refresh() override;
 
 	void update() override;
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -96,6 +96,34 @@ WarehouseReport::~WarehouseReport()
 }
 
 
+void WarehouseReport::selectStructure(Structure* structure)
+{
+	lstStructures.setSelected(structure);
+}
+
+
+void WarehouseReport::clearSelected()
+{
+	lstStructures.clearSelected();
+}
+
+
+/**
+ * Inherited interface. A better name for this function would be
+ * fillListWithAll() or something to that effect.
+ */
+void WarehouseReport::fillLists()
+{
+	fillListFromStructureList(selectWarehouses([](Warehouse*) { return true; }));
+}
+
+
+void WarehouseReport::refresh()
+{
+	onShowAll();
+}
+
+
 Warehouse* WarehouseReport::selectedWarehouse()
 {
 	return dynamic_cast<Warehouse*>(lstStructures.selectedStructure());
@@ -135,16 +163,6 @@ void WarehouseReport::fillListFromStructureList(const std::vector<Warehouse*>& w
 
 	lstStructures.setSelection(0);
 	computeTotalWarehouseCapacity();
-}
-
-
-/**
- * Inherited interface. A better name for this function would be
- * fillListWithAll() or something to that effect.
- */
-void WarehouseReport::fillLists()
-{
-	fillListFromStructureList(selectWarehouses([](Warehouse*) { return true; }));
 }
 
 
@@ -198,24 +216,6 @@ void WarehouseReport::onDoubleClick(MouseButton button, NAS2D::Point<int> positi
 	{
 		if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedWarehouse()); }
 	}
-}
-
-
-void WarehouseReport::clearSelected()
-{
-	lstStructures.clearSelected();
-}
-
-
-void WarehouseReport::refresh()
-{
-	onShowAll();
-}
-
-
-void WarehouseReport::selectStructure(Structure* structure)
-{
-	lstStructures.setSelected(structure);
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -31,11 +31,10 @@ public:
 	WarehouseReport(TakeMeThereDelegate takeMeThereHandler);
 	~WarehouseReport() override;
 
-	void fillLists() override;
-	void clearSelected() override;
-
-	void refresh() override;
 	void selectStructure(Structure*) override;
+	void clearSelected() override;
+	void fillLists() override;
+	void refresh() override;
 
 	void update() override;
 


### PR DESCRIPTION
Re-order `Report` interface methods, and update subclasses to match.

Should make it easier to find stuff when they use a consistent order.

Related:
- Issue #1608
- PR #1810
- PR #1809
