### PR TITLE
Fix `CheckBox` icon size

### DIFF
--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -25,7 +25,7 @@
 
 namespace
 {
-	constexpr auto iconSize = NAS2D::Vector{13, 13};
+	constexpr auto iconSize = NAS2D::Vector{12, 12};
 	constexpr auto uncheckedIconRect = NAS2D::Rectangle{{0, 0}, iconSize};
 	constexpr auto checkedIconRect = NAS2D::Rectangle{{13, 0}, iconSize};
 	constexpr auto internalSpacing = 2;

--- a/libControls/CheckBox.cpp
+++ b/libControls/CheckBox.cpp
@@ -103,7 +103,7 @@ void CheckBox::draw() const
 {
 	if (!visible()) { return; }
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-	const auto iconPosition = position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y + 1) / 2};
+	const auto iconPosition = position() + NAS2D::Vector{0, (mRect.size.y - iconSize.y) / 2};
 	renderer.drawSubImage(mSkin, iconPosition, (mChecked ? checkedIconRect : uncheckedIconRect));
 	renderer.drawText(mFont, mText, position() + textOffset, NAS2D::Color::White);
 }


### PR DESCRIPTION
Fix `RadioButton` icon to the real 12x12 pixels it is, to perfectly match icon image sheet.

Remove strange draw offset used previously to counteract the bad image sizing.

----

The smaller tighter fit icon size means the text will move slightly closer to the icon, though only by 1 pixel.

Original:
![image](https://github.com/user-attachments/assets/c5ce5247-2a0c-42ef-b3b9-bc0b1471efc4)

Updated:
![image](https://github.com/user-attachments/assets/6025e026-f280-4146-a4a5-e138360e91f6)

----

Related:
- PR #1927
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3050249495
