### PR TITLE
Dynamically place `MineOperationsWindow` sections

### DIFF
--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -26,6 +26,7 @@ using namespace NAS2D;
 namespace
 {
 	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};
+	const auto truckButtonOffset = NAS2D::Vector{148, 115};
 	const auto truckButtonSize = NAS2D::Vector{128, 25};
 }
 
@@ -65,8 +66,8 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck.size(truckButtonSize);
 	btnUnassignTruck.size(truckButtonSize);
 
-	add(btnUnassignTruck, {148, 115});
-	add(btnAssignTruck, {mRect.size.x - btnAssignTruck.size().x - 10, 115});
+	add(btnUnassignTruck, truckButtonOffset);
+	add(btnAssignTruck, {mRect.size.x - btnAssignTruck.size().x - 10, truckButtonOffset.y});
 
 	// ORE TOGGLE BUTTONS
 	const auto checkBoxOrigin = NAS2D::Vector{148, 145};

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -71,11 +71,11 @@ MineOperationsWindow::MineOperationsWindow() :
 
 	// ORE TOGGLE BUTTONS
 	const auto checkBoxOrigin = NAS2D::Vector{148, 145};
-	const auto checkBoxOffset = NAS2D::Vector{152, 20};
+	const auto checkBoxSpacing = NAS2D::Vector{152, 20};
 	add(chkResources[0], checkBoxOrigin);
-	add(chkResources[1], checkBoxOrigin + NAS2D::Vector{0, checkBoxOffset.y});
-	add(chkResources[2], checkBoxOrigin + NAS2D::Vector{checkBoxOffset.x, 0});
-	add(chkResources[3], checkBoxOrigin + checkBoxOffset);
+	add(chkResources[1], checkBoxOrigin + NAS2D::Vector{0, checkBoxSpacing.y});
+	add(chkResources[2], checkBoxOrigin + NAS2D::Vector{checkBoxSpacing.x, 0});
+	add(chkResources[3], checkBoxOrigin + checkBoxSpacing);
 }
 
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -67,7 +67,7 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnUnassignTruck.size(truckButtonSize);
 
 	add(btnUnassignTruck, truckButtonOffset);
-	add(btnAssignTruck, {mRect.size.x - btnAssignTruck.size().x - 10, truckButtonOffset.y});
+	add(btnAssignTruck, {mRect.size.x - truckButtonSize.x - 10, truckButtonOffset.y});
 
 	// ORE TOGGLE BUTTONS
 	const auto checkBoxOrigin = NAS2D::Vector{148, 145};

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -28,6 +28,7 @@ namespace
 	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};
 	const auto truckButtonOffset = truckAvailabilityOffset + NAS2D::Vector{0, 35};
 	const auto truckButtonSize = NAS2D::Vector{128, 25};
+	const auto checkBoxOffset = truckButtonOffset + NAS2D::Vector{0, 30};
 }
 
 
@@ -70,7 +71,6 @@ MineOperationsWindow::MineOperationsWindow() :
 	add(btnAssignTruck, {truckButtonOffset.x + truckButtonSize.x + constants::Margin, truckButtonOffset.y});
 
 	// ORE TOGGLE BUTTONS
-	const auto checkBoxOffset = NAS2D::Vector{148, 145};
 	const auto checkBoxSpacing = NAS2D::Vector{152, 20};
 	add(chkResources[0], checkBoxOffset);
 	add(chkResources[1], checkBoxOffset + NAS2D::Vector{0, checkBoxSpacing.y});

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -67,7 +67,7 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnUnassignTruck.size(truckButtonSize);
 
 	add(btnUnassignTruck, truckButtonOffset);
-	add(btnAssignTruck, {mRect.size.x - truckButtonSize.x - 10, truckButtonOffset.y});
+	add(btnAssignTruck, {truckButtonOffset.x + truckButtonSize.x + constants::Margin, truckButtonOffset.y});
 
 	// ORE TOGGLE BUTTONS
 	const auto checkBoxOrigin = NAS2D::Vector{148, 145};

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -184,9 +184,10 @@ void MineOperationsWindow::drawClientArea() const
 	drawLabelAndValue(origin + NAS2D::Vector{300, 30}, "Depth: ", mineDepth);
 
 	// TRUCK ASSIGNMENT
