### PR TITLE
Fix `ComboBox` initial list visibility

### DIFF
--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -1,7 +1,6 @@
 #include "ComboBox.h"
 
 #include <NAS2D/EnumMouseButton.h>
-#include <NAS2D/EventHandler.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/StringUtils.h>
 
@@ -21,9 +20,6 @@ ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 	mSelectionChangedHandler{selectionChangedHandler},
 	mMaxDisplayItems{MinimumDisplayItems}
 {
-	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseWheel().connect({this, &ComboBox::onMouseWheel});
-
 	btnDown.image("ui/icons/down.png");
 	btnDown.size({20, 20});
 
@@ -36,8 +32,6 @@ ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 
 ComboBox::~ComboBox()
 {
-	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseWheel().disconnect({this, &ComboBox::onMouseWheel});
 }
 
 
@@ -98,12 +92,6 @@ void ComboBox::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position
 		lstItems.visible(false);
 		mRect = mBarRect;
 	}
-}
-
-
-void ComboBox::onMouseWheel(NAS2D::Vector<int> /*scrollAmount*/)
-{
-
 }
 
 

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -41,9 +41,6 @@ ComboBox::~ComboBox()
 }
 
 
-/**
- * Resized event handler.
- */
 void ComboBox::onResize()
 {
 	Control::onResize();
@@ -64,9 +61,6 @@ void ComboBox::onResize()
 }
 
 
-/**
- * Position changed event handler.
- */
 void ComboBox::onMove(NAS2D::Vector<int> displacement)
 {
 	Control::onMove(displacement);
@@ -120,9 +114,6 @@ void ComboBox::clearSelected()
 }
 
 
-/**
- * ListBox selection changed event handler.
- */
 void ComboBox::onListSelectionChange()
 {
 	txtField.text(selectionText());
@@ -141,9 +132,6 @@ void ComboBox::maxDisplayItems(std::size_t count)
 }
 
 
-/**
- * Adds an item to the list.
- */
 void ComboBox::addItem(const std::string& item, int tag)
 {
 	lstItems.add(item, tag);
@@ -155,18 +143,12 @@ void ComboBox::addItem(const std::string& item, int tag)
 }
 
 
-/**
- * Gets the text of the selection.
- */
 const std::string& ComboBox::selectionText() const
 {
 	return lstItems.isItemSelected() ? lstItems.selected().text : EmptyString;
 }
 
 
-/**
- * Gets the tag value of the selected item.
- */
 int ComboBox::selectionUserData() const
 {
 	return lstItems.isItemSelected() ? lstItems.selected().userData : 0;

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -35,6 +35,14 @@ ComboBox::~ComboBox()
 }
 
 
+void ComboBox::onVisibilityChange(bool visible)
+{
+	ControlContainer::onVisibilityChange(visible);
+
+	lstItems.visible(false);
+}
+
+
 void ComboBox::onResize()
 {
 	Control::onResize();

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -45,6 +45,7 @@ public:
 	const std::string& text() const;
 
 protected:
+	void onVisibilityChange(bool visible) override;
 	void onResize() override;
 	void onMove(NAS2D::Vector<int> displacement) override;
 	void onListSelectionChange();


### PR DESCRIPTION
Fix `ComboBox` so the drop down list isn't initially visible.

As seen in `demoLibControls`, the drop down list was initially visible, even though the `ComboBox` constructor set the list to not be visible. The problem came from the `ControlContainer` base class responding to it's own `visible` property changes by setting the `visible` property of all contained `Control` objects. That meant setting the `ComboBox` to `visible` was also setting the contained `ListBox` to `visible`.

Using an `override` of `onVisibilityChange` allows the `ControlContainer` visibility changes to be fixed before the control is drawn. Whether the `ComboBox` is first coming into view, or just going out of view, it makes sense to hide the `ListBox` component.

Related:
- Issue #1573
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3021506666
