### PR TITLE
Move item border drawing from `ListBoxBase` to subclasses

### DIFF
--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -123,6 +123,9 @@ void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 	const auto& structureTextColor = structureTextColorFromIndex(factoryState);
 	const auto& borderColor = itemBorderColor(index);
 
+	// Draw border
+	renderer.drawBox(drawArea.inset(1), borderColor);
+
 	const auto subImageRect = NAS2D::Rectangle{item.icon_slice, {46, 46}};
 	renderer.drawSubImage(mStructureIcons, drawArea.position + NAS2D::Vector{8, 8}, subImageRect, NAS2D::Color::White.alphaFade(borderColor.alpha));
 	renderer.drawText(mFontBold, factory.name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -84,6 +84,9 @@ void ProductListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 	const auto secondStop = drawArea.size.x * 2 / 3;
 	const auto& item = getItem(index);
 
+	// Draw border
+	renderer.drawBox(drawArea.inset(1), itemBorderColor(index));
+
 	// Draw column breaks
 	renderer.drawLine(drawArea.position + NAS2D::Vector{firstStop, 2}, drawArea.position + NAS2D::Vector{firstStop, drawArea.size.y - 2}, constants::PrimaryColor);
 	renderer.drawLine(drawArea.position + NAS2D::Vector{secondStop, 2}, drawArea.position + NAS2D::Vector{secondStop, drawArea.size.y - 2}, constants::PrimaryColor);

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -131,6 +131,9 @@ void StructureListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int>
 	const auto structureState = item.structure->state();
 	const auto& structureTextColor = structureTextColorFromIndex(structureState);
 
+	// Draw border
+	renderer.drawBox(drawArea.inset(1), itemBorderColor(index));
+
 	const auto yOffset = 15 - mFontBold.height() / 2;
 	renderer.drawText(mFontBold, item.text, drawArea.position + NAS2D::Vector{5, yOffset}, structureTextColor);
 	renderer.drawText(mFont, item.stateDescription, drawArea.crossXPoint() + NAS2D::Vector{-mFont.width(item.stateDescription) - 5, yOffset}, structureTextColor);

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -219,9 +219,6 @@ void ListBoxBase::drawScrollArea(NAS2D::Renderer& renderer) const
 		// Selected highlight
 		if (index == mSelectedIndex) { renderer.drawBoxFilled(itemDrawArea, borderColor.alphaFade(75)); }
 
-		// Draw border
-		renderer.drawBox(itemDrawArea.inset(1), borderColor);
-
 		drawItem(renderer, itemDrawArea, index);
 		itemDrawArea.position.y += lineHeight;
 	}


### PR DESCRIPTION
This is really a decision that should be made in the subclasses. It just so happens that all the current subclasses use the same border style. Though that was sort of imposed by putting the item border drawing in the base class.

This makes the `ListBoxBase` draw code more consistent with `ListBox`. It also potentially allows `ListBox` draw code to inherit from `ListBoxBase`, though support for list box themes would need to be moved to `ListBoxBase` first.

Related:
- Issue #479
