### PR TITLE
Fix undefined behavior in `readRobots`

### DIFF
--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -369,8 +369,9 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		if (production_time > 0)
 		{
 			robot.startTask(production_time);
-			mRobotPool.insertRobotIntoTable(mRobotList, robot, mTileMap->getTile({{x, y}, depth}));
-			mRobotList[&robot]->bulldoze();
+			auto& tile = mTileMap->getTile({{x, y}, depth});
+			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
+			tile.bulldoze();
 		}
 
 		if (depth > 0)

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -372,11 +372,11 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 			auto& tile = mTileMap->getTile({{x, y}, depth});
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 			tile.bulldoze();
-		}
 
-		if (depth > 0)
-		{
-			mRobotList[&robot]->excavated(true);
+			if (depth > 0)
+			{
+				mRobotList[&robot]->excavated(true);
+			}
 		}
 	}
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -372,11 +372,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 			auto& tile = mTileMap->getTile({{x, y}, depth});
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 			tile.bulldoze();
-
-			if (depth > 0)
-			{
-				tile.excavated(true);
-			}
+			tile.excavated(true);
 		}
 	}
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -351,7 +351,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 
 		const auto type = dictionary.get<int>("type");
 		const auto age = dictionary.get<int>("age");
-		const auto production_time = dictionary.get<int>("production");
+		const auto productionTime = dictionary.get<int>("production");
 		const auto x = dictionary.get<int>("x", 0);
 		const auto y = dictionary.get<int>("y", 0);
 		const auto depth = dictionary.get<int>("depth", 0);
@@ -366,9 +366,9 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 
 		robot.fuelCellAge(age);
 
-		if (production_time > 0)
+		if (productionTime > 0)
 		{
-			robot.startTask(production_time);
+			robot.startTask(productionTime);
 			auto& tile = mTileMap->getTile({{x, y}, depth});
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 			tile.bulldoze();

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -375,7 +375,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 
 			if (depth > 0)
 			{
-				mRobotList[&robot]->excavated(true);
+				tile.excavated(true);
 			}
 		}
 	}


### PR DESCRIPTION
Fix undefined behavior in `readRobots` that could lead to a segmentation fault.

When reading a `Robot`, if `depth > 0`, but not `productionTime > 0`, then no `Tile` would be set for the `Robot`. This means the call to set `excavated` would dereference `nullptr`, and likely seg fault.

Includes a bit of refactoring for `readRobots`.

Related:
- Issue #1795
