### PR TITLE
Update `ListBox` small scroll size

### DIFF
--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -253,7 +253,7 @@ protected:
 	{
 		if (!visible() || !hasFocus() || isEmpty()) { return; }
 
-		mScrollBar.changeValue((scrollAmount.y < 0 ? lineHeight() : -lineHeight()));
+		mScrollBar.changeValue((scrollAmount.y < 0 ? mItemSize.y : -mItemSize.y));
 	}
 
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -68,7 +68,7 @@ public:
 	ListBox(SelectionChangedDelegate selectionChangedHandler = {}) :
 		mContext{getDefaultFont()},
 		mScrollBar{ScrollBar::ScrollBarType::Vertical, mContext.itemHeight(), {this, &ListBox::onSlideChange}},
-		mItemSize{0, static_cast<int>(mContext.itemHeight())},
+		mItemSize{0, mContext.itemHeight()},
 		mSelectionChangedHandler{selectionChangedHandler}
 	{
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &ListBox::onMouseDown});
@@ -241,7 +241,7 @@ protected:
 			return;
 		}
 
-		const auto scrollRelativeY = static_cast<int>(mScrollOffsetInPixels) + position.y - mScrollArea.position.y;
+		const auto scrollRelativeY = mScrollOffsetInPixels + position.y - mScrollArea.position.y;
 		const auto index = static_cast<std::size_t>(scrollRelativeY / mItemSize.y);
 		mHighlightIndex = (index < count()) ? index : NoSelection;
 	}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -75,8 +75,6 @@ public:
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &ListBox::onMouseMove});
 		NAS2D::Utility<NAS2D::EventHandler>::get().mouseWheel().connect({this, &ListBox::onMouseWheel});
 
-		mScrollBar.max(0);
-		mScrollBar.value(0);
 		updateScrollLayout();
 	}
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -253,7 +253,7 @@ protected:
 	{
 		if (!visible() || !hasFocus() || isEmpty()) { return; }
 
-		mScrollBar.changeValue((scrollAmount.y < 0 ? 16 : -16));
+		mScrollBar.changeValue((scrollAmount.y < 0 ? lineHeight() : -lineHeight()));
 	}
 
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -257,7 +257,7 @@ protected:
 	}
 
 
