### PR TITLE
Fix `NotificationWindow` "Take Me There" button visibility

### DIFF
--- a/appOPHD/UI/NotificationArea.h
+++ b/appOPHD/UI/NotificationArea.h
@@ -36,8 +36,8 @@ public:
 
 	struct Notification
 	{
-		std::string brief{""};
-		std::string message{""};
+		std::string brief{};
+		std::string message{};
 		MapCoordinate position{{-1, -1}, 0};
 		NotificationType type{NotificationType::Information};
 

--- a/appOPHD/UI/NotificationArea.h
+++ b/appOPHD/UI/NotificationArea.h
@@ -40,6 +40,11 @@ public:
 		std::string message{""};
 		MapCoordinate position{{-1, -1}, 0};
 		NotificationType type{NotificationType::Information};
+
+		bool hasMapCoordinate() const
+		{
+			return position.xy != NAS2D::Point{-1, -1};
+		}
 	};
 
 	using NotificationClickedDelegate = NAS2D::Delegate<void(const Notification&)>;

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -26,7 +26,13 @@ void NotificationWindow::notification(const NotificationArea::Notification& noti
 	mNotification = notification;
 	title(mNotification.brief);
 	mMessageArea.text(mNotification.message);
-	mTakeMeThereVisible = mNotification.position.xy != NAS2D::Point<int>{-1, -1}; //\fixme magic value
+}
+
+
+void NotificationWindow::onVisibilityChange(bool)
+{
+	if (!enabled() || !visible()) { return; }
+	btnTakeMeThere.visible(mNotification.position.xy != NAS2D::Point<int>{-1, -1}); //\fixme magic value
 }
 
 
@@ -48,8 +54,6 @@ void NotificationWindow::update()
 	if (!visible()) { return; }
 
 	Window::update();
-
-	btnTakeMeThere.visible(mTakeMeThereVisible); // bit of a hack
 
 	const auto iconLocation = position() + NAS2D::Vector{10, 30};
 	drawNotificationIcon(iconLocation, mNotification.type, mIcons);

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -32,7 +32,7 @@ void NotificationWindow::notification(const NotificationArea::Notification& noti
 void NotificationWindow::onVisibilityChange(bool)
 {
 	if (!enabled() || !visible()) { return; }
-	btnTakeMeThere.visible(mNotification.position.xy != NAS2D::Point<int>{-1, -1}); //\fixme magic value
+	btnTakeMeThere.visible(mNotification.hasMapCoordinate());
 }
 
 

--- a/appOPHD/UI/NotificationWindow.h
+++ b/appOPHD/UI/NotificationWindow.h
@@ -25,6 +25,7 @@ public:
 	void update() override;
 
 private:
+	void onVisibilityChange(bool) override;
 	void onOkayClicked();
 	void onTakeMeThereClicked();
 
@@ -34,7 +35,6 @@ private:
 	Button btnOkay{"Okay", {this, &NotificationWindow::onOkayClicked}};
 	Button btnTakeMeThere{"Take Me There", {this, &NotificationWindow::onTakeMeThereClicked}};
 	TextArea mMessageArea;
-	bool mTakeMeThereVisible{false};
 
 	TakeMeThereDelegate mTakeMeThereHandler;
 };


### PR DESCRIPTION
Fix graphical glitch where the "Take Me There" button could show briefly before disappearing for notifications without an assigned `MapCoordinate`.

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-2969825806
- PR #1822