### PR TITLE
Refactor `Control` visibility

### DIFF
--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -83,11 +83,3 @@ CheatMenu::CheatCode CheatMenu::stringToCheatCode(const std::string& cheatCode)
 		return CheatCode::Invalid;
 	}
 }
-
-
-void CheatMenu::update()
-{
-	if (!visible()) { return; }
-
-	Window::update();
-}

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -35,7 +35,6 @@ public:
 	CheatMenu(CheatDelegate cheatHandler);
 
 	void onOkay();
-	void update() override;
 
 	static CheatMenu::CheatCode stringToCheatCode(const std::string& cheatCode);
 

--- a/appOPHD/UI/DiggerDirection.cpp
+++ b/appOPHD/UI/DiggerDirection.cpp
@@ -85,13 +85,6 @@ void DiggerDirection::onCancel()
 }
 
 
-void DiggerDirection::update()
-{
-	if (!visible() || !mTile) { return; }
-	Window::update();
-}
-
-
 void DiggerDirection::selectDown()
 {
 	onDiggerDown();

--- a/appOPHD/UI/DiggerDirection.h
+++ b/appOPHD/UI/DiggerDirection.h
@@ -18,8 +18,6 @@ public:
 
 	DiggerDirection(DirectionSelectedDelegate directionSelectedHandler);
 
-	void update() override;
-
 	void setParameters(Tile& tile);
 
 	void selectDown();

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -227,12 +227,3 @@ void FileIo::onFileDelete()
 	mDeleteFile.enabled(false);
 	scanDirectory(constants::SaveGamePath);
 }
-
-
-
-void FileIo::update()
-{
-	if (!visible()) { return; }
-
-	Window::update();
-}

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -37,8 +37,6 @@ public:
 	void showOpen(const std::string& directory);
 	void showSave(const std::string& directory);
 
-	void update() override;
-
 protected:
 	void scanDirectory(const std::string& directory);
 

--- a/appOPHD/UI/GameOptionsDialog.cpp
+++ b/appOPHD/UI/GameOptionsDialog.cpp
@@ -52,13 +52,6 @@ void GameOptionsDialog::onEnableChange()
 }
 
 
-void GameOptionsDialog::update()
-{
-	if (!visible()) { return; }
-
-	Window::update();
-}
-
 void GameOptionsDialog::onHelp()
 {
 	shellOpenPath("https://wiki.outpost2.net/doku.php?id=outposthd:how_to_play");

--- a/appOPHD/UI/GameOptionsDialog.h
+++ b/appOPHD/UI/GameOptionsDialog.h
@@ -16,8 +16,6 @@ public:
 		ClickHandler continueClickHandler
 	);
 
-	void update() override;
-
 protected:
 	void onHelp();
 

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -29,8 +29,10 @@ void NotificationWindow::notification(const NotificationArea::Notification& noti
 }
 
 
-void NotificationWindow::onVisibilityChange(bool)
+void NotificationWindow::onVisibilityChange(bool isVisible)
 {
+	Window::onVisibilityChange(isVisible);
+
 	if (!enabled() || !visible()) { return; }
 	btnTakeMeThere.visible(mNotification.hasMapCoordinate());
 }

--- a/appOPHD/UI/NotificationWindow.h
+++ b/appOPHD/UI/NotificationWindow.h
@@ -25,7 +25,7 @@ public:
 	void update() override;
 
 private:
-	void onVisibilityChange(bool) override;
+	void onVisibilityChange(bool isVisible) override;
 	void onOkayClicked();
 	void onTakeMeThereClicked();
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -294,6 +294,8 @@ void FactoryReport::onResize()
  */
 void FactoryReport::onVisibilityChange(bool visible)
 {
+	Report::onVisibilityChange(visible);
+
 	if (!selectedFactory) { return; }
 
 	StructureState state = selectedFactory->state();

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -203,8 +203,10 @@ void MineReport::onResize()
 }
 
 
-void MineReport::onVisibilityChange(bool /*visible*/)
+void MineReport::onVisibilityChange(bool visible)
 {
+	Report::onVisibilityChange(visible);
+
 	onManagementButtonsVisibilityChange();
 }
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -237,8 +237,10 @@ void WarehouseReport::onResize()
 }
 
 
-void WarehouseReport::onVisibilityChange(bool /*visible*/)
+void WarehouseReport::onVisibilityChange(bool visible)
 {
+	Report::onVisibilityChange(visible);
+
 	setVisibility();
 }
 

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -172,6 +172,17 @@ void StructureInspector::structure(Structure* structure)
 }
 
 
