### PR TITLE
Refactor `Tile` - reduce visibility of `TerrainType`

### DIFF
--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -8,6 +8,7 @@
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <cfloat>
+#include <stdexcept>
 
 
 Tile::Tile(const MapCoordinate& position, TerrainType index) :

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -5,6 +5,7 @@
 
 #include "../Constants/Numbers.h"
 
+#include <libOPHD/EnumTerrainType.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <cfloat>

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -11,6 +11,12 @@
 #include <stdexcept>
 
 
+Tile::Tile() :
+	mIndex{TerrainType::Dozed}
+{
+}
+
+
 Tile::Tile(const MapCoordinate& position, TerrainType index) :
 	mIndex{index},
 	mPosition{position}

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -59,6 +59,12 @@ bool Tile::isSurface()
 }
 
 
+bool Tile::bulldozed() const
+{
+	return index() == TerrainType::Dozed;
+}
+
+
 /**
  * Adds a new MapObject to the tile.
  *

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -65,7 +65,7 @@ bool Tile::isSurface()
 }
 
 
-bool Tile::bulldozed() const
+bool Tile::isBulldozed() const
 {
 	return index() == TerrainType::Dozed;
 }

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -59,7 +59,7 @@ Tile::~Tile()
 }
 
 
-bool Tile::isSurface()
+bool Tile::isSurface() const
 {
 	return mPosition.z == 0;
 }

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -71,6 +71,12 @@ bool Tile::isBulldozed() const
 }
 
 
+void Tile::bulldoze()
+{
+	index(TerrainType::Dozed);
+}
+
+
 /**
  * Adds a new MapObject to the tile.
  *

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -77,6 +77,12 @@ void Tile::bulldoze()
 }
 
 
+bool Tile::isImpassable() const
+{
+	return index() == TerrainType::Impassable;
+}
+
+
 /**
  * Adds a new MapObject to the tile.
  *

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -50,6 +50,8 @@ public:
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }
 
+	bool isImpassable() const;
+
 	void mapObject(MapObject*);
 	MapObject* mapObject() const { return mMapObject; }
 

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -4,7 +4,6 @@
 #include <libOPHD/Map/MapCoordinate.h>
 
 #include <NAS2D/Math/Point.h>
-#include <NAS2D/Math/Vector.h>
 
 
 class OreDeposit;

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -42,7 +42,7 @@ public:
 	int depth() const { return mPosition.z; }
 	void depth(int i) { mPosition.z = i; }
 
-	bool isSurface();
+	bool isSurface() const;
 
 	bool isBulldozed() const;
 

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -44,7 +44,7 @@ public:
 
 	bool isSurface();
 
-	bool bulldozed() const;
+	bool isBulldozed() const;
 
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -26,7 +26,7 @@ public:
 	};
 
 public:
-	Tile() = default;
+	Tile();
 	Tile(const MapCoordinate& position, TerrainType);
 	Tile(const Tile&) = delete;
 	Tile& operator=(const Tile&) = delete;
@@ -74,7 +74,7 @@ public:
 	float movementCost() const;
 
 private:
-	TerrainType mIndex = TerrainType::Dozed;
+	TerrainType mIndex;
 
 	MapCoordinate mPosition;
 

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -45,6 +45,7 @@ public:
 	bool isSurface() const;
 
 	bool isBulldozed() const;
+	void bulldoze();
 
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <libOPHD/EnumTerrainType.h>
 #include <libOPHD/Map/MapCoordinate.h>
 
 #include <NAS2D/Math/Point.h>
 
 
+enum class TerrainType;
 class OreDeposit;
 class MapObject;
 class Robot;

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -44,7 +44,7 @@ public:
 
 	bool isSurface();
 
-	bool bulldozed() const { return index() == TerrainType::Dozed; }
+	bool bulldozed() const;
 
 	bool excavated() const { return mExcavated; }
 	void excavated(bool value) { mExcavated = value; }

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -203,7 +203,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 		{
 			auto& tile = getTile({point, depth});
 			if (
-				((depth > 0 && tile.excavated()) || (tile.index() == TerrainType::Dozed)) &&
+				((depth > 0 && tile.excavated()) || (tile.isBulldozed())) &&
 				(tile.empty() && tile.oreDeposit() == nullptr)
 			)
 			{

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -89,7 +89,7 @@ namespace {
 		{
 			auto& tile = tileMap.getTile({location, 0});
 			tile.placeOreDeposit(new OreDeposit(randYield()));
-			tile.index(TerrainType::Dozed);
+			tile.bulldoze();
 		}
 	}
 }
@@ -239,7 +239,7 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 
 		auto& tile = getTile({{x, y}, 0});
 		tile.placeOreDeposit(oreDeposit);
-		tile.index(TerrainType::Dozed);
+		tile.bulldoze();
 
 		mOreDepositLocations.push_back(Point{x, y});
 	}

--- a/appOPHD/MapObjects/Robots/Robodozer.cpp
+++ b/appOPHD/MapObjects/Robots/Robodozer.cpp
@@ -15,7 +15,7 @@ void Robodozer::startTask(Tile& tile)
 	Robot::startTask(tile);
 
 	mTileIndex = static_cast<std::size_t>(tile.index());
-	tile.index(TerrainType::Dozed);
+	tile.bulldoze();
 }
 
 

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -31,8 +31,8 @@ MineFacility& Robominer::buildMine(TileMap& tileMap, const MapCoordinate& positi
 	auto& tileBelow = tileMap.getTile(position.translate(MapOffsetDown));
 	structureManager.create<MineShaft>(tileBelow);
 
-	robotTile.index(TerrainType::Dozed);
-	tileBelow.index(TerrainType::Dozed);
+	robotTile.bulldoze();
+	tileBelow.bulldoze();
 	tileBelow.excavated(true);
 
 	die();

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -24,6 +24,6 @@ void CargoLander::think()
 	if (age() == turnsToBuild())
 	{
 		mDeploy();
-		mTile->index(TerrainType::Dozed);
+		mTile->bulldoze();
 	}
 }

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -21,6 +21,6 @@ void ColonistLander::think()
 	if (age() == turnsToBuild())
 	{
 		mDeploy();
-		mTile->index(TerrainType::Dozed);
+		mTile->bulldoze();
 	}
 }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -954,7 +954,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 	{
 		return;
 	}
-	else if (tile.index() == TerrainType::Dozed && !tile.hasStructure())
+	else if (tile.isBulldozed() && !tile.hasStructure())
 	{
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertTileBulldozed);
 		return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -780,7 +780,7 @@ void MapViewState::insertTube(ConnectorDir dir, int depth, Tile& tile)
 
 void MapViewState::placeTubes(Tile& tile)
 {
-	if (!tile.bulldozed()) {
+	if (!tile.isBulldozed()) {
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertTubeTerrain);
 		return;
 	}
@@ -838,7 +838,7 @@ void MapViewState::placeStructure(Tile& tile)
 		return;
 	}
 
-	if ((!tile.bulldozed() && !structureIsLander(mCurrentStructure)))
+	if ((!tile.isBulldozed() && !structureIsLander(mCurrentStructure)))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureTerrain);
 		return;

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -125,7 +125,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	// Bulldoze lander region
 	for (const auto& direction : DirectionScan3x3)
 	{
-		mTileMap->getTile({point + direction, 0}).index(TerrainType::Dozed);
+		mTileMap->getTile({point + direction, 0}).bulldoze();
 	}
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
@@ -206,8 +206,8 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
 		auto& airShaftBottom = structureManager.create<AirShaft>(tileMap.getTile(newPosition));
 		airShaftBottom.underground();
 
-		tileMap.getTile(position).index(TerrainType::Dozed);
-		tileMap.getTile(newPosition).index(TerrainType::Dozed);
+		tileMap.getTile(position).bulldoze();
+		tileMap.getTile(newPosition).bulldoze();
 	}
 
 	/**
@@ -253,7 +253,7 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 	auto& mineFacilityTile = structureManager.tileFromStructure(mineFacility);
 	auto& mineDepthTile = mTileMap->getTile({mineFacilityTile.xy(), mineFacility->oreDeposit().depth()});
 	structureManager.create<MineShaft>(mineDepthTile);
-	mineDepthTile.index(TerrainType::Dozed);
+	mineDepthTile.bulldoze();
 	mineDepthTile.excavated(true);
 }
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -102,7 +102,7 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
  */
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir)
 {
-	if (tile.oreDeposit() || !tile.bulldozed() || !tile.excavated() || !tile.hasStructure())
+	if (tile.oreDeposit() || !tile.isBulldozed() || !tile.excavated() || !tile.hasStructure())
 	{
 		return false;
 	}
@@ -136,7 +136,7 @@ bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnector
 bool checkStructurePlacement(Tile& tile, Direction dir)
 {
 	Structure* structure = tile.structure();
-	if (tile.oreDeposit() || !tile.bulldozed() || !tile.excavated() || !tile.hasStructure() || !structure->connected() || !structure->isConnector())
+	if (tile.oreDeposit() || !tile.isBulldozed() || !tile.excavated() || !tile.hasStructure() || !structure->connected() || !structure->isConnector())
 	{
 		return false;
 	}

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -188,7 +188,7 @@ bool validLanderSite(Tile& tile)
 		return false;
 	}
 
-	if (tile.index() == TerrainType::Impassable)
+	if (tile.isImpassable())
 	{
 		doAlertMessage(constants::AlertLanderLocation, constants::AlertLanderTerrain);
 		return false;
@@ -213,7 +213,7 @@ bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position)
 	{
 		auto& tile = tilemap.getTile({position + offset, 0});
 
-		if (tile.index() == TerrainType::Impassable)
+		if (tile.isImpassable())
 		{
 			doAlertMessage(constants::AlertLanderLocation, constants::AlertSeedTerrain);
 			return false;

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -357,7 +357,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		{
 			robot.startTask(production_time);
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, mTileMap->getTile({{x, y}, depth}));
-			mRobotList[&robot]->index(TerrainType::Dozed);
+			mRobotList[&robot]->bulldoze();
 		}
 
 		if (depth > 0)
@@ -395,7 +395,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		const auto mapCoordinate = loadMapCoordinate(dictionary);
 		auto& tile = mTileMap->getTile(mapCoordinate);
-		tile.index(TerrainType::Dozed);
+		tile.bulldoze();
 		tile.excavated(true);
 
 		auto structureId = static_cast<StructureID>(type);


### PR DESCRIPTION
Isolate code from details of `TerrainType` enum, and reduce transitive header includes from `Tile.h`.

Related:
- Issue #1573
