### PR TITLE
Add method `Window::drawClientArea`

### DIFF
--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -204,12 +204,8 @@ void FactoryProduction::factory(Factory* newFactory)
 }
 
 
-void FactoryProduction::update()
+void FactoryProduction::drawClientArea() const
 {
-	if (!visible()) { return; }
-
-	Window::update();
-
 	auto stringTable = factoryProductionStringTable(mProductCost, mFactory->productionTurnsCompleted());
 	stringTable.position(mProductGrid.area().crossXPoint() + NAS2D::Vector{constants::Margin, 0});
 	stringTable.computeRelativeCellPositions();

--- a/appOPHD/UI/FactoryProduction.h
+++ b/appOPHD/UI/FactoryProduction.h
@@ -26,7 +26,7 @@ public:
 
 	void hide() override;
 
-	void update() override;
+	void drawClientArea() const override;
 
 protected:
 	void onProductSelectionChange(const IconGrid::Item*);

--- a/appOPHD/UI/GameOverDialog.cpp
+++ b/appOPHD/UI/GameOverDialog.cpp
@@ -20,12 +20,8 @@ GameOverDialog::GameOverDialog(ClickDelegate clickHandler) :
 }
 
 
-void GameOverDialog::update()
+void GameOverDialog::drawClientArea() const
 {
-	if (!visible()) { return; }
-
-	Window::update();
-
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});

--- a/appOPHD/UI/GameOverDialog.h
+++ b/appOPHD/UI/GameOverDialog.h
@@ -14,7 +14,7 @@ public:
 public:
 	GameOverDialog(ClickDelegate clickHandler);
 
-	void update() override;
+	void drawClientArea() const override;
 
 private:
 	const NAS2D::Image& mHeader;

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -75,12 +75,8 @@ void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const C
 }
 
 
-void MajorEventAnnouncement::update()
+void MajorEventAnnouncement::drawClientArea() const
 {
-	if (!visible()) { return; }
-
-	Window::update();
-
 	auto& renderer = Utility<Renderer>::get();
 
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -24,7 +24,7 @@ public:
 
 	void onColonyShipCrash(WindowStack&, const ColonyShipData&);
 
-	void update() override;
+	void drawClientArea() const override;
 
 private:
 	void onClose();

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -157,12 +157,8 @@ void MineOperationsWindow::updateTruckAvailability()
 }
 
 
-void MineOperationsWindow::update()
+void MineOperationsWindow::drawClientArea() const
 {
-	if (!visible()) { return; }
-
-	Window::update();
-
 	auto& renderer = Utility<Renderer>::get();
 
 	const auto origin = mRect.position;

--- a/appOPHD/UI/MineOperationsWindow.h
+++ b/appOPHD/UI/MineOperationsWindow.h
@@ -25,7 +25,7 @@ public:
 
 	void updateTruckAvailability();
 
-	void update() override;
+	void drawClientArea() const override;
 	void hide() override;
 
 protected:

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -51,12 +51,8 @@ void NotificationWindow::onTakeMeThereClicked()
 }
 
 
-void NotificationWindow::update()
+void NotificationWindow::drawClientArea() const
 {
-	if (!visible()) { return; }
-
-	Window::update();
-
 	const auto iconLocation = position() + NAS2D::Vector{10, 30};
 	drawNotificationIcon(iconLocation, mNotification.type, mIcons);
 }

--- a/appOPHD/UI/NotificationWindow.h
+++ b/appOPHD/UI/NotificationWindow.h
@@ -22,7 +22,7 @@ public:
 
 	void notification(const NotificationArea::Notification&);
 
-	void update() override;
+	void drawClientArea() const override;
 
 private:
 	void onVisibilityChange(bool isVisible) override;

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -98,11 +98,8 @@ void RobotInspector::onCancel()
 }
 
 
-void RobotInspector::update()
+void RobotInspector::drawClientArea() const
 {
-	if (!visible()) { return; }
-	Window::update();
-
 	auto& renderer = Utility<Renderer>::get();
 	renderer.drawImage(robotImage(mRobot->type()), position() + Vector{constants::Margin, constants::Margin + sWindowTitleBarHeight});
 

--- a/appOPHD/UI/RobotInspector.h
+++ b/appOPHD/UI/RobotInspector.h
@@ -15,7 +15,7 @@ public:
 	void focusOnRobot(Robot*);
 	const Robot* focusedRobot() const { return mRobot; }
 
-	void update() override;
+	void drawClientArea() const override;
 
 private:
 	void onCancelOrders();

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -209,11 +209,8 @@ StringTable StructureInspector::buildSpecificStringTable(NAS2D::Point<int> posit
 }
 
 
-void StructureInspector::update()
+void StructureInspector::drawClientArea() const
 {
-	if (!visible()) { return; }
-	Window::update();
-
 	const auto genericStructureAttributes = buildGenericStringTable();
 	const auto specificAttributeTablePosition = genericStructureAttributes.area().crossYPoint() + NAS2D::Vector{0, 20 + constants::Margin};
 	const auto specificStructureAttributes = buildSpecificStringTable(specificAttributeTablePosition);

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -19,7 +19,7 @@ public:
 	void structure(Structure* structure);
 	Structure* structure() { return mStructure; }
 
-	void update() override;
+	void drawClientArea() const override;
 
 protected:
 	void onVisibilityChange(bool visible) override;

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -44,13 +44,8 @@ TileInspector::TileInspector() :
 }
 
 
-void TileInspector::update()
+void TileInspector::drawClientArea() const
 {
-	if (!visible())
-		return;
-
-	Window::update();
-
 	auto position = mRect.position + NAS2D::Vector{5, 25};
 	const auto tilePosition = mTile->xy();
 	drawLabelAndValue(position, "Location: ", NAS2D::stringFrom(tilePosition));

--- a/appOPHD/UI/TileInspector.h
+++ b/appOPHD/UI/TileInspector.h
@@ -13,7 +13,7 @@ public:
 
 	void tile(Tile& tile) { mTile = &tile; }
 
-	void update() override;
+	void drawClientArea() const override;
 
 protected:
 	void onVisibilityChange(bool visible) override;

--- a/appOPHD/UI/WarehouseInspector.cpp
+++ b/appOPHD/UI/WarehouseInspector.cpp
@@ -43,12 +43,8 @@ void WarehouseInspector::hide()
 }
 
 
-void WarehouseInspector::update()
+void WarehouseInspector::drawClientArea() const
 {
-	if (!visible()) { return; }
-
-	Window::update();
-
 	const auto& pool = mWarehouse->products();
 
 	const int labelWidth = 100;

--- a/appOPHD/UI/WarehouseInspector.h
+++ b/appOPHD/UI/WarehouseInspector.h
@@ -18,7 +18,7 @@ public:
 	void warehouse(const Warehouse* w);
 
 	void hide() override;
-	void update() override;
+	void drawClientArea() const override;
 
 private:
 	void onClose();

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -76,6 +76,13 @@ void Window::draw() const
 {
 	if (!visible()) { return; }
 
+	drawTitleBar();
+	drawClientArea();
+}
+
+
+void Window::drawTitleBar() const
+{
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	renderer.drawImage(mTitleBarLeft, mRect.position);

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -26,6 +26,8 @@ public:
 
 protected:
 	void draw() const override;
+	void drawTitleBar() const;
+	virtual void drawClientArea() const {}
 
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);


### PR DESCRIPTION
Add method `Window::drawClientArea` so `Window` derived classes can draw custom client areas without having to worry about calling base class methods to handle contained `Control` instances.

Related:
- Issue #1756
