### PR TITLE
Increase `TileInspector` line spacing from 12 to 18

### DIFF
--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -19,7 +19,7 @@ using namespace NAS2D;
 
 namespace
 {
-	const auto lineSpacing = 12;
+	const auto lineSpacing = 18;
 	const auto sectionSpacing = constants::Margin;
 
 	const std::map<TerrainType, std::string> terrainTypeStringTable =


### PR DESCRIPTION
Original:
![image](https://github.com/user-attachments/assets/920828b7-8433-49a2-819c-34f7a46bbca9)

Updated:
![image](https://github.com/user-attachments/assets/2f98f99f-909d-40a8-a1a9-04664c3d7cb4)

----

Related:
- Issue #1754
