### PR TITLE
Fix `ScrollBar` hardware floating point exception

### DIFF
--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -76,6 +76,7 @@ void ScrollBar::value(int newValue)
 	mValue = std::clamp(newValue, 0, mMax);
 	if (mValue != oldValue)
 	{
+		onLayoutChange();
 		if(mValueChangeHandler) { mValueChangeHandler(mValue); }
 	}
 }


### PR DESCRIPTION
Fix `ScrollBar` hardware floating point exception, which could cause crashes, and fix drawing so thumb position updates when the `value` is changed.

Probably not the cleanest fixes, though we can always improve the code later.

Related:
- PR #1940
- Issue #1743
