### PR TITLE
Refactor `OreDeposit`

### DIFF
--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -4,6 +4,7 @@
 
 #include "../MapObjects/Structure.h"
 
+#include <libOPHD/EnumOreDepositYield.h>
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/RandomNumberGenerator.h>
 #include <libOPHD/MapObjects/OreDeposit.h>

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -97,7 +97,7 @@ void MineFacility::think()
 		return;
 	}
 
-	storage() += mOreDeposit->pull(maxTransferAmounts());
+	storage() += mOreDeposit->extract(maxTransferAmounts());
 }
 
 

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -103,7 +103,7 @@ void MineFacility::think()
 
 bool MineFacility::canExtend() const
 {
-	return (mOreDeposit->depth() < mMaxDepth) && (mDigTurnsRemaining == 0);
+	return (mOreDeposit->digDepth() < mMaxDepth) && (mDigTurnsRemaining == 0);
 }
 
 

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -85,7 +85,7 @@ void MineFacility::think()
 		}
 	}
 
-	if (mOreDeposit->exhausted())
+	if (mOreDeposit->isExhausted())
 	{
 		idle(IdleReason::MineExhausted);
 		return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -965,7 +965,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 	}
 	else if (tile.oreDeposit())
 	{
-		if (tile.oreDeposit()->depth() != mTileMap->maxDepth() || !tile.oreDeposit()->isExhausted())
+		if (tile.oreDeposit()->digDepth() != mTileMap->maxDepth() || !tile.oreDeposit()->isExhausted())
 		{
 			doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMineNotExhausted);
 			return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -965,7 +965,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 	}
 	else if (tile.oreDeposit())
 	{
-		if (tile.oreDeposit()->depth() != mTileMap->maxDepth() || !tile.oreDeposit()->exhausted())
+		if (tile.oreDeposit()->depth() != mTileMap->maxDepth() || !tile.oreDeposit()->isExhausted())
 		{
 			doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMineNotExhausted);
 			return;

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -259,7 +259,7 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 	auto& mineFacilityTile = structureManager.tileFromStructure(mineFacility);
-	auto& mineDepthTile = mTileMap->getTile({mineFacilityTile.xy(), mineFacility->oreDeposit().depth()});
+	auto& mineDepthTile = mTileMap->getTile({mineFacilityTile.xy(), mineFacility->oreDeposit().digDepth()});
 	structureManager.create<MineShaft>(mineDepthTile);
 	mineDepthTile.bulldoze();
 	mineDepthTile.excavated(true);

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -144,7 +144,7 @@ void MineOperationsWindow::drawClientArea() const
 
 	const std::string statusString =
 		mFacility->extending() ? "Digging New Level" :
-		mFacility->oreDeposit().exhausted() ? "Exhausted" :
+		mFacility->oreDeposit().isExhausted() ? "Exhausted" :
 		mFacility->stateDescription();
 
 	drawLabelAndValue(origin + NAS2D::Vector{148, 45}, "Status: ", statusString);

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -155,7 +155,7 @@ void MineOperationsWindow::drawClientArea() const
 		drawLabelAndValue(origin + NAS2D::Vector{148, 60}, "Turns Remaining: ", extensionTimeRemaining);
 	}
 
-	const auto mineDepth = std::to_string(mFacility->oreDeposit().depth());
+	const auto mineDepth = std::to_string(mFacility->oreDeposit().digDepth());
 	drawLabelAndValue(origin + NAS2D::Vector{300, 30}, "Depth: ", mineDepth);
 
 	// TRUCK ASSIGNMENT

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -90,7 +90,7 @@ void MiniMap::draw() const
 
 		auto mineBeaconStatusOffsetX = 0;
 		if (!tile.hasStructure() || !tile.structure()->isMineFacility()) { mineBeaconStatusOffsetX = 0; }
-		else if (!oreDeposit->exhausted()) { mineBeaconStatusOffsetX = 8; }
+		else if (!oreDeposit->isExhausted()) { mineBeaconStatusOffsetX = 8; }
 		else { mineBeaconStatusOffsetX = 16; }
 
 		const auto beaconImageRect = NAS2D::Rectangle<int>{{mineBeaconStatusOffsetX, 0}, {7, 7}};

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -69,7 +69,7 @@ OreDepositYield OreDeposit::yield() const
 
 StorableResources OreDeposit::totalYield() const
 {
-	return YieldTable.at(mYield) * digDepth();
+	return YieldTable.at(mYield) * mDigDepth;
 }
 
 
