### PR TITLE
Add `makefile` targets to show stale files

### DIFF
--- a/makefile
+++ b/makefile
@@ -366,6 +366,10 @@ format:
 stale:
 	@$(MAKE) -n | grep -oE '[^ ]+\.cpp$$'
 
+.PHONY: stale-objs
+stale-objs:
+	@$(MAKE) -n | grep -oE '[^ ]+\.o$$'
+
 
 ## Compile performance ##
 

--- a/makefile
+++ b/makefile
@@ -360,6 +360,13 @@ format:
 	find $(ophd_SRCDIR) \( -name '*.cpp' -o -name '*.h' \) \! -name 'resource.h' -o -path '$(ophd_SRCDIR)MicroPather' -prune -type f | xargs clang-format -i
 
 
+## Debugging ##
+
+.PHONY: stale
+stale:
+	@$(MAKE) -n | grep -oE '[^ ]+\.cpp$$'
+
+
 ## Compile performance ##
 
 .PHONY: flame-charts


### PR DESCRIPTION
While adjusting header includes, there were often a lot of errors, and being able to focus on one source file at a time made for easier work. Getting a list of stale files that need to be rebuilt is one way to help focus that effort. After a full build, the files that had errors and could not be built will be the stale files.

Listing source filenames gives a list of what code to look at. Listing object filenames gives targets that can be passed to `make` to rebuild just that one target.

Related:
- Issue #1573
