### PR TITLE
Remove mining enable check boxes

### DIFF
--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -57,16 +57,6 @@ StorableResources MineFacility::maxTransferAmounts()
 {
 	const auto remainingCapacity = MaxCapacity - production();
 	auto maxTransfer = remainingCapacity.cap(constants::BaseMineProductionRate);
-
-	const auto enabledBits = mOreDeposit->miningEnabled();
-	for (std::size_t i = 0; i < maxTransfer.resources.size(); ++i)
-	{
-		if (!enabledBits[i])
-		{
-			maxTransfer.resources[i] = 0;
-		}
-	}
-
 	return maxTransfer;
 }
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -58,8 +58,8 @@ MineOperationsWindow::MineOperationsWindow() :
 	btnAssignTruck.size(truckButtonSize);
 	btnUnassignTruck.size(truckButtonSize);
 
-	add(btnUnassignTruck, truckButtonOffset);
-	add(btnAssignTruck, {truckButtonOffset.x + truckButtonSize.x + constants::Margin, truckButtonOffset.y});
+	add(btnAssignTruck, truckButtonOffset);
+	add(btnUnassignTruck, {truckButtonOffset.x + truckButtonSize.x + constants::Margin, truckButtonOffset.y});
 }
 
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -1,6 +1,5 @@
 #include "MineOperationsWindow.h"
 
-#include "StringTable.h"
 #include "TextRender.h"
 
 #include "../Cache.h"
@@ -8,10 +7,8 @@
 #include "../Resources.h"
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
-#include "../StructureManager.h"
 #include "../TruckAvailability.h"
 #include "../MapObjects/Structures/MineFacility.h"
-#include "../MapObjects/Structures/Warehouse.h"
 
 #include <libOPHD/MapObjects/OreDeposit.h>
 
@@ -19,6 +16,7 @@
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
+
 
 using namespace NAS2D;
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -28,7 +28,6 @@ namespace
 	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};
 	const auto truckButtonOffset = truckAvailabilityOffset + NAS2D::Vector{0, 35};
 	const auto truckButtonSize = NAS2D::Vector{128, 25};
-	const auto checkBoxOffset = truckButtonOffset + NAS2D::Vector{0, 30};
 }
 
 
@@ -39,12 +38,6 @@ MineOperationsWindow::MineOperationsWindow() :
 	mUiIcon{imageCache.load("ui/interface/mine.png")},
 	mIcons{imageCache.load("ui/icons.png")},
 	mPanel{loadRectangleSkin("ui/skin/textbox_normal")},
-	chkResources{{
-		{ResourceNamesRefined[0], {this, &MineOperationsWindow::onCheckBoxChange}},
-		{ResourceNamesRefined[1], {this, &MineOperationsWindow::onCheckBoxChange}},
-		{ResourceNamesRefined[2], {this, &MineOperationsWindow::onCheckBoxChange}},
-		{ResourceNamesRefined[3], {this, &MineOperationsWindow::onCheckBoxChange}},
-	}},
 	btnIdle{"Idle", {this, &MineOperationsWindow::onIdle}},
 	btnExtendShaft{"Dig New Level", {this, &MineOperationsWindow::onExtendShaft}},
 	btnOkay{"Close", {this, &MineOperationsWindow::onOkay}},
@@ -69,13 +62,6 @@ MineOperationsWindow::MineOperationsWindow() :
 
 	add(btnUnassignTruck, truckButtonOffset);
 	add(btnAssignTruck, {truckButtonOffset.x + truckButtonSize.x + constants::Margin, truckButtonOffset.y});
-
-	// ORE TOGGLE BUTTONS
-	const auto checkBoxSpacing = NAS2D::Vector{152, 20};
-	add(chkResources[0], checkBoxOffset);
-	add(chkResources[1], checkBoxOffset + NAS2D::Vector{0, checkBoxSpacing.y});
-	add(chkResources[2], checkBoxOffset + NAS2D::Vector{checkBoxSpacing.x, 0});
-	add(chkResources[3], checkBoxOffset + checkBoxSpacing);
 }
 
 
@@ -90,12 +76,6 @@ void MineOperationsWindow::mineFacility(MineFacility* facility)
 {
 	mFacility = facility;
 	if (!mFacility) { return; }
-
-	const auto enabledBits = mFacility->oreDeposit().miningEnabled();
-	chkResources[0].checked(enabledBits[0]);
-	chkResources[1].checked(enabledBits[1]);
-	chkResources[2].checked(enabledBits[2]);
-	chkResources[3].checked(enabledBits[3]);
 
 	btnIdle.toggle(mFacility->forceIdle());
 	btnExtendShaft.enabled(mFacility->canExtend());
@@ -145,17 +125,6 @@ void MineOperationsWindow::onUnassignTruck()
 		mFacility->removeTruck();
 		updateTruckAvailability();
 	}
