### PR TITLE
Improve robustness of `ProgressBar` with `max` of `0`

### DIFF
--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -42,7 +42,12 @@ MainWindow::MainWindow() :
 	comboBox2{{this, &MainWindow::onComboBoxSelect}},
 	rectangle1{NAS2D::Color::Green, {80, 1}},
 	rectangle2{NAS2D::Color::Red, {80, 5}},
-	progressBar{100, 50},
+	progressBarUndefined{0, 0},
+	progressBar0{100, 0},
+	progressBar10{100, 10},
+	progressBar50{100, 50},
+	progressBar90{100, 90},
+	progressBar100{100, 100},
 	image{getImage("ui/interface/product_robodozer.png")}
 {
 	const auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -89,7 +94,12 @@ MainWindow::MainWindow() :
 	comboBox2.addItem("Item2");
 	comboBox2.addItem("Item3");
 
-	progressBar.width(80);
+	progressBarUndefined.width(80);
+	progressBar0.width(80);
+	progressBar10.width(80);
+	progressBar50.width(80);
+	progressBar90.width(80);
+	progressBar100.width(80);
 
 	add(label, {10, 30});
 	add(labelFontBold, {10, 60});
@@ -121,7 +131,12 @@ MainWindow::MainWindow() :
 
 	add(rectangle1, {700, 30});
 	add(rectangle2, {700, 40});
-	add(progressBar, {700, 50});
+	add(progressBarUndefined, {700, 50});
+	add(progressBar0, {700, 80});
+	add(progressBar10, {700, 110});
+	add(progressBar50, {700, 140});
+	add(progressBar90, {700, 170});
+	add(progressBar100, {700, 200});
 
 	add(image, {800, 30});
 }

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -55,6 +55,11 @@ private:
 	ComboBox comboBox2;
 	Rectangle rectangle1;
 	Rectangle rectangle2;
-	ProgressBar progressBar;
+	ProgressBar progressBarUndefined;
+	ProgressBar progressBar0;
+	ProgressBar progressBar10;
+	ProgressBar progressBar50;
+	ProgressBar progressBar90;
+	ProgressBar progressBar100;
 	Image image;
 };

--- a/libControls/ProgressBar.cpp
+++ b/libControls/ProgressBar.cpp
@@ -6,7 +6,6 @@
 #include <NAS2D/Math/Rectangle.h>
 
 #include <algorithm>
-#include <stdexcept>
 
 
 namespace
@@ -21,10 +20,6 @@ ProgressBar::ProgressBar(int max, int value, int padding) :
 	mMax{max},
 	mValue{value}
 {
-	if (mMax == 0)
-	{
-		throw std::runtime_error("ProgressBar needs a non-zero max: " + std::to_string(mMax));
-	}
 	size({mMax + padding * 2, padding * 5});
 }
 


### PR DESCRIPTION
Remove `ProgressBar` constructor exception for a `max` setting of `0`.

During the initial design it was undecided if a `max` setting of `0` should result in an exception, or simply drawing no progress. Guards were placed in both the constructor and in the `draw` method. I've since decided that exceptions from user interface code kind of suck. There should perhaps be more robustness in the display. The decision now is to allow a setting of `0`, and simply draw no progress in that case. Either way, a division by `0` is averted.

Related:
- Issue #1743
