### PR TITLE
Refactor `StructureInspector`

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -418,7 +418,7 @@ void Structure::integrity(int integrity)
 }
 
 
-StringTable Structure::createInspectorViewTable()
+StringTable Structure::createInspectorViewTable() const
 {
 	return StringTable(0, 0);
 }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -145,7 +145,7 @@ public:
 	/**
 	* Pass limited structure specific details for drawing. Use a custom UI window if needed.
 	*/
-	virtual StringTable createInspectorViewTable();
+	virtual StringTable createInspectorViewTable() const;
 
 	virtual NAS2D::Dictionary getDataDict() const;
 

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -12,7 +12,7 @@ CommTower::CommTower() : Structure(
 }
 
 
-StringTable CommTower::createInspectorViewTable()
+StringTable CommTower::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 1);
 

--- a/appOPHD/MapObjects/Structures/CommTower.h
+++ b/appOPHD/MapObjects/Structures/CommTower.h
@@ -8,5 +8,5 @@ class CommTower : public Structure
 public:
 	CommTower();
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 };

--- a/appOPHD/MapObjects/Structures/FoodProduction.cpp
+++ b/appOPHD/MapObjects/Structures/FoodProduction.cpp
@@ -11,7 +11,7 @@ FoodProduction::FoodProduction(StructureClass structureClass, StructureID id) :
 }
 
 
-StringTable FoodProduction::createInspectorViewTable()
+StringTable FoodProduction::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 2);
 

--- a/appOPHD/MapObjects/Structures/FoodProduction.h
+++ b/appOPHD/MapObjects/Structures/FoodProduction.h
@@ -13,7 +13,7 @@ class FoodProduction : public Structure
 public:
 	FoodProduction(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 
 	int foodLevel() const;
 	void foodLevel(int level);

--- a/appOPHD/MapObjects/Structures/FusionReactor.h
+++ b/appOPHD/MapObjects/Structures/FusionReactor.h
@@ -16,7 +16,7 @@ public:
 	}
 
 protected:
-	int calculateMaxEnergyProduction() override
+	int calculateMaxEnergyProduction() const override
 	{
 		return FusionReactorBaseProduction;
 	}

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -12,7 +12,7 @@ OreRefining::OreRefining(StructureClass structureClass, StructureID id) :
 }
 
 
-StringTable OreRefining::createInspectorViewTable()
+StringTable OreRefining::createInspectorViewTable() const
 {
 	StringTable stringTable(3, 5);
 

--- a/appOPHD/MapObjects/Structures/OreRefining.h
+++ b/appOPHD/MapObjects/Structures/OreRefining.h
@@ -15,7 +15,7 @@ class OreRefining : public Structure
 public:
 	OreRefining(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 
 protected:
 	std::array<int, 4> OreConversionDivisor{2, 2, 3, 3};

--- a/appOPHD/MapObjects/Structures/PowerStructure.cpp
+++ b/appOPHD/MapObjects/Structures/PowerStructure.cpp
@@ -30,7 +30,7 @@ StringTable PowerStructure::createInspectorViewTable()
 }
 
 
-int PowerStructure::energyProduced()
+int PowerStructure::energyProduced() const
 {
 	return operational() ? calculateMaxEnergyProduction() : 0;
 }

--- a/appOPHD/MapObjects/Structures/PowerStructure.cpp
+++ b/appOPHD/MapObjects/Structures/PowerStructure.cpp
@@ -11,7 +11,7 @@ PowerStructure::PowerStructure(StructureClass structureClass, StructureID id) :
 }
 
 
-StringTable PowerStructure::createInspectorViewTable()
+StringTable PowerStructure::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 1);
 

--- a/appOPHD/MapObjects/Structures/PowerStructure.h
+++ b/appOPHD/MapObjects/Structures/PowerStructure.h
@@ -15,7 +15,7 @@ public:
 
 	StringTable createInspectorViewTable() override;
 
-	int energyProduced();
+	int energyProduced() const;
 
 protected:
 	virtual int calculateMaxEnergyProduction() const = 0;

--- a/appOPHD/MapObjects/Structures/PowerStructure.h
+++ b/appOPHD/MapObjects/Structures/PowerStructure.h
@@ -18,5 +18,5 @@ public:
 	int energyProduced();
 
 protected:
-	virtual int calculateMaxEnergyProduction() = 0;
+	virtual int calculateMaxEnergyProduction() const = 0;
 };

--- a/appOPHD/MapObjects/Structures/PowerStructure.h
+++ b/appOPHD/MapObjects/Structures/PowerStructure.h
@@ -13,7 +13,7 @@ class PowerStructure : public Structure
 public:
 	PowerStructure(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 
 	int energyProduced() const;
 

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -38,7 +38,7 @@ int Recycling::residentialSupportCount() const
 }
 
 
-StringTable Recycling::createInspectorViewTable()
+StringTable Recycling::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 2);
 

--- a/appOPHD/MapObjects/Structures/Recycling.h
+++ b/appOPHD/MapObjects/Structures/Recycling.h
@@ -11,5 +11,5 @@ public:
 	virtual int wasteProcessingCapacity() const;
 	virtual int residentialSupportCount() const;
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 };

