### PR TITLE
Un-nest `IconGridItem`

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -788,7 +788,7 @@ void MapViewState::placeTubes(Tile& tile)
 	if (tile.mapObject() || tile.oreDeposit() || !tile.excavated()) { return; }
 
 	/** FIXME: This is a kludge that only works because all of the tube structures are listed alphabetically.
-	 * Should instead take advantage of the updated meta data in the IconGrid::Item.
+	 * Should instead take advantage of the updated meta data in the IconGridItem.
 	 */
 	auto cd = static_cast<ConnectorDir>(mConnections.selectedIndex() + 1);
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -271,9 +271,9 @@ private:
 	void onReturnToGame();
 	void onGameOver();
 
-	void onStructuresSelectionChange(const IconGrid::Item*);
-	void onConnectionsSelectionChange(const IconGrid::Item*);
-	void onRobotsSelectionChange(const IconGrid::Item*);
+	void onStructuresSelectionChange(const IconGridItem*);
+	void onConnectionsSelectionChange(const IconGridItem*);
+	void onRobotsSelectionChange(const IconGridItem*);
 
 	void onDiggerSelectionDialog(Direction direction, Tile& tile);
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -29,7 +29,7 @@
 
 namespace
 {
-	const std::map<std::string, IconGrid::Item> StructureItemFromString =
+	const std::map<std::string, IconGridItem> StructureItemFromString =
 	{
 		{"SID_FUSION_REACTOR", {constants::FusionReactor, 21, SID_FUSION_REACTOR}},
 		{"SID_SOLAR_PLANT", {constants::SolarPlant, 10, StructureID::SID_SOLAR_PLANT}}

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -37,7 +37,7 @@ extern NAS2D::Point<int> MOUSE_COORDS;
 
 namespace
 {
-	void fillList(IconGrid& grid, const std::vector<IconGrid::Item>& itemList)
+	void fillList(IconGrid& grid, const std::vector<IconGridItem>& itemList)
 	{
 		for (const auto& item : itemList)
 		{
@@ -491,7 +491,7 @@ void MapViewState::onNotificationClicked(const NotificationArea::Notification& n
 }
 
 
-void MapViewState::onStructuresSelectionChange(const IconGrid::Item* item)
+void MapViewState::onStructuresSelectionChange(const IconGridItem* item)
 {
 	if (!item)
 	{
@@ -521,7 +521,7 @@ void MapViewState::onStructuresSelectionChange(const IconGrid::Item* item)
 /**
  * Handler for the Tubes Pallette dialog.
  */
-void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* item)
+void MapViewState::onConnectionsSelectionChange(const IconGridItem* item)
 {
 	if (!item)
 	{
@@ -541,7 +541,7 @@ void MapViewState::onConnectionsSelectionChange(const IconGrid::Item* item)
 /**
  * Handles clicks of the Robot Selection Menu.
  */
-void MapViewState::onRobotsSelectionChange(const IconGrid::Item* item)
+void MapViewState::onRobotsSelectionChange(const IconGridItem* item)
 {
 	if (!item)
 	{

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -8,7 +8,7 @@
 
 namespace
 {
-	const std::vector<IconGrid::Item> DefaultAvailableSurfaceStructures = {
+	const std::vector<IconGridItem> DefaultAvailableSurfaceStructures = {
 		{constants::Agridome, 5, StructureID::SID_AGRIDOME},
 		{constants::Chap, 3, StructureID::SID_CHAP},
 		{constants::CommTower, 22, StructureID::SID_COMM_TOWER},
@@ -25,7 +25,7 @@ namespace
 		{constants::Warehouse, 9, StructureID::SID_WAREHOUSE},
 	};
 
-	const std::vector<IconGrid::Item> DefaultAvailableUndergroundStructures = {
+	const std::vector<IconGridItem> DefaultAvailableUndergroundStructures = {
 		{constants::Laboratory, 58, StructureID::SID_LABORATORY},
 		{constants::Park, 75, StructureID::SID_PARK},
 		{constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE},
@@ -39,20 +39,20 @@ namespace
 		{constants::University, 63, StructureID::SID_UNIVERSITY},
 	};
 
-	const std::vector<IconGrid::Item> SurfaceTubes = {
+	const std::vector<IconGridItem> SurfaceTubes = {
 		{constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION},
 		{constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_EAST_WEST},
 		{constants::AgTubeLeft, 111, ConnectorDir::CONNECTOR_NORTH_SOUTH},
 	};
 
-	const std::vector<IconGrid::Item> UndergroundTubes = {
+	const std::vector<IconGridItem> UndergroundTubes = {
 		{constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION},
 		{constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_EAST_WEST},
 		{constants::UgTubelLeft, 114, ConnectorDir::CONNECTOR_NORTH_SOUTH},
 	};
 
 
-	void addItemToList(const IconGrid::Item& structureItem, std::vector<IconGrid::Item>& list)
+	void addItemToList(const IconGridItem& structureItem, std::vector<IconGridItem>& list)
 	{
 		for (const auto& item : list)
 		{
@@ -74,37 +74,37 @@ StructureTracker::StructureTracker() :
 }
 
 
-const std::vector<IconGrid::Item>& StructureTracker::surfaceTubes() const
+const std::vector<IconGridItem>& StructureTracker::surfaceTubes() const
 {
 	return SurfaceTubes;
 }
 
 
-const std::vector<IconGrid::Item>& StructureTracker::undergroundTubes() const
+const std::vector<IconGridItem>& StructureTracker::undergroundTubes() const
 {
 	return UndergroundTubes;
 }
 
 
-const std::vector<IconGrid::Item>& StructureTracker::availableSurfaceStructures() const
+const std::vector<IconGridItem>& StructureTracker::availableSurfaceStructures() const
 {
 	return mAvailableSurfaceStructures;
 }
 
 
-const std::vector<IconGrid::Item>& StructureTracker::availableUndergroundStructures() const
+const std::vector<IconGridItem>& StructureTracker::availableUndergroundStructures() const
 {
 	return mAvailableUndergroundStructures;
 }
 
 
-void StructureTracker::addUnlockedSurfaceStructure(const IconGrid::Item& structureItem)
+void StructureTracker::addUnlockedSurfaceStructure(const IconGridItem& structureItem)
 {
 	addItemToList(structureItem, mAvailableSurfaceStructures);
 }
 
 
-void StructureTracker::addUnlockedUndergroundStructure(const IconGrid::Item& structureItem)
+void StructureTracker::addUnlockedUndergroundStructure(const IconGridItem& structureItem)
 {
 	addItemToList(structureItem, mAvailableUndergroundStructures);
 }

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -1,6 +1,7 @@
 #include "StructureTracker.h"
 
 #include "../Constants/Strings.h"
+#include "../UI/IconGrid.h"
 
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumStructureID.h>

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <vector>
 
 

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "../UI/IconGrid.h"
-
 #include <string>
 #include <vector>
+
+
+struct IconGridItem;
 
 
 class StructureTracker

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -11,16 +11,16 @@ class StructureTracker
 public:
 	StructureTracker();
 
-	const std::vector<IconGrid::Item>& surfaceTubes() const;
-	const std::vector<IconGrid::Item>& undergroundTubes() const;
+	const std::vector<IconGridItem>& surfaceTubes() const;
+	const std::vector<IconGridItem>& undergroundTubes() const;
 
-	const std::vector<IconGrid::Item>& availableSurfaceStructures() const;
-	const std::vector<IconGrid::Item>& availableUndergroundStructures() const;
+	const std::vector<IconGridItem>& availableSurfaceStructures() const;
+	const std::vector<IconGridItem>& availableUndergroundStructures() const;
 
-	void addUnlockedSurfaceStructure(const IconGrid::Item& structureItem);
-	void addUnlockedUndergroundStructure(const IconGrid::Item& structureItem);
+	void addUnlockedSurfaceStructure(const IconGridItem& structureItem);
+	void addUnlockedUndergroundStructure(const IconGridItem& structureItem);
 
 private:
-	std::vector<IconGrid::Item> mAvailableSurfaceStructures;
-	std::vector<IconGrid::Item> mAvailableUndergroundStructures;
+	std::vector<IconGridItem> mAvailableSurfaceStructures;
+	std::vector<IconGridItem> mAvailableUndergroundStructures;
 };

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -106,7 +106,7 @@ void FactoryProduction::hide()
 }
 
 
-void FactoryProduction::onProductSelectionChange(const IconGrid::Item* item)
+void FactoryProduction::onProductSelectionChange(const IconGridItem* item)
 {
 	if (!mFactory) { return; }
 

--- a/appOPHD/UI/FactoryProduction.h
+++ b/appOPHD/UI/FactoryProduction.h
@@ -29,7 +29,7 @@ public:
 	void drawClientArea() const override;
 
 protected:
-	void onProductSelectionChange(const IconGrid::Item*);
+	void onProductSelectionChange(const IconGridItem*);
 	void onClearSelection();
 	void onApply();
 	void onOkay();

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -52,7 +52,7 @@ IconGrid::~IconGrid()
 }
 
 
-void IconGrid::addItem(const Item& item)
+void IconGrid::addItem(const IconGridItem& item)
 {
 	auto& newItem = mIconItemList.emplace_back(item);
 
@@ -155,8 +155,8 @@ void IconGrid::setSelection(Index newSelection)
  * \note	If no items in the list contain a matching meta value,
  *			the current selection index will remain unchanged.
  *
- * \remark	IconGrid::Item::meta is initialized to 0 so passing a value
- *			of 0 for IconGrid::Item's that don't use a meta value will
+ * \remark	IconGridItem::meta is initialized to 0 so passing a value
+ *			of 0 for IconGridItem's that don't use a meta value will
  *			effectively set the index to 0.
  */
 void IconGrid::setSelectionByMeta(int selectionMetaValue)

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -14,20 +14,21 @@
 #include <algorithm>
 
 
+struct IconGridItem
+{
+	std::string name{};
+	int sheetId{0};
+	int meta{0}; /**< Optional User defined value */
+	bool available{true};
+	NAS2D::Point<int> pos{};
+};
+
+
 class IconGrid : public Control
 {
 public:
-	struct Item
-	{
-		std::string name{};
-		int sheetId{0};
-		int meta{0}; /**< Optional User defined value */
-		bool available{true};
-		NAS2D::Point<int> pos{};
-	};
-
-	using Delegate = NAS2D::Delegate<void(const Item*)>;
-	using Index = std::vector<Item>::size_type;
+	using Delegate = NAS2D::Delegate<void(const IconGridItem*)>;
+	using Index = std::vector<IconGridItem>::size_type;
 
 	static const Index NoSelection;
 
@@ -35,7 +36,7 @@ public:
 	IconGrid(Delegate selectionChangedHandler, const std::string& filePath, int iconSize, int margin, bool showTooltip = false);
 	~IconGrid() override;
 
-	void addItem(const Item&);
+	void addItem(const IconGridItem&);
 	void sort();
 	void clear();
 	bool isEmpty() const { return mIconItemList.empty(); }
@@ -84,7 +85,7 @@ private:
 	const int mIconMargin;
 	NAS2D::Vector<int> mGridSizeInIcons;
 
-	std::vector<Item> mIconItemList;
+	std::vector<IconGridItem> mIconItemList;
 
 	Index mHighlightIndex = NoSelection;
 	Index mSelectedIndex = NoSelection;


### PR DESCRIPTION
Un-nest `IconGridItem`, and use a forward declare to reduce transitive header includes from `StructureTracker.h`.

Related:
- Issue #1573
