### PR TITLE
Add `ComboBox` to `demoLibControls`

### DIFF
--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -39,11 +39,26 @@ MainWindow::MainWindow() :
 	listBox2.add("Item 2");
 	listBox2.add("Item 3");
 
+	comboBox1.size({70, 20});
+	comboBox1.addItem("Item1");
+	comboBox1.addItem("Item2");
+	comboBox1.addItem("Item3");
+	comboBox1.addItem("Item4");
+	comboBox1.addItem("Item5");
+	comboBox1.addItem("Item6");
+
+	comboBox2.size({60, 20});
+	comboBox2.addItem("Item1");
+	comboBox2.addItem("Item2");
+	comboBox2.addItem("Item3");
+
 	add(button, {10, 30});
 	add(label, {10, 56});
 	add(radioButtonGroup, {10, 80});
 	add(listBox1, {130, 30});
 	add(listBox2, {220, 30});
+	add(comboBox1, {310, 30});
+	add(comboBox2, {400, 30});
 	add(image, {10, 140});
 	add(progressBar, {10, 270});
 	add(rectangle1, {10, 300});

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -9,6 +9,7 @@
 #include <libControls/RadioButtonGroup.h>
 #include <libControls/Rectangle.h>
 #include <libControls/ListBox.h>
+#include <libControls/ComboBox.h>
 
 
 class MainWindow : public Window
@@ -30,4 +31,6 @@ private:
 	Rectangle rectangle2;
 	ListBox<> listBox1;
 	ListBox<> listBox2;
+	ComboBox comboBox1;
+	ComboBox comboBox2;
 };


### PR DESCRIPTION
Note: At present there is an uncaught exception which can be triggered when clicking on a `ComboBox` list to select an item, and the `width` of the `ComboBox` is too narrow to display the full string. The problem occurs in `TextField::onMouseDown` when `substr` is called with an invalid `scrollOffset` value.

Related:
- Issue #1743
- Issue #1872
