### PR TITLE
Move `Font` fields from `ListBoxBase` to subclasses

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -21,11 +21,9 @@ using namespace NAS2D;
 
 
 FactoryListBox::FactoryListBox(SelectionChangedDelegate selectionChangedHandler) :
-	ListBoxBase{
-		fontCache.load(constants::FontPrimary, 12),
-		fontCache.load(constants::FontPrimaryBold, 12),
-		selectionChangedHandler,
-	},
+	ListBoxBase{selectionChangedHandler},
+	mFont{fontCache.load(constants::FontPrimary, 12)},
+	mFontBold{fontCache.load(constants::FontPrimaryBold, 12)},
 	mStructureIcons{imageCache.load("ui/structures.png")}
 {
 	itemHeight(58);

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -46,7 +46,9 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
-	std::vector<FactoryListBoxItem> mItems;
-
+	const NAS2D::Font& mFont;
+	const NAS2D::Font& mFontBold;
 	const NAS2D::Image& mStructureIcons;
+
+	std::vector<FactoryListBoxItem> mItems;
 };

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -16,11 +16,9 @@ using namespace NAS2D;
 
 
 ProductListBox::ProductListBox(SelectionChangedDelegate selectionChangedHandler) :
-	ListBoxBase{
-		fontCache.load(constants::FontPrimary, 12),
-		fontCache.load(constants::FontPrimaryBold, 12),
-		selectionChangedHandler,
-	}
+	ListBoxBase{selectionChangedHandler},
+	mFont{fontCache.load(constants::FontPrimary, 12)},
+	mFontBold{fontCache.load(constants::FontPrimaryBold, 12)}
 {
 	itemHeight(30);
 }

--- a/appOPHD/UI/ProductListBox.h
+++ b/appOPHD/UI/ProductListBox.h
@@ -38,5 +38,8 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
+	const NAS2D::Font& mFont;
+	const NAS2D::Font& mFontBold;
+
 	std::vector<ProductListBoxItem> mItems;
 };

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -17,11 +17,9 @@ using namespace NAS2D;
 
 
 StructureListBox::StructureListBox(SelectionChangedDelegate selectionChangedHandler) :
-	ListBoxBase{
-		fontCache.load(constants::FontPrimary, 12),
-		fontCache.load(constants::FontPrimaryBold, 12),
-		selectionChangedHandler,
-	}
+	ListBoxBase{selectionChangedHandler},
+	mFont{fontCache.load(constants::FontPrimary, 12)},
+	mFontBold{fontCache.load(constants::FontPrimaryBold, 12)}
 {
 	itemHeight(30);
 }

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -46,5 +46,8 @@ protected:
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override;
 
 private:
+	const NAS2D::Font& mFont;
+	const NAS2D::Font& mFontBold;
+
 	std::vector<StructureListBoxItem> mItems;
 };

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -12,9 +12,7 @@
 const std::size_t ListBoxBase::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
-ListBoxBase::ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold, SelectionChangedDelegate selectionChangedHandler) :
-	mFont{font},
-	mFontBold{fontBold},
+ListBoxBase::ListBoxBase(SelectionChangedDelegate selectionChangedHandler) :
 	mSelectionChangedHandler{selectionChangedHandler}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -29,7 +29,7 @@ public:
 	static const std::size_t NoSelection;
 
 
-	ListBoxBase(const NAS2D::Font& font, const NAS2D::Font& fontBold, SelectionChangedDelegate selectionChangedHandler = {});
+	ListBoxBase(SelectionChangedDelegate selectionChangedHandler = {});
 	~ListBoxBase() override;
 
 	bool isEmpty() const;
@@ -68,10 +68,6 @@ protected:
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const;
 
 	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const = 0;
-
-protected:
-	const NAS2D::Font& mFont;
-	const NAS2D::Font& mFontBold;
 
 private:
 	std::size_t mHighlightIndex = NoSelection;


### PR DESCRIPTION
These `Font` fields really didn't need to be in the base class. They were only used to support rendering of list box items, which is a concern of the subclasses. The base class only needs to know how tall each item is, and how many there are.

Related:
- Issue #479
- PR #1820