--- a/appOPHD/MapObjects/Structures/ResearchFacility.cpp
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.cpp
@@ -11,7 +11,7 @@ ResearchFacility::ResearchFacility(StructureClass structureClass, StructureID id
 {}
 
 
-StringTable ResearchFacility::createInspectorViewTable()
+StringTable ResearchFacility::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 3);
 

--- a/appOPHD/MapObjects/Structures/ResearchFacility.h
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.h
@@ -8,7 +8,7 @@ class ResearchFacility : public Structure
 public:
 	ResearchFacility(StructureClass structureClass, StructureID id);
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 
 	int regularResearchProduced() const;
 	int hotResearchProduced() const;

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -55,7 +55,7 @@ void Residence::assignColonists(int amount)
 int Residence::assignedColonists() const { return mAssignedColonists; }
 
 
-StringTable Residence::createInspectorViewTable()
+StringTable Residence::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 6);
 

--- a/appOPHD/MapObjects/Structures/Residence.h
+++ b/appOPHD/MapObjects/Structures/Residence.h
@@ -25,7 +25,7 @@ public:
 	void assignColonists(int amount);
 	int assignedColonists() const;
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 
 protected:
 	void think() override;

--- a/appOPHD/MapObjects/Structures/SeedPower.h
+++ b/appOPHD/MapObjects/Structures/SeedPower.h
@@ -15,7 +15,7 @@ public:
 	}
 
 private:
-	int calculateMaxEnergyProduction() override
+	int calculateMaxEnergyProduction() const override
 	{
 		return SeedPowerProduction;
 	}

--- a/appOPHD/MapObjects/Structures/SolarPanelArray.cpp
+++ b/appOPHD/MapObjects/Structures/SolarPanelArray.cpp
@@ -19,7 +19,7 @@ SolarPanelArray::SolarPanelArray() :
 }
 
 
-int SolarPanelArray::calculateMaxEnergyProduction()
+int SolarPanelArray::calculateMaxEnergyProduction() const
 {
 	return static_cast<int>(SolarPanelBaseProduction / getMeanSolarDistance());
 }

--- a/appOPHD/MapObjects/Structures/SolarPanelArray.h
+++ b/appOPHD/MapObjects/Structures/SolarPanelArray.h
@@ -9,5 +9,5 @@ public:
 	SolarPanelArray();
 
 protected:
-	int calculateMaxEnergyProduction() override;
+	int calculateMaxEnergyProduction() const override;
 };

--- a/appOPHD/MapObjects/Structures/SolarPlant.cpp
+++ b/appOPHD/MapObjects/Structures/SolarPlant.cpp
@@ -19,7 +19,7 @@ SolarPlant::SolarPlant() :
 }
 
 
-int SolarPlant::calculateMaxEnergyProduction()
+int SolarPlant::calculateMaxEnergyProduction() const
 {
 	return static_cast<int>(SolarPlantBaseProduction / getMeanSolarDistance());
 }

--- a/appOPHD/MapObjects/Structures/SolarPlant.h
+++ b/appOPHD/MapObjects/Structures/SolarPlant.h
@@ -9,5 +9,5 @@ public:
 	SolarPlant();
 
 protected:
-	int calculateMaxEnergyProduction() override;
+	int calculateMaxEnergyProduction() const override;
 };

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -11,7 +11,7 @@ StorageTanks::StorageTanks() : Structure(
 {
 }
 
-StringTable StorageTanks::createInspectorViewTable()
+StringTable StorageTanks::createInspectorViewTable() const
 {
 	StringTable stringTable(2, 5);
 

--- a/appOPHD/MapObjects/Structures/StorageTanks.h
+++ b/appOPHD/MapObjects/Structures/StorageTanks.h
@@ -8,5 +8,5 @@ class StorageTanks : public Structure
 public:
 	StorageTanks();
 
-	StringTable createInspectorViewTable() override;
+	StringTable createInspectorViewTable() const override;
 };

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -669,8 +669,7 @@ void MapViewState::onInspectStructure(Structure& structure, bool inspectModifier
 	}
 	else
 	{
-		mStructureInspector.structure(structure);
-		mStructureInspector.show();
+		mStructureInspector.showStructure(structure);
 		mWindowStack.bringToFront(mStructureInspector);
 	}
 }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -669,7 +669,7 @@ void MapViewState::onInspectStructure(Structure& structure, bool inspectModifier
 	}
 	else
 	{
-		mStructureInspector.structure(&structure);
+		mStructureInspector.structure(structure);
 		mStructureInspector.show();
 		mWindowStack.bringToFront(mStructureInspector);
 	}

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -982,7 +982,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 	}
 	else if (tile.hasStructure())
 	{
-		if (mStructureInspector.structure() == tile.structure()) { mStructureInspector.hide(); }
+		mStructureInspector.hideStructure(*tile.structure());
 
 		Structure* structure = tile.structure();
 

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -48,16 +48,11 @@ namespace
 
 	std::string getDisabledReason(const Structure& structure)
 	{
-		if (structure.disabled())
-		{
-			return disabledReasonTable.at(structure.disabledReason());
-		}
-		else if (structure.isIdle())
-		{
-			return idleReadonTable.at(structure.idleReason());
-		}
-
-		return "";
+		return (structure.disabled()) ?
+			disabledReasonTable.at(structure.disabledReason()) :
+			(structure.isIdle()) ?
+				idleReadonTable.at(structure.idleReason()) :
+				"";
 	}
 
 

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -46,27 +46,15 @@ namespace
 	};
 
 
