### PR TITLE
Reduce `TechnologyCatalog` transitive includes

### DIFF
--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -366,7 +366,7 @@ void ResearchReport::handleTopicChanged()
 {
 	txtTopicDescription.text("");
 
-	if (lstResearchTopics.selectedIndex() == ListBox<ListBoxItemText>::NoSelection)
+	if (!lstResearchTopics.isItemSelected())
 	{
 		return;
 	}

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -1,10 +1,5 @@
 #include "ResearchReport.h"
 
-#include <NAS2D/Utility.h>
-#include <NAS2D/EventHandler.h>
-#include <NAS2D/EnumMouseButton.h>
-#include <NAS2D/Renderer/Renderer.h>
-
 #include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 #include "../../Cache.h"
@@ -12,6 +7,11 @@
 
 #include "../../MapObjects/Structures/HotLaboratory.h"
 #include "../../MapObjects/Structures/Laboratory.h"
+
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
+#include <NAS2D/EnumMouseButton.h>
+#include <NAS2D/Renderer/Renderer.h>
 
 #include <array>
 #include <vector>

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -8,6 +8,9 @@
 #include "../../MapObjects/Structures/HotLaboratory.h"
 #include "../../MapObjects/Structures/Laboratory.h"
 
+#include <libOPHD/Technology/TechnologyCatalog.h>
+#include <libOPHD/Technology/ResearchTracker.h>
+
 #include <NAS2D/Utility.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/EnumMouseButton.h>

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -101,7 +101,7 @@ private:
 	const NAS2D::Image& imageCategoryIcons;
 	const NAS2D::Image& imageTopicIcons;
 
-	ListBox<ListBoxItemText> lstResearchTopics;
+	ListBox<> lstResearchTopics;
 
 	TextArea txtTopicDescription;
 

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -126,5 +126,4 @@ private:
 	NAS2D::Rectangle<int> mTopicDetailsArea{};
 
 	LabsAvailable mLabsAvailable{};
-
 };

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -2,9 +2,6 @@
 
 #include "Report.h"
 
-#include <libOPHD/Technology/TechnologyCatalog.h>
-#include <libOPHD/Technology/ResearchTracker.h>
-
 #include <libControls/Button.h>
 #include <libControls/ListBox.h>
 #include <libControls/TextArea.h>
@@ -23,6 +20,8 @@ namespace NAS2D
 }
 
 class Structure;
+class TechnologyCatalog;
+class ResearchTracker;
 
 
 class ResearchReport : public Report

--- a/libOPHD/Technology/TechnologyCatalog.cpp
+++ b/libOPHD/Technology/TechnologyCatalog.cpp
@@ -1,5 +1,7 @@
 #include "TechnologyCatalog.h"
 
+#include "Technology.h"
+
 #include "../XmlSerializer.h"
 
 #include <NAS2D/ParserHelper.h>

--- a/libOPHD/Technology/TechnologyCatalog.h
+++ b/libOPHD/Technology/TechnologyCatalog.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "Technology.h"
-
 #include <string>
 #include <vector>
+
+
+struct Technology;
 
 
 class TechnologyCatalog


### PR DESCRIPTION
Reduce `TechnologyCatalog` transitive includes, and a bit of refactoring for `ResearchReport`.

Related:
- Issue #1573
