### PR TITLE
Fix `ComboBox` drop down list size

### DIFF
--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -149,7 +149,7 @@ void ComboBox::addItem(const std::string& item, int tag)
 	lstItems.add(item, tag);
 
 	if (lstItems.count() > mMaxDisplayItems) { return; }
-	lstItems.height(static_cast<int>(lstItems.count()) * lstItems.lineHeight());
+	lstItems.height(static_cast<int>(lstItems.count()) * lstItems.itemHeight());
 
 	lstItems.clearSelected();
 }

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -149,7 +149,7 @@ void ComboBox::addItem(const std::string& item, int tag)
 	lstItems.add(item, tag);
 
 	if (lstItems.count() > mMaxDisplayItems) { return; }
-	lstItems.height(static_cast<int>(lstItems.count()) * lstItems.itemHeight());
+	lstItems.height(static_cast<int>(lstItems.count()) * lstItems.itemHeight() + 2);
 
 	lstItems.clearSelected();
 }

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -171,7 +171,7 @@ public:
 	}
 
 
-	int lineHeight() const
+	int itemHeight() const
 	{
 		return mItemSize.y;
 	}


### PR DESCRIPTION
Slightly increase the `ComboBox` drop down list size to account for the border.

Without the size increase, the highlight box for the final item can be clipped along the bottom.

Original:
![image](https://github.com/user-attachments/assets/8b2e3bec-80c1-4611-82fd-65097ac141de)

Updated:
![image](https://github.com/user-attachments/assets/ac6b40e6-7de3-4b7a-a0ec-7cfe22f9b942)

----

Related:
- Issue #479
- Issue #1754
