### PR TITLE
Un-nest `StructureClass` enum

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -314,6 +314,18 @@ bool Structure::repairable() const
 	return mStructureType.isRepairable && (mStructureState != StructureState::Destroyed);
 }
 
+bool Structure::isFactory() const { return mStructureClass == StructureClass::Factory; }
+bool Structure::isWarehouse() const { return mStructureClass == StructureClass::Warehouse; }
+bool Structure::isRobotCommand() const { return mStructureClass == StructureClass::RobotCommand; }
+bool Structure::isMineFacility() const { return mStructureClass == StructureClass::Mine; }
+bool Structure::isSmelter() const { return mStructureClass == StructureClass::Smelter; }
+bool Structure::isEnergyProducer() const { return mStructureClass == StructureClass::EnergyProduction; }
+bool Structure::isFoodStore() const { return mStructureClass == StructureClass::FoodProduction || mStructureId == StructureID::SID_COMMAND_CENTER; }
+bool Structure::isPolice() const { return mStructureClass == StructureClass::SurfacePolice || mStructureClass == StructureClass::UndergroundPolice; }
+bool Structure::isLander() const { return mStructureClass == StructureClass::Lander; }
+bool Structure::isConnector() const { return mStructureClass == StructureClass::Tube; }
+bool Structure::isRoad() const { return mStructureClass == StructureClass::Road; }
+
 /**
  * Called when a building is finished being built.
  *

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -314,6 +314,8 @@ bool Structure::repairable() const
 	return mStructureType.isRepairable && (mStructureState != StructureState::Destroyed);
 }
 
+bool Structure::providesCHAP() const { return mStructureClass == StructureClass::LifeSupport; }
+
 bool Structure::isFactory() const { return mStructureClass == StructureClass::Factory; }
 bool Structure::isWarehouse() const { return mStructureClass == StructureClass::Warehouse; }
 bool Structure::isRobotCommand() const { return mStructureClass == StructureClass::RobotCommand; }

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -229,6 +229,11 @@ const PopulationRequirements& Structure::populationRequirements() const
 	return mStructureType.populationRequirements;
 }
 
+StructureClass Structure::structureClass() const
+{
+	return mStructureClass;
+}
+
 const std::string& Structure::stateDescription() const
 {
 	return stateDescription(state());

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -29,35 +29,35 @@ const std::map<StructureState, std::string> StructureStateDescriptions =
 /**
  * Translation table for Structure Classes.
  */
-const std::map<Structure::StructureClass, std::string> StructureClassNames =
+const std::map<StructureClass, std::string> StructureClassNames =
 {
-	{Structure::StructureClass::Command, "Command"},
-	{Structure::StructureClass::Communication, "Communication"},
-	{Structure::StructureClass::Commercial, "Commercial"},
-	{Structure::StructureClass::EnergyProduction, "Energy Production"},
-	{Structure::StructureClass::Factory, "Factory"},
-	{Structure::StructureClass::FoodProduction, "Food Production"},
-	{Structure::StructureClass::Laboratory, "Laboratory"},
-	{Structure::StructureClass::Lander, "Lander"},
-	{Structure::StructureClass::LifeSupport, "Life Support"},
-	{Structure::StructureClass::Maintenance, "Maintenance Facility"},
-	{Structure::StructureClass::Mine, "Mine Facility"},
-	{Structure::StructureClass::MedicalCenter, "Medical Center"},
-	{Structure::StructureClass::Nursery, "Nursery"},
-	{Structure::StructureClass::Park, "Park / Reservoir"},
-	{Structure::StructureClass::Road, "Road"},
-	{Structure::StructureClass::SurfacePolice, "Police"},
-	{Structure::StructureClass::UndergroundPolice, "Police"},
-	{Structure::StructureClass::RecreationCenter, "Recreation Center"},
-	{Structure::StructureClass::Recycling, "Recycling"},
-	{Structure::StructureClass::Residence, "Residential"},
-	{Structure::StructureClass::RobotCommand, "Robot Command Center"},
-	{Structure::StructureClass::Smelter, "Raw Ore Processing"},
-	{Structure::StructureClass::Storage, "Storage"},
-	{Structure::StructureClass::Tube, "Tube"},
-	{Structure::StructureClass::Undefined, "UNDEFINED"},
-	{Structure::StructureClass::University, "University"},
-	{Structure::StructureClass::Warehouse, "Warehouse"}
+	{StructureClass::Command, "Command"},
+	{StructureClass::Communication, "Communication"},
+	{StructureClass::Commercial, "Commercial"},
+	{StructureClass::EnergyProduction, "Energy Production"},
+	{StructureClass::Factory, "Factory"},
+	{StructureClass::FoodProduction, "Food Production"},
+	{StructureClass::Laboratory, "Laboratory"},
+	{StructureClass::Lander, "Lander"},
+	{StructureClass::LifeSupport, "Life Support"},
+	{StructureClass::Maintenance, "Maintenance Facility"},
+	{StructureClass::Mine, "Mine Facility"},
+	{StructureClass::MedicalCenter, "Medical Center"},
+	{StructureClass::Nursery, "Nursery"},
+	{StructureClass::Park, "Park / Reservoir"},
+	{StructureClass::Road, "Road"},
+	{StructureClass::SurfacePolice, "Police"},
+	{StructureClass::UndergroundPolice, "Police"},
+	{StructureClass::RecreationCenter, "Recreation Center"},
+	{StructureClass::Recycling, "Recycling"},
+	{StructureClass::Residence, "Residential"},
+	{StructureClass::RobotCommand, "Robot Command Center"},
+	{StructureClass::Smelter, "Raw Ore Processing"},
+	{StructureClass::Storage, "Storage"},
+	{StructureClass::Tube, "Tube"},
+	{StructureClass::Undefined, "UNDEFINED"},
+	{StructureClass::University, "University"},
+	{StructureClass::Warehouse, "Warehouse"}
 };
 
 
