### PR TITLE
Fix `FactoryReport` right-pane visibility issue

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -297,11 +297,12 @@ void FactoryReport::onVisibilityChange(bool visible)
 {
 	Report::onVisibilityChange(visible);
 
+	checkFactoryActionControls();
+
 	if (!selectedFactory) { return; }
 
 	StructureState state = selectedFactory->state();
 	btnApply.visible(visible && (state == StructureState::Operational || state == StructureState::Idle));
-	checkFactoryActionControls();
 
 	if (selectedProductType != ProductType::PRODUCT_NONE)
 	{


### PR DESCRIPTION
Fix `FactoryReport` right-pane `Control` visibility, so nothing is drawn when there are no factories to display.

Related:
- Issue #1573
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3021942828
