### PR TITLE
Fix bug in `MineReport` "Take Me There" button

### DIFF
--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -238,6 +238,21 @@ void ReportsState::onWindowResized(NAS2D::Vector<int> newSize)
 
 void ReportsState::onTakeMeThere(const Structure* structure)
 {
+	// Ignore events that come from an inactive tab
+	// This is a bit of a hack to fix a bug where non-visible reports respond to events
+	// It would be cleaner to have non-visible reports not process user input
+	// A better fix relies up reworking event dispatch
+	for (auto& panel : panels)
+	{
+		if (panel.report)
+		{
+			if (panel.report->canView(*structure) && !panel.selected())
+			{
+				return;
+			}
+		}
+	}
+
 	if (mTakeMeThereHandler) { mTakeMeThereHandler(structure); }
 }
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -133,9 +133,9 @@ FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
 }
 
 
-bool FactoryReport::canView(Structure& structure)
+bool FactoryReport::canView(const Structure& structure)
 {
-	return dynamic_cast<Factory*>(&structure);
+	return dynamic_cast<const Factory*>(&structure);
 }
 
 

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -31,7 +31,7 @@ public:
 
 	FactoryReport(TakeMeThereDelegate takeMeThereHandler);
 
-	bool canView(Structure& structure) override;
+	bool canView(const Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -143,9 +143,9 @@ MineReport::MineReport(TakeMeThereDelegate takeMeThereHandler) :
 }
 
 
-bool MineReport::canView(Structure& structure)
+bool MineReport::canView(const Structure& structure)
 {
-	return dynamic_cast<MineFacility*>(&structure) || structure.isSmelter();
+	return dynamic_cast<const MineFacility*>(&structure) || structure.isSmelter();
 }
 
 

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -29,7 +29,7 @@ public:
 
 	MineReport(TakeMeThereDelegate takeMeThereHandler);
 
-	bool canView(Structure& structure) override;
+	bool canView(const Structure& structure) override;
 	void selectStructure(Structure& structure) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/Report.h
+++ b/appOPHD/UI/Reports/Report.h
@@ -14,7 +14,7 @@ class Structure;
 class Report : public ControlContainer
 {
 public:
-	virtual bool canView(Structure& structure) = 0;
+	virtual bool canView(const Structure& structure) = 0;
 
 	/**
 	 * Instructs a Report to set its primary selection to a specified Structure.

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -111,9 +111,9 @@ ResearchReport::~ResearchReport()
 }
 
 
-bool ResearchReport::canView(Structure& structure)
+bool ResearchReport::canView(const Structure& structure)
 {
-	return dynamic_cast<ResearchFacility*>(&structure);
+	return dynamic_cast<const ResearchFacility*>(&structure);
 }
 
 

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -33,7 +33,7 @@ public:
 	ResearchReport(TakeMeThereDelegate takeMeThereHandler);
 	~ResearchReport() override;
 
-	bool canView(Structure& structure) override;
+	bool canView(const Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -25,7 +25,7 @@ SatellitesReport::~SatellitesReport()
 }
 
 
-bool SatellitesReport::canView(Structure& /*structure*/)
+bool SatellitesReport::canView(const Structure& /*structure*/)
 {
 	return false;
 }

--- a/appOPHD/UI/Reports/SatellitesReport.h
+++ b/appOPHD/UI/Reports/SatellitesReport.h
@@ -20,7 +20,7 @@ public:
 	SatellitesReport(TakeMeThereDelegate takeMeThereHandler);
 	~SatellitesReport() override;
 
-	bool canView(Structure& structure) override;
+	bool canView(const Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -23,7 +23,7 @@ SpaceportsReport::~SpaceportsReport()
 }
 
 
-bool SpaceportsReport::canView(Structure& /*structure*/)
+bool SpaceportsReport::canView(const Structure& /*structure*/)
 {
 	return false;
 }

--- a/appOPHD/UI/Reports/SpaceportsReport.h
+++ b/appOPHD/UI/Reports/SpaceportsReport.h
@@ -20,7 +20,7 @@ public:
 	SpaceportsReport(TakeMeThereDelegate takeMeThereHandler);
 	~SpaceportsReport() override;
 
-	bool canView(Structure& structure) override;
+	bool canView(const Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -96,9 +96,9 @@ WarehouseReport::~WarehouseReport()
 }
 
 
-bool WarehouseReport::canView(Structure& structure)
+bool WarehouseReport::canView(const Structure& structure)
 {
-	return dynamic_cast<Warehouse*>(&structure);
+	return dynamic_cast<const Warehouse*>(&structure);
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.h
+++ b/appOPHD/UI/Reports/WarehouseReport.h
@@ -31,7 +31,7 @@ public:
 	WarehouseReport(TakeMeThereDelegate takeMeThereHandler);
 	~WarehouseReport() override;
 
-	bool canView(Structure& structure) override;
+	bool canView(const Structure& structure) override;
 	void selectStructure(Structure&) override;
 	void clearSelected() override;
 	void fillLists() override;


### PR DESCRIPTION
Fix bug where clicking the "Take Me There" button in the `MineReport` also triggers the `FactoryReport` "Take Me There" button, so the user ends up being presented with a factory location, rather than the expected mine.

Improved `const` correctness of new `Report::canView` method, which was recently added to help support this fix.

Related:
- Issue #1608
- PR #1817
- PR #1809
