### PR TITLE
Remove `clean` step for `flame-charts` target

### DIFF
--- a/makefile
+++ b/makefile
@@ -382,7 +382,6 @@ $(AllObjectShortNames):
 
 .PHONY: flame-charts
 flame-charts:
-	@$(MAKE) clean > /dev/null
 	$(MAKE) all CXX=clang++ CXXFLAGS_EXTRA="-ftime-trace"
 
 


### PR DESCRIPTION
We don't really need to `clean` before doing this. In fact, it may be desirable to run this incrementally, particularly to see how a change has impacted build times for a small set of files. That's easier to do when there isn't a full clean in between.

Related:
- PR #1886
- Issue #1573