-}
-
-
-void MineOperationsWindow::onCheckBoxChange()
-{
-	if (!mFacility) { return; }
-	auto& oreDeposit = mFacility->oreDeposit();
-	oreDeposit.miningEnabled(OreDeposit::OreType::CommonMetals, chkResources[0].checked());
-	oreDeposit.miningEnabled(OreDeposit::OreType::CommonMinerals, chkResources[1].checked());
-	oreDeposit.miningEnabled(OreDeposit::OreType::RareMetals, chkResources[2].checked());
-	oreDeposit.miningEnabled(OreDeposit::OreType::RareMinerals, chkResources[3].checked());
 }
 
 

--- a/appOPHD/UI/MineOperationsWindow.h
+++ b/appOPHD/UI/MineOperationsWindow.h
@@ -2,11 +2,8 @@
 
 #include <libControls/Window.h>
 #include <libControls/Button.h>
-#include <libControls/CheckBox.h>
 
 #include <NAS2D/Renderer/RectangleSkin.h>
-
-#include <array>
 
 
 class MineFacility;
@@ -29,8 +26,6 @@ public:
 	void hide() override;
 
 protected:
-	void onCheckBoxChange();
-
 	void onOkay();
 	void onExtendShaft();
 	void onIdle();
@@ -44,8 +39,6 @@ private:
 	const NAS2D::Image& mUiIcon;
 	const NAS2D::Image& mIcons;
 	NAS2D::RectangleSkin mPanel;
-
-	std::array<CheckBox, 4> chkResources;
 
 	Button btnIdle;
 	Button btnExtendShaft;

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -16,7 +16,6 @@
 #include "../../Map/Tile.h"
 #include "../../MapObjects/Structures/MineFacility.h"
 
-#include <libOPHD/ProductionCost.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <NAS2D/StringFrom.h>

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -449,7 +449,7 @@ void MineReport::drawOreProductionPane(const NAS2D::Point<int>& origin) const
 		const auto oreMovement = (i != 3) ? oreMovementComponent : oreMovementRemainder;
 		drawLabelRightJustify(resourcePosition, panelWidth, font, std::to_string(oreMovement), constants::PrimaryTextColor);
 
