### PR TITLE
Dynamic layout for `WarehouseReport` general info

### DIFF
--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -68,8 +68,8 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}},
 	lstStructures{{this, &WarehouseReport::onStructureSelectionChange}}
 {
-	auto buttonOffset = NAS2D::Vector{10, 10};
 	const auto buttonSize = NAS2D::Vector{94, 20};
+	auto buttonOffset = NAS2D::Vector{10, 10};
 	for (auto button : {&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled})
 	{
 		button->size(buttonSize);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -26,6 +26,7 @@ using namespace NAS2D;
 namespace
 {
 	constexpr auto infoSectionOffset = NAS2D::Vector{10, 40};
+	constexpr auto infoSectionHeight = 66;
 
 
 	template <typename Predicate>
@@ -330,7 +331,7 @@ void WarehouseReport::onStructureSelectionChange()
 
 void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 {
-	const auto textLineSpacing = 22;
+	const auto textLineSpacing = infoSectionHeight / 3;
 	const auto textOrigin = position() + infoSectionOffset;
 	renderer.drawText(fontMediumBold, "Warehouse Count", textOrigin, constants::PrimaryTextColor);
 	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, textLineSpacing}, constants::PrimaryTextColor);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -25,6 +25,9 @@ using namespace NAS2D;
 
 namespace
 {
+	constexpr auto infoSectionOffset = NAS2D::Vector{10, 40};
+
+
 	template <typename Predicate>
 	std::vector<Warehouse*> selectWarehouses(const Predicate& predicate)
 	{
@@ -328,7 +331,7 @@ void WarehouseReport::onStructureSelectionChange()
 void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 {
 	const auto textLineSpacing = 22;
-	const auto textOrigin = position() + NAS2D::Vector{10, 40};
+	const auto textOrigin = position() + infoSectionOffset;
 	renderer.drawText(fontMediumBold, "Warehouse Count", textOrigin, constants::PrimaryTextColor);
 	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, textLineSpacing}, constants::PrimaryTextColor);
 	renderer.drawText(fontMediumBold, "Capacity Used", textOrigin + NAS2D::Vector{0, textLineSpacing * 2}, constants::PrimaryTextColor);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -69,11 +69,11 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	lstStructures{{this, &WarehouseReport::onStructureSelectionChange}}
 {
 	const auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
-	const auto buttonSize = NAS2D::Vector{94, 20};
+	const auto filterButtonSize = NAS2D::Vector{94, 20};
 	auto buttonOffset = filterButtonSectionOffset;
 	for (auto button : {&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled})
 	{
-		button->size(buttonSize);
+		button->size(filterButtonSize);
 		button->type(Button::Type::Toggle);
 		button->toggle(false);
 		add(*button, buttonOffset);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -68,8 +68,8 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}},
 	lstStructures{{this, &WarehouseReport::onStructureSelectionChange}}
 {
-	const auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
-	const auto filterButtonSize = NAS2D::Vector{94, 20};
+	constexpr auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
+	constexpr auto filterButtonSize = NAS2D::Vector{94, 20};
 	auto buttonOffset = filterButtonSectionOffset;
 	for (auto button : {&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled})
 	{

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -66,10 +66,11 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	lstStructures{{this, &WarehouseReport::onStructureSelectionChange}}
 {
 	auto buttonOffset = NAS2D::Vector{10, 10};
+	const auto buttonSize = NAS2D::Vector{94, 20};
 	const auto buttons = std::array{&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled};
 	for (auto button : buttons)
 	{
-		button->size({94, 20});
+		button->size(buttonSize);
 		button->type(Button::Type::Toggle);
 		button->toggle(false);
 		add(*button, buttonOffset);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -325,13 +325,13 @@ void WarehouseReport::onStructureSelectionChange()
 	setVisibility();
 }
 
-
 void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 {
+	const auto textLineSpacing = 22;
 	const auto textOrigin = NAS2D::Point{10, position().y + 40};
 	renderer.drawText(fontMediumBold, "Warehouse Count", textOrigin, constants::PrimaryTextColor);
-	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, 22}, constants::PrimaryTextColor);
-	renderer.drawText(fontMediumBold, "Capacity Used", textOrigin + NAS2D::Vector{0, 44}, constants::PrimaryTextColor);
+	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, textLineSpacing}, constants::PrimaryTextColor);
+	renderer.drawText(fontMediumBold, "Capacity Used", textOrigin + NAS2D::Vector{0, textLineSpacing * 2}, constants::PrimaryTextColor);
 
 	const auto warehouseCountText = std::to_string(warehouseCount);
 	const auto warehouseCapacityText = std::to_string(warehouseCapacityTotal);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -336,12 +336,13 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, textLineSpacing}, constants::PrimaryTextColor);
 	renderer.drawText(fontMediumBold, "Capacity Used", textOrigin + NAS2D::Vector{0, textLineSpacing * 2}, constants::PrimaryTextColor);
 
+	const auto valueOrigin = textOrigin + NAS2D::Vector{mRect.size.x / 2 - 20, -5};
 	const auto warehouseCountText = std::to_string(warehouseCount);
 	const auto warehouseCapacityText = std::to_string(warehouseCapacityTotal);
 	const auto countTextWidth = fontMedium.width(warehouseCountText);
 	const auto capacityTextWidth = fontMedium.width(warehouseCapacityText);
-	renderer.drawText(fontMedium, warehouseCountText, NAS2D::Point{mRect.size.x / 2 - 10 - countTextWidth, position().y + 35}, constants::PrimaryTextColor);
-	renderer.drawText(fontMedium, warehouseCapacityText, NAS2D::Point{mRect.size.x / 2 - 10 - capacityTextWidth, position().y + 57}, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, warehouseCountText, valueOrigin + NAS2D::Vector{-countTextWidth, 0}, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, warehouseCapacityText, valueOrigin + NAS2D::Vector{-capacityTextWidth, textLineSpacing}, constants::PrimaryTextColor);
 
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
 	const auto capacityBarWidth = mRect.size.x / 2 - 30 - capacityUsedTextWidth;

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -328,7 +328,7 @@ void WarehouseReport::onStructureSelectionChange()
 void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 {
 	const auto textLineSpacing = 22;
-	const auto textOrigin = NAS2D::Point{10, position().y + 40};
+	const auto textOrigin = position() + NAS2D::Vector{10, 40};
 	renderer.drawText(fontMediumBold, "Warehouse Count", textOrigin, constants::PrimaryTextColor);
 	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, textLineSpacing}, constants::PrimaryTextColor);
 	renderer.drawText(fontMediumBold, "Capacity Used", textOrigin + NAS2D::Vector{0, textLineSpacing * 2}, constants::PrimaryTextColor);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -345,8 +345,8 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 	renderer.drawText(fontMedium, warehouseCapacityText, valueOrigin + NAS2D::Vector{-capacityTextWidth, textLineSpacing}, constants::PrimaryTextColor);
 
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
-	const auto capacityBarWidth = mRect.size.x / 2 - 30 - capacityUsedTextWidth;
 	const auto capacityBarPosition = textOrigin + NAS2D::Vector{capacityUsedTextWidth + 10, textLineSpacing * 2};
