### PR TITLE
Refactor `ColonyShip`

### DIFF
--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -18,14 +18,11 @@ namespace
 	}
 
 
-	void setManeuveringFuel(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
+	int readManeuveringFuel(NAS2D::Xml::XmlElement* element)
 	{
-		if (element)
-		{
-			auto turnCount = NAS2D::attributesToDictionary(*element).get<int>("count");
-
-			colonyShipData.turnsOfManeuveringFuel = turnCount > constants::ColonyShipOrbitTime ? 0 : constants::ColonyShipOrbitTime - turnCount + 1;
-		}
+		const auto turnCount = (element) ? NAS2D::attributesToDictionary(*element).get<int>("count") : 0;
+		const auto maneuveringFuel = (turnCount <= constants::ColonyShipOrbitTime) ? constants::ColonyShipOrbitTime - turnCount + 1 : 0;
+		return maneuveringFuel;
 	}
 }
 
@@ -37,7 +34,7 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 	{
 		ColonyShipData colonyShipData;
 		setLanders(colonyShipData, root->firstChildElement("population"));
-		setManeuveringFuel(colonyShipData, root->firstChildElement("turns"));
+		colonyShipData.turnsOfManeuveringFuel = readManeuveringFuel(root->firstChildElement("turns"));
 		return ColonyShip{colonyShipData};
 	}
 	throw std::runtime_error("Invalid save game root element.");

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -60,7 +60,7 @@ void ColonyShip::onTurn()
 
 	if (mTurnsOfManeuveringFuel == 0)
 	{
-		mCrashData = mLanders;
+		mCrashedLanders = mLanders;
 		mLanders.cargoLanders = 0;
 		mLanders.colonistLanders = 0;
 	}

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -39,7 +39,7 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 
 
 ColonyShip::ColonyShip() :
-	mColonyShipData
+	mLanders
 	{
 		.colonistLanders = 2,
 		.cargoLanders = 2,
@@ -49,7 +49,7 @@ ColonyShip::ColonyShip() :
 
 
 ColonyShip::ColonyShip(const ColonyShipLanders& colonyShipData, int turnsOfManeuveringFuel) :
-	mColonyShipData{colonyShipData},
+	mLanders{colonyShipData},
 	mTurnsOfManeuveringFuel{turnsOfManeuveringFuel}
 {}
 
@@ -60,8 +60,8 @@ void ColonyShip::onTurn()
 
 	if (mTurnsOfManeuveringFuel == 0)
 	{
-		mCrashData = mColonyShipData;
-		mColonyShipData.cargoLanders = 0;
-		mColonyShipData.colonistLanders = 0;
+		mCrashData = mLanders;
+		mLanders.cargoLanders = 0;
+		mLanders.colonistLanders = 0;
 	}
 }

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -13,8 +13,8 @@ namespace
 
 		const auto dictionary = NAS2D::attributesToDictionary(*element);
 		return {
-			.colonistLanders = dictionary.get<int>("colonist_landers"),
-			.cargoLanders = dictionary.get<int>("cargo_landers"),
+			.colonist = dictionary.get<int>("colonist_landers"),
+			.cargo = dictionary.get<int>("cargo_landers"),
 		};
 	}
 
@@ -43,8 +43,8 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 ColonyShip::ColonyShip() :
 	mLanders
 	{
-		.colonistLanders = 2,
-		.cargoLanders = 2,
+		.colonist = 2,
+		.cargo = 2,
 	},
 	mTurnsOfManeuveringFuel{constants::ColonyShipOrbitTime + 1}
 {}

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -1,5 +1,6 @@
 #include "ColonyShip.h"
 
+#include "../Constants/Numbers.h"
 #include "../Constants/Strings.h"
 
 #include <NAS2D/ParserHelper.h>
@@ -43,12 +44,18 @@ ColonyShipData colonyShipDataFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 }
 
 
-ColonyShip::ColonyShip()
+ColonyShip::ColonyShip() :
+	mColonyShipData
+	{
+		.colonistLanders = 2,
+		.cargoLanders = 2,
+		.turnsOfManeuveringFuel = constants::ColonyShipOrbitTime + 1
+	}
 {}
 
 
 ColonyShip::ColonyShip(const ColonyShipData& colonyShipData) :
