### PR TITLE
Verify `StructureType` order

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -61,56 +61,6 @@ const std::map<StructureClass, std::string> StructureClassNames =
 };
 
 
-static const std::array<std::string, StructureID::SID_COUNT> StructureNameTable =
-{
-	"Not a Structure",
-	constants::Agridome,
-	constants::AirShaft,
-	constants::CargoLander,
-	constants::Chap,
-	constants::ColonistLander,
-	constants::CommandCenter,
-	constants::Commercial,
-	constants::CommTower,
-	constants::FusionReactor,
-	constants::HotLaboratory,
-	constants::Laboratory,
-	constants::MedicalCenter,
-	constants::MineFacility,
-	constants::MineShaft,
-	constants::Nursery,
-	constants::Park,
-	constants::RecreationCenter,
-	constants::RedLightDistrict,
-	constants::Residence,
-	constants::Road,
-	constants::RobotCommand,
-	constants::SeedFactory,
-	constants::SeedLander,
-	constants::SeedPower,
-	constants::SeedSmelter,
-	constants::Smelter,
-	constants::SolarPanel1,
-	constants::SolarPlant,
-	constants::StorageTanks,
-	constants::SurfaceFactory,
-	constants::SurfacePolice,
-	constants::Tube,
-	constants::UndergroundFactory,
-	constants::UndergroundPolice,
-	constants::University,
-	constants::Warehouse,
-	constants::Recycling,
-	constants::MaintenanceFacility
-};
-
-
-std::string StructureName(StructureID id)
-{
-	return StructureNameTable[static_cast<size_t>(id)];
-}
-
-
 std::vector<StructureClass> allStructureClasses()
 {
 	std::vector<StructureClass> result;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -197,5 +197,4 @@ private:
 
 using StructureList = std::vector<Structure*>;
 
-std::string StructureName(StructureID id);
 std::vector<StructureClass> allStructureClasses();

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -31,6 +31,7 @@
 #include <libOPHD/EnumDirection.h>
 
 #include <libOPHD/Map/MapCoordinate.h>
+#include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -721,6 +722,6 @@ void MapViewState::updateStructuresAvailability()
 	for (int sid = 1; sid < StructureID::SID_COUNT; ++sid)
 	{
 		const StructureID id = static_cast<StructureID>(sid);
-		mStructures.itemAvailable(StructureName(id), StructureCatalog::canBuild(id, mResourcesCount));
+		mStructures.itemAvailable(StructureCatalog::getType(id).name, StructureCatalog::canBuild(id, mResourcesCount));
 	}
 }

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -216,7 +216,7 @@ void StructureCatalog::init(const std::string& filename)
 
 const StructureType& StructureCatalog::getType(StructureID id)
 {
-	return idToType.at(id);
+	return structureTypes.at(static_cast<std::size_t>(id));
 }
 
 

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -158,6 +158,20 @@ namespace
 	std::vector<StructureType> structureTypes;
 
 
