### PR TITLE
Add `ESC` quit key to `demoLibControls`

### DIFF
--- a/demoLibControls/MainWindowState.cpp
+++ b/demoLibControls/MainWindowState.cpp
@@ -1,9 +1,15 @@
 #include "MainWindowState.h"
 
 
+MainWindowState::MainWindowState() :
+	nextState{this}
+{
+}
+
+
 NAS2D::State* MainWindowState::update()
 {
 	mainWindow.update();
 
-	return this;
+	return nextState;
 }

--- a/demoLibControls/MainWindowState.cpp
+++ b/demoLibControls/MainWindowState.cpp
@@ -1,9 +1,15 @@
 #include "MainWindowState.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
+#include <NAS2D/EnumKeyCode.h>
+
 
 MainWindowState::MainWindowState() :
 	nextState{this}
 {
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.keyDown().connect({this, &MainWindowState::onKeyDown});
 }
 
 
@@ -12,4 +18,13 @@ NAS2D::State* MainWindowState::update()
 	mainWindow.update();
 
 	return nextState;
+}
+
+
+void MainWindowState::onKeyDown(NAS2D::KeyCode keyCode, NAS2D::KeyModifier /*keyModifier*/, bool /*repeat*/)
+{
+	if (keyCode == NAS2D::KeyCode::Escape)
+	{
+		nextState = nullptr;
+	}
 }

--- a/demoLibControls/MainWindowState.h
+++ b/demoLibControls/MainWindowState.h
@@ -12,6 +12,9 @@ public:
 
 	State* update() override;
 
+protected:
+	void onKeyDown(NAS2D::KeyCode keyCode, NAS2D::KeyModifier keyModifier, bool repeat);
+
 private:
 	MainWindow mainWindow;
 	State* nextState;

--- a/demoLibControls/MainWindowState.h
+++ b/demoLibControls/MainWindowState.h
@@ -8,8 +8,11 @@
 class MainWindowState : public NAS2D::State
 {
 public:
+	MainWindowState();
+
 	State* update() override;
 
 private:
 	MainWindow mainWindow;
+	State* nextState;
 };


### PR DESCRIPTION
A slight convenience when quickly testing and iterating on `libControl` code. Saves having to reach for the mouse, or use a key combo to close the window.

Related:
- Issue #1743
