### PR TITLE
Reduce `CrimeRateUpdate` transitive headers

### DIFF
--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -156,7 +156,7 @@ void CrimeExecution::stealResources(Structure& structure, const std::array<std::
 
 void CrimeExecution::vandalize(Structure& structure)
 {
-	mMoraleChanges.push_back(std::make_pair("Vandalism", -1));
+	mMoraleChanges.push_back({"Vandalism", -1});
 
 	mCrimeEventHandler(
 		"Vandalism",

--- a/appOPHD/States/CrimeExecution.h
+++ b/appOPHD/States/CrimeExecution.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <libOPHD/Population/MoraleChangeEntry.h>
+
 #include <NAS2D/Signal/Delegate.h>
 
 #include <vector>
 #include <array>
 #include <string>
-#include <utility>
 
 
 enum class Difficulty;
@@ -21,7 +22,7 @@ public:
 	CrimeExecution(const Difficulty& difficulty, CrimeEventDelegate crimeEventHandler);
 
 	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
-	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
+	std::vector<MoraleChangeEntry> moraleChanges() const { return mMoraleChanges; }
 
 protected:
 	void stealFood(FoodProduction& structure);
@@ -32,6 +33,6 @@ protected:
 
 private:
 	const Difficulty& mDifficulty;
-	std::vector<std::pair<std::string, int>> mMoraleChanges;
+	std::vector<MoraleChangeEntry> mMoraleChanges;
 	CrimeEventDelegate mCrimeEventHandler;
 };

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -13,12 +13,12 @@
 
 namespace
 {
-	std::map<Difficulty, float> chanceCrimeOccurs
+	std::map<Difficulty, int> chanceCrimeOccursPercent
 	{
-		{Difficulty::Beginner, 0.5f},
-		{Difficulty::Easy, 0.75f},
-		{Difficulty::Medium, 1.0f},
-		{Difficulty::Hard, 2.0f}
+		{Difficulty::Beginner, 50},
+		{Difficulty::Easy, 75},
+		{Difficulty::Medium, 100},
+		{Difficulty::Hard, 200}
 	};
 }
 
@@ -53,7 +53,7 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 		// Crime Rate of 0% means no crime
 		// Crime Rate of 100% means crime occurs 10% of the time on medium difficulty
 		// chanceCrimeOccurs multiplier increases or decreases chance based on difficulty
-		if (static_cast<int>(static_cast<float>(structure->crimeRate()) * chanceCrimeOccurs[mDifficulty]) + randomNumber.generate<int>(0, 1000) > 1000)
+		if (structure->crimeRate() * chanceCrimeOccursPercent[mDifficulty] / 100 + randomNumber.generate<int>(0, 1000) > 1000)
 		{
 			mStructuresCommittingCrimes.push_back(structure);
 		}

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -13,7 +13,6 @@
 
 namespace
 {
-	// Lower number indicates criminal activity occurs more often
 	std::map<Difficulty, float> chanceCrimeOccurs
 	{
 		{Difficulty::Beginner, 0.5f},

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -83,6 +83,24 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 }
 
 
+int CrimeRateUpdate::meanCrimeRate() const
+{
+	return mMeanCrimeRate;
+}
+
+
+std::vector<MoraleChangeEntry> CrimeRateUpdate::moraleChanges() const
+{
+	return mMoraleChanges;
+}
+
+
+std::vector<Structure*> CrimeRateUpdate::structuresCommittingCrimes() const
+{
+	return mStructuresCommittingCrimes;
+}
+
+
 int CrimeRateUpdate::calculateMoraleChange() const
 {
 	if (mMeanCrimeRate > 50)

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -105,10 +105,10 @@ void CrimeRateUpdate::updateMoraleChanges()
 
 	if (moraleChange > 0)
 	{
-		mMoraleChanges.push_back(std::make_pair("Low Crime Rate", moraleChange));
+		mMoraleChanges.push_back({"Low Crime Rate", moraleChange});
 	}
 	else if (moraleChange < 0)
 	{
-		mMoraleChanges.push_back(std::make_pair("High Crime Rate", moraleChange));
+		mMoraleChanges.push_back({"High Crime Rate", moraleChange});
 	}
 }

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -53,7 +53,7 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 		// Crime Rate of 0% means no crime
 		// Crime Rate of 100% means crime occurs 10% of the time on medium difficulty
 		// chanceCrimeOccurs multiplier increases or decreases chance based on difficulty
-		if (structure->crimeRate() * chanceCrimeOccursPercent[mDifficulty] / 100 + randomNumber.generate<int>(0, 1000) > 1000)
+		if (structure->crimeRate() * chanceCrimeOccursPercent[mDifficulty] + randomNumber.generate<int>(0, 100000) > 100000)
 		{
 			mStructuresCommittingCrimes.push_back(structure);
 		}

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -8,6 +8,21 @@
 
 #include <NAS2D/Utility.h>
 
+#include <map>
+
+
+namespace
+{
+	// Lower number indicates criminal activity occurs more often
+	std::map<Difficulty, float> chanceCrimeOccurs
+	{
+		{Difficulty::Beginner, 0.5f},
+		{Difficulty::Easy, 0.75f},
+		{Difficulty::Medium, 1.0f},
+		{Difficulty::Hard, 2.0f}
+	};
+}
+
 
 CrimeRateUpdate::CrimeRateUpdate(const Difficulty& difficulty) :
 	mDifficulty{difficulty}

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -20,6 +20,22 @@ namespace
 		{Difficulty::Medium, 100},
 		{Difficulty::Hard, 200}
 	};
+
+
+	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, Structure* structure)
+	{
+		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
+
+		for (const auto& tile : policeOverlays[static_cast<std::size_t>(structureTile.depth())])
+		{
+			if (tile->xy() == structureTile.xy())
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
 }
 
 
@@ -64,22 +80,6 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 	mMeanCrimeRate = static_cast<int>(accumulatedCrime / static_cast<double>(structuresWithCrime.size()));
 
 	updateMoraleChanges();
-}
-
-
-bool CrimeRateUpdate::isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, Structure* structure)
-{
-	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
-
-	for (const auto& tile : policeOverlays[static_cast<std::size_t>(structureTile.depth())])
-	{
-		if (tile->xy() == structureTile.xy())
-		{
-			return true;
-		}
-	}
-
-	return false;
 }
 
 