@@ -111,9 +111,9 @@ std::string StructureName(StructureID id)
 }
 
 
-std::vector<Structure::StructureClass> allStructureClasses()
+std::vector<StructureClass> allStructureClasses()
 {
-	std::vector<Structure::StructureClass> result;
+	std::vector<StructureClass> result;
 	for (const auto& entry : StructureClassNames)
 	{
 		result.push_back(entry.first);

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -31,50 +31,50 @@ enum class StructureState
 	Destroyed
 };
 
+/**
+	* Class of a Structure.
+	*
+	* Structures are grouped by 'class'. Basically it's just an easy
+	* way to know how to sort structures so that they can be updated
+	* based on priority.
+	*
+	* \note	Some structure classes will only have one structure
+	*			that uses it. This is intended behavior.
+	*/
+enum class StructureClass
+{
+	Command,
+	Communication,
+	Commercial,
+	EnergyProduction,
+	Factory,
+	FoodProduction,
+	Laboratory,
+	Lander,
+	LifeSupport,
+	Maintenance,
+	Mine,
+	MedicalCenter,
+	Nursery,
+	Park,
+	Road,
+	SurfacePolice,
+	UndergroundPolice,
+	RecreationCenter,
+	Recycling,
+	Residence,
+	RobotCommand,
+	Smelter,
+	Storage,
+	Tube,
+	Undefined, /**< Used for structures that have no need for classification. */
+	University,
+	Warehouse
+};
+
+
 class Structure : public MapObject
 {
-public:
-	/**
-	 * Class of a Structure.
-	 *
-	 * Structures are grouped by 'class'. Basically it's just an easy
-	 * way to know how to sort structures so that they can be updated
-	 * based on priority.
-	 *
-	 * \note	Some structure classes will only have one structure
-	 *			that uses it. This is intended behavior.
-	 */
-	enum class StructureClass
-	{
-		Command,
-		Communication,
-		Commercial,
-		EnergyProduction,
-		Factory,
-		FoodProduction,
-		Laboratory,
-		Lander,
-		LifeSupport,
-		Maintenance,
-		Mine,
-		MedicalCenter,
-		Nursery,
-		Park,
-		Road,
-		SurfacePolice,
-		UndergroundPolice,
-		RecreationCenter,
-		Recycling,
-		Residence,
-		RobotCommand,
-		Smelter,
-		Storage,
-		Tube,
-		Undefined, /**< Used for structures that have no need for classification. */
-		University,
-		Warehouse
-	};
-
 public:
 	Structure(StructureClass structureClass, StructureID id);
 	Structure(const std::string& initialAction, StructureClass structureClass, StructureID id);
@@ -237,4 +237,4 @@ private:
 using StructureList = std::vector<Structure*>;
 
 std::string StructureName(StructureID id);
-std::vector<Structure::StructureClass> allStructureClasses();
+std::vector<StructureClass> allStructureClasses();

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -179,7 +179,7 @@ private:
 	int mIntegrity{100};
 
 	StructureState mStructureState{StructureState::UnderConstruction};
-	StructureClass mStructureClass;
+	const StructureClass mStructureClass;
 	ConnectorDir mConnectorDirection{ConnectorDir::CONNECTOR_INTERSECTION};
 
 	PopulationRequirements mPopulationAvailable{}; /**< Determine how many of each type of population required was actually supplied to the structure. */

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -179,7 +179,7 @@ private:
 	int mIntegrity{100};
 
 	StructureState mStructureState{StructureState::UnderConstruction};
-	StructureClass mStructureClass{StructureClass::Undefined};
+	StructureClass mStructureClass;
 	ConnectorDir mConnectorDirection{ConnectorDir::CONNECTOR_INTERSECTION};
 
 	PopulationRequirements mPopulationAvailable{}; /**< Determine how many of each type of population required was actually supplied to the structure. */

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -115,7 +115,7 @@ public:
 
 	// FLAGS
 	bool requiresCHAP() const;
-	bool providesCHAP() const { return mStructureClass == StructureClass::LifeSupport; }
+	bool providesCHAP() const;
 	bool selfSustained() const;
 	bool repairable() const;
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -120,17 +120,17 @@ public:
 	bool repairable() const;
 
 	// CONVENIENCE FUCNTIONS
-	bool isFactory() const { return mStructureClass == StructureClass::Factory; }
-	bool isWarehouse() const { return mStructureClass == StructureClass::Warehouse; }
-	bool isRobotCommand() const { return mStructureClass == StructureClass::RobotCommand; }
-	bool isMineFacility() const { return mStructureClass == StructureClass::Mine; }
-	bool isSmelter() const { return mStructureClass == StructureClass::Smelter; }
-	bool isEnergyProducer() const { return mStructureClass == StructureClass::EnergyProduction; }
-	bool isFoodStore() const { return mStructureClass == StructureClass::FoodProduction || mStructureId == StructureID::SID_COMMAND_CENTER; }
-	bool isPolice() const { return mStructureClass == StructureClass::SurfacePolice || mStructureClass == StructureClass::UndergroundPolice; }
-	bool isLander() const { return mStructureClass == StructureClass::Lander; }
-	bool isConnector() const { return mStructureClass == StructureClass::Tube; }
-	bool isRoad() const { return mStructureClass == StructureClass::Road; }
+	bool isFactory() const;
+	bool isWarehouse() const;
+	bool isRobotCommand() const;
+	bool isMineFacility() const;
+	bool isSmelter() const;
+	bool isEnergyProducer() const;
+	bool isFoodStore() const;
+	bool isPolice() const;
+	bool isLander() const;
+	bool isConnector() const;
+	bool isRoad() const;
 
 	void age(int newAge) { mAge = newAge; }
 	void connectorDirection(ConnectorDir dir) { mConnectorDirection = dir; }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -85,7 +85,7 @@ public:
 	PopulationRequirements& populationAvailable() { return mPopulationAvailable; }
 
 	// ATTRIBUTES
-	StructureClass structureClass() const { return mStructureClass; }
+	StructureClass structureClass() const;
 	const std::string& stateDescription() const;
 	static const std::string& stateDescription(StructureState state);
 	const std::string& classDescription() const;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "StructureClass.h"
+
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/EnumIdleReason.h>
@@ -29,47 +31,6 @@ enum class StructureState
 	Idle,
 	Disabled,
 	Destroyed
-};
-
-/**
-	* Class of a Structure.
-	*
-	* Structures are grouped by 'class'. Basically it's just an easy
-	* way to know how to sort structures so that they can be updated
-	* based on priority.
-	*
-	* \note	Some structure classes will only have one structure
-	*			that uses it. This is intended behavior.
-	*/
-enum class StructureClass
-{
-	Command,
-	Communication,
-	Commercial,
-	EnergyProduction,
-	Factory,
-	FoodProduction,
-	Laboratory,
-	Lander,
-	LifeSupport,
-	Maintenance,
-	Mine,
-	MedicalCenter,
-	Nursery,
-	Park,
-	Road,
-	SurfacePolice,
-	UndergroundPolice,
-	RecreationCenter,
-	Recycling,
-	Residence,
-	RobotCommand,
-	Smelter,
-	Storage,
-	Tube,
-	Undefined, /**< Used for structures that have no need for classification. */
-	University,
-	Warehouse
 };
 
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -173,13 +173,13 @@ private:
 private:
 	const StructureType& mStructureType;
 	const StructureID mStructureId{StructureID::SID_NONE};
+	const StructureClass mStructureClass;
 
 	int mAge{0};
 	int mCrimeRate{0};
 	int mIntegrity{100};
 
 	StructureState mStructureState{StructureState::UnderConstruction};
-	const StructureClass mStructureClass;
 	ConnectorDir mConnectorDirection{ConnectorDir::CONNECTOR_INTERSECTION};
 
 	PopulationRequirements mPopulationAvailable{}; /**< Determine how many of each type of population required was actually supplied to the structure. */

--- a/appOPHD/MapObjects/StructureClass.h
+++ b/appOPHD/MapObjects/StructureClass.h
@@ -1,0 +1,43 @@
+#pragma once
+
+
+/**
+	* Class of a Structure.
+	*
+	* Structures are grouped by 'class'. Basically it's just an easy
+	* way to know how to sort structures so that they can be updated
+	* based on priority.
+	*
+	* \note	Some structure classes will only have one structure
+	*			that uses it. This is intended behavior.
+	*/
+enum class StructureClass
+{
+	Command,
+	Communication,
+	Commercial,
+	EnergyProduction,
+	Factory,
+	FoodProduction,
+	Laboratory,
+	Lander,
+	LifeSupport,
+	Maintenance,
+	Mine,
+	MedicalCenter,
+	Nursery,
+	Park,
+	Road,
+	SurfacePolice,
+	UndergroundPolice,
+	RecreationCenter,
+	Recycling,
+	Residence,
+	RobotCommand,
+	Smelter,
+	Storage,
+	Tube,
+	Undefined, /**< Used for structures that have no need for classification. */
+	University,
+	Warehouse
+};

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -240,7 +240,7 @@ std::size_t RobotPool::getAvailableCount(Robot::Type type) const
 void RobotPool::update()
 {
 	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
-	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().structureList(Structure::StructureClass::RobotCommand);
+	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().structureList(StructureClass::RobotCommand);
 
 	// 3 for the first command center
 	std::size_t maxRobots = 0;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -984,7 +984,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 		Structure* structure = tile.structure();
 
 		if (structure->isMineFacility()) { return; }
-		if (structure->structureClass() == Structure::StructureClass::Command)
+		if (structure->structureClass() == StructureClass::Command)
 		{
 			doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertCannotBulldozeCc);
 			return;
@@ -1021,7 +1021,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 			else { return; }
 		}
 
-		if (structure->structureClass() == Structure::StructureClass::Communication)
+		if (structure->structureClass() == StructureClass::Communication)
 		{
 			updateCommRangeOverlay();
 		}

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -476,7 +476,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			}
 		}
 
