### PR TITLE
Fix `FactoryReport` combo box size

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -537,7 +537,7 @@ void FactoryReport::draw() const
 
 	const auto positionX = cboFilterByProduct.area().position.x + cboFilterByProduct.area().size.x;
 	renderer.drawLine(NAS2D::Point{positionX + 10, mRect.position.y + 10}, NAS2D::Point{positionX + 10, mRect.position.y + mRect.size.y - 10}, constants::PrimaryTextColor);
-	const auto textPosition = NAS2D::Point{cboFilterByProduct.position().x, mRect.position.y + viewFilterOriginRow1.y + viewFilterButtonSize.y - font.height()};
+	const auto textPosition = cboFilterByProduct.position() + NAS2D::Vector{0, -font.height() - constants::MarginTight};
 	renderer.drawText(font, "Filter by Product", textPosition, constants::PrimaryTextColor);
 
 	if (selectedFactory)


### PR DESCRIPTION
Increase size of filter buttons and combo box on `FactoryReport` screen.

Adjust spacing between buttons so vertical spacing matches horizontal spacing. Change the combo box's title text to be left aligned. Position the combo box title text relative to the combo box position.

----

Original:
![image](https://github.com/user-attachments/assets/fab5dd44-d263-493f-85a6-ba56cefd8b1d)

Updated:
![image](https://github.com/user-attachments/assets/075169cb-f21f-43c1-8961-5825aa37e658)

----

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3025555680
- PR #1913
