### PR TITLE
Remove `Structure.h` include from `StructureManager.h`

### DIFF
--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -3,6 +3,8 @@
 #include "MapObjects/Structure.h"
 #include "MapObjects/StructureTypeToClass.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 #include <map>
 #include <vector>
 #include <concepts>

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "MapObjects/Structure.h"
 #include "MapObjects/StructureTypeToClass.h"
 
 #include <libOPHD/EnumStructureID.h>
@@ -18,11 +17,15 @@ namespace NAS2D
 	}
 }
 
+enum class StructureState;
 class Tile;
 class TileMap;
+class Structure;
 class PopulationPool;
 struct StorableResources;
 struct MapCoordinate;
+
+using StructureList = std::vector<Structure*>;
 
 
 /**

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -7,6 +7,7 @@
 #include "../Constants/UiConstants.h"
 #include "../States/MapViewStateHelper.h"
 #include "../MapObjects/StructureClass.h"
+#include "../MapObjects/Structure.h"
 
 #include "../StructureManager.h"
 


### PR DESCRIPTION
Use forward declares rather than direct include.

Not all uses of `StructureManager` require specific knowledge of `Structure`. For instance, there are many functions that return summary information, such as counts of structures of a given `StructureClass`, counts of operational structures, energy and food status, etc.

Related:
- Issue #1573
