### PR TITLE
Add `Button::click()` method

### DIFF
--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -144,7 +144,7 @@ void Button::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 	else
 	{
 		mIsPressed = !mIsPressed;
-		if (mClickHandler) { mClickHandler(); }
+		click();
 	}
 }
 
@@ -160,7 +160,7 @@ void Button::onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position)
 
 		if (mRect.contains(position))
 		{
-			if (mClickHandler) { mClickHandler(); }
+			click();
 		}
 	}
 }

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -78,6 +78,12 @@ Button::~Button()
 }
 
 
+void Button::click() const
+{
+	if (mClickHandler) { mClickHandler(); }
+}
+
+
 void Button::type(Type type)
 {
 	mType = type;

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -41,7 +41,8 @@ Button::Button(std::string newText) :
 }
 
 
-Button::Button(std::string newText, ClickDelegate clickHandler) : Button(newText)
+Button::Button(std::string newText, ClickDelegate clickHandler) :
+	Button(newText)
 {
 	mClickHandler = clickHandler;
 }
@@ -54,7 +55,8 @@ Button::Button(std::string text, NAS2D::Vector<int> sz, ClickDelegate clickHandl
 }
 
 
-Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) : Button()
+Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) :
+	Button()
 {
 	mImage = &image;
 	size(mImage->size() + internalPadding * 2);

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -43,6 +43,8 @@ public:
 	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler);
 	~Button() override;
 
+	void click() const;
+
 	void type(Type type);
 
 	void toggle(bool toggle);


### PR DESCRIPTION
Add `Button::click()` method to simulate button clicks.

As there is no `Delegate` accessor, we have no way of triggering the click handler, other than asking the `Button` to do it, unless we saved a copy of the `Delegate` before constructing the `Button`. Saving a copy before construction seems a bit inconvenient, and wastes memory. Easier to just call `Button::click()`.

This can be used to add hotkeys with the same function as a `Button`.

Potentially this may also have uses in writing tests for user interface code.

----

Related:
- Issue #1924
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-2998109180
