### PR TITLE
Fix `TextField` last character click bug

### DIFF
--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -217,7 +217,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 
 	// Figure out where the click occured within the visible string.
-	for (std::size_t index = 0; index < mText.length(); ++index)
+	for (std::size_t index = 0; index <= mText.length(); ++index)
 	{
 		const int subStringSizeX = mFont.width(mText.substr(0, index));
 		if (subStringSizeX > virtualOffsetX)

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -217,7 +217,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 
 	// Figure out where the click occured within the visible string.
-	for (std::size_t subStringLength = 0; subStringLength <= mText.length(); ++subStringLength)
+	for (std::size_t subStringLength = 1; subStringLength <= mText.length(); ++subStringLength)
 	{
 		const int subStringSizeX = mFont.width(mText.substr(0, subStringLength));
 		if (subStringSizeX > virtualOffsetX)

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -217,12 +217,12 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 
 
 	// Figure out where the click occured within the visible string.
-	for (std::size_t index = 0; index <= mText.length(); ++index)
+	for (std::size_t subStringLength = 0; subStringLength <= mText.length(); ++subStringLength)
 	{
-		const int subStringSizeX = mFont.width(mText.substr(0, index));
+		const int subStringSizeX = mFont.width(mText.substr(0, subStringLength));
 		if (subStringSizeX > virtualOffsetX)
 		{
-			mCursorCharacterIndex = index - 1;
+			mCursorCharacterIndex = subStringLength - 1;
 			break;
 		}
 	}


### PR DESCRIPTION
Fix for a small bug that was introduced in the previous PR that caused the last character to be ignored when clicked, so the cursor would be placed before the second last character, rather than before the last character.

Seems the wrong end was trimmed when adjusting loop boundaries. The loop value is a sub-string length, rather than an index value, so the name was perhaps a bit misleading. As we calculate the index as `subStringLength - 1`, which we never want to be negative, it makes sense to start the loop as `1` instead of `0`.

Related:
- Issue #1872
- PR #1900 (Commit 4748485d8c09a9ba41525b84f485380f1b699d4c)
