### PR TITLE
Refactor `ListBox` field types - `int`

### DIFF
--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -153,7 +153,7 @@ void ComboBox::addItem(const std::string& item, int tag)
 	lstItems.add(item, tag);
 
 	if (lstItems.count() > mMaxDisplayItems) { return; }
-	lstItems.height(static_cast<int>(lstItems.count() * lstItems.lineHeight()));
+	lstItems.height(static_cast<int>(lstItems.count()) * lstItems.lineHeight());
 
 	lstItems.clearSelected();
 }

--- a/libControls/ListBox.cpp
+++ b/libControls/ListBox.cpp
@@ -10,9 +10,9 @@ namespace
 }
 
 
-unsigned int ListBoxItemText::Context::itemHeight() const
+int ListBoxItemText::Context::itemHeight() const
 {
-	return static_cast<unsigned int>(font.height() + MarginTight);
+	return font.height() + MarginTight;
 }
 
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -291,12 +291,12 @@ private:
 		// Account for border around control
 		mClientRect = mRect.inset(1);
 
-		const auto neededDisplaySize = mContext.itemHeight() * mItems.size();
-		if (neededDisplaySize > static_cast<std::size_t>(mRect.size.y))
+		const auto neededDisplaySize = static_cast<int>(mContext.itemHeight() * mItems.size());
+		if (neededDisplaySize > mRect.size.y)
 		{
 			mScrollBar.position({area().position.x + mRect.size.x - 14, mRect.position.y});
 			mScrollBar.size({14, mRect.size.y});
-			mScrollBar.max(static_cast<ScrollBar::ValueType>(static_cast<int>(neededDisplaySize) - mRect.size.y));
+			mScrollBar.max(static_cast<ScrollBar::ValueType>(neededDisplaySize - mRect.size.y));
 			mScrollOffsetInPixels = static_cast<std::size_t>(mScrollBar.value());
 			mClientRect.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 			mScrollBar.visible(true);

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -242,8 +242,8 @@ protected:
 			return;
 		}
 
-		const auto dy = position.y - mClientRect.position.y;
-		mHighlightIndex = (static_cast<std::size_t>(dy) + mScrollOffsetInPixels) / static_cast<std::size_t>(mContext.itemHeight());
+		const auto scrollRelativeY = static_cast<int>(mScrollOffsetInPixels) + position.y - mClientRect.position.y;
+		mHighlightIndex = static_cast<std::size_t>(scrollRelativeY / mContext.itemHeight());
 
 		if (mHighlightIndex >= mItems.size())
 		{

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -172,9 +172,9 @@ public:
 	}
 
 
-	unsigned int lineHeight() const
+	int lineHeight() const
 	{
-		return static_cast<unsigned int>(mContext.itemHeight());
+		return mContext.itemHeight();
 	}
 
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -59,6 +59,7 @@ template <typename ListBoxItem = ListBoxItemText>
 class ListBox : public Control
 {
 public:
+	using Context = typename ListBoxItem::Context;
 	using SelectionChangedDelegate = NAS2D::Delegate<void()>;
 
 	static inline constexpr auto NoSelection{std::numeric_limits<std::size_t>::max()};
@@ -309,7 +310,7 @@ private:
 	}
 
 private:
-	typename ListBoxItem::Context mContext;
+	Context mContext;
 
 	ScrollBar mScrollBar;
 	NAS2D::Rectangle<int> mClientRect;

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -243,12 +243,8 @@ protected:
 		}
 
 		const auto scrollRelativeY = static_cast<int>(mScrollOffsetInPixels) + position.y - mClientRect.position.y;
-		mHighlightIndex = static_cast<std::size_t>(scrollRelativeY / mContext.itemHeight());
-
-		if (mHighlightIndex >= mItems.size())
-		{
-			mHighlightIndex = NoSelection;
-		}
+		const auto index = static_cast<std::size_t>(scrollRelativeY / mContext.itemHeight());
+		mHighlightIndex = (index < mItems.size()) ? index : NoSelection;
 	}
 
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -43,7 +43,7 @@ struct ListBoxItemText
 		NAS2D::Color textColorNormal = NAS2D::Color::White;
 		NAS2D::Color textColorMouseHover = NAS2D::Color::White;
 
