### PR TITLE
Simplify `ToolTip` multi-line support

### DIFF
--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -46,15 +46,15 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 {
 	const auto toolTipSize = mFont.size(item.second) + PaddingSize * 2;
 
-	auto tooltipPosition = item.first->position();
+	auto toolTipPosition = item.first->position();
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
-	tooltipPosition.x = (mouseX > maxX) ? maxX : mouseX;
+	toolTipPosition.x = (mouseX > maxX) ? maxX : mouseX;
 
-	tooltipPosition.y += (tooltipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
+	toolTipPosition.y += (toolTipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
 
-	area({tooltipPosition, toolTipSize});
+	area({toolTipPosition, toolTipSize});
 }
 
 

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -54,8 +54,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 
 	tooltipPosition.y += (tooltipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
 
-	position(tooltipPosition);
-	size(toolTipSize);
+	area({tooltipPosition, toolTipSize});
 }
 
 

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -6,33 +6,11 @@
 #include <NAS2D/Resource/Font.h>
 
 #include <string>
-#include <sstream>
-#include <functional>
 
 namespace
 {
 	constexpr int MarginTight{2};
 	constexpr auto PaddingSize = NAS2D::Vector{MarginTight, MarginTight};
-
-	void forEachLine(const std::string& text, const std::function<void(const std::string&)>& lineHandler)
-	{
-		std::istringstream stream(text);
-		for (std::string line; std::getline(stream, line);)
-		{
-			lineHandler(line);
-		}
-	}
-
-
-	// Returns the maximum width of the largest string from the string stream in pixels.
-	int calculateMaxWidthStringSize(const std::string& text, const NAS2D::Font& font)
-	{
-		int maxWidthStringSize = 0;
-		forEachLine(text, [&font, &maxWidthStringSize](const std::string& lineStr) {
-			maxWidthStringSize = std::max(maxWidthStringSize, font.size(lineStr).x);
-		});
-		return maxWidthStringSize;
-	}
 }
 
 
@@ -66,11 +44,7 @@ void ToolTip::add(Control& c, const std::string& str)
 
 void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX)
 {
-	const auto toolTipLineHeight = mFont.height();
-	const auto numberOfLines = static_cast<int>(std::count(item.second.begin(), item.second.end(), '\n') + 1);
-	const auto toolTipTextHeight = toolTipLineHeight * numberOfLines;
-	const auto toolTipTextWidth = calculateMaxWidthStringSize(item.second, mFont);
-	const auto toolTipSize = NAS2D::Vector{toolTipTextWidth, toolTipTextHeight} + PaddingSize * 2;
+	const auto toolTipSize = mFont.size(item.second) + PaddingSize * 2;
 
 	auto tooltipPosition = item.first->position();
 
@@ -130,12 +104,6 @@ void ToolTip::draw() const
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 		renderer.drawBoxFilled(area(), NAS2D::Color::DarkGray);
 		renderer.drawBox(area(), NAS2D::Color::Black);
-
-		auto linePosition = position() + PaddingSize;
-
-		forEachLine(mFocusedControl->second, [this, &renderer, &linePosition](const std::string& lineStr) {
-			renderer.drawText(mFont, lineStr, linePosition);
-			linePosition.y += mFont.height();
-		});
+		renderer.drawText(mFont, mFocusedControl->second, position() + PaddingSize);
 	}
 }


### PR DESCRIPTION
Since the `ToolTip` multi-line support was added, NAS2D was updated to include some support for multi-line strings. By using the updates from NAS2D, we can simplify the implementation of `ToolTip`.

Noticed this while looking to trim down on header includes.

----

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/1211
- PR https://github.com/lairworks/nas2d-core/pull/1212
- PR #1834
- Issue #1573
