### PR TITLE
Simplify list box highlight color

### DIFF
--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -232,7 +232,7 @@ void ListBoxBase::draw() const
 	renderer.clipRect(mRect.inset(1));
 
 	// Mouse over highlight and selected highlight
-	if (mHighlightIndex != NoSelection) { renderer.drawBoxFilled(itemDrawArea(mHighlightIndex), NAS2D::Color{0, 185, 0, 50}); }
+	if (mHighlightIndex != NoSelection) { renderer.drawBoxFilled(itemDrawArea(mHighlightIndex), NAS2D::Color{0, 36, 0}); }
 	if (mSelectedIndex != NoSelection) { renderer.drawBoxFilled(itemDrawArea(mSelectedIndex), itemBorderColor(mSelectedIndex).alphaFade(75)); }
 
 	drawItems();


### PR DESCRIPTION
The highlight box is being drawn on a black background, so we can pre-blend the alpha channel color, and produce a color with no alpha blending.

Related:
- Issue #479
