### PR TITLE
Add method `Report::canView`

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -589,7 +589,7 @@ void MapViewState::onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<in
 		auto& tile = mTileMap->getTile(tilePosition);
 		if (tile.hasStructure())
 		{
-			mReportsState.showReport(tile.structure());
+			mReportsState.showReport(*tile.structure());
 		}
 	}
 }

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -58,7 +58,7 @@ namespace
 			selected(true);
 			report->visible(true);
 			report->refresh();
-			report->selectStructure(structure);
+			report->selectStructure(*structure);
 		}
 
 		void selected(bool isSelected)

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -37,9 +37,6 @@ namespace
 	};
 
 	constexpr auto ResearchPanelIndex = static_cast<size_t>(NavigationPanel::Research);
-	constexpr auto ProductionPanelIndex = static_cast<size_t>(NavigationPanel::Production);
-	constexpr auto WarehousePanelIndex = static_cast<size_t>(NavigationPanel::Warehouse);
-	constexpr auto MinesPanelIndex = static_cast<size_t>(NavigationPanel::Mines);
 	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
 
 
@@ -339,36 +336,6 @@ void ReportsState::showReport(Structure* structure)
 			}
 		}
 	}
-}
-
-
-/**
- * Structure pointer is assumed to be a factory.
- */
-void ReportsState::selectFactoryPanel(Structure* structure)
-{
-	deselectAllPanels();
-	panels[ProductionPanelIndex].select(structure);
-}
-
-
-/**
- * Structure pointer is assumed to be a warehouse.
- */
-void ReportsState::selectWarehousePanel(Structure* structure)
-{
-	deselectAllPanels();
-	panels[WarehousePanelIndex].select(structure);
-}
-
-
-/**
- * Structure pointer is assumed to be a Mine Facility or Smelter.
- */
-void ReportsState::selectMinePanel(Structure* structure)
-{
-	deselectAllPanels();
-	panels[MinesPanelIndex].select(structure);
 }
 
 

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -326,25 +326,19 @@ void ReportsState::showReport()
 
 void ReportsState::showReport(Structure* structure)
 {
-	if (structure->isFactory())
+	for (auto& panel : panels)
 	{
-		selectFactoryPanel(structure);
+		if (panel.report)
+		{
+			if (panel.report->canView(*structure))
+			{
+				deselectAllPanels();
+				panel.select(structure);
+				if (mShowReportsHandler) { mShowReportsHandler(); }
+				return;
+			}
+		}
 	}
-	else if (structure->isWarehouse())
-	{
-		selectWarehousePanel(structure);
-	}
-	else if (structure->isMineFacility() || structure->isSmelter())
-	{
-		selectMinePanel(structure);
-	}
-	else
-	{
-		// avoids showing the full-screen UI on unhandled structures.
-		return;
-	}
-
-	if (mShowReportsHandler) { mShowReportsHandler(); }
 }
 
 

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -50,12 +50,12 @@ namespace
 			icon{newIcon}
 		{}
 
-		void select(Structure* structure)
+		void select(Structure& structure)
 		{
 			selected(true);
 			report->visible(true);
 			report->refresh();
-			report->selectStructure(*structure);
+			report->selectStructure(structure);
 		}
 
 		void selected(bool isSelected)
@@ -330,7 +330,7 @@ void ReportsState::showReport(Structure& structure)
 			if (panel.report->canView(structure))
 			{
 				deselectAllPanels();
-				panel.select(&structure);
+				panel.select(structure);
 				if (mShowReportsHandler) { mShowReportsHandler(); }
 				return;
 			}

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -321,16 +321,16 @@ void ReportsState::showReport()
 }
 
 