-	virtual void onSlideChange(ScrollBar::ValueType /*newPosition*/)
+	virtual void onSlideChange(int /*newPosition*/)
 	{
 		updateScrollLayout();
 	}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -156,7 +156,7 @@ public:
 	template <typename UnaryPredicate>
 	void selectIf(UnaryPredicate predicate)
 	{
-		for (std::size_t i = 0; i < mItems.size(); ++i)
+		for (std::size_t i = 0; i < count(); ++i)
 		{
 			if (predicate(mItems[i]))
 			{
@@ -202,7 +202,7 @@ protected:
 		const auto lineHeight = mItemSize.y;
 		const auto firstVisibleIndex = static_cast<std::size_t>(mScrollOffsetInPixels / lineHeight);
 		const auto firstInvisibleIndex = static_cast<std::size_t>((mScrollOffsetInPixels + mScrollArea.size.y + (lineHeight - 1)) / lineHeight);
-		const auto endVisibleIndex = std::min(firstInvisibleIndex, mItems.size());
+		const auto endVisibleIndex = std::min(firstInvisibleIndex, count());
 		auto itemDrawRect = mScrollArea;
 		itemDrawRect.position.y += -(mScrollOffsetInPixels % lineHeight);
 		itemDrawRect.size.y = lineHeight;
@@ -226,7 +226,7 @@ protected:
 
 	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 	{
-		if (!visible() || mHighlightIndex == NoSelection || mHighlightIndex >= mItems.size() || !mScrollArea.contains(position))
+		if (!visible() || mHighlightIndex == NoSelection || mHighlightIndex >= count() || !mScrollArea.contains(position))
 		{
 			return;
 		}
@@ -245,7 +245,7 @@ protected:
 
 		const auto scrollRelativeY = static_cast<int>(mScrollOffsetInPixels) + position.y - mScrollArea.position.y;
 		const auto index = static_cast<std::size_t>(scrollRelativeY / mItemSize.y);
-		mHighlightIndex = (index < mItems.size()) ? index : NoSelection;
+		mHighlightIndex = (index < count()) ? index : NoSelection;
 	}
 
 
@@ -288,7 +288,7 @@ private:
 		// Account for border around control
 		mScrollArea = mRect.inset(1);
 
-		const auto neededDisplaySize = mItemSize.y * static_cast<int>(mItems.size());
+		const auto neededDisplaySize = mItemSize.y * static_cast<int>(count());
 		if (neededDisplaySize > mRect.size.y)
 		{
 			mScrollBar.size({14, mScrollArea.size.y});

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -67,7 +67,7 @@ public:
 
 	ListBox(SelectionChangedDelegate selectionChangedHandler = {}) :
 		mContext{getDefaultFont()},
-		mScrollBar{ScrollBar::ScrollBarType::Vertical, {this, &ListBox::onSlideChange}},
+		mScrollBar{ScrollBar::ScrollBarType::Vertical, mContext.itemHeight(), {this, &ListBox::onSlideChange}},
 		mItemSize{0, static_cast<int>(mContext.itemHeight())},
 		mSelectionChangedHandler{selectionChangedHandler}
 	{

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -293,7 +293,7 @@ private:
 		{
 			mScrollBar.size({14, mScrollArea.size.y});
 			mScrollBar.position({mScrollArea.position.x + mScrollArea.size.x - mScrollBar.size().x, mScrollArea.position.y});
-			mScrollBar.max(static_cast<ScrollBar::ValueType>(neededDisplaySize - mRect.size.y));
+			mScrollBar.max(neededDisplaySize - mRect.size.y);
 			mScrollOffsetInPixels = mScrollBar.value();
 			mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 			mScrollBar.visible(true);

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -113,11 +113,12 @@ void ListBoxBase::updateScrollLayout()
 	// Account for border around control
 	const auto scrollArea = mRect.inset(1);
 
-	if ((mItemSize.y * static_cast<int>(count())) > mRect.size.y)
+	const auto neededDisplaySize = mItemSize.y * static_cast<int>(count());
+	if (neededDisplaySize > mRect.size.y)
 	{
 		mScrollBar.size({14, scrollArea.size.y});
 		mScrollBar.position({scrollArea.position.x + scrollArea.size.x - mScrollBar.size().x, scrollArea.position.y});
-		mScrollBar.max(mItemSize.y * static_cast<int>(count()) - mRect.size.y);
+		mScrollBar.max(neededDisplaySize - mRect.size.y);
 		mScrollOffsetInPixels = mScrollBar.value();
 		mItemSize.x -= mScrollBar.size().x;
 		mScrollBar.visible(true);

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -22,9 +22,6 @@ ListBoxBase::ListBoxBase(NAS2D::Vector<int> itemSize, SelectionChangedDelegate s
 	eventHandler.mouseWheel().connect({this, &ListBoxBase::onMouseWheel});
 	eventHandler.mouseButtonDown().connect({this, &ListBoxBase::onMouseDown});
 	eventHandler.mouseMotion().connect({this, &ListBoxBase::onMouseMove});
-
-	mScrollBar.max(0);
-	mScrollBar.value(0);
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -117,7 +117,7 @@ void ListBoxBase::updateScrollLayout()
 	{
 		mScrollBar.size({14, scrollArea.size.y});
 		mScrollBar.position({scrollArea.position.x + scrollArea.size.x - mScrollBar.size().x, scrollArea.position.y});
-		mScrollBar.max(static_cast<ScrollBar::ValueType>(mItemSize.y * static_cast<int>(count()) - mRect.size.y));
+		mScrollBar.max(mItemSize.y * static_cast<int>(count()) - mRect.size.y);
 		mScrollOffsetInPixels = mScrollBar.value();
 		mItemSize.x -= mScrollBar.size().x;
 		mScrollBar.visible(true);

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -14,7 +14,7 @@ const std::size_t ListBoxBase::NoSelection{std::numeric_limits<std::size_t>::max
 
 
 ListBoxBase::ListBoxBase(NAS2D::Vector<int> itemSize, SelectionChangedDelegate selectionChangedHandler) :
-	mScrollBar{ScrollBar::ScrollBarType::Vertical, {this, &ListBoxBase::onSlideChange}},
+	mScrollBar{ScrollBar::ScrollBarType::Vertical, itemSize.y, {this, &ListBoxBase::onSlideChange}},
 	mItemSize{itemSize},
 	mSelectionChangedHandler{selectionChangedHandler}
 {

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -152,7 +152,7 @@ void ListBoxBase::onResize()
 /**
  * ScrollBar changed event handler.
  */
-void ListBoxBase::onSlideChange(ScrollBar::ValueType /*newPosition*/)
+void ListBoxBase::onSlideChange(int /*newPosition*/)
 {
 	updateScrollLayout();
 }

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -208,8 +208,7 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 {
 	if (!visible() || !hasFocus() || isEmpty()) { return; }
 
-	auto change = static_cast<ScrollBar::ValueType>(mItemSize.y);
-	mScrollBar.changeValue((scrollAmount.y < 0 ? change : -change));
+	mScrollBar.changeValue((scrollAmount.y < 0 ? mItemSize.y : -mItemSize.y));
 }
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -57,7 +57,7 @@ protected:
 
 	void onVisibilityChange(bool visible) override;
 	void onResize() override;
-	void onSlideChange(ScrollBar::ValueType newPosition);
+	void onSlideChange(int newPosition);
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -72,7 +72,7 @@ ScrollBar::ValueType ScrollBar::value() const
 void ScrollBar::value(ValueType newValue)
 {
 	const auto oldValue = mValue;
-	mValue = std::clamp<ValueType>(newValue, 0, mMax);
+	mValue = std::clamp(newValue, 0, mMax);
 	if (mValue != oldValue)
 	{
 		if(mValueChangeHandler) { mValueChangeHandler(mValue); }

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -36,14 +36,15 @@ namespace
 }
 
 
-ScrollBar::ScrollBar(ScrollBarType scrollBarType, ValueChangeDelegate valueChangeHandler) :
-	ScrollBar{loadSkins(scrollBarType), scrollBarType, valueChangeHandler}
+ScrollBar::ScrollBar(ScrollBarType scrollBarType, int smallChange, ValueChangeDelegate valueChangeHandler) :
+	ScrollBar{loadSkins(scrollBarType), scrollBarType, smallChange, valueChangeHandler}
 {
 }
 
 
-ScrollBar::ScrollBar(ScrollBar::Skins skins, ScrollBarType scrollBarType, ValueChangeDelegate valueChangeHandler) :
+ScrollBar::ScrollBar(ScrollBar::Skins skins, ScrollBarType scrollBarType, int smallChange, ValueChangeDelegate valueChangeHandler) :
 	mScrollBarType{scrollBarType},
+	mSmallChange{smallChange},
 	mValueChangeHandler{valueChangeHandler},
 	mSkins{skins}
 {
@@ -109,7 +110,7 @@ void ScrollBar::update()
 		{
 			mPressedAccumulator = 30;
 			mTimer.reset();
-			changeValue((mButtonDecreaseHeld ? -1 : 1));
+			changeValue((mButtonDecreaseHeld ? -mSmallChange : mSmallChange));
 		}
 	}
 
@@ -150,11 +151,11 @@ void ScrollBar::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> positio
 		}
 		else if (mButtonDecreaseRect.contains(position))
 		{
-			onButtonClick(mButtonDecreaseHeld, -1);
+			onButtonClick(mButtonDecreaseHeld, -mSmallChange);
 		}
 		else if (mButtonIncreaseRect.contains(position))
 		{
-			onButtonClick(mButtonIncreaseHeld, 1);
+			onButtonClick(mButtonIncreaseHeld, mSmallChange);
 		}
 	}
 }

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -63,13 +63,13 @@ ScrollBar::~ScrollBar()
 }
 
 
-ScrollBar::ValueType ScrollBar::value() const
+int ScrollBar::value() const
 {
 	return mValue;
 }
 
 
-void ScrollBar::value(ValueType newValue)
+void ScrollBar::value(int newValue)
 {
 	const auto oldValue = mValue;
 	mValue = std::clamp(newValue, 0, mMax);
@@ -80,19 +80,19 @@ void ScrollBar::value(ValueType newValue)
 }
 
 
-void ScrollBar::changeValue(ValueType change)
+void ScrollBar::changeValue(int change)
 {
 	value(mValue + change);
 }
 
 
-ScrollBar::ValueType ScrollBar::max() const
+int ScrollBar::max() const
 {
 	return mMax;
 }
 
 
-void ScrollBar::max(ValueType newMax)
+void ScrollBar::max(int newMax)
 {
 	mMax = newMax;
 	value(mValue); // Re-clamp to new max
@@ -128,7 +128,7 @@ void ScrollBar::draw() const
 }
 
 
-void ScrollBar::onButtonClick(bool& buttonFlag, ValueType value)
+void ScrollBar::onButtonClick(bool& buttonFlag, int value)
 {
 	changeValue(value);
 	buttonFlag = true;

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -61,8 +61,8 @@ protected:
 
 private:
 	ScrollBarType mScrollBarType{ScrollBarType::Vertical};
-	int mValue{0};
 	int mMax{0};
+	int mValue{0};
 	ValueChangeDelegate mValueChangeHandler;
 
 	// ScrollBar button responses

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -60,7 +60,7 @@ protected:
 	void onLayoutChange();
 
 private:
-	ScrollBarType mScrollBarType{ScrollBarType::Vertical};
+	const ScrollBarType mScrollBarType;
 	int mMax{0};
 	int mValue{0};
 	ValueChangeDelegate mValueChangeHandler;

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -31,27 +31,26 @@ public:
 		NAS2D::RectangleSkin skinButtonIncrease;
 	};
 
-	using ValueType = int;
-	using ValueChangeDelegate = NAS2D::Delegate<void(ValueType)>;
+	using ValueChangeDelegate = NAS2D::Delegate<void(int)>;
 
 
 	ScrollBar(ScrollBarType scrollBarType = ScrollBarType::Vertical, ValueChangeDelegate valueChangeHandler = {});
 	ScrollBar(Skins skins, ScrollBarType scrollBarType = ScrollBarType::Vertical, ValueChangeDelegate valueChangeHandler = {});
 	~ScrollBar() override;
 
-	ValueType value() const;
-	void value(ValueType newValue);
-	void changeValue(ValueType change);
+	int value() const;
+	void value(int newValue);
+	void changeValue(int change);
 
-	ValueType max() const;
-	void max(ValueType newMax);
+	int max() const;
+	void max(int newMax);
 
 	void update() override;
 
 protected:
 	void draw() const override;
 
-	void onButtonClick(bool& buttonFlag, ValueType value);
+	void onButtonClick(bool& buttonFlag, int value);
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
@@ -62,8 +61,8 @@ protected:
 
 private:
 	ScrollBarType mScrollBarType{ScrollBarType::Vertical};
-	ValueType mValue{0};
-	ValueType mMax{0};
+	int mValue{0};
+	int mMax{0};
 	ValueChangeDelegate mValueChangeHandler;
 
 	// ScrollBar button responses

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -73,7 +73,7 @@ private:
 	bool mButtonIncreaseHeld{false};
 
 	// Drawing vars
-	Skins mSkins;
+	const Skins mSkins;
 	NAS2D::Rectangle<int> mTrackRect;
 	NAS2D::Rectangle<int> mThumbRect;
 	NAS2D::Rectangle<int> mButtonDecreaseRect; // Top/Left

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -34,8 +34,8 @@ public:
 	using ValueChangeDelegate = NAS2D::Delegate<void(int)>;
 
 
-	ScrollBar(ScrollBarType scrollBarType = ScrollBarType::Vertical, ValueChangeDelegate valueChangeHandler = {});
-	ScrollBar(Skins skins, ScrollBarType scrollBarType = ScrollBarType::Vertical, ValueChangeDelegate valueChangeHandler = {});
+	ScrollBar(ScrollBarType scrollBarType = ScrollBarType::Vertical, int smallChange = 1, ValueChangeDelegate valueChangeHandler = {});
+	ScrollBar(Skins skins, ScrollBarType scrollBarType = ScrollBarType::Vertical, int smallChange = 1, ValueChangeDelegate valueChangeHandler = {});
 	~ScrollBar() override;
 
 	int value() const;
@@ -61,6 +61,7 @@ protected:
 
 private:
 	const ScrollBarType mScrollBarType;
+	const int mSmallChange;
 	int mMax{0};
 	int mValue{0};
 	ValueChangeDelegate mValueChangeHandler;


### PR DESCRIPTION
Allow `ListBox` to be scrolled by one item at a time, rather than 1 pixel at a time.

The `ScrollBar` was updated to allow specifying a `smallChange` value, which is the scroll amount when the up/down buttons are clicked. For smooth pixel scrolling, the `ScrollBar` values can be the pixel offset, while the `smallChange` value can be the item size. When not specified, the `smallChange` value defaults to `1`, matching the previous behavior. A value of `1` may make more sense when the `ScrollBar` values represent item counts, rather than pixel offsets.

The `ListBox` makes use of this new feature to scroll by `itemSize.y`, which is much more natural than scrolling by 1 pixel at a time. The mouse wheel scroll was also updated to use `itemSize.y`, for matching behavior.

Related:
- Issue #479
- Issue #1754