-	mColonyShipData(colonyShipData)
+	mColonyShipData{colonyShipData}
 {}
 
 

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -9,12 +9,11 @@ namespace
 {
 	void setLanders(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
 	{
-		if (element)
-		{
-			const auto dictionary = NAS2D::attributesToDictionary(*element);
-			colonyShipData.colonistLanders = dictionary.get<int>("colonist_landers");
-			colonyShipData.cargoLanders = dictionary.get<int>("cargo_landers");
-		}
+		if (!element) { return; }
+
+		const auto dictionary = NAS2D::attributesToDictionary(*element);
+		colonyShipData.colonistLanders = dictionary.get<int>("colonist_landers");
+		colonyShipData.cargoLanders = dictionary.get<int>("cargo_landers");
 	}
 
 

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -56,9 +56,11 @@ ColonyShip::ColonyShip(const ColonyShipLanders& colonyShipData, int turnsOfManeu
 
 void ColonyShip::onTurn()
 {
-	if (mTurnsOfManeuveringFuel > 0) { --mTurnsOfManeuveringFuel; }
-
-	if (mTurnsOfManeuveringFuel == 0)
+	if (mTurnsOfManeuveringFuel > 0)
+	{
+		--mTurnsOfManeuveringFuel;
+	}
+	else
 	{
 		mCrashedLanders = mLanders;
 		mLanders = {};

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -61,7 +61,6 @@ void ColonyShip::onTurn()
 	if (mTurnsOfManeuveringFuel == 0)
 	{
 		mCrashedLanders = mLanders;
-		mLanders.cargoLanders = 0;
-		mLanders.colonistLanders = 0;
+		mLanders = {};
 	}
 }

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -33,8 +33,10 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
 	if (!root) { throw std::runtime_error("Invalid save game root element."); }
 
-	ColonyShipLanders colonyShipData = readLanders(root->firstChildElement("population"));
-	return ColonyShip{colonyShipData, readManeuveringFuel(root->firstChildElement("turns"))};
+	return {
+		readLanders(root->firstChildElement("population")),
+		readManeuveringFuel(root->firstChildElement("turns")),
+	};
 }
 
 

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -34,8 +34,7 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 	if (!root) { throw std::runtime_error("Invalid save game root element."); }
 
 	ColonyShipData colonyShipData = readLanders(root->firstChildElement("population"));
-	colonyShipData.turnsOfManeuveringFuel = readManeuveringFuel(root->firstChildElement("turns"));
-	return ColonyShip{colonyShipData};
+	return ColonyShip{colonyShipData, readManeuveringFuel(root->firstChildElement("turns"))};
 }
 
 
@@ -44,21 +43,22 @@ ColonyShip::ColonyShip() :
 	{
 		.colonistLanders = 2,
 		.cargoLanders = 2,
-		.turnsOfManeuveringFuel = constants::ColonyShipOrbitTime + 1
-	}
+	},
+	mTurnsOfManeuveringFuel{constants::ColonyShipOrbitTime + 1}
 {}
 
 
-ColonyShip::ColonyShip(const ColonyShipData& colonyShipData) :
-	mColonyShipData{colonyShipData}
+ColonyShip::ColonyShip(const ColonyShipData& colonyShipData, int turnsOfManeuveringFuel) :
+	mColonyShipData{colonyShipData},
+	mTurnsOfManeuveringFuel{turnsOfManeuveringFuel}
 {}
 
 
 void ColonyShip::onTurn()
 {
-	if (mColonyShipData.turnsOfManeuveringFuel > 0) { --mColonyShipData.turnsOfManeuveringFuel; }
+	if (mTurnsOfManeuveringFuel > 0) { --mTurnsOfManeuveringFuel; }
 
-	if (mColonyShipData.turnsOfManeuveringFuel == 0)
+	if (mTurnsOfManeuveringFuel == 0)
 	{
 		mCrashData = mColonyShipData;
 		mColonyShipData.cargoLanders = 0;

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -30,14 +30,12 @@ namespace
 ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 {
 	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
-	if (root)
-	{
-		ColonyShipData colonyShipData;
-		setLanders(colonyShipData, root->firstChildElement("population"));
-		colonyShipData.turnsOfManeuveringFuel = readManeuveringFuel(root->firstChildElement("turns"));
-		return ColonyShip{colonyShipData};
-	}
-	throw std::runtime_error("Invalid save game root element.");
+	if (!root) { throw std::runtime_error("Invalid save game root element."); }
+
+	ColonyShipData colonyShipData;
+	setLanders(colonyShipData, root->firstChildElement("population"));
+	colonyShipData.turnsOfManeuveringFuel = readManeuveringFuel(root->firstChildElement("turns"));
+	return ColonyShip{colonyShipData};
 }
 
 

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -50,8 +50,8 @@ ColonyShip::ColonyShip() :
 {}
 
 
-ColonyShip::ColonyShip(const ColonyShipLanders& colonyShipData, int turnsOfManeuveringFuel) :
-	mLanders{colonyShipData},
+ColonyShip::ColonyShip(const ColonyShipLanders& colonyShipLanders, int turnsOfManeuveringFuel) :
+	mLanders{colonyShipLanders},
 	mTurnsOfManeuveringFuel{turnsOfManeuveringFuel}
 {}
 

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -7,7 +7,7 @@
 
 namespace
 {
-	ColonyShipData readLanders(NAS2D::Xml::XmlElement* element)
+	ColonyShipLanders readLanders(NAS2D::Xml::XmlElement* element)
 	{
 		if (!element) { return {}; }
 
@@ -33,7 +33,7 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
 	if (!root) { throw std::runtime_error("Invalid save game root element."); }
 
-	ColonyShipData colonyShipData = readLanders(root->firstChildElement("population"));
+	ColonyShipLanders colonyShipData = readLanders(root->firstChildElement("population"));
 	return ColonyShip{colonyShipData, readManeuveringFuel(root->firstChildElement("turns"))};
 }
 
@@ -48,7 +48,7 @@ ColonyShip::ColonyShip() :
 {}
 
 
-ColonyShip::ColonyShip(const ColonyShipData& colonyShipData, int turnsOfManeuveringFuel) :
+ColonyShip::ColonyShip(const ColonyShipLanders& colonyShipData, int turnsOfManeuveringFuel) :
 	mColonyShipData{colonyShipData},
 	mTurnsOfManeuveringFuel{turnsOfManeuveringFuel}
 {}

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -7,13 +7,15 @@
 
 namespace
 {
-	void setLanders(ColonyShipData& colonyShipData, NAS2D::Xml::XmlElement* element)
+	ColonyShipData readLanders(NAS2D::Xml::XmlElement* element)
 	{
-		if (!element) { return; }
+		if (!element) { return {}; }
 
 		const auto dictionary = NAS2D::attributesToDictionary(*element);
-		colonyShipData.colonistLanders = dictionary.get<int>("colonist_landers");
-		colonyShipData.cargoLanders = dictionary.get<int>("cargo_landers");
+		return {
+			.colonistLanders = dictionary.get<int>("colonist_landers"),
+			.cargoLanders = dictionary.get<int>("cargo_landers"),
+		};
 	}
 
 
@@ -31,8 +33,7 @@ ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
 	if (!root) { throw std::runtime_error("Invalid save game root element."); }
 
-	ColonyShipData colonyShipData;
-	setLanders(colonyShipData, root->firstChildElement("population"));
+	ColonyShipData colonyShipData = readLanders(root->firstChildElement("population"));
 	colonyShipData.turnsOfManeuveringFuel = readManeuveringFuel(root->firstChildElement("turns"));
 	return ColonyShip{colonyShipData};
 }

--- a/appOPHD/States/ColonyShip.cpp
+++ b/appOPHD/States/ColonyShip.cpp
@@ -30,7 +30,7 @@ namespace
 }
 
 
-ColonyShipData colonyShipDataFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
+ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 {
 	auto* root = xmlDocument.firstChildElement(constants::SaveGameRootNode);
 	if (root)
@@ -38,7 +38,7 @@ ColonyShipData colonyShipDataFromSave(NAS2D::Xml::XmlDocument& xmlDocument)
 		ColonyShipData colonyShipData;
 		setLanders(colonyShipData, root->firstChildElement("population"));
 		setManeuveringFuel(colonyShipData, root->firstChildElement("turns"));
-		return colonyShipData;
+		return ColonyShip{colonyShipData};
 	}
 	throw std::runtime_error("Invalid save game root element.");
 }

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 
 namespace NAS2D
 {
@@ -37,11 +35,11 @@ public:
 	void onDeployColonistLander() { --mLanders.colonistLanders; }
 	void onDeployCargoLander() { --mLanders.cargoLanders; }
 	bool crashed() const { return mTurnsOfManeuveringFuel == 0; }
+	const ColonyShipLanders& crashedLanders() const { return mCrashedLanders; }
 	void onTurn();
 
-	const std::optional<ColonyShipLanders>& crashData() const { return mCrashedLanders; }
 private:
 	ColonyShipLanders mLanders;
-	std::optional<ColonyShipLanders> mCrashedLanders = std::nullopt;
+	ColonyShipLanders mCrashedLanders{};
 	int mTurnsOfManeuveringFuel = 0;
 };

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -39,9 +39,9 @@ public:
 	bool crashed() const { return mTurnsOfManeuveringFuel == 0; }
 	void onTurn();
 
-	const std::optional<ColonyShipLanders>& crashData() const { return mCrashData; }
+	const std::optional<ColonyShipLanders>& crashData() const { return mCrashedLanders; }
 private:
 	ColonyShipLanders mLanders;
-	std::optional<ColonyShipLanders> mCrashData = std::nullopt;
+	std::optional<ColonyShipLanders> mCrashedLanders = std::nullopt;
 	int mTurnsOfManeuveringFuel = 0;
 };

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -12,8 +12,8 @@ namespace NAS2D
 
 struct ColonyShipLanders
 {
-	int colonistLanders = 0;
-	int cargoLanders = 0;
+	int colonistLanders{};
+	int cargoLanders{};
 };
 
 
@@ -41,5 +41,5 @@ public:
 private:
 	ColonyShipLanders mLanders;
 	ColonyShipLanders mCrashedLanders{};
-	int mTurnsOfManeuveringFuel = 0;
+	int mTurnsOfManeuveringFuel{};
 };

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -12,8 +12,8 @@ namespace NAS2D
 
 struct ColonyShipLanders
 {
-	int colonistLanders{};
-	int cargoLanders{};
+	int colonist{};
+	int cargo{};
 };
 
 