--- a/appOPHD/States/CrimeRateUpdate.h
+++ b/appOPHD/States/CrimeRateUpdate.h
@@ -27,7 +27,6 @@ private:
 	std::vector<MoraleChangeEntry> mMoraleChanges;
 	std::vector<Structure*> mStructuresCommittingCrimes;
 
-	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, Structure* structure);
 	int calculateMoraleChange() const;
 	void updateMoraleChanges();
 };

--- a/appOPHD/States/CrimeRateUpdate.h
+++ b/appOPHD/States/CrimeRateUpdate.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <libOPHD/EnumDifficulty.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 
 #include <vector>
-#include <string>
-#include <utility>
 
 
 class Structure;
@@ -19,13 +18,13 @@ public:
 	void update(const std::vector<std::vector<Tile*>>& policeOverlays);
 
 	int meanCrimeRate() const { return mMeanCrimeRate; }
-	std::vector<std::pair<std::string, int>> moraleChanges() const { return mMoraleChanges; }
+	std::vector<MoraleChangeEntry> moraleChanges() const { return mMoraleChanges; }
 	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
 private:
 	const Difficulty& mDifficulty;
 	int mMeanCrimeRate{0};
-	std::vector<std::pair<std::string, int>> mMoraleChanges;
+	std::vector<MoraleChangeEntry> mMoraleChanges;
 	std::vector<Structure*> mStructuresCommittingCrimes;
 
 	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, Structure* structure);

--- a/appOPHD/States/CrimeRateUpdate.h
+++ b/appOPHD/States/CrimeRateUpdate.h
@@ -17,9 +17,9 @@ public:
 
 	void update(const std::vector<std::vector<Tile*>>& policeOverlays);
 
-	int meanCrimeRate() const { return mMeanCrimeRate; }
-	std::vector<MoraleChangeEntry> moraleChanges() const { return mMoraleChanges; }
-	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
+	int meanCrimeRate() const;
+	std::vector<MoraleChangeEntry> moraleChanges() const;
+	std::vector<Structure*> structuresCommittingCrimes() const;
 
 private:
 	const Difficulty& mDifficulty;

--- a/appOPHD/States/CrimeRateUpdate.h
+++ b/appOPHD/States/CrimeRateUpdate.h
@@ -3,7 +3,6 @@
 #include <libOPHD/EnumDifficulty.h>
 
 #include <vector>
-#include <map>
 #include <string>
 #include <utility>
 
@@ -24,15 +23,6 @@ public:
 	std::vector<Structure*> structuresCommittingCrimes() const { return mStructuresCommittingCrimes; }
 
 private:
-	// Lower number indicates criminal activity occurs more often
-	std::map<Difficulty, float> chanceCrimeOccurs
-	{
-		{Difficulty::Beginner, 0.5f},
-		{Difficulty::Easy, 0.75f},
-		{Difficulty::Medium, 1.0f},
-		{Difficulty::Hard, 2.0f}
-	};
-
 	const Difficulty& mDifficulty;
 	int mMeanCrimeRate{0};
 	std::vector<std::pair<std::string, int>> mMoraleChanges;

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -178,16 +178,16 @@ void MapViewState::updateMorale()
 	mMorale.journalMoraleChange({"Food Production Issues", -foodProductionHit});
 
 
