### PR TITLE
Fix `Button` constructor overload taking `ButtonSkin`

### DIFF
--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -71,6 +71,22 @@ Button::Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler) :
 }
 
 
+Button::Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string newText, ClickDelegate clickHandler) :
+	mButtonSkin{buttonSkin},
+	mImage{image},
+	mFont{&font},
+	mText{newText},
+	mClickHandler{clickHandler}
+{
+	size(mFont->size(mText) + internalPadding * 2);
+
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseButtonDown().connect({this, &Button::onMouseDown});
+	eventHandler.mouseButtonUp().connect({this, &Button::onMouseUp});
+	eventHandler.mouseMotion().connect({this, &Button::onMouseMove});
+}
+
+
 Button::~Button()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -65,9 +65,8 @@ Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) :
 
 
 Button::Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler) :
-	mButtonSkin{buttonSkin}
+	Button{buttonSkin, nullptr, getDefaultFont(), {}, clickHandler}
 {
-	mClickHandler = clickHandler;
 }
 
 

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -188,7 +188,7 @@ void Button::draw() const
 	{
 		renderer.drawImage(*mImage, mRect.center() - mImage->size() / 2);
 	}
-	else
+	if (mFont)
 	{
 		const auto textPosition = mRect.center() - mFont->size(mText) / 2;
 		renderer.drawText(*mFont, mText, textPosition, NAS2D::Color::White);

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -27,40 +27,29 @@ namespace
 }
 
 
-Button::Button(std::string newText) :
-	mButtonSkin{defaultButtonSkin()},
-	mFont{&getDefaultFont()},
-	mText{newText}
+Button::Button(std::string text) :
+	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, {}}
 {
-	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseButtonDown().connect({this, &Button::onMouseDown});
-	eventHandler.mouseButtonUp().connect({this, &Button::onMouseUp});
-	eventHandler.mouseMotion().connect({this, &Button::onMouseMove});
-
-	size(mFont->size(mText) + internalPadding * 2);
 }
 
 
-Button::Button(std::string newText, ClickDelegate clickHandler) :
-	Button(newText)
+Button::Button(std::string text, ClickDelegate clickHandler) :
+	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, clickHandler}
 {
-	mClickHandler = clickHandler;
 }
 
 
 Button::Button(std::string text, NAS2D::Vector<int> sz, ClickDelegate clickHandler):
-	Button(text, clickHandler)
+	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, clickHandler}
 {
 	size(sz);
 }
 
 
 Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) :
-	Button()
+	Button{defaultButtonSkin(), &image, getDefaultFont(), {}, clickHandler}
 {
-	mImage = &image;
 	size(mImage->size() + internalPadding * 2);
-	mClickHandler = clickHandler;
 }
 
 

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -27,12 +27,6 @@ namespace
 }
 
 
-Button::Button(std::string text) :
-	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, {}}
-{
-}
-
-
 Button::Button(std::string text, ClickDelegate clickHandler) :
 	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, clickHandler}
 {

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -36,8 +36,7 @@ public:
 
 	using ClickDelegate = NAS2D::Delegate<void()>;
 
-	Button(std::string newText = {});
-	Button(std::string newText, ClickDelegate clickHandler);
+	Button(std::string newText = {}, ClickDelegate clickHandler = {});
 	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler);
 	Button(const NAS2D::Image& image, ClickDelegate clickHandler);
 	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler);

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -41,6 +41,7 @@ public:
 	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler);
 	Button(const NAS2D::Image& image, ClickDelegate clickHandler);
 	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler);
+	Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string newText, ClickDelegate clickHandler);
 	~Button() override;
 
 	void click() const;


### PR DESCRIPTION
Fix `Button` constructor overload taking a `ButtonSkin` so that it responds to mouse events like the other constructors do.

Add new constructor taking all parameters that other constructors set using constructor init-lists. Modify existing constructors to delegate to new constructor. Adjust default parameters to remove an unnecessary constructor overload.

Allow `Button` to display both an `Image` and `Font` text, with the text overlaid on top of the `Image`.

----

We probably want to add some additional `Button` instances to `demoLibControls` to exercise the different constructors.

----

Related:
- Issue #1924
- PR #1925