@@ -29,11 +29,11 @@ public:
 	ColonyShip();
 	ColonyShip(const ColonyShipLanders&, int turnsOfManeuveringFuel);
 
-	int colonistLanders() const { return mLanders.colonistLanders; }
-	int cargoLanders() const { return mLanders.cargoLanders; }
+	int colonistLanders() const { return mLanders.colonist; }
+	int cargoLanders() const { return mLanders.cargo; }
 	int turnsOfManeuveringFuel() const { return mTurnsOfManeuveringFuel; }
-	void onDeployColonistLander() { --mLanders.colonistLanders; }
-	void onDeployCargoLander() { --mLanders.cargoLanders; }
+	void onDeployColonistLander() { --mLanders.colonist; }
+	void onDeployCargoLander() { --mLanders.cargo; }
 	bool crashed() const { return mTurnsOfManeuveringFuel == 0; }
 	const ColonyShipLanders& crashedLanders() const { return mCrashedLanders; }
 	void onTurn();

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -16,7 +16,6 @@ struct ColonyShipData
 {
 	int colonistLanders = 0;
 	int cargoLanders = 0;
-	int turnsOfManeuveringFuel = 0;
 };
 
 
@@ -30,18 +29,19 @@ class ColonyShip
 {
 public:
 	ColonyShip();
-	ColonyShip(const ColonyShipData&);
+	ColonyShip(const ColonyShipData&, int turnsOfManeuveringFuel);
 
 	int colonistLanders() const { return mColonyShipData.colonistLanders; }
 	int cargoLanders() const { return mColonyShipData.cargoLanders; }
-	int turnsOfManeuveringFuel() const { return mColonyShipData.turnsOfManeuveringFuel; }
+	int turnsOfManeuveringFuel() const { return mTurnsOfManeuveringFuel; }
 	void onDeployColonistLander() { --mColonyShipData.colonistLanders; }
 	void onDeployCargoLander() { --mColonyShipData.cargoLanders; }
-	bool crashed() const { return mColonyShipData.turnsOfManeuveringFuel == 0; }
+	bool crashed() const { return mTurnsOfManeuveringFuel == 0; }
 	void onTurn();
 
 	const std::optional<ColonyShipData>& crashData() const { return mCrashData; }
 private:
 	ColonyShipData mColonyShipData;
 	std::optional<ColonyShipData> mCrashData = std::nullopt;
+	int mTurnsOfManeuveringFuel = 0;
 };

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../Constants/Numbers.h"
-
 #include <optional>
 
 
