### PR TITLE
Reduce crime header includes

### DIFF
--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -2,6 +2,7 @@
 
 #include "../Resources.h"
 #include "../StructureManager.h"
+#include "../MapObjects/Structure.h"
 #include "../MapObjects/Structures/FoodProduction.h"
 
 #include <libOPHD/EnumDifficulty.h>

--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -6,6 +6,7 @@
 
 #include <libOPHD/EnumDifficulty.h>
 #include <libOPHD/RandomNumberGenerator.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 
 #include <NAS2D/Utility.h>
 

--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -77,6 +77,12 @@ CrimeExecution::CrimeExecution(const Difficulty& difficulty, CrimeEventDelegate 
 }
 
 
+std::vector<MoraleChangeEntry> CrimeExecution::moraleChanges() const
+{
+	return mMoraleChanges;
+}
+
+
 void CrimeExecution::executeCrimes(const std::vector<Structure*>& structuresCommittingCrime)
 {
 	mMoraleChanges.clear();

--- a/appOPHD/States/CrimeExecution.h
+++ b/appOPHD/States/CrimeExecution.h
@@ -21,8 +21,8 @@ public:
 
 	CrimeExecution(const Difficulty& difficulty, CrimeEventDelegate crimeEventHandler);
 
+	std::vector<MoraleChangeEntry> moraleChanges() const;
 	void executeCrimes(const std::vector<Structure*>& structuresCommittingCrime);
-	std::vector<MoraleChangeEntry> moraleChanges() const { return mMoraleChanges; }
 
 protected:
 	void stealFood(FoodProduction& structure);

--- a/appOPHD/States/CrimeExecution.h
+++ b/appOPHD/States/CrimeExecution.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <libOPHD/Population/MoraleChangeEntry.h>
-
 #include <NAS2D/Signal/Delegate.h>
 
 #include <vector>
@@ -10,6 +8,7 @@
 
 
 enum class Difficulty;
+struct MoraleChangeEntry;
 class Structure;
 class FoodProduction;
 

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -4,7 +4,9 @@
 #include "../MapObjects/Structure.h"
 #include "../StructureManager.h"
 
+#include <libOPHD/EnumDifficulty.h>
 #include <libOPHD/RandomNumberGenerator.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 
 #include <NAS2D/Utility.h>
 

--- a/appOPHD/States/CrimeRateUpdate.h
+++ b/appOPHD/States/CrimeRateUpdate.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <libOPHD/EnumDifficulty.h>
-#include <libOPHD/Population/MoraleChangeEntry.h>
-
 #include <vector>
 
 
+enum class Difficulty;
+struct MoraleChangeEntry;
 class Structure;
 class Tile;
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -34,6 +34,7 @@
 #include "../UI/MiniMap.h"
 #include "../UI/CheatMenu.h"
 
+#include <libOPHD/EnumDifficulty.h>
 #include <libOPHD/StorableResources.h>
 
 #include <libOPHD/Map/MapCoordinate.h>


### PR DESCRIPTION
A forward declaration is sufficient for `std::vector` element types, so long as no members are used before a full definition is seen.

Related:
- Issue #1573
