### PR TITLE
Refactor `libControls` member visibility

### DIFF
--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -39,7 +39,7 @@ public:
 	void text(const std::string& text);
 	const std::string& text() const;
 
-private:
+protected:
 	void onResize() override;
 	void onMove(NAS2D::Vector<int> displacement) override;
 	void onListSelectionChange();
@@ -47,6 +47,7 @@ private:
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
 
+private:
 	Button btnDown;
 	ListBox<> lstItems;
 	TextField txtField;

--- a/libControls/Control.h
+++ b/libControls/Control.h
@@ -86,6 +86,7 @@ protected:
 	virtual void onEnableChange() {}
 	virtual void onFocusChange() {}
 
+protected:
 	NAS2D::Rectangle<int> mRect; /**< Area of the Control. */
 
 	bool mVisible = true; /**< Flag indicating visibility of the Control. */

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -306,7 +306,7 @@ private:
 		}
 	}
 
-
+private:
 	typename ListBoxItem::Context mContext;
 
 	std::size_t mHighlightIndex = NoSelection;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -69,7 +69,7 @@ protected:
 
 	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const = 0;
 
-
+protected:
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;
 

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -24,7 +24,6 @@ public:
 protected:
 	void draw() const override;
 
-private:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void buildDrawParams(std::pair<Control*, std::string>&, int);

--- a/libControls/WindowStack.h
+++ b/libControls/WindowStack.h
@@ -28,7 +28,5 @@ public:
 	void update();
 
 private:
-	using WindowList = std::list<Window*>;
-
-	WindowList mWindowList;
+	std::list<Window*> mWindowList;
 };


### PR DESCRIPTION
Be more consistent about specifying member visibility in `libControls`.

Related:
- Issue #1756
- Issue #895
- Issue #479
