### PR TITLE
Make `ListBox` derive from `ListBoxBase`

### DIFF
--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <stdexcept>
 
 
 namespace NAS2D

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -1,22 +1,14 @@
 #pragma once
 
 #include "ListBoxBase.h"
-#include "ScrollBar.h"
 
-#include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Utility.h>
-#include <NAS2D/Signal/Delegate.h>
-#include <NAS2D/EventHandler.h>
-#include <NAS2D/Math/Point.h>
-#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <string>
 #include <vector>
 #include <utility>
-#include <cstddef>
-#include <limits>
 
 
 namespace NAS2D

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -211,11 +211,7 @@ protected:
 		itemDrawRect.size.y = lineHeight;
 		for (std::size_t index = firstVisibleIndex; index < endVisibleIndex; ++index)
 		{
-			const auto isSelected = (index == mSelectedIndex);
-			const auto isHighlighted = (index == mHighlightIndex);
-
-			mItems[index].draw(renderer, itemDrawRect, mContext, isSelected, isHighlighted);
-
+			drawItem(renderer, itemDrawRect, index);
 			itemDrawRect.position.y += lineHeight;
 		}
 
@@ -224,6 +220,14 @@ protected:
 		renderer.drawBoxFilled(itemDrawRect, mContext.backgroundColorNormal);
 
 		renderer.clipRectClear();
+	}
+
+
+	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
+	{
+		const auto isSelected = (index == mSelectedIndex);
+		const auto isHighlighted = (index == mHighlightIndex);
+		mItems[index].draw(renderer, drawArea, mContext, isSelected, isHighlighted);
 	}
 
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -68,7 +68,13 @@ public:
 
 
 	ListBox(SelectionChangedDelegate selectionChangedHandler = {}) :
-		mContext{getDefaultFont()},
+		ListBox{{getDefaultFont()}, selectionChangedHandler}
+	{
+	}
+
+
+	ListBox(Context context, SelectionChangedDelegate selectionChangedHandler = {}) :
+		mContext{context},
 		mScrollBar{ScrollBar::ScrollBarType::Vertical, mContext.itemHeight(), {this, &ListBox::onSlideChange}},
 		mItemSize{0, mContext.itemHeight()},
 		mSelectionChangedHandler{selectionChangedHandler}

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -194,8 +194,9 @@ NAS2D::Color ListBoxBase::itemBorderColor(std::size_t /*index*/) const
 void ListBoxBase::update()
 {
 	if (!visible()) { return; }
-	mScrollBar.update();
+
 	draw();
+	mScrollBar.update();
 }
 
 

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -68,7 +68,7 @@ protected:
 
 	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const = 0;
 
-private:
+protected:
 	ScrollBar mScrollBar;
 	NAS2D::Rectangle<int> mScrollArea;
 	NAS2D::Vector<int> mItemSize;


### PR DESCRIPTION
Reduce code repetition by having `ListBox` derive from `ListBoxBase`

This also allows for a substantial reduction in transitive header includes, since most of the implementation will now be in `ListBoxBase.cpp`. In particular, it allows the removal of the `EventHandler.h` include from a header file. That was the last include of `EventHandler.h` from a header file. All the remaining includes of it are in implementation files.

Related:
- Issue #479
- Issue #1573
