### PR TITLE
Fix `TextField` exception and draw scrolling

### DIFF
--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -202,7 +202,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	if (!visible() || !enabled() || !hasFocus()) { return; }
 	if (!editable()) { return; }
 
-	const int offsetX = position.x - mRect.position.x;
+	const int offsetX = position.x - (mRect.position.x + fieldPadding);
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -175,7 +175,8 @@ void TextField::draw() const
 
 	drawCursor();
 
-	renderer.drawText(mFont, mText, position() + NAS2D::Vector{fieldPadding - mScrollOffsetPixelX, fieldPadding}, NAS2D::Color::White);
+	const auto textDrawArea = mRect.inset(fieldPadding);
+	renderer.drawText(mFont, mText, textDrawArea.position + NAS2D::Vector{-mScrollOffsetPixelX, 0}, NAS2D::Color::White);
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -202,11 +202,11 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	if (!visible() || !enabled() || !hasFocus()) { return; }
 	if (!editable()) { return; }
 
-	const int offsetX = mScrollOffsetPixelX + position.x - (mRect.position.x + fieldPadding);
+	const int virtualOffsetX = mScrollOffsetPixelX + position.x - (mRect.position.x + fieldPadding);
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.
-	if (offsetX > mFont.width(mText))
+	if (virtualOffsetX > mFont.width(mText))
 	{
 		mCursorCharacterIndex = mText.length();
 		return;
@@ -218,7 +218,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	for (std::size_t index = 0; index <= mText.length() - scrollOffset; ++index)
 	{
 		const int subStringSizeX = mFont.width(mText.substr(scrollOffset, index));
-		if (subStringSizeX > offsetX)
+		if (subStringSizeX > virtualOffsetX)
 		{
 			mCursorCharacterIndex = index - 1;
 			break;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -214,10 +214,9 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 
 	// Figure out where the click occured within the visible string.
-	const auto scrollOffset = static_cast<std::size_t>(mScrollOffsetPixelX);
-	for (std::size_t index = 0; index <= mText.length() - scrollOffset; ++index)
+	for (std::size_t index = 0; index <= mText.length(); ++index)
 	{
-		const int subStringSizeX = mFont.width(mText.substr(scrollOffset, index));
+		const int subStringSizeX = mFont.width(mText.substr(0, index));
 		if (subStringSizeX > virtualOffsetX)
 		{
 			mCursorCharacterIndex = index - 1;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -202,7 +202,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	if (!visible() || !enabled() || !hasFocus()) { return; }
 	if (!editable()) { return; }
 
-	const int offsetX = position.x - (mRect.position.x + fieldPadding);
+	const int offsetX = mScrollOffsetPixelX + position.x - (mRect.position.x + fieldPadding);
 
 	// If the click occured past the width of the text, we can immediatly
 	// set the position to the end and move on.

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -176,7 +176,9 @@ void TextField::draw() const
 	drawCursor();
 
 	const auto textDrawArea = mRect.inset(fieldPadding);
+	renderer.clipRect(textDrawArea);
 	renderer.drawText(mFont, mText, textDrawArea.position + NAS2D::Vector{-mScrollOffsetPixelX, 0}, NAS2D::Color::White);
+	renderer.clipRectClear();
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -200,6 +200,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	hasFocus(mRect.contains(position)); // This is a very useful check, should probably include this in all controls.
 
 	if (!visible() || !enabled() || !hasFocus()) { return; }
+	if (!editable()) { return; }
 
 	const int offsetX = position.x - mRect.position.x;
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -175,7 +175,7 @@ void TextField::draw() const
 
 	drawCursor();
 
-	renderer.drawText(mFont, mText, position() + NAS2D::Vector{fieldPadding, fieldPadding}, NAS2D::Color::White);
+	renderer.drawText(mFont, mText, position() + NAS2D::Vector{fieldPadding - mScrollOffsetPixelX, fieldPadding}, NAS2D::Color::White);
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -214,7 +214,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 
 	// Figure out where the click occured within the visible string.
-	for (std::size_t index = 0; index <= mText.length(); ++index)
+	for (std::size_t index = 0; index < mText.length(); ++index)
 	{
 		const int subStringSizeX = mFont.width(mText.substr(0, index));
 		if (subStringSizeX > virtualOffsetX)

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -199,7 +199,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 {
 	hasFocus(mRect.contains(position)); // This is a very useful check, should probably include this in all controls.
 
-	if (!visible() || !enabled()) { return; }
+	if (!visible() || !enabled() || !hasFocus()) { return; }
 
 	const int offsetX = position.x - mRect.position.x;
 


### PR DESCRIPTION
Fix exception crash bug in `TextField::onMouseDown`, and fix the draw scrolling.

Removed an inappropriate `static_cast` where a pixel offset value was being treated as a character index offset, which was leading to out-of-bounds index values, and caused the exception to be thrown.

Additionally an offset problem was fixed in the code that converted clicks to string index values, which has caused some strange effects where clicking on a letter could cause the cursor to bounce either left or right of the character in seemingly unpredictable ways. Now the cursor consistently moves to the front of a character that's clicked on, or to the end of the string if the click is beyond the area covered by the string.

Finally the draw scrolling was made to actually work. Before the scroll values existed in memory, and were updated in a sensible way, though the drawing was always fixed, meaning the few places were the internal scroll offset values were actually used led to strange effects, such as the cursor cutting through the middle of characters. Now that drawing lines up with text, the cursor always appears between letters. On a related note, some clipping was added, so when the string overflows the `TextField` bounds, or is scrolled off the side, the part outside of the `textDrawArea` is clipped.

Related:
- Issue #1872
- PR #1899
- PR #1898
- PR #1897
- Issue #1754
