### PR TITLE
Remove inappropriate calls from `MapViewState::onCheatCodeEntry`

### DIFF
--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -707,8 +707,6 @@ void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
 	updatePlayerResources();
 	updateStructuresAvailability();
 	updateFood();
-	updatePopulation();
-	updateRobots();
 }
 
 /**


### PR DESCRIPTION
Some of the "update" functions scan resources and updated cached total counts. Other "update" functions run turn processing logic and make state changes. The two functions are very different in nature. The cheat codes update state, so may require scanning and updating of cached total values. There is no reason for cheat codes to trigger turn processing logic.

Often the game will read and display live values, rather than cached values, so it's not always necessary to update any sort of cached value for display.

Related:
- Issue #1770
