### PR TITLE
Un-nest `RobotType` enum

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -8,27 +8,27 @@
 
 namespace
 {
-	const std::map<Robot::Type, int> basicTaskTime{
-		{Robot::Type::Dozer, 0},
-		{Robot::Type::Digger, constants::DiggerTaskTime},
-		{Robot::Type::Miner, constants::MinerTaskTime},
+	const std::map<RobotType, int> basicTaskTime{
+		{RobotType::Dozer, 0},
+		{RobotType::Digger, constants::DiggerTaskTime},
+		{RobotType::Miner, constants::MinerTaskTime},
 	};
 
-	int getTaskTime(Robot::Type type, Tile& tile)
+	int getTaskTime(RobotType type, Tile& tile)
 	{
 		return std::max(1, basicTaskTime.at(type) + static_cast<int>(tile.index()));
 	}
 }
 
 
-Robot::Robot(const std::string& name, const std::string& spritePath, Type type) :
+Robot::Robot(const std::string& name, const std::string& spritePath, RobotType type) :
 	MapObject(spritePath, "running"),
 	mName(name),
 	mType{type}
 {}
 
 
-Robot::Robot(const std::string& name, const std::string& spritePath, const std::string& initialAction, Type type) :
+Robot::Robot(const std::string& name, const std::string& spritePath, const std::string& initialAction, RobotType type) :
 	MapObject(spritePath, initialAction),
 	mName(name),
 	mType{type}

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -14,23 +14,24 @@ class Tile;
 class TileMap;
 
 
+enum class RobotType
+{
+	Digger,
+	Dozer,
+	Miner,
+
+	None
+};
+
+
 class Robot : public MapObject
 {
 public:
-	enum class Type
-	{
-		Digger,
-		Dozer,
-		Miner,
-
-		None
-	};
-
 	using TaskCompleteDelegate = NAS2D::Delegate<void(Robot&)>;
 
 public:
-	Robot(const std::string&, const std::string&, Type);
-	Robot(const std::string&, const std::string&, const std::string&, Type);
+	Robot(const std::string&, const std::string&, RobotType);
+	Robot(const std::string&, const std::string&, const std::string&, RobotType);
 
 	const std::string& name() const override;
 
@@ -56,7 +57,7 @@ public:
 	bool taskCanceled() const { return mCancelTask; }
 	void reset() { mCancelTask = false; }
 
-	Type type() const { return mType; }
+	RobotType type() const { return mType; }
 
 	void taskCompleteHandler(TaskCompleteDelegate newTaskCompleteHandler);
 
@@ -74,7 +75,7 @@ private:
 	bool mSelfDestruct = false;
 	bool mCancelTask{false};
 
-	Type mType{Type::None};
+	RobotType mType{RobotType::None};
 
 	TaskCompleteDelegate mTaskCompleteHandler;
 };

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RobotType.h"
+
 #include <libOPHD/MapObjects/MapObject.h>
 
 #include <NAS2D/Signal/Delegate.h>
@@ -12,16 +14,6 @@ namespace NAS2D
 
 class Tile;
 class TileMap;
-
-
-enum class RobotType
-{
-	Digger,
-	Dozer,
-	Miner,
-
-	None
-};
 
 
 class Robot : public MapObject

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -67,7 +67,7 @@ private:
 	bool mSelfDestruct = false;
 	bool mCancelTask{false};
 
-	RobotType mType{RobotType::None};
+	const RobotType mType{RobotType::None};
 
 	TaskCompleteDelegate mTaskCompleteHandler;
 };

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -67,7 +67,7 @@ private:
 	bool mSelfDestruct = false;
 	bool mCancelTask{false};
 
-	const RobotType mType{RobotType::None};
+	const RobotType mType;
 
 	TaskCompleteDelegate mTaskCompleteHandler;
 };

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -60,14 +60,13 @@ protected:
 
 private:
 	const std::string& mName;
+	const RobotType mType;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
 
 	bool mIsDead = false;
 	bool mSelfDestruct = false;
 	bool mCancelTask{false};
-
-	const RobotType mType;
 
 	TaskCompleteDelegate mTaskCompleteHandler;
 };

--- a/appOPHD/MapObjects/RobotType.h
+++ b/appOPHD/MapObjects/RobotType.h
@@ -1,0 +1,11 @@
+#pragma once
+
+
+enum class RobotType
+{
+	Digger,
+	Dozer,
+	Miner,
+
+	None
+};