+void StructureInspector::onVisibilityChange(bool visible)
+{
+	Window::onVisibilityChange(visible);
+
+	if (visible && !mStructure)
+	{
+		throw std::runtime_error("StructureInspector needs a valid structure");
+	}
+}
+
+
 void StructureInspector::onClose()
 {
 	visible(false);
@@ -202,11 +213,6 @@ void StructureInspector::update()
 {
 	if (!visible()) { return; }
 	Window::update();
-
-	if (mStructure == nullptr)
-	{
-		throw std::runtime_error("Null pointer to structure within StructureInspector");
-	}
 
 	const auto genericStructureAttributes = buildGenericStringTable();
 	const auto specificAttributeTablePosition = genericStructureAttributes.area().crossYPoint() + NAS2D::Vector{0, 20 + constants::Margin};

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -22,6 +22,7 @@ public:
 	void update() override;
 
 protected:
+	void onVisibilityChange(bool visible) override;
 	void onClose();
 
 	StringTable buildGenericStringTable() const;

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -49,12 +49,6 @@ void TileInspector::update()
 	if (!visible())
 		return;
 
-	if (!mTile || !mTile->excavated())
-	{
-		visible(false);
-		return;
-	}
-
 	Window::update();
 
 	auto position = mRect.position + NAS2D::Vector{5, 25};
@@ -76,6 +70,17 @@ void TileInspector::update()
 
 		position.y += lineSpacing;
 		drawLabelAndValue(position, "Yield: ", oreDepositYieldEnumToString(mTile->oreDeposit()->yield()));
+	}
+}
+
+
+void TileInspector::onVisibilityChange(bool isVisible)
+{
+	Window::onVisibilityChange(isVisible);
+
+	if (isVisible && (!mTile || !mTile->excavated()))
+	{
+		visible(false);
 	}
 }
 

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -49,10 +49,7 @@ void TileInspector::update()
 	if (!visible())
 		return;
 
-	if (!mTile)
-		return;
-
-	if(!mTile->excavated())
+	if (!mTile || !mTile->excavated())
 	{
 		visible(false);
 		return;

--- a/appOPHD/UI/TileInspector.h
+++ b/appOPHD/UI/TileInspector.h
@@ -16,6 +16,7 @@ public:
 	void update() override;
 
 protected:
+	void onVisibilityChange(bool visible) override;
 	void onClose();
 
 private:

--- a/appOPHD/UI/TileInspector.h
+++ b/appOPHD/UI/TileInspector.h
@@ -15,9 +15,10 @@ public:
 
 	void update() override;
 
-private:
+protected:
 	void onClose();
 
+private:
 	Button btnClose;
 	Tile* mTile = nullptr;
 };

--- a/libControls/ControlContainer.cpp
+++ b/libControls/ControlContainer.cpp
@@ -70,6 +70,8 @@ void ControlContainer::bringToFront(Control* control)
 
 void ControlContainer::onVisibilityChange(bool visible)
 {
+	Control::onVisibilityChange(visible);
+
 	for (auto control : mControls) { control->visible(visible); }
 }
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -265,8 +265,10 @@ protected:
 	}
 
 
-	void onVisibilityChange(bool /*visible*/) override
+	void onVisibilityChange(bool visible) override
 	{
+		Control::onVisibilityChange(visible);
+
 		updateScrollLayout();
 	}
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -126,8 +126,10 @@ void ListBoxBase::updateScrollLayout()
 }
 
 
-void ListBoxBase::onVisibilityChange(bool)
+void ListBoxBase::onVisibilityChange(bool visible)
 {
+	Control::onVisibilityChange(visible);
+
 	updateScrollLayout();
 }
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -49,7 +49,7 @@ protected:
 	void clear();
 	void updateScrollLayout();
 
-	void onVisibilityChange(bool) override;
+	void onVisibilityChange(bool visible) override;
 	void onResize() override;
 	void onSlideChange(ScrollBar::ValueType newPosition);
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -91,5 +91,4 @@ void Window::draw() const
 void Window::title(const std::string& title)
 {
 	mTitle = title;
-	onTitleChanged();
 }

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -24,8 +24,6 @@ public:
 	void title(const std::string& title);
 	const std::string& title() const { return mTitle; }
 
-	virtual void onTitleChanged() {}
-
 protected:
 	void draw() const override;
 


### PR DESCRIPTION
Noticed some non-`const` method compatible code in `Control` derived `update()` methods that could get in the way of updating them to use `draw() const` methods. This lead to some additional changes to some overrides of `onVisibilityChange` so they would call their base class implementation. That may be important for `ControlContainer` derived classes, which have a non-trivial base class implementation.

Related:
- Issue #1756