@@ -114,7 +114,7 @@ NAS2D::Xml::XmlElement* OreDeposit::serialize(NAS2D::Point<int> location)
 		{{
 			{"x", location.x},
 			{"y", location.y},
-			{"depth", digDepth()},
+			{"depth", mDigDepth},
 			{"yield", static_cast<int>(mYield)},
 			// Unused fields, retained for backwards compatibility
 			{"active", true},

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -1,5 +1,7 @@
 #include "OreDeposit.h"
 
+#include "../EnumOreDepositYield.h"
+
 #include <NAS2D/ParserHelper.h>
 #include <NAS2D/Xml/XmlElement.h>
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -12,16 +12,6 @@
 
 namespace
 {
-	/**
-	 * Yield ore table
-	 *
-	 * \note Follows the array layout conventions of the StorableResources class
-	 *
-	 * [0] Common Metals
-	 * [1] Common Minerals
-	 * [2] Rare Metals
-	 * [3] Rare Minerals
-	 */
 	const std::map<OreDepositYield, StorableResources> YieldTable =
 	{
 		{OreDepositYield::Low, {800, 800, 800, 800}},

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -46,6 +46,12 @@ OreDeposit::OreDeposit(OreDepositYield yield) :
 }
 
 
+OreDepositYield OreDeposit::yield() const
+{
+	return mYield;
+}
+
+
 /**
  * Increases the depth of the mine.
  *

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -47,7 +47,7 @@ OreDeposit::OreDeposit(OreDepositYield yield) :
  */
 void OreDeposit::increaseDepth()
 {
-	mCurrentDepth++;
+	mDigDepth++;
 	mTappedReserves += YieldTable.at(mYield);
 }
 
@@ -57,7 +57,7 @@ void OreDeposit::increaseDepth()
  */
 int OreDeposit::digDepth() const
 {
-	return mCurrentDepth;
+	return mDigDepth;
 }
 
 
@@ -143,7 +143,7 @@ void OreDeposit::deserialize(NAS2D::Xml::XmlElement* element)
 {
 	const auto dictionary = NAS2D::attributesToDictionary(*element);
 
-	mCurrentDepth = dictionary.get<int>("depth");
+	mDigDepth = dictionary.get<int>("depth");
 	mYield = static_cast<OreDepositYield>(dictionary.get<int>("yield"));
 
 	mTappedReserves = {};

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -39,12 +39,6 @@ OreDeposit::OreDeposit(OreDepositYield yield) :
 }
 
 
-OreDepositYield OreDeposit::yield() const
-{
-	return mYield;
-}
-
-
 /**
  * Increases the depth of the mine.
  *
@@ -64,6 +58,12 @@ void OreDeposit::increaseDepth()
 int OreDeposit::depth() const
 {
 	return mCurrentDepth;
+}
+
+
+OreDepositYield OreDeposit::yield() const
+{
+	return mYield;
 }
 
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -41,7 +41,7 @@ OreDeposit::OreDeposit()
 
 
 OreDeposit::OreDeposit(OreDepositYield yield) :
-	mOreDepositYield{yield}
+	mYield{yield}
 {
 }
 
@@ -145,7 +145,7 @@ void OreDeposit::deserialize(NAS2D::Xml::XmlElement* element)
 	const auto dictionary = NAS2D::attributesToDictionary(*element);
 
 	mCurrentDepth = dictionary.get<int>("depth");
-	mOreDepositYield = static_cast<OreDepositYield>(dictionary.get<int>("yield"));
+	mYield = static_cast<OreDepositYield>(dictionary.get<int>("yield"));
 
 	mTappedReserves = {};
 	// Keep the vein iteration so we can still load old saved games

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -55,7 +55,7 @@ void OreDeposit::increaseDepth()
 /**
  * Gets the current depth of the mine.
  */
-int OreDeposit::depth() const
+int OreDeposit::digDepth() const
 {
 	return mCurrentDepth;
 }
@@ -69,7 +69,7 @@ OreDepositYield OreDeposit::yield() const
 
 StorableResources OreDeposit::totalYield() const
 {
-	return YieldTable.at(mYield) * depth();
+	return YieldTable.at(mYield) * digDepth();
 }
 
 
@@ -114,7 +114,7 @@ NAS2D::Xml::XmlElement* OreDeposit::serialize(NAS2D::Point<int> location)
 		{{
 			{"x", location.x},
 			{"y", location.y},
-			{"depth", depth()},
+			{"depth", digDepth()},
 			{"yield", static_cast<int>(mYield)},
 			// Unused fields, retained for backwards compatibility
 			{"active", true},

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -95,7 +95,7 @@ StorableResources OreDeposit::extract(const StorableResources& maxTransfer)
 /**
  * Indicates that there are no resources available at this mine.
  */
-bool OreDeposit::exhausted() const
+bool OreDeposit::isExhausted() const
 {
 	return mTappedReserves.isEmpty();
 }

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -48,7 +48,7 @@ OreDepositYield OreDeposit::yield() const
 /**
  * Increases the depth of the mine.
  *
- * \note	This function only modifies the Mine. It has no knowledge of the
+ * \note	This function only modifies the OreDeposit. It has no knowledge of the
  *			maximum digging depth of a planet and doesn't modify any tiles.
  */
 void OreDeposit::increaseDepth()

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -35,7 +35,8 @@ namespace
 }
 
 
-OreDeposit::OreDeposit()
+OreDeposit::OreDeposit() :
+	mYield{OreDepositYield::Low}
 {
 }
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -67,15 +67,15 @@ int OreDeposit::depth() const
 }
 
 
-StorableResources OreDeposit::availableResources() const
-{
-	return mTappedReserves;
-}
-
-
 StorableResources OreDeposit::totalYield() const
 {
 	return YieldTable.at(mYield) * depth();
+}
+
+
+StorableResources OreDeposit::availableResources() const
+{
+	return mTappedReserves;
 }
 
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -55,7 +55,7 @@ OreDeposit::OreDeposit(OreDepositYield yield) :
 void OreDeposit::increaseDepth()
 {
 	mCurrentDepth++;
-	mTappedReserves += YieldTable.at(yield());
+	mTappedReserves += YieldTable.at(mYield);
 }
 
 
@@ -76,7 +76,7 @@ StorableResources OreDeposit::availableResources() const
 
 StorableResources OreDeposit::totalYield() const
 {
-	return YieldTable.at(yield()) * depth();
+	return YieldTable.at(mYield) * depth();
 }
 
 
@@ -116,7 +116,7 @@ NAS2D::Xml::XmlElement* OreDeposit::serialize(NAS2D::Point<int> location)
 			{"x", location.x},
 			{"y", location.y},
 			{"depth", depth()},
-			{"yield", static_cast<int>(yield())},
+			{"yield", static_cast<int>(mYield)},
 			// Unused fields, retained for backwards compatibility
 			{"active", true},
 			{"flags", "011111"},

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -80,15 +80,6 @@ StorableResources OreDeposit::availableResources() const
 
 
 /**
- * Indicates that there are no resources available at this mine.
- */
-bool OreDeposit::exhausted() const
-{
-	return mTappedReserves.isEmpty();
-}
-
-
-/**
  * Pulls the specified quantities of Ore from the Mine. If
  * insufficient ore is available, only pulls what's available.
  */
@@ -98,6 +89,15 @@ StorableResources OreDeposit::pull(const StorableResources& maxTransfer)
 	mTappedReserves -= transferAmount;
 
 	return transferAmount;
+}
+
+
+/**
+ * Indicates that there are no resources available at this mine.
+ */
+bool OreDeposit::exhausted() const
+{
+	return mTappedReserves.isEmpty();
 }
 
 

--- a/libOPHD/MapObjects/OreDeposit.cpp
+++ b/libOPHD/MapObjects/OreDeposit.cpp
@@ -80,10 +80,10 @@ StorableResources OreDeposit::availableResources() const
 
 
 /**
- * Pulls the specified quantities of Ore from the Mine. If
+ * Extracts the specified quantities of Ore from the OreDeposit. If
  * insufficient ore is available, only pulls what's available.
  */
-StorableResources OreDeposit::pull(const StorableResources& maxTransfer)
+StorableResources OreDeposit::extract(const StorableResources& maxTransfer)
 {
 	const auto transferAmount = mTappedReserves.cap(maxTransfer);
 	mTappedReserves -= transferAmount;

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -32,7 +32,7 @@ public:
 	StorableResources availableResources() const;
 	StorableResources extract(const StorableResources& maxTransfer);
 
-	bool exhausted() const;
+	bool isExhausted() const;
 
 public:
 	NAS2D::Xml::XmlElement* serialize(NAS2D::Point<int> location);

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../EnumOreDepositYield.h"
 #include "../StorableResources.h"
 
 #include <NAS2D/Math/Point.h>
@@ -13,6 +12,9 @@ namespace NAS2D
 		class XmlElement;
 	}
 }
+
+
+enum class OreDepositYield;
 
 
 class OreDeposit

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -25,10 +25,10 @@ public:
 
 	bool exhausted() const;
 
-	OreDepositYield yield() const;
-
 	int depth() const;
 	void increaseDepth();
+
+	OreDepositYield yield() const;
 
 	StorableResources totalYield() const;
 	StorableResources availableResources() const;

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -30,7 +30,7 @@ public:
 
 	StorableResources totalYield() const;
 	StorableResources availableResources() const;
-	StorableResources pull(const StorableResources& maxTransfer);
+	StorableResources extract(const StorableResources& maxTransfer);
 
 	bool exhausted() const;
 

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -32,7 +32,7 @@ public:
 
 	bool exhausted() const;
 
-	OreDepositYield yield() const { return mYield; }
+	OreDepositYield yield() const;
 
 	int depth() const;
 	void increaseDepth();

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -32,7 +32,7 @@ public:
 
 	bool exhausted() const;
 
-	OreDepositYield yield() const { return mOreDepositYield; }
+	OreDepositYield yield() const { return mYield; }
 
 	int depth() const;
 	void increaseDepth();
@@ -53,5 +53,5 @@ private:
 private:
 	StorableResources mTappedReserves;
 	int mCurrentDepth{0};
-	OreDepositYield mOreDepositYield = OreDepositYield::Low;
+	OreDepositYield mYield = OreDepositYield::Low;
 };

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -53,5 +53,5 @@ private:
 private:
 	StorableResources mTappedReserves;
 	int mCurrentDepth{0};
