### PR TITLE
Add method `ProductCatalogue::has(ProductType)`

### DIFF
--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -46,7 +46,7 @@ void ProductListBox::productPool(const ProductPool& pool)
 		if (productCount > 0)
 		{
 			mItems.emplace_back(ProductListBoxItem{
-				ProductCatalogue::get(productType).Name,
+				ProductCatalogue::has(productType) ? ProductCatalogue::get(productType).Name : "Invalid product type",
 				productCount,
 				productCount * pool.productStorageRequirement(productType),
 				pool.capacity()

--- a/libOPHD/ProductCatalogue.cpp
+++ b/libOPHD/ProductCatalogue.cpp
@@ -57,6 +57,12 @@ void ProductCatalogue::init(const std::string& filename)
 }
 
 
+bool ProductCatalogue::has(ProductType type)
+{
+	return mProductTable.contains(type);
+}
+
+
 const ProductCatalogue::Product& ProductCatalogue::get(ProductType type)
 {
 	try

--- a/libOPHD/ProductCatalogue.h
+++ b/libOPHD/ProductCatalogue.h
@@ -28,6 +28,7 @@ public:
 	ProductCatalogue& operator=(ProductCatalogue&& other) noexcept = delete;
 
 	static void init(const std::string& filename);
+	static bool has(ProductType type);
 	static const Product& get(ProductType type);
 
 private:


### PR DESCRIPTION
Would be helpful for testing to have an instance of `ListBoxBase` with enough entries to require scrolling. As `ListBoxBase` only has derived classes in `appOPHD` and not in `libControls`, I opted to try testing this one in game. An easy way to produce a list box with enough entries is to make `ProductListBox` show a line for every available `ProductType`.

To that end, there is a check in `ProductList` box where a `>` can be changed to `>=` to add entries for all `ProductType` reserved values:
```cpp
if (productCount > 0)
```

----

Related:
- Issue #479
