### PR TITLE
Update `Button` constructor initial sizing

### DIFF
--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -9,6 +9,8 @@
 #include <NAS2D/Resource/Image.h>
 #include <NAS2D/Resource/Font.h>
 
+#include <utility>
+
 
 namespace
 {
@@ -28,13 +30,13 @@ namespace
 
 
 Button::Button(std::string text, ClickDelegate clickHandler) :
-	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, clickHandler}
+	Button{defaultButtonSkin(), nullptr, getDefaultFont(), std::move(text), clickHandler}
 {
 }
 
 
 Button::Button(std::string text, NAS2D::Vector<int> initialSize, ClickDelegate clickHandler):
-	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, clickHandler}
+	Button{defaultButtonSkin(), nullptr, getDefaultFont(), std::move(text), clickHandler}
 {
 	size(initialSize);
 }
@@ -47,7 +49,7 @@ Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) :
 
 
 Button::Button(const ButtonSkin& buttonSkin, std::string text, ClickDelegate clickHandler) :
-	Button{buttonSkin, nullptr, getDefaultFont(), text, clickHandler}
+	Button{buttonSkin, nullptr, getDefaultFont(), std::move(text), clickHandler}
 {
 }
 
@@ -56,7 +58,7 @@ Button::Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NA
 	mButtonSkin{buttonSkin},
 	mImage{image},
 	mFont{&font},
-	mText{text},
+	mText{std::move(text)},
 	mClickHandler{clickHandler}
 {
 	const auto imageSize = mImage ? mImage->size() : NAS2D::Vector{0, 0};

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -43,7 +43,6 @@ Button::Button(std::string text, NAS2D::Vector<int> initialSize, ClickDelegate c
 Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) :
 	Button{defaultButtonSkin(), &image, getDefaultFont(), {}, clickHandler}
 {
-	size(mImage->size() + internalPadding * 2);
 }
 
 
@@ -60,7 +59,16 @@ Button::Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NA
 	mText{text},
 	mClickHandler{clickHandler}
 {
-	size(mFont->size(mText) + internalPadding * 2);
+	const auto imageSize = mImage ? mImage->size() : NAS2D::Vector{0, 0};
+	const auto textSize = !mText.empty() ? mFont->size(mText) :
+		!mImage ? NAS2D::Vector{mFont->height(), mFont->height()} : NAS2D::Vector{0, 0};
+
+	const auto defaultSize = NAS2D::Vector{
+		(imageSize.x > textSize.x) ? imageSize.x : textSize.x,
+		(imageSize.y > textSize.y) ? imageSize.y : textSize.y,
+	};
+
+	size(defaultSize + internalPadding * 2);
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &Button::onMouseDown});

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -53,11 +53,11 @@ Button::Button(const ButtonSkin& buttonSkin, std::string text, ClickDelegate cli
 }
 
 
-Button::Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string newText, ClickDelegate clickHandler) :
+Button::Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string text, ClickDelegate clickHandler) :
 	mButtonSkin{buttonSkin},
 	mImage{image},
 	mFont{&font},
-	mText{newText},
+	mText{text},
 	mClickHandler{clickHandler}
 {
 	size(mFont->size(mText) + internalPadding * 2);

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -47,8 +47,8 @@ Button::Button(const NAS2D::Image& image, ClickDelegate clickHandler) :
 }
 
 
-Button::Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler) :
-	Button{buttonSkin, nullptr, getDefaultFont(), {}, clickHandler}
+Button::Button(const ButtonSkin& buttonSkin, std::string text, ClickDelegate clickHandler) :
+	Button{buttonSkin, nullptr, getDefaultFont(), text, clickHandler}
 {
 }
 

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -33,10 +33,10 @@ Button::Button(std::string text, ClickDelegate clickHandler) :
 }
 
 
-Button::Button(std::string text, NAS2D::Vector<int> sz, ClickDelegate clickHandler):
+Button::Button(std::string text, NAS2D::Vector<int> initialSize, ClickDelegate clickHandler):
 	Button{defaultButtonSkin(), nullptr, getDefaultFont(), text, clickHandler}
 {
-	size(sz);
+	size(initialSize);
 }
 
 

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -36,7 +36,7 @@ public:
 
 	using ClickDelegate = NAS2D::Delegate<void()>;
 
-	Button(std::string newText = {}, ClickDelegate clickHandler = {});
+	Button(std::string text = {}, ClickDelegate clickHandler = {});
 	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler);
 	Button(const NAS2D::Image& image, ClickDelegate clickHandler);
 	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler);

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -40,7 +40,7 @@ public:
 	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler = {});
 	Button(const NAS2D::Image& image, ClickDelegate clickHandler = {});
 	Button(const ButtonSkin& buttonSkin, std::string text = {}, ClickDelegate clickHandler = {});
-	Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string newText, ClickDelegate clickHandler);
+	Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string text, ClickDelegate clickHandler);
 	~Button() override;
 
 	void click() const;

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -39,7 +39,7 @@ public:
 	Button(std::string text = {}, ClickDelegate clickHandler = {});
 	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler = {});
 	Button(const NAS2D::Image& image, ClickDelegate clickHandler = {});
-	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler = {});
+	Button(const ButtonSkin& buttonSkin, std::string text = {}, ClickDelegate clickHandler = {});
 	Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string newText, ClickDelegate clickHandler);
 	~Button() override;
 

--- a/libControls/Button.h
+++ b/libControls/Button.h
@@ -37,9 +37,9 @@ public:
 	using ClickDelegate = NAS2D::Delegate<void()>;
 
 	Button(std::string text = {}, ClickDelegate clickHandler = {});
-	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler);
-	Button(const NAS2D::Image& image, ClickDelegate clickHandler);
-	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler);
+	Button(std::string text, NAS2D::Vector<int> size, ClickDelegate clickHandler = {});
+	Button(const NAS2D::Image& image, ClickDelegate clickHandler = {});
+	Button(const ButtonSkin& buttonSkin, ClickDelegate clickHandler = {});
 	Button(const ButtonSkin& buttonSkin, const NAS2D::Image* image, const NAS2D::Font& font, std::string newText, ClickDelegate clickHandler);
 	~Button() override;
 


### PR DESCRIPTION
Set `Button` initial size in delegated constructor.

Account for both `Image` and `text` being set at the same time. Expand dimensions to account for both, taking the largest of each dimension. If neither `Image` nor `text` is set, create a square `Button` based on the default `Font`'s `height`.

----

Use `std::move` for by-value `text` parameter.

----

Related:
- Issue #1754
- Issue #1924
- Issue #1743