-	for (const auto& moraleReason : mCrimeRateUpdate.moraleChanges())
+	for (const auto& moraleChangeEntry : mCrimeRateUpdate.moraleChanges())
 	{
-		mMorale.journalMoraleChange({moraleReason.first, moraleReason.second});
+		mMorale.journalMoraleChange(moraleChangeEntry);
 	}
 
 	mPopulationPanel.crimeRate(mCrimeRateUpdate.meanCrimeRate());
 
-	for (const auto& moraleReason : mCrimeExecution.moraleChanges())
+	for (const auto& moraleChangeEntry : mCrimeExecution.moraleChanges())
 	{
-		mMorale.journalMoraleChange({moraleReason.first, moraleReason.second});
+		mMorale.journalMoraleChange(moraleChangeEntry);
 	}
 }
 

--- a/appOPHD/UI/PopulationPanel.h
+++ b/appOPHD/UI/PopulationPanel.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <libOPHD/Population/MoraleChangeEntry.h>
+
 #include <libControls/Control.h>
 
 #include <NAS2D/Renderer/RectangleSkin.h>
 
-#include <string>
 #include <vector>
-#include <utility>
 
 
 class Population;
@@ -36,7 +36,7 @@ private:
 	const NAS2D::Image& mIcons;
 	NAS2D::RectangleSkin mSkin;
 
-	std::vector<std::pair<std::string,int>> mMoraleChangeReasons;
+	std::vector<MoraleChangeEntry> mMoraleChangeReasons;
 
 	const Population& mPopulation;
 	const PopulationPool& mPopulationPool;

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -59,7 +59,7 @@ void ToolTip::add(Control& c, const std::string& str)
 		}
 	}
 
-	mControls.push_back(std::make_pair(&c, str));
+	mControls.push_back({&c, str});
 }
 
 

--- a/libOPHD/Population/Morale.h
+++ b/libOPHD/Population/Morale.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MoraleChangeEntry.h"
+
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -15,11 +17,6 @@ struct MoraleModifier
 	int mortalityRate{0};
 };
 
-struct MoraleChangeEntry
-{
-	std::string description{};
-	int value{0};
-};
 
 class Morale
 {

--- a/libOPHD/Population/Morale.h
+++ b/libOPHD/Population/Morale.h
@@ -6,9 +6,7 @@
 #include <vector>
 #include <string>
 
-/**
- * Morale modifier values.
- */
+
 struct MoraleModifier
 {
 	int researchBonus{0};

--- a/libOPHD/Population/MoraleChangeEntry.h
+++ b/libOPHD/Population/MoraleChangeEntry.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+
+struct MoraleChangeEntry
+{
+	std::string description{};
+	int value{0};
+};

--- a/libOPHD/libOPHD.vcxproj
+++ b/libOPHD/libOPHD.vcxproj
@@ -203,6 +203,7 @@
     <ClInclude Include="MapObjects\OreDeposit.h" />
     <ClInclude Include="MapObjects\StructureType.h" />
     <ClInclude Include="Population\Morale.h" />
+    <ClInclude Include="Population\MoraleChangeEntry.h" />
     <ClInclude Include="Population\Population.h" />
     <ClInclude Include="Population\PopulationPool.h" />
     <ClInclude Include="Population\PopulationTable.h" />

--- a/libOPHD/libOPHD.vcxproj.filters
+++ b/libOPHD/libOPHD.vcxproj.filters
@@ -152,6 +152,9 @@
     <ClInclude Include="Population\Morale.h">
       <Filter>Header Files\Population</Filter>
     </ClInclude>
+    <ClInclude Include="Population\MoraleChangeEntry.h">
+      <Filter>Header Files\Population</Filter>
+    </ClInclude>
     <ClInclude Include="Population\Population.h">
       <Filter>Header Files\Population</Filter>
     </ClInclude>


### PR DESCRIPTION
Reduce transitive header includes from `CrimeRateUpdate.h`, and reduce need to instantiate templates for function definitions by moving function definitions to implementation file.

Part of this change involved extracting the `MoraleChangeEntry` struct to it's own header file. This allows for greater use, replacing some uses of `std::pair`, and allowing the removal of `<utility>` includes.

As part of the changes, some instances of `float` were converted to `int`, using fixed point arithmetic for crime rate calculations.

----

Related:
- Issue #1573