@@ -41,11 +39,6 @@ public:
 
 	const std::optional<ColonyShipData>& crashData() const { return mCrashData; }
 private:
-	ColonyShipData mColonyShipData = 
-	{
-		.colonistLanders = 2,
-		.cargoLanders = 2,
-		.turnsOfManeuveringFuel = constants::ColonyShipOrbitTime + 1
-	};
+	ColonyShipData mColonyShipData;
 	std::optional<ColonyShipData> mCrashData = std::nullopt;
 };

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -12,7 +12,7 @@ namespace NAS2D
 }
 
 
-struct ColonyShipData
+struct ColonyShipLanders
 {
 	int colonistLanders = 0;
 	int cargoLanders = 0;
@@ -29,7 +29,7 @@ class ColonyShip
 {
 public:
 	ColonyShip();
-	ColonyShip(const ColonyShipData&, int turnsOfManeuveringFuel);
+	ColonyShip(const ColonyShipLanders&, int turnsOfManeuveringFuel);
 
 	int colonistLanders() const { return mColonyShipData.colonistLanders; }
 	int cargoLanders() const { return mColonyShipData.cargoLanders; }
@@ -39,9 +39,9 @@ public:
 	bool crashed() const { return mTurnsOfManeuveringFuel == 0; }
 	void onTurn();
 
-	const std::optional<ColonyShipData>& crashData() const { return mCrashData; }
+	const std::optional<ColonyShipLanders>& crashData() const { return mCrashData; }
 private:
-	ColonyShipData mColonyShipData;
-	std::optional<ColonyShipData> mCrashData = std::nullopt;
+	ColonyShipLanders mColonyShipData;
+	std::optional<ColonyShipLanders> mCrashData = std::nullopt;
 	int mTurnsOfManeuveringFuel = 0;
 };

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -20,7 +20,10 @@ struct ColonyShipData
 };
 
 
