### PR TITLE
Remove storing CircleCI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "16.2.0"
+      xcode: "16.4.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ commands:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkOPHD
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkControls
       - run: make package
-      - store_artifacts:
-          path: .build/package/
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ commands:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibControls
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkOPHD
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkControls
-      - run: make package
 
 jobs:
   build-macos:


### PR DESCRIPTION
Remove storing of build artifacts on CircleCI.

We were exceeding the free tier storage limits listed by CircleCI. There wasn't any sort of cut off, though if we're getting free service we should probably try to respect their free tier limits.

Remove the `package` step. If we're not storing the build outputs, we probably don't need to package them either. This means we're not testing the packaging code with every build, though the packaging code almost never gets any attention or updates. We'll know to test it if we make changes.

Update to Xcode `16.4.0`.
