### PR TITLE
Refactor and consolidate list box drawing

### DIFF
--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -146,30 +146,6 @@ protected:
 	}
 
 
-	void drawScrollArea(NAS2D::Renderer& renderer) const
-	{
-		renderer.clipRect(mScrollArea);
-
-		// Determine visible items and draw them
-		const auto lineHeight = mItemSize.y;
-		const auto firstVisibleIndex = static_cast<std::size_t>(mScrollOffsetInPixels / lineHeight);
-		const auto firstInvisibleIndex = static_cast<std::size_t>((mScrollOffsetInPixels + mScrollArea.size.y + (lineHeight - 1)) / lineHeight);
-		const auto endVisibleIndex = std::min(firstInvisibleIndex, count());
-		auto itemDrawArea = NAS2D::Rectangle{mScrollArea.position + NAS2D::Vector{0, static_cast<int>(firstVisibleIndex) * mItemSize.y - mScrollOffsetInPixels}, mItemSize};
-		for (std::size_t index = firstVisibleIndex; index < endVisibleIndex; ++index)
-		{
-			drawItemCell(renderer, itemDrawArea, index);
-			itemDrawArea.position.y += lineHeight;
-		}
-
-		// Paint remaining section of scroll area not covered by items
-		itemDrawArea.size.y = mScrollArea.endPoint().y - itemDrawArea.position.y;
-		renderer.drawBoxFilled(itemDrawArea, emptyAreaColor());
-
-		renderer.clipRectClear();
-	}
-
-
 	void drawItemCell(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override
 	{
 		// Draw background rect

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -124,12 +124,17 @@ public:
 
 
 protected:
+	NAS2D::Color borderColor() const override
+	{
+		return hasFocus() ? mListBoxTheme.borderColorActive : mListBoxTheme.borderColorNormal;
+	}
+
+
 	void draw() const override
 	{
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-		const auto borderColor = hasFocus() ? mListBoxTheme.borderColorActive : mListBoxTheme.borderColorNormal;
-		renderer.drawBox(mRect, borderColor);
+		renderer.drawBox(mRect, borderColor());
 
 		drawScrollArea(renderer);
 	}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -158,7 +158,7 @@ protected:
 		auto itemDrawArea = NAS2D::Rectangle{mScrollArea.position + NAS2D::Vector{0, static_cast<int>(firstVisibleIndex) * mItemSize.y - mScrollOffsetInPixels}, mItemSize};
 		for (std::size_t index = firstVisibleIndex; index < endVisibleIndex; ++index)
 		{
-			drawItem(renderer, itemDrawArea, index);
+			drawItemCell(renderer, itemDrawArea, index);
 			itemDrawArea.position.y += lineHeight;
 		}
 
@@ -170,15 +170,20 @@ protected:
 	}
 
 
+	void drawItemCell(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override
+	{
+		// Draw background rect
+		const auto backgroundColor = (index == mSelectedIndex) ? mListBoxTheme.backgroundColorSelected : mListBoxTheme.backgroundColorNormal;
+		renderer.drawBoxFilled(drawArea, backgroundColor);
+
+		drawItem(renderer, drawArea, index);
+	}
+
+
 	void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override
 	{
 		const auto isSelected = (index == mSelectedIndex);
 		const auto isHighlighted = (index == mHighlightIndex);
-
-		// Draw background rect
-		const auto backgroundColor = isSelected ? mListBoxTheme.backgroundColorSelected : mListBoxTheme.backgroundColorNormal;
-		renderer.drawBoxFilled(drawArea, backgroundColor);
-
 		mItems[index].draw(renderer, drawArea, mListBoxTheme, isSelected, isHighlighted);
 	}
 

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -130,6 +130,12 @@ protected:
 	}
 
 
+	NAS2D::Color emptyAreaColor() const override
+	{
+		return mListBoxTheme.backgroundColorNormal;
+	}
+
+
 	void draw() const override
 	{
 		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -158,7 +164,7 @@ protected:
 
 		// Paint remaining section of scroll area not covered by items
 		itemDrawArea.size.y = mScrollArea.endPoint().y - itemDrawArea.position.y;
-		renderer.drawBoxFilled(itemDrawArea, mListBoxTheme.backgroundColorNormal);
+		renderer.drawBoxFilled(itemDrawArea, emptyAreaColor());
 
 		renderer.clipRectClear();
 	}

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -136,16 +136,6 @@ protected:
 	}
 
 
-	void draw() const override
-	{
-		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-
-		renderer.drawBox(mRect, borderColor());
-
-		drawScrollArea(renderer);
-	}
-
-
 	void drawItemCell(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const override
 	{
 		// Draw background rect

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -203,9 +203,7 @@ void ListBoxBase::update()
 void ListBoxBase::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-
 	renderer.drawBox(mRect, borderColor());
-
 	drawScrollArea(renderer);
 }
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -179,6 +179,12 @@ NAS2D::Color ListBoxBase::itemBorderColor(std::size_t /*index*/) const
 }
 
 