-ColonyShipData colonyShipDataFromSave(NAS2D::Xml::XmlDocument&);
+class ColonyShip;
+
+
+ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument&);
 
 
 class ColonyShip

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -20,14 +20,14 @@ struct ColonyShipLanders
 class ColonyShip;
 
 
-ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument&);
+ColonyShip colonyShipFromSave(NAS2D::Xml::XmlDocument& xmlDocument);
 
 
 class ColonyShip
 {
 public:
 	ColonyShip();
-	ColonyShip(const ColonyShipLanders&, int turnsOfManeuveringFuel);
+	ColonyShip(const ColonyShipLanders& colonyShipLanders, int turnsOfManeuveringFuel);
 
 	int colonistLanders() const { return mLanders.colonist; }
 	int cargoLanders() const { return mLanders.cargo; }

--- a/appOPHD/States/ColonyShip.h
+++ b/appOPHD/States/ColonyShip.h
@@ -31,17 +31,17 @@ public:
 	ColonyShip();
 	ColonyShip(const ColonyShipLanders&, int turnsOfManeuveringFuel);
 
-	int colonistLanders() const { return mColonyShipData.colonistLanders; }
-	int cargoLanders() const { return mColonyShipData.cargoLanders; }
+	int colonistLanders() const { return mLanders.colonistLanders; }
+	int cargoLanders() const { return mLanders.cargoLanders; }
 	int turnsOfManeuveringFuel() const { return mTurnsOfManeuveringFuel; }
-	void onDeployColonistLander() { --mColonyShipData.colonistLanders; }
-	void onDeployCargoLander() { --mColonyShipData.cargoLanders; }
+	void onDeployColonistLander() { --mLanders.colonistLanders; }
+	void onDeployCargoLander() { --mLanders.cargoLanders; }
 	bool crashed() const { return mTurnsOfManeuveringFuel == 0; }
 	void onTurn();
 
 	const std::optional<ColonyShipLanders>& crashData() const { return mCrashData; }
 private:
-	ColonyShipLanders mColonyShipData;
+	ColonyShipLanders mLanders;
 	std::optional<ColonyShipLanders> mCrashData = std::nullopt;
 	int mTurnsOfManeuveringFuel = 0;
 };

--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -38,7 +38,7 @@ GameState::GameState(const std::string& savedGameFilename) :
 	mSaveGameDocument{saveGameDocument(savedGameFilename)},
 	mReportsState{{this, &GameState::onTakeMeThere}, {this, &GameState::onShowReports}, {this, &GameState::onHideReports}},
 	mMapViewState{*this, mSaveGameDocument, {this, &GameState::onQuit}},
