### PR TITLE
Use `Vector` for `ListBoxBase` item size

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -21,12 +21,11 @@ using namespace NAS2D;
 
 
 FactoryListBox::FactoryListBox(SelectionChangedDelegate selectionChangedHandler) :
-	ListBoxBase{selectionChangedHandler},
+	ListBoxBase{{0, 58}, selectionChangedHandler},
 	mFont{fontCache.load(constants::FontPrimary, 12)},
 	mFontBold{fontCache.load(constants::FontPrimaryBold, 12)},
 	mStructureIcons{imageCache.load("ui/structures.png")}
 {
-	itemHeight(58);
 }
 
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -16,11 +16,10 @@ using namespace NAS2D;
 
 
 ProductListBox::ProductListBox(SelectionChangedDelegate selectionChangedHandler) :
-	ListBoxBase{selectionChangedHandler},
+	ListBoxBase{{0, 30}, selectionChangedHandler},
 	mFont{fontCache.load(constants::FontPrimary, 12)},
 	mFontBold{fontCache.load(constants::FontPrimaryBold, 12)}
 {
-	itemHeight(30);
 }
 
 

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -17,11 +17,10 @@ using namespace NAS2D;
 
 
 StructureListBox::StructureListBox(SelectionChangedDelegate selectionChangedHandler) :
-	ListBoxBase{selectionChangedHandler},
+	ListBoxBase{{0, 30}, selectionChangedHandler},
 	mFont{fontCache.load(constants::FontPrimary, 12)},
 	mFontBold{fontCache.load(constants::FontPrimaryBold, 12)}
 {
-	itemHeight(30);
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -215,12 +215,6 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 }
 
 
-NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
-{
-	return mItemSize;
-}
-
-
 NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 {
 	return position() + NAS2D::Vector{0, static_cast<int>(index) * mItemSize.y - mScrollOffsetInPixels};
@@ -229,7 +223,7 @@ NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 
 NAS2D::Rectangle<int> ListBoxBase::itemDrawArea(std::size_t index) const
 {
-	return {itemDrawPosition(index), itemDrawSize()};
+	return {itemDrawPosition(index), mItemSize};
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -215,12 +215,6 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 }
 
 
-int ListBoxBase::itemHeight() const
-{
-	return mItemSize.y;
-}
-
-
 NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 {
 	return mItemSize;
@@ -229,7 +223,7 @@ NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 
 NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 {
-	return position() + NAS2D::Vector{0, static_cast<int>(index) * itemHeight() - mScrollOffsetInPixels};
+	return position() + NAS2D::Vector{0, static_cast<int>(index) * mItemSize.y - mScrollOffsetInPixels};
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -227,17 +227,6 @@ unsigned int ListBoxBase::itemHeight() const
 }
 
 
-/**
- * Sets item height.
- *
- * \note	Internal function for specialized types.
- */
-void ListBoxBase::itemHeight(int h)
-{
-	mItemSize.y = h;
-}
-
-
 unsigned int ListBoxBase::drawOffset() const
 {
 	return mScrollOffsetInPixels;

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -107,15 +107,15 @@ void ListBoxBase::clear()
  */
 void ListBoxBase::updateScrollLayout()
 {
-	mItemWidth = mRect.size.x;
+	mItemSize.x = mRect.size.x;
 
-	if ((mItemHeight * static_cast<int>(count())) > mRect.size.y)
+	if ((mItemSize.y * static_cast<int>(count())) > mRect.size.y)
 	{
 		mScrollBar.position({area().position.x + mRect.size.x - 14, mRect.position.y});
 		mScrollBar.size({14, mRect.size.y});
-		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemHeight * static_cast<int>(count()) - mRect.size.y));
+		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemSize.y * static_cast<int>(count()) - mRect.size.y));
 		mScrollOffsetInPixels = static_cast<unsigned int>(mScrollBar.value());
-		mItemWidth -= mScrollBar.size().x;
+		mItemSize.x -= mScrollBar.size().x;
 		mScrollBar.visible(true);
 	}
 	else
@@ -194,7 +194,7 @@ void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*r
 		return;
 	}
 
-	mHighlightIndex = (static_cast<unsigned int>(position.y - this->position().y) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemHeight);
+	mHighlightIndex = (static_cast<unsigned int>(position.y - this->position().y) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemSize.y);
 
 	if (mHighlightIndex >= count())
 	{
@@ -208,7 +208,7 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 	if (!enabled() || !visible()) { return; }
 	if (!mHasFocus) { return; }
 
-	auto change = static_cast<ScrollBar::ValueType>(mItemHeight);
+	auto change = static_cast<ScrollBar::ValueType>(mItemSize.y);
 
 	mScrollBar.changeValue((scrollAmount.y < 0 ? change : -change));
 }
