### PR TITLE
Refactor `TextField` - Additional, `onMouseDown`

### DIFF
--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -207,14 +207,14 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	// set the position to the end and move on.
 	if (offsetX > mFont.width(mText))
 	{
-		mCursorCharacterIndex = mText.size();
+		mCursorCharacterIndex = mText.length();
 		return;
 	}
 
 
 	// Figure out where the click occured within the visible string.
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
-	for (std::size_t index = 0; index <= mText.size() - scrollOffset; ++index)
+	for (std::size_t index = 0; index <= mText.length() - scrollOffset; ++index)
 	{
 		const std::string subString = mText.substr(scrollOffset, index);
 		const int subStringSizeX = mFont.width(subString);

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -201,7 +201,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 	if (!enabled() || !visible()) { return; }
 
-	int offsetX = position.x - mRect.position.x;
+	const int offsetX = position.x - mRect.position.x;
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -216,8 +216,8 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
 	for (std::size_t index = 0; index <= text().size() - scrollOffset; ++index)
 	{
-		const std::string cmpStr = text().substr(scrollOffset, index);
-		const int strLen = mFont.width(cmpStr);
+		const std::string subString = text().substr(scrollOffset, index);
+		const int strLen = mFont.width(subString);
 		if (strLen > offsetX)
 		{
 			mCursorCharacterIndex = index - 1;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -216,8 +216,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
 	for (std::size_t index = 0; index <= mText.length() - scrollOffset; ++index)
 	{
-		const std::string subString = mText.substr(scrollOffset, index);
-		const int subStringSizeX = mFont.width(subString);
+		const int subStringSizeX = mFont.width(mText.substr(scrollOffset, index));
 		if (subStringSizeX > offsetX)
 		{
 			mCursorCharacterIndex = index - 1;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -217,8 +217,8 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	for (std::size_t index = 0; index <= text().size() - scrollOffset; ++index)
 	{
 		const std::string subString = text().substr(scrollOffset, index);
-		const int strLen = mFont.width(subString);
-		if (strLen > offsetX)
+		const int subStringSizeX = mFont.width(subString);
+		if (subStringSizeX > offsetX)
 		{
 			mCursorCharacterIndex = index - 1;
 			break;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -214,13 +214,13 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 	// Figure out where the click occured within the visible string.
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
-	for (std::size_t i = 0; i <= text().size() - scrollOffset; ++i)
+	for (std::size_t index = 0; index <= text().size() - scrollOffset; ++index)
 	{
-		std::string cmpStr = text().substr(scrollOffset, i);
+		std::string cmpStr = text().substr(scrollOffset, index);
 		int strLen = mFont.width(cmpStr);
 		if (strLen > offsetX)
 		{
-			mCursorCharacterIndex = i - 1;
+			mCursorCharacterIndex = index - 1;
 			break;
 		}
 	}

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -199,7 +199,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 {
 	hasFocus(mRect.contains(position)); // This is a very useful check, should probably include this in all controls.
 
-	if (!enabled() || !visible()) { return; }
+	if (!visible() || !enabled()) { return; }
 
 	const int offsetX = position.x - mRect.position.x;
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -216,8 +216,8 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
 	for (std::size_t index = 0; index <= text().size() - scrollOffset; ++index)
 	{
-		std::string cmpStr = text().substr(scrollOffset, index);
-		int strLen = mFont.width(cmpStr);
+		const std::string cmpStr = text().substr(scrollOffset, index);
+		const int strLen = mFont.width(cmpStr);
 		if (strLen > offsetX)
 		{
 			mCursorCharacterIndex = index - 1;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -213,9 +213,8 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 
 	// Figure out where the click occured within the visible string.
-	std::size_t i = 0;
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
-	while(i <= text().size() - scrollOffset)
+	for (std::size_t i = 0; i <= text().size() - scrollOffset; ++i)
 	{
 		std::string cmpStr = text().substr(scrollOffset, i);
 		int strLen = mFont.width(cmpStr);
@@ -224,8 +223,6 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 			mCursorCharacterIndex = i - 1;
 			break;
 		}
-
-		i++;
 	}
 }
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -66,7 +66,7 @@ const std::string& TextField::text() const
 
 bool TextField::isEmpty() const
 {
-	return text().empty();
+	return mText.empty();
 }
 
 
@@ -134,7 +134,7 @@ void TextField::update()
 
 void TextField::updateScrollPosition()
 {
-	int cursorX = mFont.width(text().substr(0, mCursorCharacterIndex));
+	int cursorX = mFont.width(mText.substr(0, mCursorCharacterIndex));
 
 	// Check if cursor is after visible area
 	if (mScrollOffsetPixelX <= cursorX - textAreaWidth())
@@ -175,7 +175,7 @@ void TextField::draw() const
 
 	drawCursor();
 
-	renderer.drawText(mFont, text(), position() + NAS2D::Vector{fieldPadding, fieldPadding}, NAS2D::Color::White);
+	renderer.drawText(mFont, mText, position() + NAS2D::Vector{fieldPadding, fieldPadding}, NAS2D::Color::White);
 }
 
 
@@ -205,18 +205,18 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
-	if (offsetX > mFont.width(text()))
+	if (offsetX > mFont.width(mText))
 	{
-		mCursorCharacterIndex = text().size();
+		mCursorCharacterIndex = mText.size();
 		return;
 	}
 
 
 	// Figure out where the click occured within the visible string.
 	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
-	for (std::size_t index = 0; index <= text().size() - scrollOffset; ++index)
+	for (std::size_t index = 0; index <= mText.size() - scrollOffset; ++index)
 	{
-		const std::string subString = text().substr(scrollOffset, index);
+		const std::string subString = mText.substr(scrollOffset, index);
 		const int subStringSizeX = mFont.width(subString);
 		if (subStringSizeX > offsetX)
 		{
@@ -236,7 +236,7 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 	{
 		// Command keys
 		case NAS2D::KeyCode::Backspace:
-			if (!text().empty() && mCursorCharacterIndex > 0)
+			if (!mText.empty() && mCursorCharacterIndex > 0)
 			{
 				mCursorCharacterIndex--;
 				mText.erase(mCursorCharacterIndex, 1);
@@ -245,7 +245,7 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 			break;
 
 		case NAS2D::KeyCode::Delete:
-			if (!text().empty())
+			if (!mText.empty())
 			{
 				mText = mText.erase(mCursorCharacterIndex, 1);
 				onTextChange();
@@ -257,7 +257,7 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 			break;
 
 		case NAS2D::KeyCode::End:
-			mCursorCharacterIndex = text().length();
+			mCursorCharacterIndex = mText.length();
 			break;
 
 		// Arrow keys
@@ -267,7 +267,7 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 			break;
 
 		case NAS2D::KeyCode::Right:
-			if (mCursorCharacterIndex < text().length())
+			if (mCursorCharacterIndex < mText.length())
 				++mCursorCharacterIndex;
 			break;
 
@@ -278,7 +278,7 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 			break;
 
 		case NAS2D::KeyCode::Keypad6:
-			if ((mCursorCharacterIndex < text().length()) && !NAS2D::EventHandler::numlock(mod))
+			if ((mCursorCharacterIndex < mText.length()) && !NAS2D::EventHandler::numlock(mod))
 				++mCursorCharacterIndex;
 			break;
 
@@ -298,7 +298,7 @@ void TextField::onTextInput(const std::string& newTextInput)
 {
 	if (!visible() || !enabled() || !hasFocus()) { return; }
 	if (!editable() || newTextInput.empty()) { return; }
-	if (mMaxCharacters > 0 && text().length() >= mMaxCharacters) { return; }
+	if (mMaxCharacters > 0 && mText.length() >= mMaxCharacters) { return; }
 	if (mNumbersOnly && !std::isdigit(newTextInput[0], std::locale{})) { return; }
 
 	mText.insert(mCursorCharacterIndex, newTextInput);

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -73,7 +73,7 @@ bool TextField::isEmpty() const
 void TextField::clear()
 {
 	mText.clear();
-	mCursorCharacterPosition = 0;
+	mCursorCharacterIndex = 0;
 	onTextChange();
 }
 
@@ -134,7 +134,7 @@ void TextField::update()
 
 void TextField::updateScrollPosition()
 {
-	int cursorX = mFont.width(text().substr(0, mCursorCharacterPosition));
+	int cursorX = mFont.width(text().substr(0, mCursorCharacterIndex));
 
 	// Check if cursor is after visible area
 	if (mScrollOffsetPixelX <= cursorX - textAreaWidth())
@@ -207,7 +207,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	// set the position to the end and move on.
 	if (offsetX > mFont.width(text()))
 	{
-		mCursorCharacterPosition = text().size();
+		mCursorCharacterIndex = text().size();
 		return;
 	}
 
@@ -221,7 +221,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 		int strLen = mFont.width(cmpStr);
 		if (strLen > offsetX)
 		{
-			mCursorCharacterPosition = i - 1;
+			mCursorCharacterIndex = i - 1;
 			break;
 		}
 
@@ -239,10 +239,10 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 	{
 		// Command keys
 		case NAS2D::KeyCode::Backspace:
-			if (!text().empty() && mCursorCharacterPosition > 0)
+			if (!text().empty() && mCursorCharacterIndex > 0)
 			{
-				mCursorCharacterPosition--;
-				mText.erase(mCursorCharacterPosition, 1);
+				mCursorCharacterIndex--;
+				mText.erase(mCursorCharacterIndex, 1);
 				onTextChange();
 			}
 			break;
@@ -250,39 +250,39 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 		case NAS2D::KeyCode::Delete:
 			if (!text().empty())
 			{
-				mText = mText.erase(mCursorCharacterPosition, 1);
+				mText = mText.erase(mCursorCharacterIndex, 1);
 				onTextChange();
 			}
 			break;
 
 		case NAS2D::KeyCode::Home:
-			mCursorCharacterPosition = 0;
+			mCursorCharacterIndex = 0;
 			break;
 
 		case NAS2D::KeyCode::End:
-			mCursorCharacterPosition = text().length();
+			mCursorCharacterIndex = text().length();
 			break;
 
 		// Arrow keys
 		case NAS2D::KeyCode::Left:
-			if (mCursorCharacterPosition > 0)
-				--mCursorCharacterPosition;
+			if (mCursorCharacterIndex > 0)
+				--mCursorCharacterIndex;
 			break;
 
 		case NAS2D::KeyCode::Right:
-			if (mCursorCharacterPosition < text().length())
-				++mCursorCharacterPosition;
+			if (mCursorCharacterIndex < text().length())
+				++mCursorCharacterIndex;
 			break;
 
 		// Keypad arrow keys
 		case NAS2D::KeyCode::Keypad4:
-			if ((mCursorCharacterPosition > 0) && !NAS2D::EventHandler::numlock(mod))
-				--mCursorCharacterPosition;
+			if ((mCursorCharacterIndex > 0) && !NAS2D::EventHandler::numlock(mod))
+				--mCursorCharacterIndex;
 			break;
 
 		case NAS2D::KeyCode::Keypad6:
-			if ((mCursorCharacterPosition < text().length()) && !NAS2D::EventHandler::numlock(mod))
-				++mCursorCharacterPosition;
+			if ((mCursorCharacterIndex < text().length()) && !NAS2D::EventHandler::numlock(mod))
+				++mCursorCharacterIndex;
 			break;
 
 		// Enter/Return (ignore)
@@ -304,9 +304,9 @@ void TextField::onTextInput(const std::string& newTextInput)
 	if (mMaxCharacters > 0 && text().length() >= mMaxCharacters) { return; }
 	if (mNumbersOnly && !std::isdigit(newTextInput[0], std::locale{})) { return; }
 
-	mText.insert(mCursorCharacterPosition, newTextInput);
+	mText.insert(mCursorCharacterIndex, newTextInput);
 	onTextChange();
-	mCursorCharacterPosition++;
+	mCursorCharacterIndex++;
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -201,11 +201,11 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 	if (!enabled() || !visible()) { return; }
 
-	int relativePosition = position.x - mRect.position.x;
+	int offsetX = position.x - mRect.position.x;
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
-	if (mFont.width(text()) < relativePosition)
+	if (mFont.width(text()) < offsetX)
 	{
 		mCursorCharacterPosition = text().size();
 		return;
@@ -219,7 +219,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	{
 		std::string cmpStr = text().substr(scrollOffset, i);
 		int strLen = mFont.width(cmpStr);
-		if (strLen > relativePosition)
+		if (strLen > offsetX)
 		{
 			mCursorCharacterPosition = i - 1;
 			break;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -205,7 +205,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
-	if (mFont.width(text()) < offsetX)
+	if (offsetX > mFont.width(text()))
 	{
 		mCursorCharacterPosition = text().size();
 		return;

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -89,7 +89,7 @@ private:
 	TextChangedDelegate mTextChangedHandler;
 
 	NAS2D::Timer mCursorBlinkTimer;
-	std::size_t mCursorCharacterPosition = 0;
+	std::size_t mCursorCharacterIndex = 0;
 	int mCursorPixelX = 0;
 	int mScrollOffsetPixelX = 0;
 


### PR DESCRIPTION
Additional refactoring of `TextField`, with more of a focus on the problem method `onMouseDown`.

I wanted to keep some of the more general cleanup separate from the changes needed to fix the bug. The bug is somewhat more obvious now. There is an inappropriate `static_cast` that uses a pixel offset value as a character index offset. Additionally there is no clipping of mouse position to the control bounds, so the `TextField` is responding to inappropriate messages. Additionally there is a discrepancy in the offset calculations, where it uses the `TextField` control's origin, rather than than accounting for the padding to get to the text draw position.

Related:
- Issue #1872
- PR #1898
- PR #1897
