### PR TITLE
Refactor `WindowStack`

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -495,7 +495,7 @@ void MapViewState::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*
 			if (NAS2D::Utility<NAS2D::EventHandler>::get().control(mod) && NAS2D::Utility<NAS2D::EventHandler>::get().shift(mod))
 			{
 				mCheatMenu.show();
-				mWindowStack.bringToFront(&mCheatMenu);
+				mWindowStack.bringToFront(mCheatMenu);
 			}
 			break;
 
@@ -649,25 +649,25 @@ void MapViewState::onInspectStructure(Structure& structure, bool inspectModifier
 	{
 		mFactoryProduction.factory(&dynamic_cast<Factory&>(structure));
 		mFactoryProduction.show();
-		mWindowStack.bringToFront(&mFactoryProduction);
+		mWindowStack.bringToFront(mFactoryProduction);
 	}
 	else if (structure.isWarehouse() && preferStructureSpecificView)
 	{
 		mWarehouseInspector.warehouse(&dynamic_cast<Warehouse&>(structure));
 		mWarehouseInspector.show();
-		mWindowStack.bringToFront(&mWarehouseInspector);
+		mWindowStack.bringToFront(mWarehouseInspector);
 	}
 	else if (structure.isMineFacility() && preferStructureSpecificView)
 	{
 		mMineOperationsWindow.mineFacility(&dynamic_cast<MineFacility&>(structure));
 		mMineOperationsWindow.show();
-		mWindowStack.bringToFront(&mMineOperationsWindow);
+		mWindowStack.bringToFront(mMineOperationsWindow);
 	}
 	else
 	{
 		mStructureInspector.structure(&structure);
 		mStructureInspector.show();
-		mWindowStack.bringToFront(&mStructureInspector);
+		mWindowStack.bringToFront(mStructureInspector);
 	}
 }
 
@@ -676,7 +676,7 @@ void MapViewState::onInspectRobot(Robot& robot)
 {
 	mRobotInspector.focusOnRobot(&robot);
 	mRobotInspector.show();
-	mWindowStack.bringToFront(&mRobotInspector);
+	mWindowStack.bringToFront(mRobotInspector);
 }
 
 
@@ -684,7 +684,7 @@ void MapViewState::onInspectTile(Tile& tile)
 {
 	mTileInspector.tile(tile);
 	mTileInspector.show();
-	mWindowStack.bringToFront(&mTileInspector);
+	mWindowStack.bringToFront(mTileInspector);
 }
 
 