-		if (structure.structureClass() == Structure::StructureClass::Maintenance)
+		if (structure.structureClass() == StructureClass::Maintenance)
 		{
 			auto personnel = structureElement->firstChildElement("personnel");
 			if (personnel)

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -65,10 +65,10 @@ void MapViewState::updatePopulation()
 {
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	int residences = structureManager.getCountInState(Structure::StructureClass::Residence, StructureState::Operational);
-	int universities = structureManager.getCountInState(Structure::StructureClass::University, StructureState::Operational);
-	int nurseries = structureManager.getCountInState(Structure::StructureClass::Nursery, StructureState::Operational);
-	int hospitals = structureManager.getCountInState(Structure::StructureClass::MedicalCenter, StructureState::Operational);
+	int residences = structureManager.getCountInState(StructureClass::Residence, StructureState::Operational);
+	int universities = structureManager.getCountInState(StructureClass::University, StructureState::Operational);
+	int nurseries = structureManager.getCountInState(StructureClass::Nursery, StructureState::Operational);
+	int hospitals = structureManager.getCountInState(StructureClass::MedicalCenter, StructureState::Operational);
 
 	auto foodProducers = structureManager.getStructures<FoodProduction>();
 	const auto& commandCenters = structureManager.getStructures<CommandCenter>();
@@ -84,12 +84,12 @@ void MapViewState::updateCommercial()
 	StructureManager& structureManager = NAS2D::Utility<StructureManager>::get();
 
 	const auto& warehouses = structureManager.getStructures<Warehouse>();
-	const auto& commercial = structureManager.structureList(Structure::StructureClass::Commercial);
+	const auto& commercial = structureManager.structureList(StructureClass::Commercial);
 
 	// No need to do anything if there are no commercial structures.
 	if (commercial.empty()) { return; }
 
-	int luxuryCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
+	int luxuryCount = structureManager.getCountInState(StructureClass::Commercial, StructureState::Operational);
 	int commercialCount = luxuryCount;
 
 	for (auto* warehouse : warehouses)
@@ -143,10 +143,10 @@ void MapViewState::updateMorale()
 	// POSITIVE MORALE EFFECTS
 	// =========================================
 	const int birthCount = mPopulation.birthCount();
-	const int parkCount = structureManager.getCountInState(Structure::StructureClass::Park, StructureState::Operational);
-	const int recreationCount = structureManager.getCountInState(Structure::StructureClass::RecreationCenter, StructureState::Operational);
-	const int foodProducingStructures = structureManager.getCountInState(Structure::StructureClass::FoodProduction, StructureState::Operational);
-	const int commercialCount = structureManager.getCountInState(Structure::StructureClass::Commercial, StructureState::Operational);
+	const int parkCount = structureManager.getCountInState(StructureClass::Park, StructureState::Operational);
+	const int recreationCount = structureManager.getCountInState(StructureClass::RecreationCenter, StructureState::Operational);
+	const int foodProducingStructures = structureManager.getCountInState(StructureClass::FoodProduction, StructureState::Operational);
+	const int commercialCount = structureManager.getCountInState(StructureClass::Commercial, StructureState::Operational);
 
 	// NEGATIVE MORALE EFFECTS
 	// =========================================

--- a/appOPHD/StructureCatalogue.cpp
+++ b/appOPHD/StructureCatalogue.cpp
@@ -169,8 +169,6 @@ const StructureType& StructureCatalogue::getType(StructureID id)
  */
 Structure* StructureCatalogue::create(StructureID id, Tile* tile)
 {
-	using StructureClass = Structure::StructureClass;
-
 	Structure* structure = nullptr;
 
 	// This seems like a naive approach... I usually see these implemented as the base

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -23,7 +23,7 @@ namespace
 {
 	auto populateKeys()
 	{
-		std::map<Structure::StructureClass, StructureList> result;
+		std::map<StructureClass, StructureList> result;
 		for (const auto structureClass : allStructureClasses())
 		{
 			result[structureClass]; // Generate blank array value for given key
@@ -118,7 +118,7 @@ namespace
 			);
 		}
 
-		if (structure.structureClass() == Structure::StructureClass::Maintenance)
+		if (structure.structureClass() == StructureClass::Maintenance)
 		{
 			auto& maintenance = dynamic_cast<const MaintenanceFacility&>(structure);
 			structureElement->linkEndChild(
@@ -202,7 +202,7 @@ void StructureManager::removeStructure(Structure& structure)
 }
 
 
-const StructureList& StructureManager::structureList(Structure::StructureClass structureClass) const
+const StructureList& StructureManager::structureList(StructureClass structureClass) const
 {
 	return mStructureLists.at(structureClass);
 }
@@ -238,7 +238,7 @@ Tile& StructureManager::tileFromStructure(const Structure* structure) const
 std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions() const
 {
 	std::vector<MapCoordinate> positions;
-	for (const auto* commandCenter : structureList(Structure::StructureClass::Command))
+	for (const auto* commandCenter : structureList(StructureClass::Command))
 	{
 		if (commandCenter->operational())
 		{
@@ -310,7 +310,7 @@ int StructureManager::count() const
 }
 
 
-int StructureManager::getCountInState(Structure::StructureClass structureClass, StructureState state) const
+int StructureManager::getCountInState(StructureClass structureClass, StructureState state) const
 {
 	int count = 0;
 	for (const auto* structure : structureList(structureClass))
@@ -356,7 +356,7 @@ int StructureManager::destroyed() const
 
 bool StructureManager::CHAPAvailable() const
 {
-	for (const auto* chap : structureList(Structure::StructureClass::LifeSupport))
+	for (const auto* chap : structureList(StructureClass::LifeSupport))
 	{
 		if (chap->operational()) { return true; }
 	}
@@ -370,7 +370,7 @@ void StructureManager::updateEnergyProduction()
 	mTotalEnergyOutput = 0;
 	mTotalEnergyUsed = 0;
 
-	for (auto* structure : mStructureLists[Structure::StructureClass::EnergyProduction])
+	for (auto* structure : mStructureLists[StructureClass::EnergyProduction])
 	{
 		auto* powerStructure = dynamic_cast<PowerStructure*>(structure);
 		if (powerStructure->operational())
@@ -421,7 +421,7 @@ int StructureManager::totalFoodStorageCapacity() const
 void StructureManager::assignColonistsToResidences(PopulationPool& population)
 {
 	int populationCount = population.size();
-	for (auto* structure : mStructureLists[Structure::StructureClass::Residence])
+	for (auto* structure : mStructureLists[StructureClass::Residence])
 	{
 		Residence* residence = dynamic_cast<Residence*>(structure);
 		if (residence && residence->operational())
@@ -436,7 +436,7 @@ void StructureManager::assignColonistsToResidences(PopulationPool& population)
 void StructureManager::assignScientistsToResearchFacilities(PopulationPool& population)
 {
 	int availableScientists = population.availableScientists();
-	for (auto* laboratory : mStructureLists[Structure::StructureClass::Laboratory])
+	for (auto* laboratory : mStructureLists[StructureClass::Laboratory])
 	{
 		auto* lab = dynamic_cast<ResearchFacility*>(laboratory);
 		lab->assignScientists(0);
@@ -459,41 +459,41 @@ void StructureManager::update(const StorableResources& resources, PopulationPool
 	// Called separately so that 1) high priority structures can be updated first and
 	// 2) so that resource handling code (like energy) can be handled between update
 	// calls to lower priority structures.
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Lander]); // No resource needs
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Command]); // Self sufficient
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::EnergyProduction]); // Nothing can work without energy
+	updateStructures(resources, population, mStructureLists[StructureClass::Lander]); // No resource needs
+	updateStructures(resources, population, mStructureLists[StructureClass::Command]); // Self sufficient
+	updateStructures(resources, population, mStructureLists[StructureClass::EnergyProduction]); // Nothing can work without energy
 
 	updateEnergyProduction();
 
 	// Basic resource production
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Mine]); // Can't operate without resources.
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Smelter]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Mine]); // Can't operate without resources.
+	updateStructures(resources, population, mStructureLists[StructureClass::Smelter]);
 
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::LifeSupport]); // Air, water food must come before others
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::FoodProduction]);
+	updateStructures(resources, population, mStructureLists[StructureClass::LifeSupport]); // Air, water food must come before others
+	updateStructures(resources, population, mStructureLists[StructureClass::FoodProduction]);
 
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::MedicalCenter]); // No medical facilities, people die
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Nursery]);
+	updateStructures(resources, population, mStructureLists[StructureClass::MedicalCenter]); // No medical facilities, people die
+	updateStructures(resources, population, mStructureLists[StructureClass::Nursery]);
 
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Factory]); // Production
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Maintenance]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Factory]); // Production
+	updateStructures(resources, population, mStructureLists[StructureClass::Maintenance]);
 
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Storage]); // Everything else.
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Park]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::SurfacePolice]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::UndergroundPolice]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::RecreationCenter]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Recycling]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Residence]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::RobotCommand]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Warehouse]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Laboratory]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Commercial]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::University]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Communication]);
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Road]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Storage]); // Everything else.
+	updateStructures(resources, population, mStructureLists[StructureClass::Park]);
+	updateStructures(resources, population, mStructureLists[StructureClass::SurfacePolice]);
+	updateStructures(resources, population, mStructureLists[StructureClass::UndergroundPolice]);
+	updateStructures(resources, population, mStructureLists[StructureClass::RecreationCenter]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Recycling]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Residence]);
+	updateStructures(resources, population, mStructureLists[StructureClass::RobotCommand]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Warehouse]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Laboratory]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Commercial]);
+	updateStructures(resources, population, mStructureLists[StructureClass::University]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Communication]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Road]);
 
