### PR TITLE
Add `ScrollBar` property `largeDelta`

### DIFF
--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -115,6 +115,9 @@ MainWindow::MainWindow() :
 	scrollBarVerticalMax1.max(1);
 	scrollBarVertical.max(200);
 
+	scrollBarHorizontal.largeDelta(10);
+	scrollBarVertical.largeDelta(10);
+
 	scrollBarHorizontalMax0.size({70, 20});
 	scrollBarHorizontalMax1.size({70, 20});
 	scrollBarHorizontal.size({70, 20});

--- a/libControls/ListBoxBase.cpp
+++ b/libControls/ListBoxBase.cpp
@@ -105,6 +105,7 @@ void ListBoxBase::updateScrollLayout()
 		mScrollBar.size({14, mScrollArea.size.y});
 		mScrollBar.position({mScrollArea.position.x + mScrollArea.size.x - mScrollBar.size().x, mScrollArea.position.y});
 		mScrollBar.max(neededDisplaySize - mScrollArea.size.y);
+		mScrollBar.largeDelta((mScrollArea.size.y / mItemSize.y) * mItemSize.y); // Pixel size of integral number of displayed items
 		mScrollBar.visible(true);
 		mScrollArea.size.x -= mScrollBar.size().x; // Remove scroll bar from scroll area
 	}

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -112,6 +112,18 @@ void ScrollBar::max(int newMax)
 }
 
 
+int ScrollBar::largeDelta() const
+{
+	return mLargeDelta;
+}
+
+
+void ScrollBar::largeDelta(int newLargeDelta)
+{
+	mLargeDelta = newLargeDelta;
+}
+
+
 void ScrollBar::update()
 {
 	if (!visible()) { return; }

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -197,12 +197,12 @@ void ScrollBar::onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position)
 
 	if (mTrackRect.contains(position) && !mThumbRect.contains(position))
 	{
-		const auto& [clickPosition, thumbPosition, viewSize] =
+		const auto& [clickPosition, thumbPosition] =
 			(mScrollBarType == ScrollBarType::Vertical) ?
-				std::tuple{position.y, mThumbRect.position.y, mRect.size.y} :
-				std::tuple{position.x, mThumbRect.position.x, mRect.size.x};
+				std::tuple{position.y, mThumbRect.position.y} :
+				std::tuple{position.x, mThumbRect.position.x};
 		const auto valueDelta = (clickPosition < thumbPosition) ?
-			-viewSize : viewSize;
+			-mLargeDelta : mLargeDelta;
 		changeValue(valueDelta);
 	}
 }

--- a/libControls/ScrollBar.h
+++ b/libControls/ScrollBar.h
@@ -45,6 +45,9 @@ public:
 	int max() const;
 	void max(int newMax);
 
+	int largeDelta() const;
+	void largeDelta(int newLargeDelta);
+
 	void update() override;
 
 protected:
@@ -63,6 +66,7 @@ protected:
 private:
 	const ScrollBarType mScrollBarType;
 	const int mSmallDelta;
+	int mLargeDelta{1};
 	int mMax{0};
 	int mValue{0};
 	ValueChangeDelegate mValueChangeHandler;


### PR DESCRIPTION
Add a `largeDelta` property to `ScrollBar`, and use it as the increment when clicking on the blank area of the track.

The `ListBoxBase` class was updated to set `largeDelta` based on available scroll area, rounded down to an integer multiple of `itemSize.y`. It's used is also demonstrated in `demoLibControls`.

Not included is using the `largeDelta` value to set the thumb size. That will be handled as a separate change set.

Related:
- Issue #1944
