### PR TITLE
Require `ListBox` to have focus for mouse scrolling

### DIFF
--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -253,7 +253,7 @@ protected:
 
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount)
 	{
-		if (!visible() || isEmpty()) { return; }
+		if (!visible() || !hasFocus() || isEmpty()) { return; }
 
 		mScrollBar.changeValue((scrollAmount.y < 0 ? 16 : -16));
 	}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -253,7 +253,7 @@ protected:
 
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount)
 	{
-		if (isEmpty() || !visible()) { return; }
+		if (!visible() || isEmpty()) { return; }
 
 		mScrollBar.changeValue((scrollAmount.y < 0 ? 16 : -16));
 	}

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -206,11 +206,9 @@ void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*r
 
 void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 {
-	if (!enabled() || !visible()) { return; }
-	if (!mHasFocus) { return; }
+	if (!visible() || !hasFocus() || isEmpty()) { return; }
 
 	auto change = static_cast<ScrollBar::ValueType>(mItemSize.y);
-
 	mScrollBar.changeValue((scrollAmount.y < 0 ? change : -change));
 }
 


### PR DESCRIPTION
Previously the `ListBox` could be scrolled with the mouse wheel even when it wasn't the active control. If multiple `ListBox` instances were present, they would all scroll for the same mouse wheel message.

I don't think we need to check for `enabled` though. It seems reasonable to allow a disabled `ListBox` to be scrolled. It just can't have the selection changed.

Related:
- Issue #479
