### PR TITLE
Rename `RobotType` to `RobotTypeIndex`

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -24,7 +24,7 @@ namespace
 Robot::Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex robotTypeIndex) :
 	MapObject(spritePath, "running"),
 	mName(name),
-	mType{robotTypeIndex}
+	mRobotTypeIndex{robotTypeIndex}
 {}
 
 
@@ -49,7 +49,7 @@ bool Robot::isDead() const
 
 void Robot::startTask(Tile& tile)
 {
-	startTask(getTaskTime(mType, tile));
+	startTask(getTaskTime(mRobotTypeIndex, tile));
 }
 
 
@@ -69,7 +69,7 @@ void Robot::taskCompleteHandler(TaskCompleteDelegate newTaskCompleteHandler)
 NAS2D::Dictionary Robot::getDataDict() const
 {
 	return {{
-		{"type", static_cast<int>(mType)},
+		{"type", static_cast<int>(mRobotTypeIndex)},
 		{"age", mFuelCellAge},
 		{"production", mTurnsToCompleteTask},
 	}};

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -14,17 +14,17 @@ namespace
 		{RobotTypeIndex::Miner, constants::MinerTaskTime},
 	};
 
-	int getTaskTime(RobotTypeIndex type, Tile& tile)
+	int getTaskTime(RobotTypeIndex robotTypeIndex, Tile& tile)
 	{
-		return std::max(1, basicTaskTime.at(type) + static_cast<int>(tile.index()));
+		return std::max(1, basicTaskTime.at(robotTypeIndex) + static_cast<int>(tile.index()));
 	}
 }
 
 
-Robot::Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex type) :
+Robot::Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex robotTypeIndex) :
 	MapObject(spritePath, "running"),
 	mName(name),
-	mType{type}
+	mType{robotTypeIndex}
 {}
 
 

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -8,20 +8,20 @@
 
 namespace
 {
-	const std::map<RobotType, int> basicTaskTime{
-		{RobotType::Dozer, 0},
-		{RobotType::Digger, constants::DiggerTaskTime},
-		{RobotType::Miner, constants::MinerTaskTime},
+	const std::map<RobotTypeIndex, int> basicTaskTime{
+		{RobotTypeIndex::Dozer, 0},
+		{RobotTypeIndex::Digger, constants::DiggerTaskTime},
+		{RobotTypeIndex::Miner, constants::MinerTaskTime},
 	};
 
-	int getTaskTime(RobotType type, Tile& tile)
+	int getTaskTime(RobotTypeIndex type, Tile& tile)
 	{
 		return std::max(1, basicTaskTime.at(type) + static_cast<int>(tile.index()));
 	}
 }
 
 
-Robot::Robot(const std::string& name, const std::string& spritePath, RobotType type) :
+Robot::Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex type) :
 	MapObject(spritePath, "running"),
 	mName(name),
 	mType{type}

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -28,13 +28,6 @@ Robot::Robot(const std::string& name, const std::string& spritePath, RobotType t
 {}
 
 
-Robot::Robot(const std::string& name, const std::string& spritePath, const std::string& initialAction, RobotType type) :
-	MapObject(spritePath, initialAction),
-	mName(name),
-	mType{type}
-{}
-
-
 const std::string& Robot::name() const
 {
 	return mName;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -22,7 +22,7 @@ public:
 	using TaskCompleteDelegate = NAS2D::Delegate<void(Robot&)>;
 
 public:
-	Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex type);
+	Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex robotTypeIndex);
 
 	const std::string& name() const override;
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RobotType.h"
+#include "RobotTypeIndex.h"
 
 #include <libOPHD/MapObjects/MapObject.h>
 
@@ -22,7 +22,7 @@ public:
 	using TaskCompleteDelegate = NAS2D::Delegate<void(Robot&)>;
 
 public:
-	Robot(const std::string& name, const std::string& spritePath, RobotType type);
+	Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex type);
 
 	const std::string& name() const override;
 
@@ -48,7 +48,7 @@ public:
 	bool taskCanceled() const { return mCancelTask; }
 	void reset() { mCancelTask = false; }
 
-	RobotType type() const { return mType; }
+	RobotTypeIndex type() const { return mType; }
 
 	void taskCompleteHandler(TaskCompleteDelegate newTaskCompleteHandler);
 
