### PR TITLE
Fix `ListBoxBase` draw offsets

### DIFF
--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -207,7 +207,7 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 
 NAS2D::Point<int> ListBoxBase::itemDrawPosition(std::size_t index) const
 {
-	return position() + NAS2D::Vector{0, static_cast<int>(index) * mItemSize.y - mScrollOffsetInPixels};
+	return mScrollArea.position + NAS2D::Vector{0, static_cast<int>(index) * mItemSize.y - mScrollOffsetInPixels};
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -253,7 +253,7 @@ void ListBoxBase::drawItems() const
 			renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75));
 		}
 		// Draw border
-		renderer.drawBox(drawArea.inset(2), borderColor);
+		renderer.drawBox(drawArea.inset(1), borderColor);
 
 		drawItem(renderer, drawArea, index);
 	}

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -265,8 +265,7 @@ void ListBoxBase::draw() const
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// CONTROL EXTENTS
-	const auto backgroundRect = NAS2D::Rectangle<int>{{mRect.position.x, mRect.position.y}, {mItemSize.x, mRect.size.y}};
-	renderer.drawBoxFilled(backgroundRect, NAS2D::Color::Black);
+	renderer.drawBoxFilled(mScrollArea, NAS2D::Color::Black);
 	renderer.drawBox(mRect, (hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75}));
 
 	renderer.clipRect(mRect.inset(1));


### PR DESCRIPTION
Fixes the graphical bug introduced in the previous change (PR #1877).

This moves items slightly closer together in the Y-direction, though this seems to better balance the space around the items in the different directions.

Original:
![image](https://github.com/user-attachments/assets/06634874-a639-49a6-8d2c-be725d998be6)

Updated:
![image](https://github.com/user-attachments/assets/7dae9150-41af-437c-aa06-ea95dc37c164)

----

Related:
- PR #1877
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3021506666