-	mColonyShip{colonyShipDataFromSave(mSaveGameDocument)},
+	mColonyShip{colonyShipFromSave(mSaveGameDocument)},
 	mFileIoDialog{{this, &GameState::onLoadGame}, {this, &GameState::onSaveGame}}
 {}
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -200,7 +200,7 @@ private:
 
 	// TURN LOGIC
 	void checkColonyShip();
-	void onColonyShipCrash(const ColonyShipData&);
+	void onColonyShipCrash(const ColonyShipLanders&);
 	void checkWarehouseCapacity();
 	void nextTurn();
 	void updatePopulation();

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -327,7 +327,7 @@ void MapViewState::checkColonyShip()
 }
 
 
-void MapViewState::onColonyShipCrash(const ColonyShipData& colonyShipData)
+void MapViewState::onColonyShipCrash(const ColonyShipLanders& colonyShipData)
 {
 	if(colonyShipData.colonistLanders > 0)
 	{

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -319,10 +319,11 @@ void MapViewState::updateResources()
 
 void MapViewState::checkColonyShip()
 {
-	if (mColonyShip.crashed() && mColonyShip.crashData().has_value())
+	if (mColonyShip.crashed())
 	{
-		onColonyShipCrash(mColonyShip.crashData().value());
-		mAnnouncement.onColonyShipCrash(mWindowStack, mColonyShip.crashData().value());
+		const auto& crashedLanders = mColonyShip.crashedLanders();
+		onColonyShipCrash(crashedLanders);
+		mAnnouncement.onColonyShipCrash(mWindowStack, crashedLanders);
 	}
 }
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -328,17 +328,17 @@ void MapViewState::checkColonyShip()
 }
 
 
-void MapViewState::onColonyShipCrash(const ColonyShipLanders& colonyShipData)
+void MapViewState::onColonyShipCrash(const ColonyShipLanders& colonyShipLanders)
 {
-	if(colonyShipData.colonistLanders > 0)
+	if(colonyShipLanders.colonistLanders > 0)
 	{
-		int moraleChange = -1 * colonyShipData.colonistLanders * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * ColonistsPerLander;
+		int moraleChange = -1 * colonyShipLanders.colonistLanders * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * ColonistsPerLander;
 		mMorale.journalMoraleChange({moraleString(MoraleIndexs::ColonistLanderLost), moraleChange});
 	}
 
-	if (colonyShipData.cargoLanders > 0)
+	if (colonyShipLanders.cargoLanders > 0)
 	{
-		int moraleChange = -1 * colonyShipData.cargoLanders * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * CargoMoraleLossPerLander;
+		int moraleChange = -1 * colonyShipLanders.cargoLanders * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * CargoMoraleLossPerLander;
 		mMorale.journalMoraleChange({moraleString(MoraleIndexs::CargoLanderLost), moraleChange});
 	}
 }

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -330,15 +330,15 @@ void MapViewState::checkColonyShip()
 
 void MapViewState::onColonyShipCrash(const ColonyShipLanders& colonyShipLanders)
 {
-	if(colonyShipLanders.colonistLanders > 0)
+	if(colonyShipLanders.colonist > 0)
 	{
-		int moraleChange = -1 * colonyShipLanders.colonistLanders * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * ColonistsPerLander;
+		int moraleChange = -1 * colonyShipLanders.colonist * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * ColonistsPerLander;
 		mMorale.journalMoraleChange({moraleString(MoraleIndexs::ColonistLanderLost), moraleChange});
 	}
 
-	if (colonyShipLanders.cargoLanders > 0)
+	if (colonyShipLanders.cargo > 0)
 	{
-		int moraleChange = -1 * colonyShipLanders.cargoLanders * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * CargoMoraleLossPerLander;
+		int moraleChange = -1 * colonyShipLanders.cargo * ColonyShipDeorbitMoraleLossMultiplier.at(mDifficulty) * CargoMoraleLossPerLander;
 		mMorale.journalMoraleChange({moraleString(MoraleIndexs::CargoLanderLost), moraleChange});
 	}
 }

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -32,7 +32,7 @@ void MajorEventAnnouncement::onClose()
 }
 
 
-MajorEventAnnouncement::AnnouncementType MajorEventAnnouncement::colonyShipCrashAnnouncement(const ColonyShipData& colonyShipData)
+MajorEventAnnouncement::AnnouncementType MajorEventAnnouncement::colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipData)
 {
 	if (colonyShipData.colonistLanders && colonyShipData.cargoLanders)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithColonistsAndCargo;
@@ -67,7 +67,7 @@ void MajorEventAnnouncement::announcement(AnnouncementType a)
 }
 
 