-void ReportsState::showReport(Structure* structure)
+void ReportsState::showReport(Structure& structure)
 {
 	for (auto& panel : panels)
 	{
 		if (panel.report)
 		{
-			if (panel.report->canView(*structure))
+			if (panel.report->canView(structure))
 			{
 				deselectAllPanels();
-				panel.select(structure);
+				panel.select(&structure);
 				if (mShowReportsHandler) { mShowReportsHandler(); }
 				return;
 			}

--- a/appOPHD/States/ReportsState.h
+++ b/appOPHD/States/ReportsState.h
@@ -31,7 +31,7 @@ public:
 	~ReportsState() override;
 
 	void showReport();
-	void showReport(Structure* structure);
+	void showReport(Structure& structure);
 
 	void injectTechnology(TechnologyCatalog&, ResearchTracker&);
 

--- a/appOPHD/States/ReportsState.h
+++ b/appOPHD/States/ReportsState.h
@@ -51,9 +51,6 @@ protected:
 	void onExit();
 
 	void deselectAllPanels();
-	void selectFactoryPanel(Structure*);
-	void selectWarehousePanel(Structure*);
-	void selectMinePanel(Structure*);
 
 private:
 	const NAS2D::Font& fontMain;

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -138,9 +138,9 @@ FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
  *
  * \note	Pointer
  */
-void FactoryReport::selectStructure(Structure* structure)
+void FactoryReport::selectStructure(Structure& structure)
 {
-	lstFactoryList.setSelected(dynamic_cast<Factory*>(structure));
+	lstFactoryList.setSelected(dynamic_cast<Factory*>(&structure));
 }
 
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -133,6 +133,12 @@ FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
 }
 
 
+bool FactoryReport::canView(Structure& structure)
+{
+	return dynamic_cast<Factory*>(&structure);
+}
+
+
 /**
  * Override of the interface provided by Report class.
  *

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -31,7 +31,7 @@ public:
 
 	FactoryReport(TakeMeThereDelegate takeMeThereHandler);
 
-	void selectStructure(Structure*) override;
+	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -31,6 +31,7 @@ public:
 
 	FactoryReport(TakeMeThereDelegate takeMeThereHandler);
 
+	bool canView(Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -143,9 +143,9 @@ MineReport::MineReport(TakeMeThereDelegate takeMeThereHandler) :
 }
 
 
-void MineReport::selectStructure(Structure* structure)
+void MineReport::selectStructure(Structure& structure)
 {
-	lstMineFacilities.setSelected(structure);
+	lstMineFacilities.setSelected(&structure);
 }
 
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -143,6 +143,12 @@ MineReport::MineReport(TakeMeThereDelegate takeMeThereHandler) :
 }
 
 
+bool MineReport::canView(Structure& structure)
+{
+	return dynamic_cast<MineFacility*>(&structure) || structure.isSmelter();
+}
+
+
 void MineReport::selectStructure(Structure& structure)
 {
 	lstMineFacilities.setSelected(&structure);

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -29,6 +29,7 @@ public:
 
 	MineReport(TakeMeThereDelegate takeMeThereHandler);
 
+	bool canView(Structure& structure) override;
 	void selectStructure(Structure& structure) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -29,7 +29,7 @@ public:
 
 	MineReport(TakeMeThereDelegate takeMeThereHandler);
 
-	void selectStructure(Structure* structure) override;
+	void selectStructure(Structure& structure) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/Report.h
+++ b/appOPHD/UI/Reports/Report.h
@@ -14,6 +14,8 @@ class Structure;
 class Report : public ControlContainer
 {
 public:
+	virtual bool canView(Structure& structure) = 0;
+
 	/**
 	 * Instructs a Report to set its primary selection to a specified Structure.
 	 *

--- a/appOPHD/UI/Reports/Report.h
+++ b/appOPHD/UI/Reports/Report.h
@@ -21,7 +21,7 @@ public:
 	 *			classes. Be mindful to pass pointers to objects that can be safely
 	 *			downcasted to a more derived type (take advantage of dynamic_cast)
 	 */
-	virtual void selectStructure(Structure*) = 0;
+	virtual void selectStructure(Structure&) = 0;
 
 	/**
 	 * Instructs the Report to clear any selections it may have.

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -111,6 +111,12 @@ ResearchReport::~ResearchReport()
 }
 
 
+bool ResearchReport::canView(Structure& /*structure*/)
+{
+	return false;
+}
+
+
 void ResearchReport::selectStructure(Structure&)
 {
 }

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -111,7 +111,7 @@ ResearchReport::~ResearchReport()
 }
 
 
