### PR TITLE
Reduce `Morale` transitive includes

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -28,6 +28,7 @@
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/MeanSolarDistance.h>
 #include <libOPHD/ProductCatalog.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <NAS2D/StringFrom.h>

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -26,6 +26,7 @@
 #include <libOPHD/MeanSolarDistance.h>
 #include <libOPHD/ProductCatalog.h>
 #include <libOPHD/XmlSerializer.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 #include <libOPHD/Technology/ResearchTracker.h>
 
 #include <NAS2D/Utility.h>

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -20,6 +20,7 @@
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumMoraleIndex.h>
 #include <libOPHD/StorableResources.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>

--- a/appOPHD/UI/PopulationPanel.cpp
+++ b/appOPHD/UI/PopulationPanel.cpp
@@ -11,6 +11,7 @@
 #include <libOPHD/Population/Population.h>
 #include <libOPHD/Population/PopulationPool.h>
 #include <libOPHD/Population/Morale.h>
+#include <libOPHD/Population/MoraleChangeEntry.h>
 
 #include <libControls/LoadRectangleSkin.h>
 
@@ -77,6 +78,11 @@ PopulationPanel::PopulationPanel(const Population& pop, const PopulationPool& po
 
 
 	size({windowWidth, windowHeight});
+}
+
+
+PopulationPanel::~PopulationPanel()
+{
 }
 
 

--- a/appOPHD/UI/PopulationPanel.h
+++ b/appOPHD/UI/PopulationPanel.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <libOPHD/Population/MoraleChangeEntry.h>
-
 #include <libControls/Control.h>
 
 #include <NAS2D/Renderer/RectangleSkin.h>
@@ -9,6 +7,7 @@
 #include <vector>
 
 
+struct MoraleChangeEntry;
 class Population;
 class PopulationPool;
 class Morale;
@@ -23,6 +22,7 @@ class PopulationPanel : public Control
 {
 public:
 	PopulationPanel(const Population& pop, const PopulationPool& popPool, const Morale& morale);
+	~PopulationPanel() override;
 
 	void residentialCapacity(int val) { mResidentialCapacity = val; }
 

--- a/libOPHD/Population/Morale.cpp
+++ b/libOPHD/Population/Morale.cpp
@@ -1,5 +1,7 @@
 #include "Morale.h"
 
+#include "MoraleChangeEntry.h"
+
 #include <algorithm>
 
 namespace

--- a/libOPHD/Population/Morale.h
+++ b/libOPHD/Population/Morale.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "MoraleChangeEntry.h"
-
 #include <cstdint>
 #include <vector>
 #include <string>
+
+
+struct MoraleChangeEntry;
 
 
 struct MoraleModifier


### PR DESCRIPTION
I suspect using forward declares for `MoraleChangeEntry` may be of questionable value, though I suppose it at least sets the right pattern to follow.

Admittedly I'm a bit puzzled why the destructor is needed for `PopulationPanel`, but not for `CrimeRateUpdate`. I would have expected the destructor to be needed for both.

Related:
- Issue #1573
