### PR TITLE
Reduce unnecessary `Control` events

### DIFF
--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -190,8 +190,11 @@ bool Control::enabled() const
  */
 void Control::visible(bool visible)
 {
-	mVisible = visible;
-	onVisibilityChange(mVisible);
+	if (mVisible != visible)
+	{
+		mVisible = visible;
+		onVisibilityChange(mVisible);
+	}
 }
 
 

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -89,14 +89,14 @@ void Control::area(const NAS2D::Rectangle<int>& newRect)
 /**
  * Sets the position of the Control.
  *
- * \param pos	2D Coordinate to position the Control at.
+ * \param newPosition	2D Coordinate to position the Control at.
  */
-void Control::position(NAS2D::Point<int> pos)
+void Control::position(NAS2D::Point<int> newPosition)
 {
-	if (mRect.position != pos)
+	if (mRect.position != newPosition)
 	{
-		const auto displacement = pos - mRect.position;
-		mRect.position = pos;
+		const auto displacement = newPosition - mRect.position;
+		mRect.position = newPosition;
 		onMove(displacement);
 	}
 }

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -80,9 +80,11 @@ const NAS2D::Rectangle<int>& Control::area() const
 void Control::area(const NAS2D::Rectangle<int>& newRect)
 {
 	const auto displacement = newRect.position - mRect.position;
+	const auto hasMoved = mRect.position != newRect.position;
+	const auto hasResized = mRect.size != newRect.size;
 	mRect = newRect;
-	onMove(displacement);
-	onResize();
+	if (hasMoved) { onMove(displacement); }
+	if (hasResized) { onResize(); }
 }
 
 

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -224,8 +224,11 @@ void Control::show()
  */
 void Control::hasFocus(bool focus)
 {
-	mHasFocus = focus;
-	onFocusChange();
+	if (mHasFocus != focus)
+	{
+		mHasFocus = focus;
+		onFocusChange();
+	}
 }
 
 

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -93,9 +93,12 @@ void Control::area(const NAS2D::Rectangle<int>& newRect)
  */
 void Control::position(NAS2D::Point<int> pos)
 {
-	const auto displacement = pos - mRect.position;
-	mRect.startPoint(pos);
-	onMove(displacement);
+	if (mRect.position != pos)
+	{
+		const auto displacement = pos - mRect.position;
+		mRect.startPoint(pos);
+		onMove(displacement);
+	}
 }
 
 

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -96,7 +96,7 @@ void Control::position(NAS2D::Point<int> pos)
 	if (mRect.position != pos)
 	{
 		const auto displacement = pos - mRect.position;
-		mRect.startPoint(pos);
+		mRect.position = pos;
 		onMove(displacement);
 	}
 }

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -101,8 +101,11 @@ void Control::position(NAS2D::Point<int> pos)
 
 void Control::size(NAS2D::Vector<int> newSize)
 {
-	mRect.size = newSize;
-	onResize();
+	if (mRect.size != newSize)
+	{
+		mRect.size = newSize;
+		onResize();
+	}
 }
 
 

--- a/libControls/Control.cpp
+++ b/libControls/Control.cpp
@@ -167,8 +167,11 @@ bool Control::highlight() const
  */
 void Control::enabled(bool enabled)
 {
-	mEnabled = enabled;
-	onEnableChange();
+	if (mEnabled != enabled)
+	{
+		mEnabled = enabled;
+		onEnableChange();
+	}
 }
 
 

--- a/libControls/Control.h
+++ b/libControls/Control.h
@@ -51,7 +51,7 @@ public:
 	void area(const NAS2D::Rectangle<int>& area);
 
 	NAS2D::Point<int> position() const { return mRect.position; }
-	void position(NAS2D::Point<int> pos);
+	void position(NAS2D::Point<int> newPosition);
 
 	NAS2D::Vector<int> size() const { return mRect.size; }
 	void size(NAS2D::Vector<int> newSize);