-		unsigned int itemHeight() const;
+		int itemHeight() const;
 	};
 
 	void draw(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> itemDrawRect, const Context& context, bool isSelected, bool isHighlighted) const;
@@ -174,7 +174,7 @@ public:
 
 	unsigned int lineHeight() const
 	{
-		return mContext.itemHeight();
+		return static_cast<unsigned int>(mContext.itemHeight());
 	}
 
 
@@ -198,7 +198,7 @@ protected:
 		renderer.clipRect(mRect);
 
 		// display actuals values that are meant to be
-		const auto lineHeight = mContext.itemHeight();
+		const auto lineHeight = static_cast<unsigned int>(mContext.itemHeight());
 		const auto firstVisibleIndex = mScrollOffsetInPixels / lineHeight;
 		const auto lastVisibleIndex = (mScrollOffsetInPixels + static_cast<std::size_t>(mClientRect.size.y) + (lineHeight - 1)) / lineHeight;
 		const auto endVisibleIndex = std::min(lastVisibleIndex, mItems.size());
@@ -291,7 +291,7 @@ private:
 		// Account for border around control
 		mClientRect = mRect.inset(1);
 
-		const auto neededDisplaySize = static_cast<int>(mContext.itemHeight() * mItems.size());
+		const auto neededDisplaySize = mContext.itemHeight() * static_cast<int>(mItems.size());
 		if (neededDisplaySize > mRect.size.y)
 		{
 			mScrollBar.position({area().position.x + mRect.size.x - 14, mRect.position.y});

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -198,13 +198,13 @@ protected:
 		renderer.clipRect(mRect);
 
 		// display actuals values that are meant to be
-		const auto lineHeight = static_cast<unsigned int>(mContext.itemHeight());
-		const auto firstVisibleIndex = mScrollOffsetInPixels / lineHeight;
-		const auto lastVisibleIndex = (mScrollOffsetInPixels + static_cast<std::size_t>(mClientRect.size.y) + (lineHeight - 1)) / lineHeight;
+		const auto lineHeight = mContext.itemHeight();
+		const auto firstVisibleIndex = static_cast<std::size_t>(mScrollOffsetInPixels / lineHeight);
+		const auto lastVisibleIndex = static_cast<std::size_t>((mScrollOffsetInPixels + mClientRect.size.y + (lineHeight - 1)) / lineHeight);
 		const auto endVisibleIndex = std::min(lastVisibleIndex, mItems.size());
 		auto itemDrawRect = mClientRect;
-		itemDrawRect.position.y += -static_cast<int>(mScrollOffsetInPixels % lineHeight);
-		itemDrawRect.size.y = static_cast<int>(lineHeight);
+		itemDrawRect.position.y += -(mScrollOffsetInPixels % lineHeight);
+		itemDrawRect.size.y = lineHeight;
 		for (std::size_t i = firstVisibleIndex; i < endVisibleIndex; i++)
 		{
 			const auto isSelected = (i == mSelectedIndex);
@@ -212,7 +212,7 @@ protected:
 
 			mItems[i].draw(renderer, itemDrawRect, mContext, isSelected, isHighlighted);
 
-			itemDrawRect.position.y += static_cast<int>(lineHeight);
+			itemDrawRect.position.y += lineHeight;
 		}
 
 		// Paint remaining section of scroll area not covered by items
@@ -293,7 +293,7 @@ private:
 			mScrollBar.position({area().position.x + mRect.size.x - 14, mRect.position.y});
 			mScrollBar.size({14, mRect.size.y});
 			mScrollBar.max(static_cast<ScrollBar::ValueType>(neededDisplaySize - mRect.size.y));
-			mScrollOffsetInPixels = static_cast<std::size_t>(mScrollBar.value());
+			mScrollOffsetInPixels = mScrollBar.value();
 			mClientRect.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 			mScrollBar.visible(true);
 		}