+NAS2D::Color ListBoxBase::emptyAreaColor() const
+{
+	return NAS2D::Color::Black;
+}
+
+
 void ListBoxBase::update()
 {
 	if (!visible()) { return; }
@@ -217,7 +223,7 @@ void ListBoxBase::drawScrollArea(NAS2D::Renderer& renderer) const
 
 	// Paint remaining section of scroll area not covered by items
 	itemDrawArea.size.y = mScrollArea.endPoint().y - itemDrawArea.position.y;
-	renderer.drawBoxFilled(itemDrawArea, NAS2D::Color::Black);
+	renderer.drawBoxFilled(itemDrawArea, emptyAreaColor());
 
 	renderer.clipRectClear();
 }

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -211,15 +211,7 @@ void ListBoxBase::drawScrollArea(NAS2D::Renderer& renderer) const
 	auto itemDrawArea = NAS2D::Rectangle{mScrollArea.position + NAS2D::Vector{0, static_cast<int>(firstVisibleIndex) * mItemSize.y - mScrollOffsetInPixels}, mItemSize};
 	for (std::size_t index = firstVisibleIndex; index < endVisibleIndex; ++index)
 	{
-		const auto borderColor = itemBorderColor(index);
-
-		// Draw background color
-		const auto backgroundColor = (index == mHighlightIndex) ? NAS2D::Color{0, 36, 0} : NAS2D::Color::Black;
-		renderer.drawBoxFilled(itemDrawArea, backgroundColor);
-		// Selected highlight
-		if (index == mSelectedIndex) { renderer.drawBoxFilled(itemDrawArea, borderColor.alphaFade(75)); }
-
-		drawItem(renderer, itemDrawArea, index);
+		drawItemCell(renderer, itemDrawArea, index);
 		itemDrawArea.position.y += lineHeight;
 	}
 
@@ -228,4 +220,18 @@ void ListBoxBase::drawScrollArea(NAS2D::Renderer& renderer) const
 	renderer.drawBoxFilled(itemDrawArea, NAS2D::Color::Black);
 
 	renderer.clipRectClear();
+}
+
+
+void ListBoxBase::drawItemCell(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const
+{
+	const auto borderColor = itemBorderColor(index);
+
+	// Draw background color
+	const auto backgroundColor = (index == mHighlightIndex) ? NAS2D::Color{0, 36, 0} : NAS2D::Color::Black;
+	renderer.drawBoxFilled(drawArea, backgroundColor);
+	// Selected highlight
+	if (index == mSelectedIndex) { renderer.drawBoxFilled(drawArea, borderColor.alphaFade(75)); }
+
+	drawItem(renderer, drawArea, index);
 }

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -173,6 +173,12 @@ void ListBoxBase::onMouseWheel(NAS2D::Vector<int> scrollAmount)
 }
 
 
+NAS2D::Color ListBoxBase::borderColor() const
+{
+	return hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75};
+}
+
+
 NAS2D::Color ListBoxBase::itemBorderColor(std::size_t /*index*/) const
 {
 	return {0, 185, 0};
@@ -198,8 +204,7 @@ void ListBoxBase::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const auto borderColor = hasFocus() ? NAS2D::Color{0, 185, 0} : NAS2D::Color{75, 75, 75};
-	renderer.drawBox(mRect, borderColor);
+	renderer.drawBox(mRect, borderColor());
 
 	drawScrollArea(renderer);
 }

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -51,6 +51,7 @@ public:
 protected:
 	void draw() const override;
 	void drawScrollArea(NAS2D::Renderer& renderer) const;
+	virtual void drawItemCell(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const;
 	virtual void drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> drawArea, std::size_t index) const = 0;
 
 	void clear();

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -65,6 +65,7 @@ protected:
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const;
+	virtual NAS2D::Color emptyAreaColor() const;
 
 protected:
 	ScrollBar mScrollBar;

--- a/libControls/ListBoxBase.h
+++ b/libControls/ListBoxBase.h
@@ -64,6 +64,7 @@ protected:
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 
+	virtual NAS2D::Color borderColor() const;
 	virtual NAS2D::Color itemBorderColor(std::size_t index) const;
 	virtual NAS2D::Color emptyAreaColor() const;
 


### PR DESCRIPTION
Refactor and consolidate `ListBox` and `ListBoxBase` drawing code.

Extract differences to `virtual` methods. Eliminate duplication of methods that are then left identical.

Related:
- Issue #479
