### PR TITLE
Optimize empty string init

### DIFF
--- a/appOPHD/Map/Connections.cpp
+++ b/appOPHD/Map/Connections.cpp
@@ -58,11 +58,8 @@ namespace
 
 	std::string roadAnimationName(int integrity, const std::array<bool, 4>& surroundingTiles)
 	{
-		std::string tag = "";
-
-		if (integrity == 0) { tag = "-destroyed"; }
-		else if (integrity < constants::RoadIntegrityChange) { tag = "-decayed"; }
-
+		const std::string tag = (integrity == 0) ? "-destroyed" :
+			(integrity < constants::RoadIntegrityChange) ? "-decayed" : "";
 		return IntersectionPatternTable.at(surroundingTiles) + tag;
 	}
 }

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -31,7 +31,7 @@ public:
 
 	using ClickDelegate = NAS2D::Delegate<void()>;
 
-	Button(std::string newText = "");
+	Button(std::string newText = {});
 	Button(std::string newText, ClickDelegate clickHandler);
 	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler);
 	Button(const NAS2D::Image& image, ClickDelegate clickHandler);

--- a/libControls/CheckBox.h
+++ b/libControls/CheckBox.h
@@ -21,7 +21,7 @@ class CheckBox : public TextControl
 public:
 	using ClickDelegate = NAS2D::Delegate<void()>;
 
-	CheckBox(std::string newText = "", ClickDelegate clickHandler = {});
+	CheckBox(std::string newText = {}, ClickDelegate clickHandler = {});
 	~CheckBox() override;
 
 	void checked(bool toggle);

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -14,7 +14,7 @@
 class Window : public ControlContainer
 {
 public:
-	Window(std::string newTitle = "", const NAS2D::Font& titleFont = getDefaultFontBold());
+	Window(std::string newTitle = {}, const NAS2D::Font& titleFont = getDefaultFontBold());
 	~Window() override;
 
 	void anchored(bool isAnchored);


### PR DESCRIPTION
It's easier for the compiler to default initialize a `std::string` to empty, rather than copy initialize it from a C-string, which may require scanning it to find the length, and copying every character. With a C-string copy, the compiler may not be able to see the string is empty and optimize accordingly.

Related:
- Issue #895
