### PR TITLE
Fix segmentation fault in `WarehouseReport`

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -383,7 +383,10 @@ void FactoryReport::onClearProduction()
 
 void FactoryReport::onTakeMeThere()
 {
-	if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedFactory); }
+	if (selectedFactory)
+	{
+		if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedFactory); }
+	}
 }
 
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -289,7 +289,10 @@ void MineReport::onDigNewLevel()
 
 void MineReport::onTakeMeThere()
 {
-	if (mTakeMeThereHandler) { mTakeMeThereHandler(mSelectedFacility); }
+	if (mSelectedFacility)
+	{
+		if (mTakeMeThereHandler) { mTakeMeThereHandler(mSelectedFacility); }
+	}
 }
 
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -317,7 +317,11 @@ void WarehouseReport::onDisabled()
 
 void WarehouseReport::onTakeMeThere()
 {
-	if (mTakeMeThereHandler) { mTakeMeThereHandler(selectedWarehouse()); }
+	const auto* warehouse = selectedWarehouse();
+	if (warehouse)
+	{
+		if (mTakeMeThereHandler) { mTakeMeThereHandler(warehouse); }
+	}
 }
 
 


### PR DESCRIPTION
Add `nullptr` checking to avoid segmentation fault in `WarehouseReport`.

Ideally the "Take Me There" `Button` should not be visible when no `Warehouse` is selected. I think that's the proper fix. Though it seems easy enough to fail on that invariant as the user interface is updated, so it probably makes sense to have the right checks in place, just in case. Graphical glitches are annoying, but they don't ruin your day quite like losing hours of unsaved play due to a segmentation fault.

Related:
- Issue #1933