-void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const ColonyShipData& colonyShipData)
+void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const ColonyShipLanders& colonyShipData)
 {
 	windowStack.bringToFront(*this);
 	announcement(colonyShipCrashAnnouncement(colonyShipData));

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -34,13 +34,13 @@ void MajorEventAnnouncement::onClose()
 
 MajorEventAnnouncement::AnnouncementType MajorEventAnnouncement::colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipLanders)
 {
-	if (colonyShipLanders.colonistLanders && colonyShipLanders.cargoLanders)
+	if (colonyShipLanders.colonist && colonyShipLanders.cargo)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithColonistsAndCargo;
 
-	if (colonyShipLanders.colonistLanders)
+	if (colonyShipLanders.colonist)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithColonists;
 
-	if (colonyShipLanders.cargoLanders)
+	if (colonyShipLanders.cargo)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithCargo;
 
 	return MajorEventAnnouncement::AnnouncementType::ColonyShipCrash;

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -32,15 +32,15 @@ void MajorEventAnnouncement::onClose()
 }
 
 
-MajorEventAnnouncement::AnnouncementType MajorEventAnnouncement::colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipData)
+MajorEventAnnouncement::AnnouncementType MajorEventAnnouncement::colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipLanders)
 {
-	if (colonyShipData.colonistLanders && colonyShipData.cargoLanders)
+	if (colonyShipLanders.colonistLanders && colonyShipLanders.cargoLanders)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithColonistsAndCargo;
 
-	if (colonyShipData.colonistLanders)
+	if (colonyShipLanders.colonistLanders)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithColonists;
 
-	if (colonyShipData.cargoLanders)
+	if (colonyShipLanders.cargoLanders)
 		return MajorEventAnnouncement::AnnouncementType::ColonyShipCrashWithCargo;
 
 	return MajorEventAnnouncement::AnnouncementType::ColonyShipCrash;
@@ -67,10 +67,10 @@ void MajorEventAnnouncement::announcement(AnnouncementType a)
 }
 
 
-void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const ColonyShipLanders& colonyShipData)
+void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const ColonyShipLanders& colonyShipLanders)
 {
 	windowStack.bringToFront(*this);
-	announcement(colonyShipCrashAnnouncement(colonyShipData));
+	announcement(colonyShipCrashAnnouncement(colonyShipLanders));
 	show();
 }
 

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -4,7 +4,7 @@
 #include <libControls/Button.h>
 
 class WindowStack;
-struct ColonyShipData;
+struct ColonyShipLanders;
 
 class MajorEventAnnouncement : public Window
 {
@@ -22,14 +22,14 @@ public:
 
 	void announcement(AnnouncementType a);
 
-	void onColonyShipCrash(WindowStack&, const ColonyShipData&);
+	void onColonyShipCrash(WindowStack&, const ColonyShipLanders&);
 
 	void drawClientArea() const override;
 
 private:
 	void onClose();
 
-	MajorEventAnnouncement::AnnouncementType colonyShipCrashAnnouncement(const ColonyShipData&);
+	MajorEventAnnouncement::AnnouncementType colonyShipCrashAnnouncement(const ColonyShipLanders&);
 
 	const NAS2D::Image& mHeader;
 	std::string mMessage;


### PR DESCRIPTION
This started out as a simple removal of an `include` from a header file, accomplished by moving some initialization to the implementation file, though snowballed into a bunch of tiny stylistic changes affecting much of the class.

A lot of existing code has a more pure functional style, preferring to return new objects using the return value, rather than take an `[out]` parameter which receives modifications. That resulted in some changes to the saved game loading code.

A lot of existing code tends to check conditions first and either throw exceptions or use an early return, and then continue on the happy path, without additional indentation.

There was a `struct` change to reduce copy and duplication of a guaranteed `0` value for fuel after a crash.

Use of `std::optional` was removed. It has it's uses when there is a single function returning data, which might not always be valid. It's not necessary when there are a pair of related functions, to check data validity and return the data. Since this code already used a pair of functions, and most of the rest of the code base used that same pattern, I opted to use the validity checking and data returning pair, rather than use `std::optional` from a single method.

Related:
- Issue #1573