-		const auto resourceNameHeight = std::max({ResourceImageRectsOre[i].size.y, fontBold.height()});
+		const auto resourceNameHeight = std::max(ResourceImageRectsOre[i].size.y, fontBold.height());
 		const auto progressBarPosition = resourcePosition + NAS2D::Vector{0, resourceNameHeight + constants::MarginTight + 2};
 		const auto progressBarArea = NAS2D::Rectangle{progressBarPosition, progressBarSize};
 		drawProgressBar(

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -443,10 +443,9 @@ void MineReport::drawOreProductionPane(const NAS2D::Point<int>& origin) const
 	for (size_t i = 0; i < 4; ++i)
 	{
 		const auto resourcePosition = origin + resourceOffset;
-		const auto resourceIconPosition = resourcePosition;
-		renderer.drawSubImage(uiIcons, resourceIconPosition, ResourceImageRectsOre[i]);
+		renderer.drawSubImage(uiIcons, resourcePosition, ResourceImageRectsOre[i]);
 		const auto resourceNameOffset = NAS2D::Vector{ResourceImageRectsOre[i].size.x + constants::MarginTight + 2, 0};
-		renderer.drawText(fontBold, "Mine " + ResourceNamesOre[i], resourceIconPosition + resourceNameOffset, constants::PrimaryTextColor);
+		renderer.drawText(fontBold, "Mine " + ResourceNamesOre[i], resourcePosition + resourceNameOffset, constants::PrimaryTextColor);
 		const auto oreMovement = (i != 3) ? oreMovementComponent : oreMovementRemainder;
 		drawLabelRightJustify(resourcePosition, panelWidth, font, std::to_string(oreMovement), constants::PrimaryTextColor);
 

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -5,12 +5,9 @@
 #include "../StructureListBox.h"
 
 #include <libControls/Button.h>
-#include <libControls/CheckBox.h>
 
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Signal/Delegate.h>
-
-#include <array>
 
 
 namespace NAS2D
@@ -56,11 +53,6 @@ protected:
 	void onDigNewLevel();
 	void onTakeMeThere();
 
-	void onCheckBoxCommonMetalsChange();
-	void onCheckBoxCommonMineralsChange();
-	void onCheckBoxRareMetalsChange();
-	void onCheckBoxRareMineralsChange();
-
 	void onAddTruck();
 	void onRemoveTruck();
 
@@ -91,8 +83,6 @@ private:
 
 	Button btnAddTruck;
 	Button btnRemoveTruck;
-
-	std::array<CheckBox, 4> chkResources;
 
 	StructureListBox lstMineFacilities;
 	MineFacility* mSelectedFacility;

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -64,19 +64,6 @@ void OreDeposit::active(bool newActive)
 }
 
 
-std::bitset<4> OreDeposit::miningEnabled() const
-{
-	// We only want ore mining enabled bits
-	return {mFlags.to_ulong() & 0xF};
-}
-
-
-void OreDeposit::miningEnabled(OreType oreType, bool value)
-{
-	mFlags[static_cast<std::size_t>(oreType)] = value;
-}
-
-
 /**
  * Increases the depth of the mine.
  *

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -164,7 +164,7 @@ void OreDeposit::deserialize(NAS2D::Xml::XmlElement* element)
 	mCurrentDepth = dictionary.get<int>("depth");
 	mOreDepositYield = static_cast<OreDepositYield>(dictionary.get<int>("yield"));
 	const auto active = dictionary.get<bool>("active");
-	mFlags = std::bitset<5>(dictionary.get("flags"));
+	mFlags = std::bitset<5>{dictionary.get("flags")};
 
 	this->active(active);
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -35,7 +35,7 @@ namespace
 
 
 	// [Active, 4x miningEnabled]
-	const std::bitset<5> DefaultFlags{"01111"};
+	const std::bitset<5> DefaultFlags{0b01111};
 }
 
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -128,6 +128,8 @@ StorableResources OreDeposit::pull(const StorableResources& maxTransfer)
  */
 NAS2D::Xml::XmlElement* OreDeposit::serialize(NAS2D::Point<int> location)
 {
+	auto saveFlags = std::bitset<5>{0b01111};
+	saveFlags[4] = mFlags[4];
 	auto* element = NAS2D::dictionaryToAttributes(
 		"mine",
 		{{
@@ -136,7 +138,7 @@ NAS2D::Xml::XmlElement* OreDeposit::serialize(NAS2D::Point<int> location)
 			{"depth", depth()},
 			{"active", active()},
 			{"yield", static_cast<int>(yield())},
-			{"flags", mFlags.to_string()},
+			{"flags", saveFlags.to_string()},
 		}}
 	);
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -164,7 +164,10 @@ void OreDeposit::deserialize(NAS2D::Xml::XmlElement* element)
 	mCurrentDepth = dictionary.get<int>("depth");
 	mOreDepositYield = static_cast<OreDepositYield>(dictionary.get<int>("yield"));
 	const auto active = dictionary.get<bool>("active");
-	mFlags = std::bitset<5>{dictionary.get("flags")};
+	// Force mining enable bits on during load (there is no longer any UI to enable them)
+	const auto loadedFlags = std::bitset<5>{dictionary.get("flags")};
+	mFlags = std::bitset<5>{0b01111};
+	mFlags[4] = loadedFlags[4];
 
 	this->active(active);
 

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -5,8 +5,6 @@
 
 #include <NAS2D/Math/Point.h>
 
-#include <bitset>
-
 
 namespace NAS2D
 {
@@ -59,15 +57,5 @@ private:
 	StorableResources mTappedReserves;
 	int mCurrentDepth{0};
 	OreDepositYield mOreDepositYield = OreDepositYield::Low;
-
-	/**
-	 * Flags indicating several states for the mine:
-	 *
-	 * [0] : Mine Common Metal Ore
-	 * [1] : Mine Common Mineral Ore
-	 * [2] : Mine Rare Metal Ore
-	 * [3] : Mine Rare Mineral Ore
-	 * [4] : Mine is active
-	 */
-	std::bitset<5> mFlags; /**< Set of flags. */
+	bool mIsActive{false};
 };

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -45,9 +45,6 @@ public:
 	StorableResources availableResources() const;
 	StorableResources totalYield() const;
 
-	std::bitset<4> miningEnabled() const;
-	void miningEnabled(OreType oreType, bool value);
-
 	StorableResources pull(const StorableResources& maxTransfer);
 
 public:


### PR DESCRIPTION
Removes the mining enable `CheckBox` instances from the `MineOperationsWindow` and the `MineReport`.

Additionally remove the support for the mining enable bits in `MineFacility` and `OreDeposit`. Maintain the saved game flag format, though force enable the mining enable bits when saving. This is to ensure anything saved with the current version may still be usable with older versions of the game. Remove the `mFlags` member field, and replace with a `mIsActive` flag field.

Closes #1845

----

Related:
- Issue #1845
