### PR TITLE
Fix load game crash from `MineOperationsWindow`

### DIFF
--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -73,7 +73,7 @@ MineOperationsWindow::MineOperationsWindow() :
 
 void MineOperationsWindow::hide()
 {
-	Control::hide();
+	Window::hide();
 	mFacility = nullptr;
 }
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -31,10 +31,10 @@ MineOperationsWindow::MineOperationsWindow() :
 	mIcons{imageCache.load("ui/icons.png")},
 	mPanel{loadRectangleSkin("ui/skin/textbox_normal")},
 	chkResources{{
-		{ResourceNamesRefined[0], {this, &MineOperationsWindow::onCheckBoxCommonMetalsChange}},
-		{ResourceNamesRefined[1], {this, &MineOperationsWindow::onCheckBoxCommonMineralsChange}},
-		{ResourceNamesRefined[2], {this, &MineOperationsWindow::onCheckBoxRareMetalsChange}},
-		{ResourceNamesRefined[3], {this, &MineOperationsWindow::onCheckBoxRareMineralsChange}},
+		{ResourceNamesRefined[0], {this, &MineOperationsWindow::onCheckBoxChange}},
+		{ResourceNamesRefined[1], {this, &MineOperationsWindow::onCheckBoxChange}},
+		{ResourceNamesRefined[2], {this, &MineOperationsWindow::onCheckBoxChange}},
+		{ResourceNamesRefined[3], {this, &MineOperationsWindow::onCheckBoxChange}},
 	}},
 	btnIdle{"Idle", {this, &MineOperationsWindow::onIdle}},
 	btnExtendShaft{"Dig New Level", {this, &MineOperationsWindow::onExtendShaft}},
@@ -140,27 +140,13 @@ void MineOperationsWindow::onUnassignTruck()
 }
 
 
-void MineOperationsWindow::onCheckBoxCommonMetalsChange()
+void MineOperationsWindow::onCheckBoxChange()
 {
-	mFacility->oreDeposit().miningEnabled(OreDeposit::OreType::CommonMetals, chkResources[0].checked());
-}
-
-
-void MineOperationsWindow::onCheckBoxCommonMineralsChange()
-{
-	mFacility->oreDeposit().miningEnabled(OreDeposit::OreType::CommonMinerals, chkResources[1].checked());
-}
-
-
-void MineOperationsWindow::onCheckBoxRareMetalsChange()
-{
-	mFacility->oreDeposit().miningEnabled(OreDeposit::OreType::RareMetals, chkResources[2].checked());
-}
-
-
-void MineOperationsWindow::onCheckBoxRareMineralsChange()
-{
-	mFacility->oreDeposit().miningEnabled(OreDeposit::OreType::RareMinerals, chkResources[3].checked());
+	auto& oreDeposit = mFacility->oreDeposit();
+	oreDeposit.miningEnabled(OreDeposit::OreType::CommonMetals, chkResources[0].checked());
+	oreDeposit.miningEnabled(OreDeposit::OreType::CommonMinerals, chkResources[1].checked());
+	oreDeposit.miningEnabled(OreDeposit::OreType::RareMetals, chkResources[2].checked());
+	oreDeposit.miningEnabled(OreDeposit::OreType::RareMinerals, chkResources[3].checked());
 }
 
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -142,6 +142,7 @@ void MineOperationsWindow::onUnassignTruck()
 
 void MineOperationsWindow::onCheckBoxChange()
 {
+	if (!mFacility) { return; }
 	auto& oreDeposit = mFacility->oreDeposit();
 	oreDeposit.miningEnabled(OreDeposit::OreType::CommonMetals, chkResources[0].checked());
 	oreDeposit.miningEnabled(OreDeposit::OreType::CommonMinerals, chkResources[1].checked());

--- a/appOPHD/UI/MineOperationsWindow.h
+++ b/appOPHD/UI/MineOperationsWindow.h
@@ -29,10 +29,7 @@ public:
 	void hide() override;
 
 protected:
-	void onCheckBoxCommonMetalsChange();
-	void onCheckBoxCommonMineralsChange();
-	void onCheckBoxRareMetalsChange();
-	void onCheckBoxRareMineralsChange();
+	void onCheckBoxChange();
 
 	void onOkay();
 	void onExtendShaft();

--- a/appOPHD/UI/MineOperationsWindow.h
+++ b/appOPHD/UI/MineOperationsWindow.h
@@ -28,7 +28,7 @@ public:
 	void update() override;
 	void hide() override;
 
-private:
+protected:
 	void onCheckBoxCommonMetalsChange();
 	void onCheckBoxCommonMineralsChange();
 	void onCheckBoxRareMetalsChange();
@@ -41,6 +41,7 @@ private:
 	void onAssignTruck();
 	void onUnassignTruck();
 
+private:
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;
 

--- a/appOPHD/UI/MineOperationsWindow.h
+++ b/appOPHD/UI/MineOperationsWindow.h
@@ -44,12 +44,8 @@ protected:
 private:
 	const NAS2D::Font& mFont;
 	const NAS2D::Font& mFontBold;
-
-	MineFacility* mFacility = nullptr;
-
 	const NAS2D::Image& mUiIcon;
 	const NAS2D::Image& mIcons;
-
 	NAS2D::RectangleSkin mPanel;
 
 	std::array<CheckBox, 4> chkResources;
@@ -61,5 +57,6 @@ private:
 	Button btnAssignTruck;
 	Button btnUnassignTruck;
 
+	MineFacility* mFacility = nullptr;
 	int mAvailableTrucks = 0;
 };

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -64,12 +64,6 @@ void Window::anchored(bool isAnchored)
 }
 
 
-void Window::show()
-{
-	Control::show();
-}
-
-
 void Window::update()
 {
 	draw();

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -19,8 +19,6 @@ public:
 
 	void anchored(bool isAnchored);
 
-	void show() override;
-
 	void update() override;
 
 	void title(const std::string& title);


### PR DESCRIPTION
A bit of light refactoring and a bug fix for a segmentation fault described in an Issue comment.

Fixes #1608

Related:
- Issue #1608
- Comment https://github.com/OutpostUniverse/OPHD/issues/1608#issuecomment-2958304209
