### PR TITLE
Refactor `ToolTip`

### DIFF
--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -57,7 +57,7 @@ void ToolTip::add(const Control& control, const std::string& toolTipText)
 }
 
 
-void ToolTip::buildDrawParams(ControlText& controlText, int mouseX)
+void ToolTip::setToolTipArea(ControlText& controlText, int mouseX)
 {
 	area(toolTipArea(controlText.control->area(), mFont.size(controlText.text), mouseX));
 }
@@ -82,7 +82,7 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 		if (controlText.control->area().contains(position))
 		{
 			mFocus = &controlText;
-			buildDrawParams(controlText, position.x);
+			setToolTipArea(controlText, position.x);
 			return;
 		}
 	}

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -11,6 +11,22 @@ namespace
 {
 	constexpr int MarginTight{2};
 	constexpr auto PaddingSize = NAS2D::Vector{MarginTight, MarginTight};
+
+
+	NAS2D::Rectangle<int> toolTipArea(NAS2D::Rectangle<int> controlArea, NAS2D::Vector<int> textSize, int mouseX)
+	{
+		const auto toolTipSize = textSize + PaddingSize * 2;
+
+		const auto screenSizeX = NAS2D::Utility<NAS2D::Renderer>::get().size().x;
+		const auto maxX = screenSizeX - toolTipSize.x;
+		auto toolTipPosition = controlArea.position;
+		toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
+		if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
+
+		toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : controlArea.size.y;
+
+		return {toolTipPosition, toolTipSize};
+	}
 }
 
 
@@ -44,18 +60,7 @@ void ToolTip::add(const Control& control, const std::string& toolTipText)
 
 void ToolTip::buildDrawParams(ControlText& controlText, int mouseX)
 {
-	const auto toolTipSize = mFont.size(controlText.text) + PaddingSize * 2;
-	const auto& controlArea = controlText.control->area();
-
-	const auto screenSizeX = NAS2D::Utility<NAS2D::Renderer>::get().size().x;
-	const auto maxX = screenSizeX - toolTipSize.x;
-	auto toolTipPosition = controlArea.position;
-	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
-	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
-
-	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : controlArea.size.y;
-
-	area({toolTipPosition, toolTipSize});
+	area(toolTipArea(controlText.control->area(), mFont.size(controlText.text), mouseX));
 }
 
 

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -30,7 +30,8 @@ namespace
 
 
 ToolTip::ToolTip():