--- a/libControls/ControlContainer.cpp
+++ b/libControls/ControlContainer.cpp
@@ -70,16 +70,12 @@ void ControlContainer::bringToFront(Control* control)
 
 void ControlContainer::onVisibilityChange(bool visible)
 {
-	Control::onVisibilityChange(visible);
-
 	for (auto control : mControls) { control->visible(visible); }
 }
 
 
 void ControlContainer::onMove(NAS2D::Vector<int> displacement)
 {
-	Control::onMove(displacement);
-
 	for (auto control : mControls)
 	{
 		control->position(control->position() + displacement);

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -154,11 +154,6 @@ protected:
 	}
 
 
-	void onMove(NAS2D::Vector<int> /*displacement*/) override
-	{
-		updateScrollLayout();
-	}
-
 private:
 	ListBoxTheme mListBoxTheme;
 	std::vector<ListBoxItem> mItems;

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -100,11 +100,11 @@ void ListBoxBase::updateScrollLayout()
 	mScrollArea = mRect.inset(1);
 
 	const auto neededDisplaySize = mItemSize.y * static_cast<int>(count());
-	if (neededDisplaySize > mRect.size.y)
+	if (neededDisplaySize > mScrollArea.size.y)
 	{
 		mScrollBar.size({14, mScrollArea.size.y});
 		mScrollBar.position({mScrollArea.position.x + mScrollArea.size.x - mScrollBar.size().x, mScrollArea.position.y});
-		mScrollBar.max(neededDisplaySize - mRect.size.y);
+		mScrollBar.max(neededDisplaySize - mScrollArea.size.y);
 		mScrollBar.visible(true);
 		mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 	}
@@ -123,7 +123,7 @@ void ListBoxBase::onVisibilityChange(bool visible)
 	if (visible)
 	{
 		const auto neededDisplaySize = mItemSize.y * static_cast<int>(count());
-		mScrollBar.visible(neededDisplaySize > mRect.size.y);
+		mScrollBar.visible(neededDisplaySize > mScrollArea.size.y);
 	}
 }
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -110,7 +110,6 @@ void ListBoxBase::updateScrollLayout()
 	}
 	else
 	{
-		mScrollOffsetInPixels = 0;
 		mScrollBar.max(0);
 		mScrollBar.visible(false);
 	}

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -122,9 +122,11 @@ void ListBoxBase::updateScrollLayout()
 
 void ListBoxBase::onVisibilityChange(bool visible)
 {
-	Control::onVisibilityChange(visible);
-
-	updateScrollLayout();
+	if (visible)
+	{
+		const auto neededDisplaySize = mItemSize.y * static_cast<int>(count());
+		mScrollBar.visible(neededDisplaySize > mRect.size.y);
+	}
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -105,8 +105,8 @@ void ListBoxBase::updateScrollLayout()
 		mScrollBar.size({14, mScrollArea.size.y});
 		mScrollBar.position({mScrollArea.position.x + mScrollArea.size.x - mScrollBar.size().x, mScrollArea.position.y});
 		mScrollBar.max(neededDisplaySize - mRect.size.y);
-		mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 		mScrollBar.visible(true);
+		mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 	}
 	else
 	{

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -105,7 +105,6 @@ void ListBoxBase::updateScrollLayout()
 		mScrollBar.size({14, mScrollArea.size.y});
 		mScrollBar.position({mScrollArea.position.x + mScrollArea.size.x - mScrollBar.size().x, mScrollArea.position.y});
 		mScrollBar.max(neededDisplaySize - mRect.size.y);
-		mScrollOffsetInPixels = mScrollBar.value();
 		mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 		mScrollBar.visible(true);
 	}
@@ -145,7 +144,7 @@ void ListBoxBase::onResize()
 
 void ListBoxBase::onSlideChange(int /*newPosition*/)
 {
-	updateScrollLayout();
+	mScrollOffsetInPixels = mScrollBar.value();
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -130,9 +130,10 @@ void ListBoxBase::onVisibilityChange(bool visible)
 }
 
 
-void ListBoxBase::onMove(NAS2D::Vector<int> /*displacement*/)
+void ListBoxBase::onMove(NAS2D::Vector<int> displacement)
 {
-	updateScrollLayout();
+	mScrollArea.position += displacement;
+	mScrollBar.position(mScrollBar.position() + displacement);
 }
 
 

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -142,9 +142,9 @@ void ListBoxBase::onResize()
 }
 
 
-void ListBoxBase::onSlideChange(int /*newPosition*/)
+void ListBoxBase::onSlideChange(int newPosition)
 {
-	mScrollOffsetInPixels = mScrollBar.value();
+	mScrollOffsetInPixels = newPosition;
 }
 
 