--- a/appOPHD/MapObjects/Robots/Robodigger.cpp
+++ b/appOPHD/MapObjects/Robots/Robodigger.cpp
@@ -8,7 +8,7 @@
 
 
 Robodigger::Robodigger() :
-	Robot(constants::Robodigger, "robots/robodigger.sprite", Robot::Type::Digger),
+	Robot(constants::Robodigger, "robots/robodigger.sprite", RobotType::Digger),
 	mDirection(Direction::Down)
 {
 }

--- a/appOPHD/MapObjects/Robots/Robodozer.cpp
+++ b/appOPHD/MapObjects/Robots/Robodozer.cpp
@@ -5,7 +5,7 @@
 
 
 Robodozer::Robodozer() :
-	Robot(constants::Robodozer, "robots/robodozer.sprite", Robot::Type::Dozer)
+	Robot(constants::Robodozer, "robots/robodozer.sprite", RobotType::Dozer)
 {
 }
 

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -13,7 +13,7 @@
 
 
 Robominer::Robominer() :
-	Robot(constants::Robominer, "robots/robominer.sprite", Robot::Type::Miner)
+	Robot(constants::Robominer, "robots/robominer.sprite", RobotType::Miner)
 {
 }
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -138,24 +138,24 @@ void RobotPool::erase(Robot* robot)
  *
  * \return Returns a reference to the robot, or throws if type was invalid.
  */
-Robot& RobotPool::addRobot(Robot::Type type)
+Robot& RobotPool::addRobot(RobotType type)
 {
 	switch (type)
 	{
-	case Robot::Type::Dozer:
+	case RobotType::Dozer:
 		mDozers.emplace_back();
 		mRobots.push_back(&mDozers.back());
 		break;
-	case Robot::Type::Digger:
+	case RobotType::Digger:
 		mDiggers.emplace_back();
 		mRobots.push_back(&mDiggers.back());
 		break;
-	case Robot::Type::Miner:
+	case RobotType::Miner:
 		mMiners.emplace_back();
 		mRobots.push_back(&mMiners.back());
 		break;
 	default:
-		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));
+		throw std::runtime_error("Unknown RobotType: " + std::to_string(static_cast<int>(type)));
 	}
 
 	return *mRobots.back();
@@ -194,19 +194,19 @@ Robominer& RobotPool::getMiner()
  *
  * \return	Returns true if the requested robot type is available. False otherwise.
  */