@@ -59,7 +59,7 @@ protected:
 
 private:
 	const std::string& mName;
-	const RobotType mType;
+	const RobotTypeIndex mType;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -23,7 +23,6 @@ public:
 
 public:
 	Robot(const std::string& name, const std::string& spritePath, RobotType type);
-	Robot(const std::string& name, const std::string& spritePath, const std::string& initialAction, RobotType type);
 
 	const std::string& name() const override;
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -48,7 +48,7 @@ public:
 	bool taskCanceled() const { return mCancelTask; }
 	void reset() { mCancelTask = false; }
 
-	RobotTypeIndex type() const { return mType; }
+	RobotTypeIndex type() const { return mRobotTypeIndex; }
 
 	void taskCompleteHandler(TaskCompleteDelegate newTaskCompleteHandler);
 
@@ -59,7 +59,7 @@ protected:
 
 private:
 	const std::string& mName;
-	const RobotTypeIndex mType;
+	const RobotTypeIndex mRobotTypeIndex;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -22,8 +22,8 @@ public:
 	using TaskCompleteDelegate = NAS2D::Delegate<void(Robot&)>;
 
 public:
-	Robot(const std::string&, const std::string&, RobotType);
-	Robot(const std::string&, const std::string&, const std::string&, RobotType);
+	Robot(const std::string& name, const std::string& spritePath, RobotType type);
+	Robot(const std::string& name, const std::string& spritePath, const std::string& initialAction, RobotType type);
 
 	const std::string& name() const override;
 

--- a/appOPHD/MapObjects/RobotTypeIndex.h
+++ b/appOPHD/MapObjects/RobotTypeIndex.h
@@ -1,7 +1,7 @@
 #pragma once
 
 
