### PR TITLE
Fix `RadioButton` icon size and slice

### DIFF
--- a/libControls/RadioButton.cpp
+++ b/libControls/RadioButton.cpp
@@ -70,7 +70,7 @@ const std::string& RadioButtonGroup::RadioButton::text() const
 void RadioButtonGroup::RadioButton::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto iconPosition = position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y + 1) / 2};
+	const auto iconPosition = position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y) / 2};
 	renderer.drawSubImage(mSkin, iconPosition, (mChecked ? selectedIconRect : unselectedIconRect));
 	renderer.drawText(mFont, text(), position() + textOffset, NAS2D::Color::White);
 }

--- a/libControls/RadioButton.cpp
+++ b/libControls/RadioButton.cpp
@@ -11,9 +11,9 @@
 
 namespace
 {
-	constexpr auto iconSize = NAS2D::Vector{13, 13};
-	constexpr auto unselectedIconRect = NAS2D::Rectangle{{0, 0}, iconSize};
-	constexpr auto selectedIconRect = NAS2D::Rectangle{{13, 0}, iconSize};
+	constexpr auto iconSize = NAS2D::Vector{10, 10};
+	constexpr auto unselectedIconRect = NAS2D::Rectangle{{1, 1}, iconSize};
+	constexpr auto selectedIconRect = NAS2D::Rectangle{{14, 1}, iconSize};
 	constexpr auto internalSpacing = 2;
 	constexpr auto textOffset = NAS2D::Vector{iconSize.x + internalSpacing, 0};
 }


### PR DESCRIPTION
Fix `RadioButton` icon to the real 10x10 pixels it is, and adjust image slice to perfectly match icon image sheet.

Remove strange draw offset used previously to counteract the bad image sizing and slicing.

----

The icon should appear the same as previous, though there will be a smaller empty area around it, so the text will group tighter with the icon.

Original:
<img width="83" height="61" alt="Image" src="https://github.com/user-attachments/assets/712ab8c9-b38d-48e9-b3b7-663f085aa83f" />

Updated:
<img width="85" height="56" alt="Image" src="https://github.com/user-attachments/assets/5303bfe1-8559-43c5-9018-11cd047e39c1" />

---

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3050249495