-	updateStructures(resources, population, mStructureLists[Structure::StructureClass::Undefined]);
+	updateStructures(resources, population, mStructureLists[StructureClass::Undefined]);
 
 	assignColonistsToResidences(population);
 

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -26,37 +26,37 @@ struct MapCoordinate;
 template <typename T> constexpr bool dependent_false = false;
 
 template <typename StructureType>
-constexpr Structure::StructureClass structureTypeToClass() {
-	if constexpr (std::is_same_v<StructureType, Agridome>) { return Structure::StructureClass::FoodProduction; }
-	else if constexpr (std::is_same_v<StructureType, AirShaft>) { return Structure::StructureClass::Tube; }
-	else if constexpr (std::is_same_v<StructureType, CargoLander>) { return Structure::StructureClass::Lander; }
-	else if constexpr (std::is_same_v<StructureType, ColonistLander>) { return Structure::StructureClass::Lander; }
-	else if constexpr (std::is_same_v<StructureType, CommandCenter>) { return Structure::StructureClass::Command; }
-	else if constexpr (std::is_same_v<StructureType, CommTower>) { return Structure::StructureClass::Communication; }
-	else if constexpr (std::is_same_v<StructureType, Factory>) { return Structure::StructureClass::Factory; }
-	else if constexpr (std::is_same_v<StructureType, FoodProduction>) { return Structure::StructureClass::FoodProduction; }
-	else if constexpr (std::is_same_v<StructureType, FusionReactor>) { return Structure::StructureClass::EnergyProduction; }
-	else if constexpr (std::is_same_v<StructureType, HotLaboratory>) { return Structure::StructureClass::Laboratory; }
-	else if constexpr (std::is_same_v<StructureType, Laboratory>) { return Structure::StructureClass::Laboratory; }
-	else if constexpr (std::is_same_v<StructureType, MaintenanceFacility>) { return Structure::StructureClass::Maintenance; }
-	else if constexpr (std::is_same_v<StructureType, MineFacility>) { return Structure::StructureClass::Mine; }
-	else if constexpr (std::is_same_v<StructureType, MineShaft>) { return Structure::StructureClass::Undefined; }
-	else if constexpr (std::is_same_v<StructureType, OreRefining>) { return Structure::StructureClass::Smelter; }
-	else if constexpr (std::is_same_v<StructureType, PowerStructure>) { return Structure::StructureClass::EnergyProduction; }
-	else if constexpr (std::is_same_v<StructureType, Recycling>) { return Structure::StructureClass::Recycling; }
-	else if constexpr (std::is_same_v<StructureType, ResearchFacility>) { return Structure::StructureClass::Laboratory; }
-	else if constexpr (std::is_same_v<StructureType, Residence>) { return Structure::StructureClass::Residence; }
-	else if constexpr (std::is_same_v<StructureType, Road>) { return Structure::StructureClass::Road; }
-	else if constexpr (std::is_same_v<StructureType, SeedFactory>) { return Structure::StructureClass::Factory; }
-	else if constexpr (std::is_same_v<StructureType, SeedLander>) { return Structure::StructureClass::Lander; }
-	else if constexpr (std::is_same_v<StructureType, SeedPower>) { return Structure::StructureClass::EnergyProduction; }
-	else if constexpr (std::is_same_v<StructureType, SolarPanelArray>) { return Structure::StructureClass::EnergyProduction; }
-	else if constexpr (std::is_same_v<StructureType, SolarPlant>) { return Structure::StructureClass::EnergyProduction; }
-	else if constexpr (std::is_same_v<StructureType, StorageTanks>) { return Structure::StructureClass::Storage; }
-	else if constexpr (std::is_same_v<StructureType, SurfaceFactory>) { return Structure::StructureClass::Factory; }
-	else if constexpr (std::is_same_v<StructureType, Tube>) { return Structure::StructureClass::Tube; }
-	else if constexpr (std::is_same_v<StructureType, UndergroundFactory>) { return Structure::StructureClass::Factory; }
-	else if constexpr (std::is_same_v<StructureType, Warehouse>) { return Structure::StructureClass::Warehouse; }
+constexpr StructureClass structureTypeToClass() {
+	if constexpr (std::is_same_v<StructureType, Agridome>) { return StructureClass::FoodProduction; }
+	else if constexpr (std::is_same_v<StructureType, AirShaft>) { return StructureClass::Tube; }
+	else if constexpr (std::is_same_v<StructureType, CargoLander>) { return StructureClass::Lander; }
+	else if constexpr (std::is_same_v<StructureType, ColonistLander>) { return StructureClass::Lander; }
+	else if constexpr (std::is_same_v<StructureType, CommandCenter>) { return StructureClass::Command; }
+	else if constexpr (std::is_same_v<StructureType, CommTower>) { return StructureClass::Communication; }
+	else if constexpr (std::is_same_v<StructureType, Factory>) { return StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, FoodProduction>) { return StructureClass::FoodProduction; }
+	else if constexpr (std::is_same_v<StructureType, FusionReactor>) { return StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, HotLaboratory>) { return StructureClass::Laboratory; }
+	else if constexpr (std::is_same_v<StructureType, Laboratory>) { return StructureClass::Laboratory; }
+	else if constexpr (std::is_same_v<StructureType, MaintenanceFacility>) { return StructureClass::Maintenance; }
+	else if constexpr (std::is_same_v<StructureType, MineFacility>) { return StructureClass::Mine; }
+	else if constexpr (std::is_same_v<StructureType, MineShaft>) { return StructureClass::Undefined; }
+	else if constexpr (std::is_same_v<StructureType, OreRefining>) { return StructureClass::Smelter; }
+	else if constexpr (std::is_same_v<StructureType, PowerStructure>) { return StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, Recycling>) { return StructureClass::Recycling; }
+	else if constexpr (std::is_same_v<StructureType, ResearchFacility>) { return StructureClass::Laboratory; }
+	else if constexpr (std::is_same_v<StructureType, Residence>) { return StructureClass::Residence; }
+	else if constexpr (std::is_same_v<StructureType, Road>) { return StructureClass::Road; }
+	else if constexpr (std::is_same_v<StructureType, SeedFactory>) { return StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, SeedLander>) { return StructureClass::Lander; }
+	else if constexpr (std::is_same_v<StructureType, SeedPower>) { return StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, SolarPanelArray>) { return StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, SolarPlant>) { return StructureClass::EnergyProduction; }
+	else if constexpr (std::is_same_v<StructureType, StorageTanks>) { return StructureClass::Storage; }
+	else if constexpr (std::is_same_v<StructureType, SurfaceFactory>) { return StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, Tube>) { return StructureClass::Tube; }
+	else if constexpr (std::is_same_v<StructureType, UndergroundFactory>) { return StructureClass::Factory; }
+	else if constexpr (std::is_same_v<StructureType, Warehouse>) { return StructureClass::Warehouse; }
 	else { static_assert(dependent_false<StructureType>, "Unknown type"); }
 }
 
@@ -113,7 +113,7 @@ public:
 		return output;
 	}
 