-bool RobotPool::robotAvailable(Robot::Type type) const
+bool RobotPool::robotAvailable(RobotType type) const
 {
 	switch (type)
 	{
-	case Robot::Type::Digger:
+	case RobotType::Digger:
 	{
 		return hasIdleRobot(mDiggers);
 	}
-	case Robot::Type::Dozer:
+	case RobotType::Dozer:
 	{
 		return hasIdleRobot(mDozers);
 	}
-	case Robot::Type::Miner:
+	case RobotType::Miner:
 	{
 		return hasIdleRobot(mMiners);
 	}
@@ -218,17 +218,17 @@ bool RobotPool::robotAvailable(Robot::Type type) const
 }
 
 
-std::size_t RobotPool::getAvailableCount(Robot::Type type) const
+std::size_t RobotPool::getAvailableCount(RobotType type) const
 {
 	switch (type)
 	{
-	case Robot::Type::Digger:
+	case RobotType::Digger:
 		return getIdleCount(mDiggers);
 
-	case Robot::Type::Dozer:
+	case RobotType::Dozer:
 		return getIdleCount(mDozers);
 
-	case Robot::Type::Miner:
+	case RobotType::Miner:
 		return getIdleCount(mMiners);
 
 	default:

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -32,14 +32,14 @@ public:
 	RobotPool();
 	~RobotPool();
 
-	Robot& addRobot(Robot::Type type);
+	Robot& addRobot(RobotType type);
 
 	Robodigger& getDigger();
 	Robodozer& getDozer();
 	Robominer& getMiner();
 
-	bool robotAvailable(Robot::Type type) const;
-	std::size_t getAvailableCount(Robot::Type type) const;
+	bool robotAvailable(RobotType type) const;
+	std::size_t getAvailableCount(RobotType type) const;
 
 	bool isControlCapacityAvailable() const { return mRobotControlCount < mRobotControlMax; }
 	bool commandCapacityAvailable() { return mRobots.size() < mRobotControlMax; }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -60,11 +60,11 @@ namespace
 		const int sheetIndex;
 	};
 
-	const std::map<Robot::Type, RobotMeta> RobotMetaTable
+	const std::map<RobotType, RobotMeta> RobotMetaTable
 	{
-		{Robot::Type::Digger, RobotMeta{constants::Robodigger, constants::RobodiggerSheetId}},
-		{Robot::Type::Dozer, RobotMeta{constants::Robodozer, constants::RobodozerSheetId}},
-		{Robot::Type::Miner, RobotMeta{constants::Robominer, constants::RobominerSheetId}}
+		{RobotType::Digger, RobotMeta{constants::Robodigger, constants::RobodiggerSheetId}},
+		{RobotType::Dozer, RobotMeta{constants::Robodozer, constants::RobodozerSheetId}},
+		{RobotType::Miner, RobotMeta{constants::Robominer, constants::RobominerSheetId}}
 	};
 
 
@@ -763,7 +763,7 @@ void MapViewState::clearMode()
 	setCursor(PointerType::Normal);
 
 	mCurrentStructure = StructureID::SID_NONE;
-	mCurrentRobot = Robot::Type::None;
+	mCurrentRobot = RobotType::None;
 }
 
 
@@ -933,13 +933,13 @@ void MapViewState::placeRobot(Tile& tile)
 
 	switch (mCurrentRobot)
 	{
-	case Robot::Type::Dozer:
+	case RobotType::Dozer:
 		placeRobodozer(tile);
 		break;
-	case Robot::Type::Digger:
+	case RobotType::Digger:
 		placeRobodigger(tile);
 		break;
-	case Robot::Type::Miner:
+	case RobotType::Miner:
 		placeRobominer(tile);
 		break;
 	default:
@@ -1054,7 +1054,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
-	if (!mRobotPool.robotAvailable(Robot::Type::Dozer))
+	if (!mRobotPool.robotAvailable(RobotType::Dozer))
 	{
 		mRobots.removeItem(constants::Robodozer);
 		clearMode();
@@ -1164,7 +1164,7 @@ void MapViewState::placeRobominer(Tile& tile)
 	robot.startTask(tile);
 	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 
-	if (!mRobotPool.robotAvailable(Robot::Type::Miner))
+	if (!mRobotPool.robotAvailable(RobotType::Miner))
 	{
 		mRobots.removeItem(constants::Robominer);
 		clearMode();
@@ -1172,18 +1172,18 @@ void MapViewState::placeRobominer(Tile& tile)
 }
 
 
-Robot& MapViewState::addRobot(Robot::Type type)
+Robot& MapViewState::addRobot(RobotType type)
 {
-	const std::map<Robot::Type, void (MapViewState::*)(Robot&)> RobotTypeToHandler
+	const std::map<RobotType, void (MapViewState::*)(Robot&)> RobotTypeToHandler
 	{
-		{Robot::Type::Digger, &MapViewState::onDiggerTaskComplete},
-		{Robot::Type::Dozer, &MapViewState::onDozerTaskComplete},
-		{Robot::Type::Miner, &MapViewState::onMinerTaskComplete},
+		{RobotType::Digger, &MapViewState::onDiggerTaskComplete},
+		{RobotType::Dozer, &MapViewState::onDozerTaskComplete},
+		{RobotType::Miner, &MapViewState::onMinerTaskComplete},
 	};
 
 	if (RobotTypeToHandler.find(type) == RobotTypeToHandler.end())
 	{
-		throw std::runtime_error("Unknown Robot::Type: " + std::to_string(static_cast<int>(type)));
+		throw std::runtime_error("Unknown RobotType: " + std::to_string(static_cast<int>(type)));
 	}
 
 	auto& robot = mRobotPool.addRobot(type);
@@ -1271,7 +1271,7 @@ void MapViewState::updateRobots()
 					NotificationArea::NotificationType::Critical
 				});
 			}
-			else if (robot->type() != Robot::Type::Miner)
+			else if (robot->type() != RobotType::Miner)
 			{
 				const auto text = "Your " + robot->name() + " at location " + NAS2D::stringFrom(position.xy) + " has broken down. It will not be able to complete its task and will be removed from your inventory.";
 				mNotificationArea.push({"Robot Broke Down", text, position, NotificationArea::NotificationType::Critical});

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -174,7 +174,7 @@ private:
 	void placeRobodigger(Tile&);
 	void placeRobominer(Tile&);
 
-	Robot& addRobot(Robot::Type type);
+	Robot& addRobot(RobotType type);
 
 	// MISCELLANEOUS UTILITY FUNCTIONS
 	void updateFood();
@@ -335,7 +335,7 @@ private:
 
 	InsertMode mInsertMode = InsertMode::None; /**< What's being inserted into the TileMap if anything. */
 	StructureID mCurrentStructure = StructureID::SID_NONE; /**< Structure being placed. */
-	Robot::Type mCurrentRobot = Robot::Type::None; /**< Robot being placed. */
+	RobotType mCurrentRobot = RobotType::None; /**< Robot being placed. */
 
 	// USER INTERFACE
 	Button mBtnTurns;

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -22,11 +22,11 @@
 
 void MapViewState::pullRobotFromFactory(ProductType productType, Factory& factory)
 {
-	const std::map<ProductType, Robot::Type> ProductTypeToRobotType
+	const std::map<ProductType, RobotType> ProductTypeToRobotType
 	{
-		{ProductType::PRODUCT_DIGGER, Robot::Type::Digger},
-		{ProductType::PRODUCT_DOZER, Robot::Type::Dozer},
-		{ProductType::PRODUCT_MINER, Robot::Type::Miner},
+		{ProductType::PRODUCT_DIGGER, RobotType::Digger},
+		{ProductType::PRODUCT_DOZER, RobotType::Dozer},
+		{ProductType::PRODUCT_MINER, RobotType::Miner},
 	};
 
 	if (ProductTypeToRobotType.find(productType) == ProductTypeToRobotType.end())
@@ -155,9 +155,9 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	seedFactory.resourcePool(&mResourcesCount);
 	seedFactory.productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
 
-	mRobotPool.addRobot(Robot::Type::Dozer).taskCompleteHandler({this, &MapViewState::onDozerTaskComplete});
-	mRobotPool.addRobot(Robot::Type::Digger).taskCompleteHandler({this, &MapViewState::onDiggerTaskComplete});
-	mRobotPool.addRobot(Robot::Type::Miner).taskCompleteHandler({this, &MapViewState::onMinerTaskComplete});
+	mRobotPool.addRobot(RobotType::Dozer).taskCompleteHandler({this, &MapViewState::onDozerTaskComplete});
+	mRobotPool.addRobot(RobotType::Digger).taskCompleteHandler({this, &MapViewState::onDiggerTaskComplete});
+	mRobotPool.addRobot(RobotType::Miner).taskCompleteHandler({this, &MapViewState::onMinerTaskComplete});
 
 	populateRobotMenu();
 }

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -344,9 +344,9 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		const auto depth = dictionary.get<int>("depth", 0);
 		const auto direction = dictionary.get<int>("direction", 0);
 
-		const auto robotType = static_cast<Robot::Type>(type);
+		const auto robotType = static_cast<RobotType>(type);
 		auto& robot = addRobot(robotType);
-		if (robotType == Robot::Type::Digger)
+		if (robotType == RobotType::Digger)
 		{
 			dynamic_cast<Robodigger&>(robot).direction(static_cast<Direction>(direction));
 		}

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -552,7 +552,7 @@ void MapViewState::onRobotsSelectionChange(const IconGrid::Item* item)
 	mConnections.clearSelection();
 	mStructures.clearSelection();
 
-	mCurrentRobot = static_cast<Robot::Type>(item->meta);
+	mCurrentRobot = static_cast<RobotType>(item->meta);
 	mInsertMode = InsertMode::Robot;
 	setCursor(PointerType::PlaceTile);
 }
@@ -581,7 +581,7 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 		mTileMap->getTile(tile.xyz().translate(direction)).excavated(true);
 	}
 