@@ -1127,7 +1127,7 @@ void MapViewState::placeRobodigger(Tile& tile)
 	else
 	{
 		mDiggerDirection.show();
-		mWindowStack.bringToFront(&mDiggerDirection);
+		mWindowStack.bringToFront(mDiggerDirection);
 
 		// Popup to the right of the mouse
 		auto position = MOUSE_COORDS + NAS2D::Vector{20, -32};

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -89,16 +89,16 @@ void MapViewState::initUi()
 	mMineOperationsWindow.hide();
 	mWarehouseInspector.hide();
 
-	mWindowStack.addWindow(&mTileInspector);
-	mWindowStack.addWindow(&mStructureInspector);
-	mWindowStack.addWindow(&mFactoryProduction);
-	mWindowStack.addWindow(&mDiggerDirection);
-	mWindowStack.addWindow(&mAnnouncement);
-	mWindowStack.addWindow(&mWarehouseInspector);
-	mWindowStack.addWindow(&mMineOperationsWindow);
-	mWindowStack.addWindow(&mRobotInspector);
-	mWindowStack.addWindow(&mNotificationWindow);
-	mWindowStack.addWindow(&mCheatMenu);
+	mWindowStack.addWindow(mTileInspector);
+	mWindowStack.addWindow(mStructureInspector);
+	mWindowStack.addWindow(mFactoryProduction);
+	mWindowStack.addWindow(mDiggerDirection);
+	mWindowStack.addWindow(mAnnouncement);
+	mWindowStack.addWindow(mWarehouseInspector);
+	mWindowStack.addWindow(mMineOperationsWindow);
+	mWindowStack.addWindow(mRobotInspector);
+	mWindowStack.addWindow(mNotificationWindow);
+	mWindowStack.addWindow(mCheatMenu);
 
 	mNotificationWindow.hide();
 
@@ -487,7 +487,7 @@ void MapViewState::onNotificationClicked(const NotificationArea::Notification& n
 {
 	mNotificationWindow.notification(notification);
 	mNotificationWindow.show();
-	mWindowStack.bringToFront(&mNotificationWindow);
+	mWindowStack.bringToFront(mNotificationWindow);
 }
 
 

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -69,7 +69,7 @@ void MajorEventAnnouncement::announcement(AnnouncementType a)
 
 void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const ColonyShipData& colonyShipData)
 {
-	windowStack.bringToFront(this);
+	windowStack.bringToFront(*this);
 	announcement(colonyShipCrashAnnouncement(colonyShipData));
 	show();
 }

--- a/libControls/WindowStack.cpp
+++ b/libControls/WindowStack.cpp
@@ -8,8 +8,6 @@
 
 /**
  * Adds a Window to be handled by the WindowStack.
- *
- * \note	Pointer is not owned by WindowStack, it is up to the caller to properly handle memory.
  */
 void WindowStack::addWindow(Window& window)
 {
@@ -24,8 +22,6 @@ void WindowStack::addWindow(Window& window)
 
 /**
  * Removes a Window from the WindowStack.
- *
- * \note Pointer is not owned by WindowStack, it is up to the caller to properly handle memory.
  */
 void WindowStack::removeWindow(Window& window)
 {

--- a/libControls/WindowStack.cpp
+++ b/libControls/WindowStack.cpp
@@ -33,33 +33,6 @@ void WindowStack::removeWindow(Window* window)
 }
 
 
-bool WindowStack::pointInWindow(const NAS2D::Point<int>& point) const
-{
-	for (auto* window : mWindowList)
-	{
-		if (window->visible() && window->area().contains(point))
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
-void WindowStack::updateStack(const NAS2D::Point<int>& point)
-{
-	for (auto* window : mWindowList)
-	{
-		if (window->visible() && window->area().contains(point))
-		{
-			bringToFront(window);
-			return;
-		}
-	}
-}
-
-
 void WindowStack::bringToFront(Window* window)
 {
 	const auto windowPosition = find(mWindowList.begin(), mWindowList.end(), window);
@@ -77,6 +50,33 @@ void WindowStack::bringToFront(Window* window)
 	mWindowList.remove(window);
 	mWindowList.push_front(window);
 	window->hasFocus(true);
+}
+
+
+void WindowStack::updateStack(const NAS2D::Point<int>& point)
+{
+	for (auto* window : mWindowList)
+	{
+		if (window->visible() && window->area().contains(point))
+		{
+			bringToFront(window);
+			return;
+		}
+	}
+}
+
+
+bool WindowStack::pointInWindow(const NAS2D::Point<int>& point) const
+{
+	for (auto* window : mWindowList)
+	{
+		if (window->visible() && window->area().contains(point))
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 

--- a/libControls/WindowStack.cpp
+++ b/libControls/WindowStack.cpp
@@ -6,9 +6,6 @@
 #include <stdexcept>
 
 
-/**
- * Adds a Window to be handled by the WindowStack.
- */
 void WindowStack::addWindow(Window& window)
 {
 	if (find(mWindowList.begin(), mWindowList.end(), &window) != mWindowList.end())
@@ -20,9 +17,6 @@ void WindowStack::addWindow(Window& window)
 }
 
 
-/**
- * Removes a Window from the WindowStack.
- */
 void WindowStack::removeWindow(Window& window)
 {
 	mWindowList.remove(&window);

--- a/libControls/WindowStack.cpp
+++ b/libControls/WindowStack.cpp
@@ -36,7 +36,6 @@ void WindowStack::bringToFront(Window& window)
 	}
 
 	mWindowList.front()->hasFocus(false);
-
 	mWindowList.remove(&window);
 	mWindowList.push_front(&window);
 	window.hasFocus(true);

--- a/libControls/WindowStack.cpp
+++ b/libControls/WindowStack.cpp
@@ -11,14 +11,14 @@
  *
  * \note	Pointer is not owned by WindowStack, it is up to the caller to properly handle memory.
  */
-void WindowStack::addWindow(Window* window)
+void WindowStack::addWindow(Window& window)
 {
-	if (find(mWindowList.begin(), mWindowList.end(), window) != mWindowList.end())
+	if (find(mWindowList.begin(), mWindowList.end(), &window) != mWindowList.end())
 	{
 		throw std::runtime_error("WindowStack::addWindow(): Attempting to add a Window that's already in this stack.");
 	}
 
-	mWindowList.push_back(window);
+	mWindowList.push_back(&window);
 }
 
 
@@ -27,15 +27,15 @@ void WindowStack::addWindow(Window* window)
  *
  * \note Pointer is not owned by WindowStack, it is up to the caller to properly handle memory.
  */
-void WindowStack::removeWindow(Window* window)
+void WindowStack::removeWindow(Window& window)
 {
-	mWindowList.remove(window);
+	mWindowList.remove(&window);
 }
 
 
-void WindowStack::bringToFront(Window* window)
+void WindowStack::bringToFront(Window& window)
 {
-	const auto windowPosition = find(mWindowList.begin(), mWindowList.end(), window);
+	const auto windowPosition = find(mWindowList.begin(), mWindowList.end(), &window);
 	if (windowPosition == mWindowList.end())
 	{
 		throw std::runtime_error("WindowStack::bringToFront(): Window is not managed by this stack.");
@@ -47,9 +47,9 @@ void WindowStack::bringToFront(Window* window)
 
 	mWindowList.front()->hasFocus(false);
 
-	mWindowList.remove(window);
-	mWindowList.push_front(window);
-	window->hasFocus(true);
+	mWindowList.remove(&window);
+	mWindowList.push_front(&window);
+	window.hasFocus(true);
 }
 
 
@@ -59,7 +59,7 @@ void WindowStack::updateStack(const NAS2D::Point<int>& point)
 	{
 		if (window->visible() && window->area().contains(point))
 		{
-			bringToFront(window);
+			bringToFront(*window);
 			return;
 		}
 	}

--- a/libControls/WindowStack.h
+++ b/libControls/WindowStack.h
@@ -14,9 +14,9 @@ public:
 	WindowStack() = default;
 	~WindowStack() = default;
 
-	void addWindow(Window* window);
-	void removeWindow(Window* window);
-	void bringToFront(Window* window);
+	void addWindow(Window& window);
+	void removeWindow(Window& window);
+	void bringToFront(Window& window);
 	void updateStack(const NAS2D::Point<int>& point);
 	bool pointInWindow(const NAS2D::Point<int>& point) const;
 

--- a/libControls/WindowStack.h
+++ b/libControls/WindowStack.h
@@ -8,7 +8,7 @@
 class Window;
 
 
-class WindowStack final
+class WindowStack
 {
 public:
 	WindowStack() = default;

--- a/libControls/WindowStack.h
+++ b/libControls/WindowStack.h
@@ -16,12 +16,9 @@ public:
 
 	void addWindow(Window* window);
 	void removeWindow(Window* window);
-
-	bool pointInWindow(const NAS2D::Point<int>& point) const;
-
-	void updateStack(const NAS2D::Point<int>& point);
-
 	void bringToFront(Window* window);
+	void updateStack(const NAS2D::Point<int>& point);
+	bool pointInWindow(const NAS2D::Point<int>& point) const;
 
 	void hide();
 


### PR DESCRIPTION
Noticed a few things while working on recent `update` changes.

The `WindowStack` class is a bit odd in that it's part of `libControls`, but does not derive from `Control`, though still has some `Control` like methods such as `update()`.

Also of note is the collection order (front to back) is opposite from that of `ControlContainer` (back to front). That was not changed here.

Related:
- Issue #1756