@@ -311,7 +311,7 @@ private:
 	ScrollBar mScrollBar;
 	NAS2D::Rectangle<int> mClientRect;
 
-	std::size_t mScrollOffsetInPixels = 0;
+	int mScrollOffsetInPixels = 0;
 	std::size_t mHighlightIndex = NoSelection;
 	std::size_t mSelectedIndex = 0;
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -68,6 +68,7 @@ public:
 	ListBox(SelectionChangedDelegate selectionChangedHandler = {}) :
 		mContext{getDefaultFont()},
 		mScrollBar{ScrollBar::ScrollBarType::Vertical, {this, &ListBox::onSlideChange}},
+		mItemSize{0, static_cast<int>(mContext.itemHeight())},
 		mSelectionChangedHandler{selectionChangedHandler}
 	{
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &ListBox::onMouseDown});
@@ -174,7 +175,7 @@ public:
 
 	int lineHeight() const
 	{
-		return mContext.itemHeight();
+		return mItemSize.y;
 	}
 
 
@@ -198,7 +199,7 @@ protected:
 		renderer.clipRect(mRect);
 
 		// display actuals values that are meant to be
-		const auto lineHeight = mContext.itemHeight();
+		const auto lineHeight = mItemSize.y;
 		const auto firstVisibleIndex = static_cast<std::size_t>(mScrollOffsetInPixels / lineHeight);
 		const auto lastVisibleIndex = static_cast<std::size_t>((mScrollOffsetInPixels + mClientRect.size.y + (lineHeight - 1)) / lineHeight);
 		const auto endVisibleIndex = std::min(lastVisibleIndex, mItems.size());
@@ -243,7 +244,7 @@ protected:
 		}
 
 		const auto scrollRelativeY = static_cast<int>(mScrollOffsetInPixels) + position.y - mClientRect.position.y;
-		const auto index = static_cast<std::size_t>(scrollRelativeY / mContext.itemHeight());
+		const auto index = static_cast<std::size_t>(scrollRelativeY / mItemSize.y);
 		mHighlightIndex = (index < mItems.size()) ? index : NoSelection;
 	}
 
@@ -287,7 +288,7 @@ private:
 		// Account for border around control
 		mClientRect = mRect.inset(1);
 
-		const auto neededDisplaySize = mContext.itemHeight() * static_cast<int>(mItems.size());
+		const auto neededDisplaySize = mItemSize.y * static_cast<int>(mItems.size());
 		if (neededDisplaySize > mRect.size.y)
 		{
 			mScrollBar.position({area().position.x + mRect.size.x - 14, mRect.position.y});
@@ -310,6 +311,7 @@ private:
 
 	ScrollBar mScrollBar;
 	NAS2D::Rectangle<int> mClientRect;
+	NAS2D::Vector<int> mItemSize;
 
 	int mScrollOffsetInPixels = 0;
 	std::size_t mHighlightIndex = NoSelection;

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -195,12 +195,9 @@ void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*r
 		return;
 	}
 
-	mHighlightIndex = (static_cast<unsigned int>(mScrollOffsetInPixels + position.y - this->position().y)) / static_cast<unsigned int>(mItemSize.y);
-
-	if (mHighlightIndex >= count())
-	{
-		mHighlightIndex = NoSelection;
-	}
+	const auto scrollRelativeY = mScrollOffsetInPixels + position.y - this->position().y;
+	const auto index = static_cast<std::size_t>(scrollRelativeY / mItemSize.y);
+	mHighlightIndex = (index < count()) ? index : NoSelection;
 }
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -72,7 +72,7 @@ protected:
 private:
 	ScrollBar mScrollBar;
 
-	NAS2D::Vector<int> mItemSize{0, 1};
+	NAS2D::Vector<int> mItemSize;
 
 	int mScrollOffsetInPixels = 0;
 	std::size_t mHighlightIndex = NoSelection;


### PR DESCRIPTION
Be consistent about field types between `ListBox` and `ListBoxBase`.

Prefer `int` for graphics calculations.

Related:
- Issue #479
