### PR TITLE
Split `PopulationRequirements` struct to own header file

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -8,7 +8,7 @@
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/MapObject.h>
-#include <libOPHD/Population/PopulationPool.h>
+#include <libOPHD/Population/PopulationRequirements.h>
 
 
 namespace NAS2D

--- a/libOPHD/MapObjects/StructureType.h
+++ b/libOPHD/MapObjects/StructureType.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../StorableResources.h"
-#include "../Population/PopulationPool.h"
+#include "../Population/PopulationRequirements.h"
 
 
 struct StructureType

--- a/libOPHD/Population/PopulationPool.cpp
+++ b/libOPHD/Population/PopulationPool.cpp
@@ -1,6 +1,7 @@
 #include "PopulationPool.h"
 
 #include "Population.h"
+#include "PopulationRequirements.h"
 
 #include <algorithm>
 #include <string>

--- a/libOPHD/Population/PopulationPool.h
+++ b/libOPHD/Population/PopulationPool.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "PopulationRequirements.h"
 
-
+struct PopulationRequirements;
 class Population;
 
 

--- a/libOPHD/Population/PopulationPool.h
+++ b/libOPHD/Population/PopulationPool.h
@@ -1,13 +1,9 @@
 #pragma once
 
+#include "PopulationRequirements.h"
+
+
 class Population;
-
-
-struct PopulationRequirements
-{
-	int workers;
-	int scientists;
-};
 
 
 class PopulationPool

--- a/libOPHD/Population/PopulationRequirements.h
+++ b/libOPHD/Population/PopulationRequirements.h
@@ -1,0 +1,8 @@
+#pragma once
+
+
+struct PopulationRequirements
+{
+	int workers;
+	int scientists;
+};

--- a/libOPHD/libOPHD.vcxproj
+++ b/libOPHD/libOPHD.vcxproj
@@ -206,6 +206,7 @@
     <ClInclude Include="Population\MoraleChangeEntry.h" />
     <ClInclude Include="Population\Population.h" />
     <ClInclude Include="Population\PopulationPool.h" />
+    <ClInclude Include="Population\PopulationRequirements.h" />
     <ClInclude Include="Population\PopulationTable.h" />
     <ClInclude Include="Technology\ResearchTracker.h" />
     <ClInclude Include="Technology\Technology.h" />

--- a/libOPHD/libOPHD.vcxproj.filters
+++ b/libOPHD/libOPHD.vcxproj.filters
@@ -161,6 +161,9 @@
     <ClInclude Include="Population\PopulationPool.h">
       <Filter>Header Files\Population</Filter>
     </ClInclude>
+    <ClInclude Include="Population\PopulationRequirements.h">
+      <Filter>Header Files\Population</Filter>
+    </ClInclude>
     <ClInclude Include="Population\PopulationTable.h">
       <Filter>Header Files\Population</Filter>
     </ClInclude>


### PR DESCRIPTION
A number of includes for `PopulationPool.h` only needed `PopulationRequirements`. By splitting `PopulationRequirements` to it's own header file, we can drastically cut down on includes of the larger `PopulationPool` class.

Using `cppinclude` gave info showing `PopulationPool.h` was one of the most included header files, and that was mainly because `Structure.h` included it so it could access `PopulationRequirements`.

Related:
- Issue #1573