@@ -216,13 +216,13 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 
 unsigned int ListBoxBase::itemWidth() const
 {
-	return static_cast<unsigned int>(mItemWidth);
+	return static_cast<unsigned int>(mItemSize.x);
 }
 
 
 unsigned int ListBoxBase::itemHeight() const
 {
-	return static_cast<unsigned int>(mItemHeight);
+	return static_cast<unsigned int>(mItemSize.y);
 }
 
 
@@ -233,7 +233,7 @@ unsigned int ListBoxBase::itemHeight() const
  */
 void ListBoxBase::itemHeight(int h)
 {
-	mItemHeight = h;
+	mItemSize.y = h;
 }
 
 
@@ -308,15 +308,15 @@ void ListBoxBase::draw() const
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// CONTROL EXTENTS
-	const auto backgroundRect = NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y}, {mItemWidth, mRect.size.y}};
+	const auto backgroundRect = NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y}, {mItemSize.x, mRect.size.y}};
 	renderer.drawBoxFilled(backgroundRect, NAS2D::Color::Black);
 	renderer.drawBox(backgroundRect, (hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75}));
 
 	renderer.clipRect(mRect);
 
 	// MOUSE HIGHLIGHT
-	const auto highlightPosition = position() + NAS2D::Vector{0, static_cast<int>(mHighlightIndex) * mItemHeight - static_cast<int>(mScrollOffsetInPixels)};
-	renderer.drawBoxFilled(NAS2D::Rectangle<int>{highlightPosition, {mItemWidth, mItemHeight}}, NAS2D::Color{0, 185, 0, 50});
+	const auto highlightPosition = position() + NAS2D::Vector{0, static_cast<int>(mHighlightIndex) * mItemSize.y - static_cast<int>(mScrollOffsetInPixels)};
+	renderer.drawBoxFilled(NAS2D::Rectangle<int>{highlightPosition, mItemSize}, NAS2D::Color{0, 185, 0, 50});
 
 	renderer.clipRectClear();
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -215,9 +215,9 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 }
 
 
-unsigned int ListBoxBase::itemHeight() const
+int ListBoxBase::itemHeight() const
 {
-	return static_cast<unsigned int>(mItemSize.y);
+	return mItemSize.y;
 }
 
 
@@ -229,7 +229,7 @@ NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 
 NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 {
-	return position() + NAS2D::Vector{0, static_cast<int>(index * itemHeight()) - mScrollOffsetInPixels};
+	return position() + NAS2D::Vector{0, static_cast<int>(index) * itemHeight() - mScrollOffsetInPixels};
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -221,12 +221,6 @@ unsigned int ListBoxBase::itemHeight() const
 }
 
 
-unsigned int ListBoxBase::drawOffset() const
-{
-	return mScrollOffsetInPixels;
-}
-
-
 NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 {
 	return mItemSize;
@@ -235,7 +229,7 @@ NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 
 NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 {
-	return position() + NAS2D::Vector{0, static_cast<int>(index * itemHeight() - drawOffset())};
+	return position() + NAS2D::Vector{0, static_cast<int>(index * itemHeight() - mScrollOffsetInPixels)};
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -215,12 +215,6 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 }
 
 
-unsigned int ListBoxBase::itemWidth() const
-{
-	return static_cast<unsigned int>(mItemSize.x);
-}
-
-
 unsigned int ListBoxBase::itemHeight() const
 {
 	return static_cast<unsigned int>(mItemSize.y);

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -13,8 +13,9 @@
 const std::size_t ListBoxBase::NoSelection{std::numeric_limits<std::size_t>::max()};
 
 
-ListBoxBase::ListBoxBase(SelectionChangedDelegate selectionChangedHandler) :
+ListBoxBase::ListBoxBase(NAS2D::Vector<int> itemSize, SelectionChangedDelegate selectionChangedHandler) :
 	mScrollBar{ScrollBar::ScrollBarType::Vertical, {this, &ListBoxBase::onSlideChange}},
+	mItemSize{itemSize},
 	mSelectionChangedHandler{selectionChangedHandler}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -245,7 +245,7 @@ unsigned int ListBoxBase::drawOffset() const
 
 NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 {
-	return NAS2D::Vector{itemWidth(), itemHeight()}.to<int>();
+	return mItemSize;
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -115,7 +115,7 @@ void ListBoxBase::updateScrollLayout()
 		mScrollBar.position({area().position.x + mRect.size.x - 14, mRect.position.y});
 		mScrollBar.size({14, mRect.size.y});
 		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemSize.y * static_cast<int>(count()) - mRect.size.y));
-		mScrollOffsetInPixels = static_cast<unsigned int>(mScrollBar.value());
+		mScrollOffsetInPixels = mScrollBar.value();
 		mItemSize.x -= mScrollBar.size().x;
 		mScrollBar.visible(true);
 	}
