### PR TITLE
Add `MapViewState` constructor `Delegate` for quit event

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -35,7 +35,7 @@ NAS2D::Point<int> MOUSE_COORDS; /**< Mouse Coordinates. Used by other states/wra
 GameState::GameState(const std::string& savedGameFilename) :
 	mSaveGameDocument{saveGameDocument(savedGameFilename)},
 	mReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onShowReports}, {this, &GameState::onHideReports}},
-	mMapViewState{*this, mSaveGameDocument},
+	mMapViewState{*this, mSaveGameDocument, {this, &GameState::onQuit}},
 	mColonyShip{colonyShipDataFromSave(mSaveGameDocument)},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
 {}
@@ -43,7 +43,7 @@ GameState::GameState(const std::string& savedGameFilename) :
 
 GameState::GameState(const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty) :
 	mReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onShowReports}, {this, &GameState::onHideReports}},
-	mMapViewState{*this, planetAttributes, selectedDifficulty},
+	mMapViewState{*this, planetAttributes, selectedDifficulty, {this, &GameState::onQuit}},
 	mColonyShip{},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
 {}
@@ -80,7 +80,6 @@ void GameState::initializeMapViewState()
 	mActiveState = &mMapViewState;
 	mMapViewState.activate();
 
-	mMapViewState.quitHandler({this, &GameState::onQuit});
 	mMapViewState.mapChangedHandler({this, &GameState::onMapChange});
 }
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -154,7 +154,7 @@ const std::map<Difficulty, int> MapViewState::ColonyShipDeorbitMoraleLossMultipl
 };
 
 
-MapViewState::MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument) :
+MapViewState::MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument, EventDelegate quitHandler) :
 	mCrimeRateUpdate{mDifficulty},
 	mCrimeExecution{mDifficulty, {this, &MapViewState::onCrimeEvent}},
 	mTechnologyReader{"tech0-1.xml"},
@@ -183,6 +183,7 @@ MapViewState::MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGa
 	mNotificationArea{{this, &MapViewState::onNotificationClicked}},
 	mNotificationWindow{{this, &MapViewState::onTakeMeThere}},
 	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
+	mQuitHandler{quitHandler},
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mColonyShip{gameState.colonyShip()}
@@ -191,7 +192,7 @@ MapViewState::MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGa
 }
 
 
-MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty) :
+MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty, EventDelegate quitHandler) :
 	mDifficulty{selectedDifficulty},
 	mTileMap{std::make_unique<TileMap>(planetAttributes.mapImagePath, planetAttributes.maxDepth, planetAttributes.maxOreDeposits, HostilityOreDepositYields.at(planetAttributes.hostility))},
 	mCrimeRateUpdate{mDifficulty},
@@ -222,6 +223,7 @@ MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetA
 	mNotificationArea{{this, &MapViewState::onNotificationClicked}},
 	mNotificationWindow{{this, &MapViewState::onTakeMeThere}},
 	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
+	mQuitHandler{quitHandler},
 	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth() + 1)},
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -109,8 +109,8 @@ public:
 	using EventDelegate = NAS2D::Delegate<void()>;
 
 public:
-	MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument, EventDelegate quitHandler = {});
-	MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty, EventDelegate quitHandler = {});
+	MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument, EventDelegate quitHandler);
+	MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty, EventDelegate quitHandler);
 	~MapViewState() override;
 
 	void quitHandler(EventDelegate newQuitHandler) { mQuitHandler = newQuitHandler; }

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -109,8 +109,8 @@ public:
 	using EventDelegate = NAS2D::Delegate<void()>;
 
 public:
-	MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument);
-	MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty);
+	MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGameDocument, EventDelegate quitHandler = {});
+	MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty, EventDelegate quitHandler = {});
 	~MapViewState() override;
 
 	void quitHandler(EventDelegate newQuitHandler) { mQuitHandler = newQuitHandler; }

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -113,7 +113,6 @@ public:
 	MapViewState(GameState& gameState, const PlanetAttributes& planetAttributes, Difficulty selectedDifficulty, EventDelegate quitHandler);
 	~MapViewState() override;
 
-	void quitHandler(EventDelegate newQuitHandler) { mQuitHandler = newQuitHandler; }
 	void mapChangedHandler(EventDelegate newMapChangedHandler) { mMapChangedHandler = newMapChangedHandler; }
 
 	void focusOnStructure(const Structure* s);


### PR DESCRIPTION
We can't add all events to the constructor, namely the map change event causes crashes to initialize that early, but we can add the quit event to the constructor for early initialization.

Related:
- Issue #875
- Comment https://github.com/OutpostUniverse/OPHD/issues/875#issuecomment-2980073550
- PR #1784
