### PR TITLE
Make mouse down handling consistent between `ListBox` and `ListBoxBase`

### DIFF
--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -2,6 +2,8 @@
 
 #include "Control.h"
 #include "ScrollBar.h"
+
+#include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/EventHandler.h>
@@ -222,9 +224,10 @@ protected:
 	}
 
 
-	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
+	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 	{
 		if (!visible() || !enabled() || !mRect.contains(position)) { return; }
+		if (isEmpty() || button == NAS2D::MouseButton::Middle) { return; }
 
 		if (mHighlightIndex == NoSelection || !mScrollArea.contains(position)) { return; }
 		setSelected(mHighlightIndex);

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -302,6 +302,8 @@ private:
 			mScrollBar.max(0);
 			mScrollBar.visible(false);
 		}
+
+		mItemSize.x = mScrollArea.size.x;
 	}
 
 private:

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -225,11 +225,8 @@ protected:
 	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 	{
 		if (!visible() || !enabled() || !mRect.contains(position)) { return; }
-		if (mHighlightIndex == NoSelection || !mScrollArea.contains(position))
-		{
-			return;
-		}
 
+		if (mHighlightIndex == NoSelection || !mScrollArea.contains(position)) { return; }
 		setSelected(mHighlightIndex);
 	}
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -224,7 +224,8 @@ protected:
 
 	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 	{
-		if (!visible() || !enabled() || mHighlightIndex == NoSelection || mHighlightIndex >= count() || !mScrollArea.contains(position))
+		if (!visible() || !enabled() || !mRect.contains(position)) { return; }
+		if (mHighlightIndex == NoSelection || mHighlightIndex >= count() || !mScrollArea.contains(position))
 		{
 			return;
 		}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -225,7 +225,7 @@ protected:
 	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 	{
 		if (!visible() || !enabled() || !mRect.contains(position)) { return; }
-		if (mHighlightIndex == NoSelection || mHighlightIndex >= count() || !mScrollArea.contains(position))
+		if (mHighlightIndex == NoSelection || !mScrollArea.contains(position))
 		{
 			return;
 		}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -224,7 +224,7 @@ protected:
 
 	virtual void onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 	{
-		if (!visible() || mHighlightIndex == NoSelection || mHighlightIndex >= count() || !mScrollArea.contains(position))
+		if (!visible() || !enabled() || mHighlightIndex == NoSelection || mHighlightIndex >= count() || !mScrollArea.contains(position))
 		{
 			return;
 		}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -229,6 +229,12 @@ protected:
 		if (!visible() || !enabled() || !mRect.contains(position)) { return; }
 		if (isEmpty() || button == NAS2D::MouseButton::Middle) { return; }
 
+		if (button == NAS2D::MouseButton::Right)
+		{
+			clearSelected();
+			return;
+		}
+
 		if (mHighlightIndex == NoSelection || !mScrollArea.contains(position)) { return; }
 		setSelected(mHighlightIndex);
 	}

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -170,7 +170,6 @@ void ListBoxBase::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> posit
 	// A few basic checks
 	if (mHighlightIndex == NoSelection) { return; }
 	if (mScrollBar.visible() && mScrollBar.area().contains(position)) { return; }
-	if (mHighlightIndex >= count()) { return; }
 
 	setSelection(mHighlightIndex);
 }

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -105,19 +105,17 @@ void ListBoxBase::clear()
  */
 void ListBoxBase::updateScrollLayout()
 {
-	mItemSize.x = mRect.size.x;
-
 	// Account for border around control
-	const auto scrollArea = mRect.inset(1);
+	mScrollArea = mRect.inset(1);
 
 	const auto neededDisplaySize = mItemSize.y * static_cast<int>(count());
 	if (neededDisplaySize > mRect.size.y)
 	{
-		mScrollBar.size({14, scrollArea.size.y});
-		mScrollBar.position({scrollArea.position.x + scrollArea.size.x - mScrollBar.size().x, scrollArea.position.y});
+		mScrollBar.size({14, mScrollArea.size.y});
+		mScrollBar.position({mScrollArea.position.x + mScrollArea.size.x - mScrollBar.size().x, mScrollArea.position.y});
 		mScrollBar.max(neededDisplaySize - mRect.size.y);
 		mScrollOffsetInPixels = mScrollBar.value();
-		mItemSize.x -= mScrollBar.size().x;
+		mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 		mScrollBar.visible(true);
 	}
 	else
@@ -126,6 +124,8 @@ void ListBoxBase::updateScrollLayout()
 		mScrollBar.max(0);
 		mScrollBar.visible(false);
 	}
+
+	mItemSize.x = mScrollArea.size.x;
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -157,7 +157,7 @@ void ListBoxBase::onSlideChange(int /*newPosition*/)
 
 void ListBoxBase::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 {
-	if (!enabled() || !visible()) { return; }
+	if (!visible() || !enabled()) { return; }
 
 	if (isEmpty() || button == NAS2D::MouseButton::Middle) { return; }
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -157,18 +157,18 @@ void ListBoxBase::onSlideChange(int /*newPosition*/)
 
 void ListBoxBase::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 {
-	if (!visible() || !enabled()) { return; }
+	if (!visible() || !enabled() || !mRect.contains(position)) { return; }
 
 	if (isEmpty() || button == NAS2D::MouseButton::Middle) { return; }
 
-	if (button == NAS2D::MouseButton::Right && mRect.contains(position))
+	if (button == NAS2D::MouseButton::Right)
 	{
 		clearSelected();
 		return;
 	}
 
 	// A few basic checks
-	if (!area().contains(position) || mHighlightIndex == NoSelection) { return; }
+	if (mHighlightIndex == NoSelection) { return; }
 	if (mScrollBar.visible() && mScrollBar.area().contains(position)) { return; }
 	if (mHighlightIndex >= count()) { return; }
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -158,7 +158,6 @@ void ListBoxBase::onSlideChange(int /*newPosition*/)
 void ListBoxBase::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!visible() || !enabled() || !mRect.contains(position)) { return; }
-
 	if (isEmpty() || button == NAS2D::MouseButton::Middle) { return; }
 
 	if (button == NAS2D::MouseButton::Right)

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -166,10 +166,7 @@ void ListBoxBase::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> posit
 		return;
 	}
 
-	// A few basic checks
-	if (mHighlightIndex == NoSelection) { return; }
-	if (mScrollBar.visible() && mScrollBar.area().contains(position)) { return; }
-
+	if (mHighlightIndex == NoSelection || !mScrollArea.contains(position)) { return; }
 	setSelection(mHighlightIndex);
 }
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -71,7 +71,7 @@ protected:
 
 private:
 	ScrollBar mScrollBar;
-
+	NAS2D::Rectangle<int> mScrollArea;
 	NAS2D::Vector<int> mItemSize;
 
 	int mScrollOffsetInPixels = 0;


### PR DESCRIPTION
Make the `onMouseDown` event processing for `ListBox` and `ListBoxBase` consistent with each other.

Also includes some changes to add a `mScrollArea` field, used by mouse handling code, and make `updateScrollLayout` consistent with each other, where `mScrollArea` is set.

Enabled right-click unselect for both list box types, and consistently ignores middle click. Adjusts response zones for left vs right click. Ignore certain input when not `enabled()`. Use consistent early return when there is no processing to do.