--- a/libControls/RadioButtonGroup.cpp
+++ b/libControls/RadioButtonGroup.cpp
@@ -52,8 +52,6 @@ void RadioButtonGroup::select(RadioButtonGroup::RadioButton& button)
 
 void RadioButtonGroup::onMove(NAS2D::Vector<int> displacement)
 {
-	Control::onMove(displacement);
-
 	for (auto &control : mRadioButtons)
 	{
 		control.position(control.position() + displacement);

--- a/libControls/RadioButtonGroup.cpp
+++ b/libControls/RadioButtonGroup.cpp
@@ -50,15 +50,6 @@ void RadioButtonGroup::select(RadioButtonGroup::RadioButton& button)
 }
 
 
-void RadioButtonGroup::onMove(NAS2D::Vector<int> displacement)
-{
-	for (auto &control : mRadioButtons)
-	{
-		control.position(control.position() + displacement);
-	}
-}
-
-
 void RadioButtonGroup::onClearSelection()
 {
 	if (mIndex != NoSelection)

--- a/libControls/RadioButtonGroup.h
+++ b/libControls/RadioButtonGroup.h
@@ -63,7 +63,6 @@ public:
 	void select(RadioButtonGroup::RadioButton& button);
 
 protected:
-	void onMove(NAS2D::Vector<int> displacement) override;
 	void onClearSelection();
 	void onSetSelection(std::size_t index);
 

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -103,8 +103,11 @@ int ScrollBar::max() const
 
 void ScrollBar::max(int newMax)
 {
-	mMax = newMax;
-	onThumbResize();
+	if (mMax != newMax)
+	{
+		mMax = newMax;
+		onThumbResize();
+	}
 	value(mValue); // Re-clamp to new max
 }
 

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -35,7 +35,6 @@ const std::string& TextArea::text() const
 
 void TextArea::onResize()
 {
-	Control::onResize();
 	processString();
 }
 

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -23,7 +23,7 @@ TextArea::TextArea(const NAS2D::Font& font, NAS2D::Color textColor) :
 void TextArea::text(const std::string& text)
 {
 	mText = text;
-	onTextChange();
+	onLayoutText();
 }
 
 
@@ -34,12 +34,6 @@ const std::string& TextArea::text() const
 
 
 void TextArea::onResize()
-{
-	onLayoutText();
-}
-
-
-void TextArea::onTextChange()
 {
 	onLayoutText();
 }

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -35,13 +35,13 @@ const std::string& TextArea::text() const
 
 void TextArea::onResize()
 {
-	processString();
+	onLayoutText();
 }
 
 
 void TextArea::onTextChange()
 {
-	processString();
+	onLayoutText();
 }
 
 
@@ -62,7 +62,7 @@ void TextArea::draw() const
 }
 
 
-void TextArea::processString()
+void TextArea::onLayoutText()
 {
 	mFormattedList.clear();
 

--- a/libControls/TextArea.h
+++ b/libControls/TextArea.h
@@ -28,8 +28,7 @@ public:
 protected:
 	void onResize() override;
 	void onTextChange();
-
-	void processString();
+	void onLayoutText();
 
 private:
 	const NAS2D::Font& mFont;

--- a/libControls/TextArea.h
+++ b/libControls/TextArea.h
@@ -27,7 +27,6 @@ public:
 
 protected:
 	void onResize() override;
-	void onTextChange();
 	void onLayoutText();
 
 private:

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -53,8 +53,11 @@ TextField::~TextField()
 
 void TextField::text(const std::string& text)
 {
-	mText = text;
-	onTextChange();
+	if (mText != text)
+	{
+		mText = text;
+		onTextChange();
+	}
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -72,9 +72,12 @@ bool TextField::isEmpty() const
 
 void TextField::clear()
 {
-	mText.clear();
-	mCursorCharacterIndex = 0;
-	onTextChange();
+	if (!mText.empty())
+	{
+		mText.clear();
+		mCursorCharacterIndex = 0;
+		onTextChange();
+	}
 }
 
 


### PR DESCRIPTION
Add guards around many `Control` events so change events are only emitted if there was a real change. Setting a value that is already set will not emit a change event.

In a few cases, event handler overrides were removed once it was found they were identical to the base class version.

There may be a bit more to look at in `TextField`, though that will be a problem for another day.

----

There was a small fix to `ListBoxBase` to use `mScrollArea` for `ScrollBar` calculations, rather than `mRect`, which also includes the border. Before the fix, the last row of pixels of a list box cell could be clipped. This could be seen in the `ListBox` class, using a screen magnifier.

----

Related:
- PR #1943
- Issue #1944
- Issue #1743