-	const StructureList& structureList(Structure::StructureClass structureClass) const;
+	const StructureList& structureList(StructureClass structureClass) const;
 	StructureList allStructures() const;
 
 	Tile& tileFromStructure(const Structure* structure) const;
@@ -127,7 +127,7 @@ public:
 
 	int count() const;
 
-	int getCountInState(Structure::StructureClass structureClass, StructureState state) const;
+	int getCountInState(StructureClass structureClass, StructureState state) const;
 
 	template <typename StructureType>
 	unsigned int countInState(StructureState state) const
@@ -169,7 +169,7 @@ public:
 
 private:
 	using StructureTileTable = std::map<Structure*, Tile*>;
-	using StructureClassTable = std::map<Structure::StructureClass, StructureList>;
+	using StructureClassTable = std::map<StructureClass, StructureList>;
 
 	void disconnectAll();
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -6,6 +6,7 @@
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../States/MapViewStateHelper.h"
+#include "../MapObjects/StructureClass.h"
 
 #include "../StructureManager.h"
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -174,7 +174,7 @@ void ResourceInfoBar::draw() const
 	const auto& sm = NAS2D::Utility<StructureManager>::get();
 	const std::array storageCapacities
 	{
-		std::tuple{NAS2D::Rectangle<int>{{96, 32}, {iconSize, iconSize}}, mResourcesCount.total(), totalStorage(Structure::StructureClass::Storage, 1000), totalStorage(Structure::StructureClass::Storage, 1000) - mResourcesCount.total() <= 100},
+		std::tuple{NAS2D::Rectangle<int>{{96, 32}, {iconSize, iconSize}}, mResourcesCount.total(), totalStorage(StructureClass::Storage, 1000), totalStorage(StructureClass::Storage, 1000) - mResourcesCount.total() <= 100},
 		std::tuple{NAS2D::Rectangle<int>{{64, 32}, {iconSize, iconSize}}, mFood, sm.totalFoodStorageCapacity(), mFood <= 10},
 		std::tuple{NAS2D::Rectangle<int>{{80, 32}, {iconSize, iconSize}}, sm.totalEnergyAvailable(), sm.totalEnergyProduction(), sm.totalEnergyAvailable() <= 5}
 	};
