### PR TITLE
Complete `TextField` `BorderVisibility` feature

### DIFF
--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -74,6 +74,13 @@ MainWindow::MainWindow() :
 	textFieldOverflow.size(textFieldMax.size());
 	textFieldOverflow.text("Overflowing text");
 
+	textFieldBorderNever.width(130);
+	textFieldBorderNever.text("Border Never");
+	textFieldBorderNever.border(TextField::BorderVisibility::Never);
+	textFieldBorderAlways.width(130);
+	textFieldBorderAlways.text("Border Always");
+	textFieldBorderAlways.border(TextField::BorderVisibility::Always);
+
 	textArea.size({100, 100});
 	textArea.text("This is some\nTextArea\ntext.");
 
@@ -132,7 +139,9 @@ MainWindow::MainWindow() :
 	add(textFieldNumbersMax, {150, 90});
 	add(textFieldMax, {150, 120});
 	add(textFieldOverflow, {150, 150});
-	add(textArea, {150, 180});
+	add(textFieldBorderNever, {150, 180});
+	add(textFieldBorderAlways, {150, 210});
+	add(textArea, {150, 240});
 
 	add(button, {300, 30});
 	add(buttonWithSkin, {300, 60});

--- a/demoLibControls/MainWindow.h
+++ b/demoLibControls/MainWindow.h
@@ -41,6 +41,8 @@ private:
 	TextField textFieldNumbersMax;
 	TextField textFieldMax;
 	TextField textFieldOverflow;
+	TextField textFieldBorderNever;
+	TextField textFieldBorderAlways;
 	TextArea textArea;
 	NAS2D::Image imageButton;
 	Button::ButtonSkin buttonSkin;

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -173,7 +173,8 @@ void TextField::draw() const
 {
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
-	const auto showFocused = hasFocus() && editable();
+	const auto showFocused = (mBorderVisibility == BorderVisibility::Always) ||
+		((mBorderVisibility == BorderVisibility::FocusOnly) && hasFocus() && editable());
 	const auto& skin = showFocused ? mSkinFocus : mSkinNormal;
 	skin.draw(renderer, mRect);
 

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -84,6 +84,7 @@ private:
 	const NAS2D::Font& mFont;
 	const NAS2D::RectangleSkin mSkinNormal;
 	const NAS2D::RectangleSkin mSkinFocus;
+	BorderVisibility mBorderVisibility = BorderVisibility::FocusOnly;
 
 	std::string mText;
 	TextChangedDelegate mTextChangedHandler;
@@ -94,8 +95,6 @@ private:
 	int mScrollOffsetPixelX = 0;
 
 	std::size_t mMaxCharacters = 0;
-
-	BorderVisibility mBorderVisibility = BorderVisibility::FocusOnly;
 
 	bool mEditable = true;
 	bool mShowCursor = true;


### PR DESCRIPTION
Complete `TextField`'s `BorderVisibility` feature so setting the property actually does what it says it will do.

Related:
- Issue #1743