+	void verifyStructureTypeOrder()
+	{
+		for (std::size_t i = 1; i < StructureID::SID_COUNT; ++i)
+		{
+			const auto& expectedName = StructureNameTable[i];
+			const auto& actualName = structureTypes[i].name;
+			if (expectedName != actualName)
+			{
+				throw std::runtime_error("Unexpected StructureType at index: " + std::to_string(i) + " : " + expectedName + " != " + actualName);
+			}
+		}
+	}
+
+
 	const StructureType& findStructureType(const std::string& name)
 	{
 		for (const auto& structureType : structureTypes)
@@ -194,6 +208,7 @@ namespace
 void StructureCatalog::init(const std::string& filename)
 {
 	structureTypes = loadStructureTypes(filename);
+	verifyStructureTypeOrder();
 	idToType = buildStructureTypeLookup();
 	StructureRecycleValueTable = buildRecycleValueTable(DefaultRecyclePercent);
 }

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -2,6 +2,7 @@
 
 #include "MapObjects/Structures.h"
 #include "IOHelper.h"
+#include "Constants/Strings.h"
 
 #include <libOPHD/MapObjects/StructureType.h>
 #include <libOPHD/StorableResources.h>
@@ -12,11 +13,62 @@
 #include <NAS2D/ParserHelper.h>
 
 #include <map>
+#include <array>
 #include <stdexcept>
 
 
 namespace
 {
+	static const std::array<std::string, StructureID::SID_COUNT> StructureNameTable =
+	{
+		"Not a Structure",
+		constants::Agridome,
+		constants::AirShaft,
+		constants::CargoLander,
+		constants::Chap,
+		constants::ColonistLander,
+		constants::CommandCenter,
+		constants::Commercial,
+		constants::CommTower,
+		constants::FusionReactor,
+		constants::HotLaboratory,
+		constants::Laboratory,
+		constants::MedicalCenter,
+		constants::MineFacility,
+		constants::MineShaft,
+		constants::Nursery,
+		constants::Park,
+		constants::RecreationCenter,
+		constants::RedLightDistrict,
+		constants::Residence,
+		constants::Road,
+		constants::RobotCommand,
+		constants::SeedFactory,
+		constants::SeedLander,
+		constants::SeedPower,
+		constants::SeedSmelter,
+		constants::Smelter,
+		constants::SolarPanel1,
+		constants::SolarPlant,
+		constants::StorageTanks,
+		constants::SurfaceFactory,
+		constants::SurfacePolice,
+		constants::Tube,
+		constants::UndergroundFactory,
+		constants::UndergroundPolice,
+		constants::University,
+		constants::Warehouse,
+		constants::Recycling,
+		constants::MaintenanceFacility
+	};
+
+
+	std::string StructureName(StructureID id)
+	{
+		return StructureNameTable[static_cast<size_t>(id)];
+	}
+
+
 	std::map<StructureID, StorableResources> buildRecycleValueTable(int recoveryPercent);
 
 	/**	Currently set at 90% but this should probably be

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -63,12 +63,6 @@ namespace
 	};
 
 
-	std::string StructureName(StructureID id)
-	{
-		return StructureNameTable[static_cast<size_t>(id)];
-	}
-
-
 	std::map<StructureID, StorableResources> buildRecycleValueTable(int recoveryPercent);
 
 	/**	Currently set at 90% but this should probably be
@@ -183,7 +177,7 @@ namespace
 		for (std::size_t i = 1; i < StructureID::SID_COUNT; ++i)
 		{
 			const auto structureId = static_cast<StructureID>(i);
-			const auto& structureName = StructureName(structureId);
+			const auto& structureName = StructureNameTable[i];
 			idToType.emplace(structureId, findStructureType(structureName));
 		}
 		return idToType;

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -170,35 +170,6 @@ namespace
 			}
 		}
 	}
-
-
-	const StructureType& findStructureType(const std::string& name)
-	{
-		for (const auto& structureType : structureTypes)
-		{
-			if (structureType.name == name)
-			{
-				return structureType;
-			}
-		}
-		throw std::runtime_error("StructureType not found: " + name);
-	}
-
-
-	auto buildStructureTypeLookup()
-	{
-		std::map<StructureID, const StructureType&> idToType;
-		for (std::size_t i = 1; i < StructureID::SID_COUNT; ++i)
-		{
-			const auto structureId = static_cast<StructureID>(i);
-			const auto& structureName = StructureNameTable[i];
-			idToType.emplace(structureId, findStructureType(structureName));
-		}
-		return idToType;
-	}
-
-
-	std::map<StructureID, const StructureType&> idToType;
 }
 
 
@@ -209,7 +180,6 @@ void StructureCatalog::init(const std::string& filename)
 {
 	structureTypes = loadStructureTypes(filename);
 	verifyStructureTypeOrder();
-	idToType = buildStructureTypeLookup();
 	StructureRecycleValueTable = buildRecycleValueTable(DefaultRecyclePercent);
 }
 


### PR DESCRIPTION
Add restriction that `StructureTypes.xml` must list entries in the same order as `StructureID` values.

This strengthens though also simplifies verification checks on the data. It also means we can safely use `static_cast` to convert from a `StructureID` enum value to an index into the `StructureType` collection.

Related:
- Issue #1723
- PR https://github.com/OutpostUniverse/ophd-assets/pull/21