+	const auto capacityBarWidth = valueOrigin.x - capacityBarPosition.x;
 	drawProgressBar(
 		warehouseCapacityUsed,
 		warehouseCapacityTotal,

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -328,9 +328,10 @@ void WarehouseReport::onStructureSelectionChange()
 
 void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 {
-	renderer.drawText(fontMediumBold, "Warehouse Count", NAS2D::Point{10, position().y + 40}, constants::PrimaryTextColor);
-	renderer.drawText(fontMediumBold, "Total Storage", NAS2D::Point{10, position().y + 62}, constants::PrimaryTextColor);
-	renderer.drawText(fontMediumBold, "Capacity Used", NAS2D::Point{10, position().y + 84}, constants::PrimaryTextColor);
+	const auto textOrigin = NAS2D::Point{10, position().y + 40};
+	renderer.drawText(fontMediumBold, "Warehouse Count", textOrigin, constants::PrimaryTextColor);
+	renderer.drawText(fontMediumBold, "Total Storage", textOrigin + NAS2D::Vector{0, 22}, constants::PrimaryTextColor);
+	renderer.drawText(fontMediumBold, "Capacity Used", textOrigin + NAS2D::Vector{0, 44}, constants::PrimaryTextColor);
 
 	const auto warehouseCountText = std::to_string(warehouseCount);
 	const auto warehouseCapacityText = std::to_string(warehouseCapacityTotal);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -68,8 +68,9 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}},
 	lstStructures{{this, &WarehouseReport::onStructureSelectionChange}}
 {
+	const auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
 	const auto buttonSize = NAS2D::Vector{94, 20};
-	auto buttonOffset = NAS2D::Vector{10, 10};
+	auto buttonOffset = filterButtonSectionOffset;
 	for (auto button : {&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled})
 	{
 		button->size(buttonSize);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -346,11 +346,11 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
 	const auto capacityBarPosition = textOrigin + NAS2D::Vector{capacityUsedTextWidth + 10, textLineSpacing * 2};
-	const auto capacityBarWidth = valueOrigin.x - capacityBarPosition.x;
+	const auto capacityBarSize = NAS2D::Vector{valueOrigin.x - capacityBarPosition.x, 20};
 	drawProgressBar(
 		warehouseCapacityUsed,
 		warehouseCapacityTotal,
-		{capacityBarPosition, {capacityBarWidth, 20}}
+		{capacityBarPosition, capacityBarSize}
 	);
 }
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -24,6 +24,8 @@ using namespace NAS2D;
 
 namespace
 {
+	constexpr auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
+	constexpr auto filterButtonSize = NAS2D::Vector{94, 20};
 	constexpr auto infoSectionOffset = NAS2D::Vector{10, 40};
 	constexpr auto infoSectionHeight = 66;
 
@@ -68,8 +70,6 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	btnTakeMeThere{constants::TakeMeThere, {this, &WarehouseReport::onTakeMeThere}},
 	lstStructures{{this, &WarehouseReport::onStructureSelectionChange}}
 {
-	constexpr auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
-	constexpr auto filterButtonSize = NAS2D::Vector{94, 20};
 	auto buttonOffset = filterButtonSectionOffset;
 	for (auto button : {&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled})
 	{

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -26,9 +26,9 @@ namespace
 {
 	constexpr auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
 	constexpr auto filterButtonSize = NAS2D::Vector{94, 20};
-	constexpr auto infoSectionOffset = NAS2D::Vector{10, 40};
+	constexpr auto infoSectionOffset = filterButtonSectionOffset + NAS2D::Vector{0, filterButtonSize.y + 10};
 	constexpr auto infoSectionHeight = 66;
-	constexpr auto structureListBoxOffset = NAS2D::Vector{10, 115};
+	constexpr auto structureListBoxOffset = infoSectionOffset + NAS2D::Vector{0, infoSectionHeight + 9};
 
 
 	template <typename Predicate>

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -346,7 +346,7 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
 	const auto capacityBarWidth = mRect.size.x / 2 - 30 - capacityUsedTextWidth;
-	const auto capacityBarPosition = NAS2D::Point{20 + capacityUsedTextWidth, position().y + 84};
+	const auto capacityBarPosition = textOrigin + NAS2D::Vector{capacityUsedTextWidth + 10, 44};
 	drawProgressBar(
 		warehouseCapacityUsed,
 		warehouseCapacityTotal,

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -14,7 +14,6 @@
 #include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Renderer/Renderer.h>
 
-#include <array>
 #include <string>
 #include <iterator>
 #include <algorithm>
@@ -71,8 +70,7 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 {
 	auto buttonOffset = NAS2D::Vector{10, 10};
 	const auto buttonSize = NAS2D::Vector{94, 20};
-	const auto buttons = std::array{&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled};
-	for (auto button : buttons)
+	for (auto button : {&btnShowAll, &btnFull, &btnVacancy, &btnEmpty, &btnDisabled})
 	{
 		button->size(buttonSize);
 		button->type(Button::Type::Toggle);

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -346,7 +346,7 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 
 	const auto capacityUsedTextWidth = fontMediumBold.width("Capacity Used");
 	const auto capacityBarWidth = mRect.size.x / 2 - 30 - capacityUsedTextWidth;
-	const auto capacityBarPosition = textOrigin + NAS2D::Vector{capacityUsedTextWidth + 10, 44};
+	const auto capacityBarPosition = textOrigin + NAS2D::Vector{capacityUsedTextWidth + 10, textLineSpacing * 2};
 	drawProgressBar(
 		warehouseCapacityUsed,
 		warehouseCapacityTotal,

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -234,7 +234,7 @@ void WarehouseReport::onResize()
 {
 	Control::onResize();
 
-	lstStructures.size({(mRect.size.x / 2) - 20, mRect.size.y - 126});
+	lstStructures.size({(mRect.size.x / 2) - 20, mRect.position.y + mRect.size.y - lstStructures.position().y - 10});
 	lstProducts.size({(mRect.size.x / 2) - 20, mRect.size.y - 184});
 	lstProducts.position({Utility<Renderer>::get().center().x + 10, lstProducts.position().y});
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -28,6 +28,7 @@ namespace
 	constexpr auto filterButtonSize = NAS2D::Vector{94, 20};
 	constexpr auto infoSectionOffset = NAS2D::Vector{10, 40};
 	constexpr auto infoSectionHeight = 66;
+	constexpr auto structureListBoxOffset = NAS2D::Vector{10, 115};
 
 
 	template <typename Predicate>
@@ -89,7 +90,7 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 	fillLists();
 
 	add(btnTakeMeThere, {10, 10});
-	add(lstStructures, {10, 115});
+	add(lstStructures, structureListBoxOffset);
 	add(lstProducts, {Utility<Renderer>::get().center().x + 10, 173});
 }
 


### PR DESCRIPTION
Use dynamic layout for `WarehouseReport` filter buttons, general info section, and `StructureListBox`.

No graphical changes as part of this change set.

----

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3025555680
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3047474155
- PR #1915
- PR #1913
