### PR TITLE
Fix multi line `ToolTip` offset

### DIFF
--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -52,7 +52,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	const auto maxX = renderer.size().x - toolTipSize.x;
 	toolTipPosition.x = (mouseX > maxX) ? maxX : mouseX;
 
-	toolTipPosition.y += (toolTipPosition.y < toolTipSize.y) ? item.first->size().y : -toolTipSize.y;
+	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : item.first->size().y;
 
 	area({toolTipPosition, toolTipSize});
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -52,7 +52,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	const auto maxX = renderer.size().x - toolTipSize.x;
 	toolTipPosition.x = (mouseX > maxX) ? maxX : mouseX;
 
-	toolTipPosition.y += (toolTipPosition.y < toolTipSize.y) ? toolTipSize.y : -toolTipSize.y;
+	toolTipPosition.y += (toolTipPosition.y < toolTipSize.y) ? item.first->size().y : -toolTipSize.y;
 
 	area({toolTipPosition, toolTipSize});
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -50,7 +50,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
-	toolTipPosition.x = (mouseX > maxX) ? maxX : mouseX;
+	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
 
 	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : item.first->size().y;
 

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -51,6 +51,7 @@ void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
 	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
+	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
 
 	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : item.first->size().y;
 


### PR DESCRIPTION
Fix the y-offset issue for multi-line `ToolTip` text when the `ToolTip` is too close to the top of the screen and must be placed below the `Control` it explains.

Also adds `0` clipping for the `x` coordinate, mostly affecting `ToolTip` text that is wider than the screen space, so the `ToolTip` is never moved off the left edge of the screen.

----

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3010252039
- PR #1837