-	renderer.drawText(mFontBold, "Trucks", origin + NAS2D::Vector{148, 80}, NAS2D::Color::White);
-	drawLabelAndValue(origin + NAS2D::Vector{148, 95}, "Assigned: ", std::to_string(mFacility->assignedTrucks()));
-	drawLabelAndValue(origin + NAS2D::Vector{285, 95}, "Available: ", std::to_string(mAvailableTrucks));
+	const auto truckAssignmentOrigin = origin + NAS2D::Vector{148, 80};
+	renderer.drawText(mFontBold, "Trucks", truckAssignmentOrigin, NAS2D::Color::White);
+	drawLabelAndValue(truckAssignmentOrigin + NAS2D::Vector{0, 15}, "Assigned: ", std::to_string(mFacility->assignedTrucks()));
+	drawLabelAndValue(truckAssignmentOrigin + NAS2D::Vector{137, 15}, "Available: ", std::to_string(mAvailableTrucks));
 
 	// REMAINING ORE PANEL
 	const auto tableSize = NAS2D::Vector{mRect.size.x - 20, 40};

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -70,12 +70,12 @@ MineOperationsWindow::MineOperationsWindow() :
 	add(btnAssignTruck, {truckButtonOffset.x + truckButtonSize.x + constants::Margin, truckButtonOffset.y});
 
 	// ORE TOGGLE BUTTONS
-	const auto checkBoxOrigin = NAS2D::Vector{148, 145};
+	const auto checkBoxOffset = NAS2D::Vector{148, 145};
 	const auto checkBoxSpacing = NAS2D::Vector{152, 20};
-	add(chkResources[0], checkBoxOrigin);
-	add(chkResources[1], checkBoxOrigin + NAS2D::Vector{0, checkBoxSpacing.y});
-	add(chkResources[2], checkBoxOrigin + NAS2D::Vector{checkBoxSpacing.x, 0});
-	add(chkResources[3], checkBoxOrigin + checkBoxSpacing);
+	add(chkResources[0], checkBoxOffset);
+	add(chkResources[1], checkBoxOffset + NAS2D::Vector{0, checkBoxSpacing.y});
+	add(chkResources[2], checkBoxOffset + NAS2D::Vector{checkBoxSpacing.x, 0});
+	add(chkResources[3], checkBoxOffset + checkBoxSpacing);
 }
 
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -65,8 +65,8 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck.size(truckButtonSize);
 	btnUnassignTruck.size(truckButtonSize);
 
-	add(btnAssignTruck, {mRect.size.x - btnAssignTruck.size().x - 10, 115});
 	add(btnUnassignTruck, {148, 115});
+	add(btnAssignTruck, {mRect.size.x - btnAssignTruck.size().x - 10, 115});
 
 	// ORE TOGGLE BUTTONS
 	const auto checkBoxOrigin = NAS2D::Vector{148, 145};

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -26,7 +26,7 @@ using namespace NAS2D;
 namespace
 {
 	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};
-	const auto truckButtonOffset = NAS2D::Vector{148, 115};
+	const auto truckButtonOffset = truckAvailabilityOffset + NAS2D::Vector{0, 35};
 	const auto truckButtonSize = NAS2D::Vector{128, 25};
 }
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -23,6 +23,12 @@
 using namespace NAS2D;
 
 
+namespace
+{
+	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};
+}
+
+
 MineOperationsWindow::MineOperationsWindow() :
 	Window{constants::WindowMineOperations},
 	mFont{Control::getDefaultFont()},
@@ -184,7 +190,7 @@ void MineOperationsWindow::drawClientArea() const
 	drawLabelAndValue(origin + NAS2D::Vector{300, 30}, "Depth: ", mineDepth);
 
 	// TRUCK ASSIGNMENT
-	const auto truckAssignmentOrigin = origin + NAS2D::Vector{148, 80};
+	const auto truckAssignmentOrigin = origin + truckAvailabilityOffset;
 	renderer.drawText(mFontBold, "Trucks", truckAssignmentOrigin, NAS2D::Color::White);
 	drawLabelAndValue(truckAssignmentOrigin + NAS2D::Vector{0, 15}, "Assigned: ", std::to_string(mFacility->assignedTrucks()));
 	drawLabelAndValue(truckAssignmentOrigin + NAS2D::Vector{137, 15}, "Available: ", std::to_string(mAvailableTrucks));

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -26,6 +26,7 @@ using namespace NAS2D;
 namespace
 {
 	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};
+	const auto truckButtonSize = NAS2D::Vector{128, 25};
 }
 
 
@@ -61,8 +62,8 @@ MineOperationsWindow::MineOperationsWindow() :
 	add(btnExtendShaft, {76, buttonBottomRowY});
 	add(btnOkay, {mRect.size.x - 70, buttonBottomRowY});
 
-	btnAssignTruck.size({128, 25});
-	btnUnassignTruck.size({128, 25});
+	btnAssignTruck.size(truckButtonSize);
+	btnUnassignTruck.size(truckButtonSize);
 
 	add(btnAssignTruck, {mRect.size.x - btnAssignTruck.size().x - 10, 115});
 	add(btnUnassignTruck, {148, 115});


### PR DESCRIPTION
Use relative positioning for `MineOperationsWindow` sections.

This should make it easier to move stuff around and add more data. In particular, we should display route data.

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3014351087