@@ -195,7 +195,7 @@ void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*r
 		return;
 	}
 
-	mHighlightIndex = (static_cast<unsigned int>(position.y - this->position().y) + mScrollOffsetInPixels) / static_cast<unsigned int>(mItemSize.y);
+	mHighlightIndex = (static_cast<unsigned int>(mScrollOffsetInPixels + position.y - this->position().y)) / static_cast<unsigned int>(mItemSize.y);
 
 	if (mHighlightIndex >= count())
 	{
@@ -229,7 +229,7 @@ NAS2D::Vector<int> ListBoxBase::itemDrawSize() const
 
 NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 {
-	return position() + NAS2D::Vector{0, static_cast<int>(index * itemHeight() - mScrollOffsetInPixels)};
+	return position() + NAS2D::Vector{0, static_cast<int>(index * itemHeight()) - mScrollOffsetInPixels};
 }
 
 
@@ -293,7 +293,7 @@ void ListBoxBase::draw() const
 	renderer.clipRect(mRect);
 
 	// MOUSE HIGHLIGHT
-	const auto highlightPosition = position() + NAS2D::Vector{0, static_cast<int>(mHighlightIndex) * mItemSize.y - static_cast<int>(mScrollOffsetInPixels)};
+	const auto highlightPosition = position() + NAS2D::Vector{0, static_cast<int>(mHighlightIndex) * mItemSize.y - mScrollOffsetInPixels};
 	renderer.drawBoxFilled(NAS2D::Rectangle<int>{highlightPosition, mItemSize}, NAS2D::Color{0, 185, 0, 50});
 
 	renderer.clipRectClear();

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -34,7 +34,7 @@ public:
 	static const std::size_t NoSelection;
 
 
-	ListBoxBase(SelectionChangedDelegate selectionChangedHandler = {});
+	ListBoxBase(NAS2D::Vector<int> itemSize, SelectionChangedDelegate selectionChangedHandler = {});
 	~ListBoxBase() override;
 
 	bool isEmpty() const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -77,7 +77,7 @@ private:
 
 	NAS2D::Vector<int> mItemSize{0, 1};
 
-	unsigned int mScrollOffsetInPixels = 0;
+	int mScrollOffsetInPixels = 0;
 	std::size_t mHighlightIndex = NoSelection;
 	std::size_t mSelectedIndex = NoSelection;
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -62,7 +62,7 @@ protected:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
-	unsigned int itemHeight() const;
+	int itemHeight() const;
 
 	NAS2D::Vector<int> itemDrawSize() const;
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -62,7 +62,6 @@ protected:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
-	unsigned int itemWidth() const;
 	unsigned int itemHeight() const;
 
 	unsigned int drawOffset() const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -78,8 +78,7 @@ protected:
 private:
 	ScrollBar mScrollBar;
 
-	int mItemHeight = 1;
-	int mItemWidth = 0;
+	NAS2D::Vector<int> mItemSize{0, 1};
 
 	unsigned int mScrollOffsetInPixels = 0;
 	std::size_t mHighlightIndex = NoSelection;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -64,7 +64,6 @@ protected:
 
 	unsigned int itemWidth() const;
 	unsigned int itemHeight() const;
-	void itemHeight(int);
 
 	unsigned int drawOffset() const;
 	NAS2D::Vector<int> itemDrawSize() const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -62,8 +62,6 @@ protected:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
-	int itemHeight() const;
-
 	NAS2D::Vector<int> itemDrawSize() const;
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -64,7 +64,6 @@ protected:
 
 	unsigned int itemHeight() const;
 
-	unsigned int drawOffset() const;
 	NAS2D::Vector<int> itemDrawSize() const;
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -62,7 +62,6 @@ protected:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
-	NAS2D::Vector<int> itemDrawSize() const;
 	NAS2D::Point<int> itemDrawPosition(std::size_t index) const;
 	NAS2D::Rectangle<int> itemDrawArea(std::size_t index) const;
 


### PR DESCRIPTION
Allow item size to be set using the base class constructor.

Related:
- Issue #479