-	mFont{getDefaultFont()}
+	mFont{getDefaultFont()},
+	mFocus{nullptr}
 {
 	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &ToolTip::onMouseMove});
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -63,10 +63,10 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 {
 	if (relative != NAS2D::Vector{0, 0})
 	{
-		if (mFocusedControl)
+		if (mFocus)
 		{
-			if (mFocusedControl->control->area().contains(position)) { return; }
-			else { mFocusedControl = nullptr; }
+			if (mFocus->control->area().contains(position)) { return; }
+			else { mFocus = nullptr; }
 		}
 
 		mTimer.reset();
@@ -74,16 +74,16 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 
 	for (auto& controlText : mControlTexts)
 	{
-		if (mFocusedControl) { break; }
+		if (mFocus) { break; }
 		if (controlText.control->area().contains(position))
 		{
-			mFocusedControl = &controlText;
+			mFocus = &controlText;
 			buildDrawParams(controlText, position.x);
 			return;
 		}
 	}
 
-	mFocusedControl = nullptr;
+	mFocus = nullptr;
 }
 
 
@@ -99,11 +99,11 @@ void ToolTip::update()
 
 void ToolTip::draw() const
 {
-	if (mFocusedControl)
+	if (mFocus)
 	{
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 		renderer.drawBoxFilled(area(), NAS2D::Color::DarkGray);
 		renderer.drawBox(area(), NAS2D::Color::Black);
-		renderer.drawText(mFont, mFocusedControl->text, position() + PaddingSize);
+		renderer.drawText(mFont, mFocus->text, position() + PaddingSize);
 	}
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -46,20 +46,20 @@ void ToolTip::add(const Control& control, const std::string& toolTipText)
 {
 	for (auto& controlText : mControlTexts)
 	{
-		if (controlText.control == &control)
+		if (&controlText.control == &control)
 		{
 			controlText.text = toolTipText;
 			return;
 		}
 	}
 
-	mControlTexts.push_back({&control, toolTipText});
+	mControlTexts.emplace_back(control, toolTipText);
 }
 
 
 void ToolTip::setToolTipArea(ControlText& controlText, int mouseX)
 {
-	area(toolTipArea(controlText.control->area(), mFont.size(controlText.text), mouseX));
+	area(toolTipArea(controlText.control.area(), mFont.size(controlText.text), mouseX));
 }
 
 
@@ -69,7 +69,7 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 	{
 		if (mFocus)
 		{
-			if (mFocus->control->area().contains(position)) { return; }
+			if (mFocus->control.area().contains(position)) { return; }
 			else { mFocus = nullptr; }
 		}
 
@@ -79,7 +79,7 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 	for (auto& controlText : mControlTexts)
 	{
 		if (mFocus) { break; }
-		if (controlText.control->area().contains(position))
+		if (controlText.control.area().contains(position))
 		{
 			mFocus = &controlText;
 			setToolTipArea(controlText, position.x);

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -5,7 +5,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
 
-#include <string>
 
 namespace
 {

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -45,14 +45,15 @@ void ToolTip::add(const Control& control, const std::string& toolTipText)
 void ToolTip::buildDrawParams(ControlText& controlText, int mouseX)
 {
 	const auto toolTipSize = mFont.size(controlText.text) + PaddingSize * 2;
+	const auto& controlArea = controlText.control->area();
 
 	const auto screenSizeX = NAS2D::Utility<NAS2D::Renderer>::get().size().x;
 	const auto maxX = screenSizeX - toolTipSize.x;
-	auto toolTipPosition = controlText.control->position();
+	auto toolTipPosition = controlArea.position;
 	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
 	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
 
-	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : controlText.control->size().y;
+	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : controlArea.size.y;
 
 	area({toolTipPosition, toolTipSize});
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -31,9 +31,9 @@ void ToolTip::add(Control& c, const std::string& str)
 {
 	for (auto& item : mControls)
 	{
-		if (item.first == &c)
+		if (item.control == &c)
 		{
-			item.second = str;
+			item.text = str;
 			return;
 		}
 	}
@@ -42,18 +42,18 @@ void ToolTip::add(Control& c, const std::string& str)
 }
 
 
-void ToolTip::buildDrawParams(std::pair<Control*, std::string>& item, int mouseX)
+void ToolTip::buildDrawParams(ControlText& item, int mouseX)
 {
-	const auto toolTipSize = mFont.size(item.second) + PaddingSize * 2;
+	const auto toolTipSize = mFont.size(item.text) + PaddingSize * 2;
 
-	auto toolTipPosition = item.first->position();
+	auto toolTipPosition = item.control->position();
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
 	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
 	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
 
-	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : item.first->size().y;
+	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : item.control->size().y;
 
 	area({toolTipPosition, toolTipSize});
 }
@@ -65,7 +65,7 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 	{
 		if (mFocusedControl)
 		{
-			if (mFocusedControl->first->area().contains(position)) { return; }
+			if (mFocusedControl->control->area().contains(position)) { return; }
 			else { mFocusedControl = nullptr; }
 		}
 
@@ -75,7 +75,7 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 	for (auto& item : mControls)
 	{
 		if (mFocusedControl) { break; }
-		if (item.first->area().contains(position))
+		if (item.control->area().contains(position))
 		{
 			mFocusedControl = &item;
 			buildDrawParams(item, position.x);
@@ -104,6 +104,6 @@ void ToolTip::draw() const
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 		renderer.drawBoxFilled(area(), NAS2D::Color::DarkGray);
 		renderer.drawBox(area(), NAS2D::Color::Black);
-		renderer.drawText(mFont, mFocusedControl->second, position() + PaddingSize);
+		renderer.drawText(mFont, mFocusedControl->text, position() + PaddingSize);
 	}
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -46,10 +46,9 @@ void ToolTip::buildDrawParams(ControlText& controlText, int mouseX)
 {
 	const auto toolTipSize = mFont.size(controlText.text) + PaddingSize * 2;
 
-	auto toolTipPosition = controlText.control->position();
-
 	const auto screenSizeX = NAS2D::Utility<NAS2D::Renderer>::get().size().x;
 	const auto maxX = screenSizeX - toolTipSize.x;
+	auto toolTipPosition = controlText.control->position();
 	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
 	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
 

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -27,7 +27,7 @@ ToolTip::~ToolTip()
 }
 
 
-void ToolTip::add(Control& c, const std::string& str)
+void ToolTip::add(const Control& c, const std::string& str)
 {
 	for (auto& item : mControls)
 	{

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -27,33 +27,33 @@ ToolTip::~ToolTip()
 }
 
 
-void ToolTip::add(const Control& c, const std::string& str)
+void ToolTip::add(const Control& control, const std::string& toolTipText)
 {
 	for (auto& item : mControls)
 	{
-		if (item.control == &c)
+		if (item.control == &control)
 		{
-			item.text = str;
+			item.text = toolTipText;
 			return;
 		}
 	}
 
-	mControls.push_back({&c, str});
+	mControls.push_back({&control, toolTipText});
 }
 
 
-void ToolTip::buildDrawParams(ControlText& item, int mouseX)
+void ToolTip::buildDrawParams(ControlText& controlText, int mouseX)
 {
-	const auto toolTipSize = mFont.size(item.text) + PaddingSize * 2;
+	const auto toolTipSize = mFont.size(controlText.text) + PaddingSize * 2;
 
-	auto toolTipPosition = item.control->position();
+	auto toolTipPosition = controlText.control->position();
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto maxX = renderer.size().x - toolTipSize.x;
 	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
 	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
 
-	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : item.control->size().y;
+	toolTipPosition.y += (toolTipSize.y <= toolTipPosition.y) ? -toolTipSize.y : controlText.control->size().y;
 
 	area({toolTipPosition, toolTipSize});
 }

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -48,8 +48,8 @@ void ToolTip::buildDrawParams(ControlText& controlText, int mouseX)
 
 	auto toolTipPosition = controlText.control->position();
 
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto maxX = renderer.size().x - toolTipSize.x;
+	const auto screenSizeX = NAS2D::Utility<NAS2D::Renderer>::get().size().x;
+	const auto maxX = screenSizeX - toolTipSize.x;
 	toolTipPosition.x = (mouseX <= maxX) ? mouseX : maxX;
 	if (toolTipPosition.x < 0) { toolTipPosition.x = 0; }
 

--- a/libControls/ToolTip.cpp
+++ b/libControls/ToolTip.cpp
@@ -29,16 +29,16 @@ ToolTip::~ToolTip()
 
 void ToolTip::add(const Control& control, const std::string& toolTipText)
 {
-	for (auto& item : mControls)
+	for (auto& controlText : mControlTexts)
 	{
-		if (item.control == &control)
+		if (controlText.control == &control)
 		{
-			item.text = toolTipText;
+			controlText.text = toolTipText;
 			return;
 		}
 	}
 
-	mControls.push_back({&control, toolTipText});
+	mControlTexts.push_back({&control, toolTipText});
 }
 
 
@@ -72,13 +72,13 @@ void ToolTip::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relativ
 		mTimer.reset();
 	}
 
-	for (auto& item : mControls)
+	for (auto& controlText : mControlTexts)
 	{
 		if (mFocusedControl) { break; }
-		if (item.control->area().contains(position))
+		if (controlText.control->area().contains(position))
 		{
-			mFocusedControl = &item;
-			buildDrawParams(item, position.x);
+			mFocusedControl = &controlText;
+			buildDrawParams(controlText, position.x);
 			return;
 		}
 	}

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -45,5 +45,5 @@ private:
 
 	ControlText* mFocusedControl{nullptr};
 
-	std::vector<ControlText> mControls;
+	std::vector<ControlText> mControlTexts;
 };

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -43,7 +43,6 @@ private:
 	const NAS2D::Font& mFont;
 	NAS2D::Timer mTimer;
 
-	ControlText* mFocusedControl{nullptr};
-
 	std::vector<ControlText> mControlTexts;
+	ControlText* mFocus{nullptr};
 };

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -29,7 +29,7 @@ public:
 protected:
 	struct ControlText
 	{
-		const Control* control;
+		const Control& control;
 		std::string text;
 	};
 

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -6,7 +6,6 @@
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Timer.h>
 
-#include <utility>
 #include <string>
 #include <vector>
 
@@ -28,17 +27,23 @@ public:
 	void update() override;
 
 protected:
+	struct ControlText
+	{
+		Control* control;
+		std::string text;
+	};
+
 	void draw() const override;
 
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
-	void buildDrawParams(std::pair<Control*, std::string>&, int);
+	void buildDrawParams(ControlText&, int);
 
 private:
 	const NAS2D::Font& mFont;
 	NAS2D::Timer mTimer;
 
-	std::pair<Control*, std::string>* mFocusedControl{nullptr};
+	ControlText* mFocusedControl{nullptr};
 
-	std::vector<std::pair<Control*, std::string>> mControls;
+	std::vector<ControlText> mControls;
 };

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -37,7 +37,7 @@ protected:
 
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
-	void buildDrawParams(ControlText& controlText, int mouseX);
+	void setToolTipArea(ControlText& controlText, int mouseX);
 
 private:
 	const NAS2D::Font& mFont;

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -22,7 +22,7 @@ public:
 	ToolTip();
 	~ToolTip() override;
 
-	void add(const Control&, const std::string&);
+	void add(const Control& control, const std::string& toolTipText);
 
 	void update() override;
 
@@ -37,7 +37,7 @@ protected:
 
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
-	void buildDrawParams(ControlText&, int);
+	void buildDrawParams(ControlText& controlText, int mouseX);
 
 private:
 	const NAS2D::Font& mFont;

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -7,6 +7,7 @@
 #include <NAS2D/Timer.h>
 
 #include <utility>
+#include <string>
 #include <vector>
 
 

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -22,14 +22,14 @@ public:
 	ToolTip();
 	~ToolTip() override;
 
-	void add(Control&, const std::string&);
+	void add(const Control&, const std::string&);
 
 	void update() override;
 
 protected:
 	struct ControlText
 	{
-		Control* control;
+		const Control* control;
 		std::string text;
 	};
 

--- a/libControls/ToolTip.h
+++ b/libControls/ToolTip.h
@@ -44,5 +44,5 @@ private:
 	NAS2D::Timer mTimer;
 
 	std::vector<ControlText> mControlTexts;
-	ControlText* mFocus{nullptr};
+	ControlText* mFocus;
 };


### PR DESCRIPTION
Replace use of `std::pair` with a custom `struct`, and remove dependence on `<utility>`.

Improved `const` correctness of `Control` parameter.

Add parameter names to header file methods.

Extracted a function for `toolTipArea` to an unnamed namespace.

Related:
- Issue #1573
- Issue #1446
