### PR TITLE
Consistent list box mouse move handling

### DIFF
--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -242,7 +242,9 @@ protected:
 
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 	{
-		if (!visible() || !mScrollArea.contains(position))
+		if (!visible() || isEmpty()) { return; }
+
+		if (!mScrollArea.contains(position))
 		{
 			mHighlightIndex = NoSelection;
 			return;

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -244,6 +244,8 @@ protected:
 	{
 		if (!visible() || isEmpty()) { return; }
 
+		mHasFocus = area().contains(position);
+
 		if (!mScrollArea.contains(position))
 		{
 			mHighlightIndex = NoSelection;

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -177,15 +177,7 @@ void ListBoxBase::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*r
 
 	mHasFocus = area().contains(position);
 
-	// Ignore mouse motion events if the pointer isn't within the menu rect.
-	if (!mHasFocus)
-	{
-		mHighlightIndex = NoSelection;
-		return;
-	}
-
-	// if the mouse is on the scroll bar then the scroll bar should handle that
-	if (mScrollBar.visible() && mScrollBar.area().contains(position))
+	if (!mScrollArea.contains(position))
 	{
 		mHighlightIndex = NoSelection;
 		return;


### PR DESCRIPTION
Update `ListBox` and `ListBoxBase` so they have consistent handling of mouse move events.

Only set highlight when over the scroll area (not when over the list box border). There was an oddity in `ListBoxBase` before this change, where a scroll bar could be visible between the item and the list box border, and the items could be highlighted from the border region on the far side of the scroll bar (but not while over the scroll bar).

Set focus on `ListBox` on mouse over, which enables mouse wheel scrolling without having to first click. This also solves the issue of not losing focusing when clicking off of a `ListBox` and onto a `RadioButtonGroup`. Now focus is lost as soon as the mouse leaves the control, well before it makes it to any `RadioButtonGroup`, or other `Control` object.

Related:
- Issue #479
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3021506666
