### PR TITLE
Add `makefile` target for `flame-charts`

### DIFF
--- a/makefile
+++ b/makefile
@@ -359,6 +359,14 @@ format:
 	find $(ophd_SRCDIR) \( -name '*.cpp' -o -name '*.h' \) \! -name 'resource.h' -o -path '$(ophd_SRCDIR)MicroPather' -prune -type f | xargs clang-format -i
 
 
+## Compile performance ##
+
+.PHONY: flame-charts
+flame-charts:
+	@$(MAKE) clean > /dev/null
+	$(MAKE) all CXX=clang++ CXXFLAGS_EXTRA="-ftime-trace"
+
+
 ## GitHub ##
 .PHONY: cache-list-all cache-list-main cache-list-branch cache-delete-main-stale cache-delete-branch
 GhCacheKeyIncremental := ophd-

--- a/makefile
+++ b/makefile
@@ -302,6 +302,7 @@ clean:
 	-rm -fr $(libControls_OBJDIR)
 	-rm -fr $(testLibOphd_OBJDIR)
 	-rm -fr $(testLibControls_OBJDIR)
+	-rm -fr $(demoLibControls_OBJDIR)
 	-rm -fr $(ophd_OBJDIR)
 clean-all:
 	-rm -rf $(ROOTBUILDDIR)


### PR DESCRIPTION
Run the build using `clang++` with the `-ftime-trace` option to generate the `.json` files needed for flame charts.

Related:
- Issue #1573