-void ResearchReport::selectStructure(Structure*)
+void ResearchReport::selectStructure(Structure&)
 {
 }
 

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -111,9 +111,9 @@ ResearchReport::~ResearchReport()
 }
 
 
-bool ResearchReport::canView(Structure& /*structure*/)
+bool ResearchReport::canView(Structure& structure)
 {
-	return false;
+	return dynamic_cast<ResearchFacility*>(&structure);
 }
 
 

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -33,7 +33,7 @@ public:
 	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 
-	void selectStructure(Structure*) override;
+	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -33,6 +33,7 @@ public:
 	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 
+	bool canView(Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -25,6 +25,12 @@ SatellitesReport::~SatellitesReport()
 }
 
 
+bool SatellitesReport::canView(Structure& /*structure*/)
+{
+	return false;
+}
+
+
 void SatellitesReport::selectStructure(Structure&)
 {
 }

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -25,7 +25,7 @@ SatellitesReport::~SatellitesReport()
 }
 
 
-void SatellitesReport::selectStructure(Structure*)
+void SatellitesReport::selectStructure(Structure&)
 {
 }
 

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -20,7 +20,7 @@ public:
 	SatellitesReport(TakeMeThereDelegate takeMeThereHandler);
 	~SatellitesReport() override;
 
-	void selectStructure(Structure*) override;
+	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -20,6 +20,7 @@ public:
 	SatellitesReport(TakeMeThereDelegate takeMeThereHandler);
 	~SatellitesReport() override;
 
+	bool canView(Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -23,6 +23,12 @@ SpaceportsReport::~SpaceportsReport()
 }
 
 
+bool SpaceportsReport::canView(Structure& /*structure*/)
+{
+	return false;
+}
+
+
 void SpaceportsReport::selectStructure(Structure&)
 {
 }

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -23,7 +23,7 @@ SpaceportsReport::~SpaceportsReport()
 }
 
 
-void SpaceportsReport::selectStructure(Structure*)
+void SpaceportsReport::selectStructure(Structure&)
 {
 }
 

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -20,6 +20,7 @@ public:
 	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler);
 	~SpaceportsReport() override;
 
+	bool canView(Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -20,7 +20,7 @@ public:
 	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler);
 	~SpaceportsReport() override;
 
-	void selectStructure(Structure*) override;
+	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -96,6 +96,12 @@ WarehouseReport::~WarehouseReport()
 }
 
 
+bool WarehouseReport::canView(Structure& structure)
+{
+	return dynamic_cast<Warehouse*>(&structure);
+}
+
+
 void WarehouseReport::selectStructure(Structure& structure)
 {
 	lstStructures.setSelected(&structure);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -96,9 +96,9 @@ WarehouseReport::~WarehouseReport()
 }
 
 
-void WarehouseReport::selectStructure(Structure* structure)
+void WarehouseReport::selectStructure(Structure& structure)
 {
-	lstStructures.setSelected(structure);
+	lstStructures.setSelected(&structure);
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -31,6 +31,7 @@ public:
 	WarehouseReport(TakeMeThereDelegate takeMeThereHandler);
 	~WarehouseReport() override;
 
+	bool canView(Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -31,7 +31,7 @@ public:
 	WarehouseReport(TakeMeThereDelegate takeMeThereHandler);
 	~WarehouseReport() override;
 
-	void selectStructure(Structure*) override;
+	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;


### PR DESCRIPTION
Add method `Report::canView`, and use it to simplify selecting of the right `Report` to view for a given `Structure`.

Rather than putting logic in `ReportsState` for which `Report` to display, we can now ask the `Report` instances if they can view the given `Structure`. This makes it easy to loop over the `Report` instances to ask each one, rather than hardcode a bunch of `if` checks or a `switch` statement.

Prefer using reference syntax. The non-nullability of references means compilers don't need to warn about a lack of `nullptr` checks. In an earlier attempt, MSVC was giving a warning:
> Warning C6011
> Dereferencing NULL pointer 'pointer-name'.

----

Related:
- Issue #1608
- PR #1816
- PR #1810
- PR #1809