@@ -219,7 +219,7 @@ void ResourceInfoBar::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> p
  * Get the total amount of storage given a structure class and capacity of each
  * structure.
  */
-int ResourceInfoBar::totalStorage(Structure::StructureClass structureClass, int capacity) const
+int ResourceInfoBar::totalStorage(StructureClass structureClass, int capacity) const
 {
 	int storageCapacity = 0;
 

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -35,7 +35,7 @@ public:
 protected:
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
 
-	int totalStorage(Structure::StructureClass, int) const;
+	int totalStorage(StructureClass, int) const;
 
 private:
 	const StorableResources& mResourcesCount;

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../MapObjects/StructureClass.h"
-
 #include <libControls/ControlContainer.h>
 #include <libControls/ToolTip.h>
 
@@ -14,6 +12,7 @@ namespace NAS2D
 	enum class MouseButton;
 }
 
+enum class StructureClass;
 struct StorableResources;
 class Population;
 class Morale;

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../MapObjects/Structure.h"
+#include "../MapObjects/StructureClass.h"
 
 #include <libControls/ControlContainer.h>
 #include <libControls/ToolTip.h>

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -305,6 +305,7 @@
     <ClInclude Include="MapObjects\Robot.h" />
     <ClInclude Include="MapObjects\Robots.h" />
     <ClInclude Include="MapObjects\Structure.h" />
+    <ClInclude Include="MapObjects\StructureClass.h" />
     <ClInclude Include="MapObjects\Structures.h" />
     <ClInclude Include="MapObjects\Structures\Agridome.h" />
     <ClInclude Include="MapObjects\Structures\AirShaft.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -434,6 +434,9 @@
     <ClInclude Include="MapObjects\Structure.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
+    <ClInclude Include="MapObjects\StructureClass.h">
+      <Filter>Header Files\MapObjects</Filter>
+    </ClInclude>
     <ClInclude Include="MapObjects\Structures.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>


### PR DESCRIPTION
It's impossible to forward declare a nested type. By un-nesting the type, we offer more opportunities to forward declare, and reduce transitive header includes.

Ultimately I would like to eventually remove the `StructureClass` enum and rely on data from `StructureTypes.xml`. In particular, the `priority` field may be able to replace some uses of `StructureClass`, while searching for non-zero `StructureType` fields may replace other uses.

Related:
- Issue #1573