-enum class RobotType
+enum class RobotTypeIndex
 {
 	Digger,
 	Dozer,

--- a/appOPHD/MapObjects/Robots/Robodigger.cpp
+++ b/appOPHD/MapObjects/Robots/Robodigger.cpp
@@ -8,7 +8,7 @@
 
 
 Robodigger::Robodigger() :
-	Robot(constants::Robodigger, "robots/robodigger.sprite", RobotType::Digger),
+	Robot(constants::Robodigger, "robots/robodigger.sprite", RobotTypeIndex::Digger),
 	mDirection(Direction::Down)
 {
 }

--- a/appOPHD/MapObjects/Robots/Robodozer.cpp
+++ b/appOPHD/MapObjects/Robots/Robodozer.cpp
@@ -5,7 +5,7 @@
 
 
 Robodozer::Robodozer() :
-	Robot(constants::Robodozer, "robots/robodozer.sprite", RobotType::Dozer)
+	Robot(constants::Robodozer, "robots/robodozer.sprite", RobotTypeIndex::Dozer)
 {
 }
 

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -14,7 +14,7 @@
 
 
 Robominer::Robominer() :
-	Robot(constants::Robominer, "robots/robominer.sprite", RobotType::Miner)
+	Robot(constants::Robominer, "robots/robominer.sprite", RobotTypeIndex::Miner)
 {
 }
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -148,24 +148,24 @@ void RobotPool::erase(Robot* robot)
  *
  * \return Returns a reference to the robot, or throws if type was invalid.
  */
-Robot& RobotPool::addRobot(RobotType type)
+Robot& RobotPool::addRobot(RobotTypeIndex type)
 {
 	switch (type)
 	{
-	case RobotType::Dozer:
+	case RobotTypeIndex::Dozer:
 		mDozers.emplace_back();
 		mRobots.push_back(&mDozers.back());
 		break;
-	case RobotType::Digger:
+	case RobotTypeIndex::Digger:
 		mDiggers.emplace_back();
 		mRobots.push_back(&mDiggers.back());
 		break;
-	case RobotType::Miner:
+	case RobotTypeIndex::Miner:
 		mMiners.emplace_back();
 		mRobots.push_back(&mMiners.back());
 		break;
 	default:
-		throw std::runtime_error("Unknown RobotType: " + std::to_string(static_cast<int>(type)));
+		throw std::runtime_error("Unknown RobotTypeIndex: " + std::to_string(static_cast<int>(type)));
 	}
 
 	return *mRobots.back();
@@ -204,19 +204,19 @@ Robominer& RobotPool::getMiner()
  *
  * \return	Returns true if the requested robot type is available. False otherwise.
  */
-bool RobotPool::robotAvailable(RobotType type) const
+bool RobotPool::robotAvailable(RobotTypeIndex type) const
 {
 	switch (type)
 	{
-	case RobotType::Digger:
+	case RobotTypeIndex::Digger:
 	{
 		return hasIdleRobot(mDiggers);
 	}
-	case RobotType::Dozer:
+	case RobotTypeIndex::Dozer:
 	{
 		return hasIdleRobot(mDozers);
 	}
-	case RobotType::Miner:
+	case RobotTypeIndex::Miner:
 	{
 		return hasIdleRobot(mMiners);
 	}
@@ -228,17 +228,17 @@ bool RobotPool::robotAvailable(RobotType type) const
 }
 
 
-std::size_t RobotPool::getAvailableCount(RobotType type) const
+std::size_t RobotPool::getAvailableCount(RobotTypeIndex type) const
 {
 	switch (type)
 	{
-	case RobotType::Digger:
+	case RobotTypeIndex::Digger:
 		return getIdleCount(mDiggers);
 
-	case RobotType::Dozer:
+	case RobotTypeIndex::Dozer:
 		return getIdleCount(mDozers);
 
-	case RobotType::Miner:
+	case RobotTypeIndex::Miner:
 		return getIdleCount(mMiners);
 
 	default:

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -144,13 +144,13 @@ void RobotPool::erase(Robot* robot)
 
 
 /**
- * Adds a robot of specified type to the pool.
+ * Adds a robot of specified robotTypeIndex to the pool.
  *
- * \return Returns a reference to the robot, or throws if type was invalid.
+ * \return Returns a reference to the robot, or throws if robotTypeIndex was invalid.
  */
-Robot& RobotPool::addRobot(RobotTypeIndex type)
+Robot& RobotPool::addRobot(RobotTypeIndex robotTypeIndex)
 {
-	switch (type)
+	switch (robotTypeIndex)
 	{
 	case RobotTypeIndex::Dozer:
 		mDozers.emplace_back();
@@ -165,7 +165,7 @@ Robot& RobotPool::addRobot(RobotTypeIndex type)
 		mRobots.push_back(&mMiners.back());
 		break;
 	default:
-		throw std::runtime_error("Unknown RobotTypeIndex: " + std::to_string(static_cast<int>(type)));
+		throw std::runtime_error("Unknown RobotTypeIndex: " + std::to_string(static_cast<int>(robotTypeIndex)));
 	}
 
 	return *mRobots.back();
@@ -200,13 +200,13 @@ Robominer& RobotPool::getMiner()
 
 
 /**
- * Determines if a requested robot type is available.
+ * Determines if a requested robot robotTypeIndex is available.
  *
- * \return	Returns true if the requested robot type is available. False otherwise.
+ * \return	Returns true if the requested robot robotTypeIndex is available. False otherwise.
  */
-bool RobotPool::robotAvailable(RobotTypeIndex type) const
+bool RobotPool::robotAvailable(RobotTypeIndex robotTypeIndex) const
 {
-	switch (type)
+	switch (robotTypeIndex)
 	{
 	case RobotTypeIndex::Digger:
 	{
@@ -228,9 +228,9 @@ bool RobotPool::robotAvailable(RobotTypeIndex type) const
 }
 
 
-std::size_t RobotPool::getAvailableCount(RobotTypeIndex type) const
+std::size_t RobotPool::getAvailableCount(RobotTypeIndex robotTypeIndex) const
 {
-	switch (type)
+	switch (robotTypeIndex)
 	{
 	case RobotTypeIndex::Digger:
 		return getIdleCount(mDiggers);

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -36,14 +36,14 @@ public:
 	RobotPool();
 	~RobotPool();
 
-	Robot& addRobot(RobotTypeIndex type);
+	Robot& addRobot(RobotTypeIndex robotTypeIndex);
 
 	Robodigger& getDigger();
 	Robodozer& getDozer();
 	Robominer& getMiner();
 
-	bool robotAvailable(RobotTypeIndex type) const;
-	std::size_t getAvailableCount(RobotTypeIndex type) const;
+	bool robotAvailable(RobotTypeIndex robotTypeIndex) const;
+	std::size_t getAvailableCount(RobotTypeIndex robotTypeIndex) const;
 
 	bool isControlCapacityAvailable() const { return mRobotControlCount < mRobotControlMax; }
 	bool commandCapacityAvailable() { return mRobots.size() < mRobotControlMax; }

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -6,7 +6,7 @@
 #include <map>
 
 
-enum class RobotType;
+enum class RobotTypeIndex;
 class Robot;
 class Robodigger;
 class Robodozer;
@@ -36,14 +36,14 @@ public:
 	RobotPool();
 	~RobotPool();
 
-	Robot& addRobot(RobotType type);
+	Robot& addRobot(RobotTypeIndex type);
 
 	Robodigger& getDigger();
 	Robodozer& getDozer();
 	Robominer& getMiner();
 
-	bool robotAvailable(RobotType type) const;
-	std::size_t getAvailableCount(RobotType type) const;
+	bool robotAvailable(RobotTypeIndex type) const;
+	std::size_t getAvailableCount(RobotTypeIndex type) const;
 
 	bool isControlCapacityAvailable() const { return mRobotControlCount < mRobotControlMax; }
 	bool commandCapacityAvailable() { return mRobots.size() < mRobotControlMax; }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -907,7 +907,7 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 }
 
 
-void MapViewState::placeRobot(Tile& tile, RobotTypeIndex robotType)
+void MapViewState::placeRobot(Tile& tile, RobotTypeIndex robotTypeIndex)
 {
 	if (!tile.excavated()) { return; }
 	if (!mRobotPool.isControlCapacityAvailable()) { return; }
@@ -918,7 +918,7 @@ void MapViewState::placeRobot(Tile& tile, RobotTypeIndex robotType)
 		return;
 	}
 
-	switch (robotType)
+	switch (robotTypeIndex)
 	{
 	case RobotTypeIndex::Dozer:
 		placeRobodozer(tile);
@@ -1187,11 +1187,11 @@ void MapViewState::populateRobotMenu()
 {
 	mRobots.clear();
 
-	for (auto& [robotType, robotMeta] : RobotMetaTable)
+	for (auto& [robotTypeIndex, robotMeta] : RobotMetaTable)
 	{
-		if (mRobotPool.robotAvailable(robotType))
+		if (mRobotPool.robotAvailable(robotTypeIndex))
 		{
-			mRobots.addItem({robotMeta.name, robotMeta.sheetIndex, static_cast<int>(robotType)});
+			mRobots.addItem({robotMeta.name, robotMeta.sheetIndex, static_cast<int>(robotTypeIndex)});
 		}
 	}
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1159,7 +1159,7 @@ void MapViewState::placeRobominer(Tile& tile)
 }
 
 
-Robot& MapViewState::addRobot(RobotTypeIndex type)
+Robot& MapViewState::addRobot(RobotTypeIndex robotTypeIndex)
 {
 	const std::map<RobotTypeIndex, void (MapViewState::*)(Robot&)> RobotTypeIndexToHandler
 	{
@@ -1168,13 +1168,13 @@ Robot& MapViewState::addRobot(RobotTypeIndex type)
 		{RobotTypeIndex::Miner, &MapViewState::onMinerTaskComplete},
 	};
 
-	if (RobotTypeIndexToHandler.find(type) == RobotTypeIndexToHandler.end())
+	if (RobotTypeIndexToHandler.find(robotTypeIndex) == RobotTypeIndexToHandler.end())
 	{
-		throw std::runtime_error("Unknown RobotTypeIndex: " + std::to_string(static_cast<int>(type)));
+		throw std::runtime_error("Unknown RobotTypeIndex: " + std::to_string(static_cast<int>(robotTypeIndex)));
 	}
 
-	auto& robot = mRobotPool.addRobot(type);
-	robot.taskCompleteHandler({this, RobotTypeIndexToHandler.at(type)});
+	auto& robot = mRobotPool.addRobot(robotTypeIndex);
+	robot.taskCompleteHandler({this, RobotTypeIndexToHandler.at(robotTypeIndex)});
 	return robot;
 }
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -168,7 +168,7 @@ private:
 
 	void placeTubes(Tile& tile, ConnectorDir connectorDirection);
 	void placeStructure(Tile& tile, StructureID structureID);
-	void placeRobot(Tile& tile, RobotTypeIndex robotType);
+	void placeRobot(Tile& tile, RobotTypeIndex robotTypeIndex);
 
 	void placeRobodozer(Tile&);
 	void placeRobodigger(Tile&);

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -174,7 +174,7 @@ private:
 	void placeRobodigger(Tile&);
 	void placeRobominer(Tile&);
 
-	Robot& addRobot(RobotTypeIndex type);
+	Robot& addRobot(RobotTypeIndex robotTypeIndex);
 
 	// MISCELLANEOUS UTILITY FUNCTIONS
 	void updateFood();

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -70,7 +70,7 @@ namespace micropather
 }
 
 enum class Direction;
-enum class RobotType;
+enum class RobotTypeIndex;
 
 class Structure;
 class Tile;
@@ -168,13 +168,13 @@ private:
 
 	void placeTubes(Tile& tile, ConnectorDir connectorDirection);
 	void placeStructure(Tile& tile, StructureID structureID);
-	void placeRobot(Tile& tile, RobotType robotType);
+	void placeRobot(Tile& tile, RobotTypeIndex robotType);
 
 	void placeRobodozer(Tile&);
 	void placeRobodigger(Tile&);
 	void placeRobominer(Tile&);
 
-	Robot& addRobot(RobotType type);
+	Robot& addRobot(RobotTypeIndex type);
 
 	// MISCELLANEOUS UTILITY FUNCTIONS
 	void updateFood();
@@ -332,7 +332,7 @@ private:
 	// Map Object picking
 	InsertMode mInsertMode = InsertMode::None; /**< What's being inserted into the TileMap if anything. */
 	StructureID mCurrentStructure = StructureID::SID_NONE; /**< Structure being placed. */
-	RobotType mCurrentRobot; /**< Robot being placed. */
+	RobotTypeIndex mCurrentRobot; /**< Robot being placed. */
 	IconGrid mStructures;
 	IconGrid mRobots;
 	IconGrid mConnections;

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -30,21 +30,21 @@
 
 void MapViewState::pullRobotFromFactory(ProductType productType, Factory& factory)
 {
-	const std::map<ProductType, RobotType> ProductTypeToRobotType
+	const std::map<ProductType, RobotTypeIndex> ProductTypeToRobotTypeIndex
 	{
-		{ProductType::PRODUCT_DIGGER, RobotType::Digger},
-		{ProductType::PRODUCT_DOZER, RobotType::Dozer},
-		{ProductType::PRODUCT_MINER, RobotType::Miner},
+		{ProductType::PRODUCT_DIGGER, RobotTypeIndex::Digger},
+		{ProductType::PRODUCT_DOZER, RobotTypeIndex::Dozer},
+		{ProductType::PRODUCT_MINER, RobotTypeIndex::Miner},
 	};
 
-	if (ProductTypeToRobotType.find(productType) == ProductTypeToRobotType.end())
+	if (ProductTypeToRobotTypeIndex.find(productType) == ProductTypeToRobotTypeIndex.end())
 	{
 		throw std::runtime_error("pullRobotFromFactory():: unsuitable ProductType: " + std::to_string(static_cast<int>(productType)));
 	}
 
 	if (mRobotPool.commandCapacityAvailable())
 	{
-		addRobot(ProductTypeToRobotType.at(productType));
+		addRobot(ProductTypeToRobotTypeIndex.at(productType));
 		factory.pullProduct();
 
 		populateRobotMenu();
@@ -163,9 +163,9 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	seedFactory.resourcePool(&mResourcesCount);
 	seedFactory.productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
 
-	mRobotPool.addRobot(RobotType::Dozer).taskCompleteHandler({this, &MapViewState::onDozerTaskComplete});
-	mRobotPool.addRobot(RobotType::Digger).taskCompleteHandler({this, &MapViewState::onDiggerTaskComplete});
-	mRobotPool.addRobot(RobotType::Miner).taskCompleteHandler({this, &MapViewState::onMinerTaskComplete});
+	mRobotPool.addRobot(RobotTypeIndex::Dozer).taskCompleteHandler({this, &MapViewState::onDozerTaskComplete});
+	mRobotPool.addRobot(RobotTypeIndex::Digger).taskCompleteHandler({this, &MapViewState::onDiggerTaskComplete});
+	mRobotPool.addRobot(RobotTypeIndex::Miner).taskCompleteHandler({this, &MapViewState::onMinerTaskComplete});
 
 	populateRobotMenu();
 }

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -357,9 +357,9 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		const auto depth = dictionary.get<int>("depth", 0);
 		const auto direction = dictionary.get<int>("direction", 0);
 
-		const auto robotType = static_cast<RobotType>(type);
+		const auto robotType = static_cast<RobotTypeIndex>(type);
 		auto& robot = addRobot(robotType);
-		if (robotType == RobotType::Digger)
+		if (robotType == RobotTypeIndex::Digger)
 		{
 			dynamic_cast<Robodigger&>(robot).direction(static_cast<Direction>(direction));
 		}

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -357,9 +357,9 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		const auto depth = dictionary.get<int>("depth", 0);
 		const auto direction = dictionary.get<int>("direction", 0);
 
-		const auto robotType = static_cast<RobotTypeIndex>(type);
-		auto& robot = addRobot(robotType);
-		if (robotType == RobotTypeIndex::Digger)
+		const auto robotTypeIndex = static_cast<RobotTypeIndex>(type);
+		auto& robot = addRobot(robotTypeIndex);
+		if (robotTypeIndex == RobotTypeIndex::Digger)
 		{
 			dynamic_cast<Robodigger&>(robot).direction(static_cast<Direction>(direction));
 		}

--- a/appOPHD/States/MapViewStateMapObjectPicker.cpp
+++ b/appOPHD/States/MapViewStateMapObjectPicker.cpp
@@ -1,7 +1,7 @@
 #include "MapViewState.h"
 
 #include "MapViewStateHelper.h"
-#include "../MapObjects/RobotType.h"
+#include "../MapObjects/RobotTypeIndex.h"
 
 
 bool MapViewState::isInserting() const
@@ -20,7 +20,7 @@ void MapViewState::clearBuildMode()
 {
 	mInsertMode = InsertMode::None;
 	mCurrentStructure = StructureID::SID_NONE;
-	mCurrentRobot = RobotType::None;
+	mCurrentRobot = RobotTypeIndex::None;
 	onMapObjectSelectionChanged();
 }
 
@@ -102,7 +102,7 @@ void MapViewState::onRobotsSelectionChange(const IconGridItem* item)
 	mConnections.clearSelection();
 	mStructures.clearSelection();
 
-	mCurrentRobot = static_cast<RobotType>(item->meta);
+	mCurrentRobot = static_cast<RobotTypeIndex>(item->meta);
 	mInsertMode = InsertMode::Robot;
 	onMapObjectSelectionChanged();
 }

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -520,7 +520,7 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 		mTileMap->getTile(tile.xyz().translate(direction)).excavated(true);
 	}
 
-	if (!mRobotPool.robotAvailable(RobotType::Digger))
+	if (!mRobotPool.robotAvailable(RobotTypeIndex::Digger))
 	{
 		mRobots.removeItem(constants::Robodigger);
 		clearBuildMode();
@@ -637,9 +637,9 @@ void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
 			mPopulation.removePopulation({0, 0, 0, 0, 10});
 		break;
 		case CheatMenu::CheatCode::AddRobots:
-			mRobotPool.addRobot(RobotType::Digger);
-			mRobotPool.addRobot(RobotType::Dozer);
-			mRobotPool.addRobot(RobotType::Miner);
+			mRobotPool.addRobot(RobotTypeIndex::Digger);
+			mRobotPool.addRobot(RobotTypeIndex::Dozer);
+			mRobotPool.addRobot(RobotTypeIndex::Miner);
 		break;
 
 	}

--- a/appOPHD/UI/RobotDeploymentSummary.cpp
+++ b/appOPHD/UI/RobotDeploymentSummary.cpp
@@ -3,7 +3,7 @@
 #include "../RobotPool.h"
 #include "../Cache.h"
 #include "../Constants/UiConstants.h"
-#include "../MapObjects/RobotType.h"
+#include "../MapObjects/RobotTypeIndex.h"
 #include "../States/MapViewStateHelper.h"
 
 #include <NAS2D/Renderer/Renderer.h>
@@ -31,9 +31,9 @@ void RobotDeploymentSummary::draw(NAS2D::Renderer& renderer) const
 
 	const std::array icons{
 		std::tuple{robotSummaryImageRect, mRobotPool.currentControlCount(), mRobotPool.robotControlMax()},
-		std::tuple{diggerImageRect, mRobotPool.getAvailableCount(RobotType::Digger), mRobotPool.diggers().size()},
-		std::tuple{dozerImageRect, mRobotPool.getAvailableCount(RobotType::Dozer), mRobotPool.dozers().size()},
-		std::tuple{minerImageRect, mRobotPool.getAvailableCount(RobotType::Miner), mRobotPool.miners().size()},
+		std::tuple{diggerImageRect, mRobotPool.getAvailableCount(RobotTypeIndex::Digger), mRobotPool.diggers().size()},
+		std::tuple{dozerImageRect, mRobotPool.getAvailableCount(RobotTypeIndex::Dozer), mRobotPool.dozers().size()},
+		std::tuple{minerImageRect, mRobotPool.getAvailableCount(RobotTypeIndex::Miner), mRobotPool.miners().size()},
 	};
 
 	for (const auto& [imageRect, parts, total] : icons)

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -17,7 +17,7 @@ using namespace NAS2D;
 
 namespace
 {
-	const NAS2D::Image& robotImage(RobotTypeIndex robotType)
+	const NAS2D::Image& robotImage(RobotTypeIndex robotTypeIndex)
 	{
 		static const std::map<RobotTypeIndex, const Image*> robotImages
 		{
@@ -25,7 +25,7 @@ namespace
 			{RobotTypeIndex::Dozer, &imageCache.load("ui/interface/product_robodozer.png")},
 			{RobotTypeIndex::Miner, &imageCache.load("ui/interface/product_robominer.png")}
 		};
-		return *robotImages.at(robotType);
+		return *robotImages.at(robotTypeIndex);
 	}
 }
 

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -17,13 +17,13 @@ using namespace NAS2D;
 
 namespace
 {
-	const NAS2D::Image& robotImage(RobotType robotType)
+	const NAS2D::Image& robotImage(RobotTypeIndex robotType)
 	{
-		static const std::map<RobotType, const Image*> robotImages
+		static const std::map<RobotTypeIndex, const Image*> robotImages
 		{
-			{RobotType::Digger, &imageCache.load("ui/interface/product_robodigger.png")},
-			{RobotType::Dozer, &imageCache.load("ui/interface/product_robodozer.png")},
-			{RobotType::Miner, &imageCache.load("ui/interface/product_robominer.png")}
+			{RobotTypeIndex::Digger, &imageCache.load("ui/interface/product_robodigger.png")},
+			{RobotTypeIndex::Dozer, &imageCache.load("ui/interface/product_robodozer.png")},
+			{RobotTypeIndex::Miner, &imageCache.load("ui/interface/product_robominer.png")}
 		};
 		return *robotImages.at(robotType);
 	}
@@ -42,7 +42,7 @@ RobotInspector::RobotInspector() :
 	const auto buttonSize = mainFont.size("Cancel Orders") + NAS2D::Vector{padding, padding};
 	const int buttonOffsetY = buttonSize.y + constants::MarginTight;
 
-	const int imageWidth = robotImage(RobotType::Digger).size().x + padding;
+	const int imageWidth = robotImage(RobotTypeIndex::Digger).size().x + padding;
 	const int contentWidth = imageWidth + buttonSize.x;
 
 	mContentRect = {

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -305,7 +305,7 @@
     <ClInclude Include="MapObjects\Robots\Robominer.h" />
     <ClInclude Include="MapObjects\Robot.h" />
     <ClInclude Include="MapObjects\Robots.h" />
-    <ClInclude Include="MapObjects\RobotType.h" />
+    <ClInclude Include="MapObjects\RobotTypeIndex.h" />
     <ClInclude Include="MapObjects\Structure.h" />
     <ClInclude Include="MapObjects\StructureClass.h" />
     <ClInclude Include="MapObjects\Structures.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -434,7 +434,7 @@
     <ClInclude Include="MapObjects\Robots.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
-    <ClInclude Include="MapObjects\RobotType.h">
+    <ClInclude Include="MapObjects\RobotTypeIndex.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
     <ClInclude Include="MapObjects\Structure.h">


### PR DESCRIPTION
Rename `RobotType` to `RobotTypeIndex`, so the name `RobotType` can be re-used for a `struct` akin to `StructureType`.

Add constructor parameter names to `Robot` header file. Remove an unused `Robot` constructor overload.

Related:
- Issue #1795
- Issue #1723
