### PR TITLE
Refactor `ComboBox` - reduce event over delivery

### DIFF
--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -180,11 +180,6 @@ void ComboBox::setSelected(std::size_t index) {
 	lstItems.selectedIndex(index);
 }
 
-void ComboBox::text(const std::string& text) {
-	txtField.text(text);
-	lstItems.selectIf([target = NAS2D::toLowercase(txtField.text())](const auto& item){ return NAS2D::toLowercase(item.text) == target; });
-	if (mSelectionChangedHandler) { mSelectionChangedHandler(); }
-}
 
 const std::string& ComboBox::text() const {
 	return txtField.text();

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -163,6 +163,12 @@ bool ComboBox::isItemSelected() const
 }
 
 
+std::size_t ComboBox::selectedIndex() const
+{
+	return lstItems.selectedIndex();
+}
+
+
 void ComboBox::setSelected(std::size_t index) {
 	lstItems.selectedIndex(index);
 	text(selectionText());

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -85,19 +85,25 @@ void ComboBox::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position
 
 	if (mBarRect.contains(position))
 	{
-		lstItems.visible(!lstItems.visible());
-		if (lstItems.visible())
-		{
-			mRect.size.y += lstItems.size().y;
-		}
-		else
-		{
-			mRect = mBarRect;
-		}
+		onDropdownButtonClick();
 	}
 	else if (!lstItems.area().contains(position))
 	{
 		lstItems.visible(false);
+		mRect = mBarRect;
+	}
+}
+
+
+void ComboBox::onDropdownButtonClick()
+{
+	lstItems.visible(!lstItems.visible());
+	if (lstItems.visible())
+	{
+		mRect.size.y += lstItems.size().y;
+	}
+	else
+	{
 		mRect = mBarRect;
 	}
 }

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -16,11 +16,11 @@ namespace
 
 ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 	ControlContainer{{&btnDown, &txtField, &lstItems}},
+	btnDown{getImage("ui/icons/down.png")},
 	lstItems{{this, &ComboBox::onListSelectionChange}},
 	mSelectionChangedHandler{selectionChangedHandler},
 	mMaxDisplayItems{MinimumDisplayItems}
 {
-	btnDown.image("ui/icons/down.png");
 	btnDown.size({20, 20});
 
 	txtField.editable(false);

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -18,6 +18,7 @@ ComboBox::ComboBox(SelectionChangedDelegate selectionChangedHandler) :
 	ControlContainer{{&btnDown, &txtField, &lstItems}},
 	btnDown{getImage("ui/icons/down.png")},
 	lstItems{{this, &ComboBox::onListSelectionChange}},
+	mMinHeight{std::max(txtField.size().y, btnDown.size().y)},
 	mSelectionChangedHandler{selectionChangedHandler},
 	mMaxDisplayItems{MinimumDisplayItems}
 {
@@ -48,9 +49,9 @@ void ComboBox::onResize()
 	Control::onResize();
 
 	// Enforce minimum size
-	if (mRect.size.x < 50 || mRect.size.y < 20)
+	if (mRect.size.x < 50 || mRect.size.y < mMinHeight)
 	{
-		size({std::max(mRect.size.x, 50), std::max(mRect.size.y, 20)});
+		size({std::max(mRect.size.x, 50), std::max(mRect.size.y, mMinHeight)});
 	}
 
 	txtField.size(size() - NAS2D::Vector{btnDown.size().x, 0});

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -178,8 +178,6 @@ std::size_t ComboBox::selectedIndex() const
 
 void ComboBox::setSelected(std::size_t index) {
 	lstItems.selectedIndex(index);
-	text(selectionText());
-	if (mSelectionChangedHandler) { mSelectionChangedHandler(); }
 }
 
 void ComboBox::text(const std::string& text) {

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -54,7 +54,7 @@ void ComboBox::onResize()
 		size({std::max(mRect.size.x, 50), std::max(mRect.size.y, mMinHeight)});
 	}
 
-	txtField.size(size() - NAS2D::Vector{btnDown.size().x, 0});
+	txtField.size(mRect.size - NAS2D::Vector{btnDown.size().x, 0});
 	btnDown.position(txtField.area().crossXPoint());
 	btnDown.height(mRect.size.y);
 	lstItems.width(mRect.size.x);

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -53,7 +53,7 @@ void ComboBox::onResize()
 		size({std::max(mRect.size.x, 50), std::max(mRect.size.y, 20)});
 	}
 
-	txtField.size(size() - NAS2D::Vector{20, 0});
+	txtField.size(size() - NAS2D::Vector{btnDown.size().x, 0});
 	btnDown.position(txtField.area().crossXPoint());
 	btnDown.height(mRect.size.y);
 	lstItems.width(mRect.size.x);

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -125,6 +125,12 @@ void ComboBox::onListSelectionChange()
 }
 
 
+std::size_t ComboBox::maxDisplayItems() const
+{
+	return mMaxDisplayItems;
+}
+
+
 /**
  * Sets the maximum number of items to display before showing a scroll bar.
  */

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -52,6 +52,7 @@ protected:
 
 	void onMouseWheel(NAS2D::Vector<int> scrollAmount);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
+	void onDropdownButtonClick();
 
 private:
 	Button btnDown;

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -38,7 +38,7 @@ public:
 	int selectionUserData() const;
 
 	bool isItemSelected() const;
-	std::size_t selectedIndex() { return lstItems.selectedIndex(); }
+	std::size_t selectedIndex() const { return lstItems.selectedIndex(); }
 	void setSelected(std::size_t index);
 
 	void text(const std::string& text);

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -38,7 +38,7 @@ public:
 	int selectionUserData() const;
 
 	bool isItemSelected() const;
-	std::size_t selectedIndex() const { return lstItems.selectedIndex(); }
+	std::size_t selectedIndex() const;
 	void setSelected(std::size_t index);
 
 	void text(const std::string& text);

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -55,9 +55,9 @@ protected:
 	void onDropdownButtonClick();
 
 private:
+	TextField txtField;
 	Button btnDown;
 	ListBox<> lstItems;
-	TextField txtField;
 
 	NAS2D::Rectangle<int> mBarRect;
 

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -41,7 +41,6 @@ public:
 	std::size_t selectedIndex() const;
 	void setSelected(std::size_t index);
 
-	void text(const std::string& text);
 	const std::string& text() const;
 
 protected:

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -29,7 +29,7 @@ public:
 
 	void addItem(const std::string& item, int tag = 0);
 
-	std::size_t maxDisplayItems() const { return mMaxDisplayItems; }
+	std::size_t maxDisplayItems() const;
 	void maxDisplayItems(std::size_t count);
 
 	void clearSelected();

--- a/libControls/ComboBox.h
+++ b/libControls/ComboBox.h
@@ -59,6 +59,7 @@ private:
 	Button btnDown;
 	ListBox<> lstItems;
 
+	const int mMinHeight;
 	NAS2D::Rectangle<int> mBarRect;
 
 	SelectionChangedDelegate mSelectionChangedHandler;


### PR DESCRIPTION
Some general refactoring of `ComboBox`, making better use of constructor init lists, improve `const` correctness, reducing over delivery of change events, and removing an unused and questionable feature.

Noticed some of this after doing a recent refactoring of `ScrollBar`.

Related:
- PR #1942
- Issue #1743
