### PR TITLE
Refactor `FileIo` - hide `FileOperation` enum

### DIFF
--- a/appOPHD/States/MainMenuState.h
+++ b/appOPHD/States/MainMenuState.h
@@ -2,6 +2,8 @@
 
 #include "../UI/FileIo.h"
 
+#include <libControls/Label.h>
+
 #include <NAS2D/State.h>
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Renderer/Fade.h>

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -10,6 +10,7 @@
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/EnumKeyCode.h>
+#include <NAS2D/Math/Point.h>
 
 #include <string>
 #include <algorithm>

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -4,7 +4,6 @@
 #include <libControls/Button.h>
 #include <libControls/TextField.h>
 #include <libControls/ListBox.h>
-#include <libControls/Label.h>
 
 #include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/Math/Point.h>

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -6,7 +6,6 @@
 #include <libControls/ListBox.h>
 
 #include <NAS2D/Signal/Delegate.h>
-#include <NAS2D/Math/Point.h>
 
 
 namespace NAS2D
@@ -14,6 +13,8 @@ namespace NAS2D
 	enum class KeyModifier : uint16_t;
 	enum class KeyCode : uint32_t;
 	enum class MouseButton;
+
+	template <typename BaseType> struct Point;
 }
 
 

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -20,12 +20,6 @@ namespace NAS2D
 class FileIo : public Window
 {
 public:
-	enum class FileOperation
-	{
-		Load,
-		Save
-	};
-
 	using FileLoadDelegate = NAS2D::Delegate<void(const std::string&)>;
 	using FileSaveDelegate = NAS2D::Delegate<void(const std::string&)>;
 
@@ -37,6 +31,12 @@ public:
 	void showSave(const std::string& directory);
 
 protected:
+	enum class FileOperation
+	{
+		Load,
+		Save
+	};
+
 	void scanDirectory(const std::string& directory);
 
 	void onDoubleClick(NAS2D::MouseButton button, NAS2D::Point<int> position);


### PR DESCRIPTION
Noticed an improper header include while looking to reduce header includes.

Also noticed the `FileOperation` enum had become an implementation detail with no `public` uses.

Related:
- Issue #1573