-	const std::string& disabledReasonToString(DisabledReason disabledReason)
-	{
-		return disabledReasonTable.at(disabledReason);
-	}
-
-
-	const std::string& idleReasonToString(IdleReason idleReason)
-	{
-		return idleReadonTable.at(idleReason);
-	}
-
-
 	std::string getDisabledReason(const Structure& structure)
 	{
 		if (structure.disabled())
 		{
-			return disabledReasonToString(structure.disabledReason());
+			return disabledReasonTable.at(structure.disabledReason());
 		}
 		else if (structure.isIdle())
 		{
-			return idleReasonToString(structure.idleReason());
+			return idleReadonTable.at(structure.idleReason());
 		}
 
 		return "";

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -156,7 +156,11 @@ void StructureInspector::showStructure(Structure& structure)
 
 void StructureInspector::hideStructure(Structure& structure)
 {
-	if (mStructure == &structure) { hide(); }
+	if (mStructure == &structure)
+	{
+		hide();
+		mStructure = nullptr;
+	}
 }
 
 

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -132,12 +132,9 @@ StructureInspector::StructureInspector() :
 }
 
 
-void StructureInspector::structure(Structure* structure)
+void StructureInspector::structure(Structure& structure)
 {
-	mStructure = structure;
-
-	if (!mStructure) { return; }
-
+	mStructure = &structure;
 	title(mStructure->name());
 
 	const auto genericStructureAttributes = buildGenericStringTable();

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -154,6 +154,12 @@ void StructureInspector::showStructure(Structure& structure)
 }
 
 
+void StructureInspector::hideStructure(Structure& structure)
+{
+	if (mStructure == &structure) { hide(); }
+}
+
+
 void StructureInspector::onVisibilityChange(bool visible)
 {
 	Window::onVisibilityChange(visible);

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -132,7 +132,7 @@ StructureInspector::StructureInspector() :
 }
 
 
-void StructureInspector::structure(Structure& structure)
+void StructureInspector::showStructure(Structure& structure)
 {
 	mStructure = &structure;
 	title(mStructure->name());
@@ -149,6 +149,8 @@ void StructureInspector::structure(Structure& structure)
 	size(windowSize);
 
 	btnClose.position(area().endPoint() - btnClose.size() - NAS2D::Vector{constants::Margin, constants::Margin});
+
+	show();
 }
 
 

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -132,7 +132,7 @@ StructureInspector::StructureInspector() :
 }
 
 
-void StructureInspector::showStructure(Structure& structure)
+void StructureInspector::showStructure(const Structure& structure)
 {
 	mStructure = &structure;
 	title(mStructure->name());
@@ -154,7 +154,7 @@ void StructureInspector::showStructure(Structure& structure)
 }
 
 
-void StructureInspector::hideStructure(Structure& structure)
+void StructureInspector::hideStructure(const Structure& structure)
 {
 	if (mStructure == &structure)
 	{

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -17,6 +17,7 @@ public:
 	StructureInspector();
 
 	void showStructure(Structure& structure);
+	void hideStructure(Structure& structure);
 	Structure* structure() { return mStructure; }
 
 	void drawClientArea() const override;

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -16,8 +16,8 @@ class StructureInspector : public Window
 public:
 	StructureInspector();
 
-	void showStructure(Structure& structure);
-	void hideStructure(Structure& structure);
+	void showStructure(const Structure& structure);
+	void hideStructure(const Structure& structure);
 
 	void drawClientArea() const override;
 
@@ -31,5 +31,5 @@ protected:
 private:
 	Button btnClose;
 	const NAS2D::Image& mIcons;
-	Structure* mStructure = nullptr;
+	const Structure* mStructure = nullptr;
 };

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -16,7 +16,7 @@ class StructureInspector : public Window
 public:
 	StructureInspector();
 
-	void structure(Structure* structure);
+	void structure(Structure& structure);
 	Structure* structure() { return mStructure; }
 
 	void drawClientArea() const override;

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -18,7 +18,6 @@ public:
 
 	void showStructure(Structure& structure);
 	void hideStructure(Structure& structure);
-	Structure* structure() { return mStructure; }
 
 	void drawClientArea() const override;
 

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -16,7 +16,7 @@ class StructureInspector : public Window
 public:
 	StructureInspector();
 
-	void structure(Structure& structure);
+	void showStructure(Structure& structure);
 	Structure* structure() { return mStructure; }
 
 	void drawClientArea() const override;


### PR DESCRIPTION
A bit of `StructureInspector` refactoring before working on removing the `Structure` dependence on `StringTable`.

Related:
- Issue #1908