-	OreDepositYield mYield = OreDepositYield::Low;
+	OreDepositYield mYield;
 };

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -44,6 +44,6 @@ private:
 
 private:
 	StorableResources mTappedReserves;
-	int mCurrentDepth{0};
+	int mDigDepth{0};
 	OreDepositYield mYield;
 };

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -23,8 +23,6 @@ public:
 	OreDeposit();
 	OreDeposit(OreDepositYield yield);
 
-	bool exhausted() const;
-
 	int depth() const;
 	void increaseDepth();
 
@@ -33,6 +31,8 @@ public:
 	StorableResources totalYield() const;
 	StorableResources availableResources() const;
 	StorableResources pull(const StorableResources& maxTransfer);
+
+	bool exhausted() const;
 
 public:
 	NAS2D::Xml::XmlElement* serialize(NAS2D::Point<int> location);

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -20,15 +20,6 @@ enum class OreDepositYield;
 class OreDeposit
 {
 public:
-	enum class OreType
-	{
-		CommonMetals,
-		CommonMinerals,
-		RareMetals,
-		RareMinerals,
-	};
-
-public:
 	OreDeposit();
 	OreDeposit(OreDepositYield yield);
 

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -44,6 +44,6 @@ private:
 
 private:
 	StorableResources mTappedReserves;
-	int mDigDepth{0};
 	OreDepositYield mYield;
+	int mDigDepth{0};
 };

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -30,9 +30,8 @@ public:
 	int depth() const;
 	void increaseDepth();
 
-	StorableResources availableResources() const;
 	StorableResources totalYield() const;
-
+	StorableResources availableResources() const;
 	StorableResources pull(const StorableResources& maxTransfer);
 
 public:

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -23,7 +23,7 @@ public:
 	OreDeposit();
 	OreDeposit(OreDepositYield yield);
 
-	int depth() const;
+	int digDepth() const;
 	void increaseDepth();
 
 	OreDepositYield yield() const;


### PR DESCRIPTION
Noticed a few things while looking at the code to remove the mining enabled check boxes.

Mostly internal refactoring, though with a few `public` method renames. There was also some reduction in transitive header includes.

Related:
- Issue #1845
