### PR TITLE
Reduce `TextField` scroll updates

### DIFF
--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -141,7 +141,7 @@ void TextField::update()
 
 void TextField::updateScrollPosition()
 {
-	int cursorX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
+	const auto cursorX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
 	const auto viewWidth = mRect.size.x - fieldPadding * 2;
 
 	// Check if cursor is after visible area

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -142,8 +142,8 @@ void TextField::update()
 void TextField::updateScrollPosition()
 {
 	int cursorX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
+	const auto viewWidth = mRect.size.x - fieldPadding * 2;
 
-	const auto viewWidth = textAreaWidth();
 	// Check if cursor is after visible area
 	if (mScrollOffsetPixelX <= cursorX - viewWidth)
 	{
@@ -162,12 +162,6 @@ void TextField::updateScrollPosition()
 	}
 
 	mCursorPixelX = mRect.position.x + fieldPadding + cursorX - mScrollOffsetPixelX;
-}
-
-
-int TextField::textAreaWidth() const
-{
-	return mRect.size.x - fieldPadding * 2;
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -17,6 +17,7 @@
 #include <NAS2D/Math/Point.h>
 
 #include <locale>
+#include <string_view>
 
 
 namespace
@@ -140,7 +141,7 @@ void TextField::update()
 
 void TextField::updateScrollPosition()
 {
-	int cursorX = mFont.width(mText.substr(0, mCursorCharacterIndex));
+	int cursorX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
 
 	// Check if cursor is after visible area
 	if (mScrollOffsetPixelX <= cursorX - textAreaWidth())

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -30,8 +30,8 @@ TextField::TextField(std::size_t maxCharacters, TextChangedDelegate textChangedH
 	mFont{getDefaultFont()},
 	mSkinNormal{loadRectangleSkin("ui/skin/textbox_normal")},
 	mSkinFocus{loadRectangleSkin("ui/skin/textbox_highlight")},
-	mTextChangedHandler{textChangedHandler},
-	mMaxCharacters{maxCharacters}
+	mMaxCharacters{maxCharacters},
+	mTextChangedHandler{textChangedHandler}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &TextField::onMouseDown});

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -323,9 +323,9 @@ void TextField::onTextInput(const std::string& newTextInput)
 	if (mNumbersOnly && !std::isdigit(newTextInput[0], std::locale{})) { return; }
 
 	mText.insert(mCursorCharacterIndex, newTextInput);
-	onTextChange();
 	mCursorCharacterIndex++;
 	updateScrollPosition();
+	onTextChange();
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -143,16 +143,17 @@ void TextField::updateScrollPosition()
 {
 	int cursorX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
 
+	const auto viewWidth = textAreaWidth();
 	// Check if cursor is after visible area
-	if (mScrollOffsetPixelX <= cursorX - textAreaWidth())
+	if (mScrollOffsetPixelX <= cursorX - viewWidth)
 	{
-		mScrollOffsetPixelX = cursorX - textAreaWidth();
+		mScrollOffsetPixelX = cursorX - viewWidth;
 	}
 
 	// Check if cursor is before visible area
 	if (mScrollOffsetPixelX >= cursorX)
 	{
-		mScrollOffsetPixelX = cursorX - textAreaWidth() / 2;
+		mScrollOffsetPixelX = cursorX - viewWidth / 2;
 	}
 
 	if (mScrollOffsetPixelX < 0)

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -323,7 +323,7 @@ void TextField::onTextInput(const std::string& newTextInput)
 	if (mNumbersOnly && !std::isdigit(newTextInput[0], std::locale{})) { return; }
 
 	mText.insert(mCursorCharacterIndex, newTextInput);
-	mCursorCharacterIndex++;
+	mCursorCharacterIndex += newTextInput.length();
 	updateScrollPosition();
 	onTextChange();
 }

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -80,6 +80,7 @@ void TextField::clear()
 	{
 		mText.clear();
 		mCursorCharacterIndex = 0;
+		updateScrollPosition();
 		onTextChange();
 	}
 }
@@ -125,9 +126,6 @@ void TextField::maxCharacters(std::size_t count)
 void TextField::update()
 {
 	if (!visible()) { return; }
-
-	// Should be called only on events relating to the cursor so this is temporary.
-	updateScrollPosition();
 
 	if (mCursorBlinkTimer.elapsedTicks() > cursorBlinkDelay)
 	{
@@ -215,6 +213,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 	if (virtualOffsetX > mFont.width(mText))
 	{
 		mCursorCharacterIndex = mText.length();
+		updateScrollPosition();
 		return;
 	}
 
@@ -226,6 +225,7 @@ void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> pos
 		if (subStringSizeX > virtualOffsetX)
 		{
 			mCursorCharacterIndex = subStringLength - 1;
+			updateScrollPosition();
 			break;
 		}
 	}
@@ -245,6 +245,7 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 			{
 				mCursorCharacterIndex--;
 				mText.erase(mCursorCharacterIndex, 1);
+				updateScrollPosition();
 				onTextChange();
 			}
 			break;
@@ -253,38 +254,53 @@ void TextField::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool /*rep
 			if (!mText.empty())
 			{
 				mText = mText.erase(mCursorCharacterIndex, 1);
+				updateScrollPosition();
 				onTextChange();
 			}
 			break;
 
 		case NAS2D::KeyCode::Home:
 			mCursorCharacterIndex = 0;
+			updateScrollPosition();
 			break;
 
 		case NAS2D::KeyCode::End:
 			mCursorCharacterIndex = mText.length();
+			updateScrollPosition();
 			break;
 
 		// Arrow keys
 		case NAS2D::KeyCode::Left:
 			if (mCursorCharacterIndex > 0)
+			{
 				--mCursorCharacterIndex;
+				updateScrollPosition();
+			}
 			break;
 
 		case NAS2D::KeyCode::Right:
 			if (mCursorCharacterIndex < mText.length())
+			{
 				++mCursorCharacterIndex;
+				updateScrollPosition();
+			}
 			break;
 
 		// Keypad arrow keys
 		case NAS2D::KeyCode::Keypad4:
 			if ((mCursorCharacterIndex > 0) && !NAS2D::EventHandler::numlock(mod))
+			{
 				--mCursorCharacterIndex;
+				updateScrollPosition();
+			}
 			break;
 
 		case NAS2D::KeyCode::Keypad6:
 			if ((mCursorCharacterIndex < mText.length()) && !NAS2D::EventHandler::numlock(mod))
+			{
 				++mCursorCharacterIndex;
+				updateScrollPosition();
+			}
 			break;
 
 		// Enter/Return (ignore)
@@ -309,6 +325,7 @@ void TextField::onTextInput(const std::string& newTextInput)
 	mText.insert(mCursorCharacterIndex, newTextInput);
 	onTextChange();
 	mCursorCharacterIndex++;
+	updateScrollPosition();
 }
 
 

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -86,6 +86,7 @@ private:
 	const NAS2D::RectangleSkin mSkinFocus;
 	BorderVisibility mBorderVisibility = BorderVisibility::FocusOnly;
 
+	std::size_t mMaxCharacters = 0;
 	std::string mText;
 	TextChangedDelegate mTextChangedHandler;
 
@@ -93,8 +94,6 @@ private:
 	std::size_t mCursorCharacterIndex = 0;
 	int mCursorPixelX = 0;
 	int mScrollOffsetPixelX = 0;
-
-	std::size_t mMaxCharacters = 0;
 
 	bool mEditable = true;
 	bool mShowCursor = true;

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -70,7 +70,6 @@ public:
 
 protected:
 	void updateScrollPosition();
-	int textAreaWidth() const;
 
 	void draw() const override;
 	void drawCursor() const;


### PR DESCRIPTION
Reduce `TextField` scroll updates so they happen once when the cursor index is updated, rather than every frame.

Related:
- PR #1945
- Issue #1902
- Issue #1743