-	if (!mRobotPool.robotAvailable(Robot::Type::Digger))
+	if (!mRobotPool.robotAvailable(RobotType::Digger))
 	{
 		mRobots.removeItem(constants::Robodigger);
 		clearMode();
@@ -698,9 +698,9 @@ void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
 			mPopulation.removePopulation({0, 0, 0, 0, 10});
 		break;
 		case CheatMenu::CheatCode::AddRobots:
-			mRobotPool.addRobot(Robot::Type::Digger);
-			mRobotPool.addRobot(Robot::Type::Dozer);
-			mRobotPool.addRobot(Robot::Type::Miner);
+			mRobotPool.addRobot(RobotType::Digger);
+			mRobotPool.addRobot(RobotType::Dozer);
+			mRobotPool.addRobot(RobotType::Miner);
 		break;
 
 	}

--- a/appOPHD/UI/RobotDeploymentSummary.cpp
+++ b/appOPHD/UI/RobotDeploymentSummary.cpp
@@ -33,9 +33,9 @@ void RobotDeploymentSummary::draw() const
 
 	const std::array icons{
 		std::tuple{robotSummaryImageRect, mRobotPool.currentControlCount(), mRobotPool.robotControlMax()},
-		std::tuple{diggerImageRect, mRobotPool.getAvailableCount(Robot::Type::Digger), mRobotPool.diggers().size()},
-		std::tuple{dozerImageRect, mRobotPool.getAvailableCount(Robot::Type::Dozer), mRobotPool.dozers().size()},
-		std::tuple{minerImageRect, mRobotPool.getAvailableCount(Robot::Type::Miner), mRobotPool.miners().size()},
+		std::tuple{diggerImageRect, mRobotPool.getAvailableCount(RobotType::Digger), mRobotPool.diggers().size()},
+		std::tuple{dozerImageRect, mRobotPool.getAvailableCount(RobotType::Dozer), mRobotPool.dozers().size()},
+		std::tuple{minerImageRect, mRobotPool.getAvailableCount(RobotType::Miner), mRobotPool.miners().size()},
 	};
 
 	for (const auto& [imageRect, parts, total] : icons)

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -17,13 +17,13 @@ using namespace NAS2D;
 
 namespace
 {
-	const NAS2D::Image& robotImage(Robot::Type robotType)
+	const NAS2D::Image& robotImage(RobotType robotType)
 	{
-		static const std::map<Robot::Type, const Image*> robotImages
+		static const std::map<RobotType, const Image*> robotImages
 		{
-			{Robot::Type::Digger, &imageCache.load("ui/interface/product_robodigger.png")},
-			{Robot::Type::Dozer, &imageCache.load("ui/interface/product_robodozer.png")},
-			{Robot::Type::Miner, &imageCache.load("ui/interface/product_robominer.png")}
+			{RobotType::Digger, &imageCache.load("ui/interface/product_robodigger.png")},
+			{RobotType::Dozer, &imageCache.load("ui/interface/product_robodozer.png")},
+			{RobotType::Miner, &imageCache.load("ui/interface/product_robominer.png")}
 		};
 		return *robotImages.at(robotType);
 	}
@@ -42,7 +42,7 @@ RobotInspector::RobotInspector() :
 	const auto buttonSize = mainFont.size("Cancel Orders") + NAS2D::Vector{padding, padding};
 	const int buttonOffsetY = buttonSize.y + constants::MarginTight;
 
-	const int imageWidth = robotImage(Robot::Type::Digger).size().x + padding;
+	const int imageWidth = robotImage(RobotType::Digger).size().x + padding;
 	const int contentWidth = imageWidth + buttonSize.x;
 
 	mContentRect = {

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -304,6 +304,7 @@
     <ClInclude Include="MapObjects\Robots\Robominer.h" />
     <ClInclude Include="MapObjects\Robot.h" />
     <ClInclude Include="MapObjects\Robots.h" />
+    <ClInclude Include="MapObjects\RobotType.h" />
     <ClInclude Include="MapObjects\Structure.h" />
     <ClInclude Include="MapObjects\StructureClass.h" />
     <ClInclude Include="MapObjects\Structures.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -431,6 +431,9 @@
     <ClInclude Include="MapObjects\Robots.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
+    <ClInclude Include="MapObjects\RobotType.h">
+      <Filter>Header Files\MapObjects</Filter>
+    </ClInclude>
     <ClInclude Include="MapObjects\Structure.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>


### PR DESCRIPTION
It's impossible to forward declare a nested type. By un-nesting the type, we offer more opportunities to forward declare, and reduce transitive header includes.

Potentially this `enum` may eventually be removed. The `mType` and `mName` fields of `Robot` seem like the start of a `RobotType` `struct` similar to the `StructureType` `struct`. The value of `mType` may eventually become an index into a collection of `RobotType` structs.

Related:
- Issue #1573
- PR #1857
