### PR TITLE
Add `RobotType` struct

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -31,8 +31,14 @@ namespace
 }
 
 
+const RobotType& Robot::robotType(RobotTypeIndex robotTypeIndex)
+{
+	return robotTypes.at(static_cast<std::size_t>(robotTypeIndex));
+}
+
+
 Robot::Robot(RobotTypeIndex robotTypeIndex) :
-	Robot{robotTypeIndex, robotTypes.at(static_cast<std::size_t>(robotTypeIndex))}
+	Robot{robotTypeIndex, robotType(robotTypeIndex)}
 {}
 
 

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -49,6 +49,12 @@ Robot::Robot(RobotTypeIndex robotTypeIndex, const RobotType& robotType) :
 {}
 
 
+const RobotType& Robot::robotType() const
+{
+	return mRobotType;
+}
+
+
 const std::string& Robot::name() const
 {
 	return mRobotType.name;

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -39,14 +39,13 @@ Robot::Robot(RobotTypeIndex robotTypeIndex) :
 Robot::Robot(RobotTypeIndex robotTypeIndex, const RobotType& robotType) :
 	MapObject(robotType.spritePath, "running"),
 	mRobotType{robotType},
-	mName(robotType.name),
 	mRobotTypeIndex{robotTypeIndex}
 {}
 
 
 const std::string& Robot::name() const
 {
-	return mName;
+	return mRobotType.name;
 }
 
 

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -18,15 +18,15 @@ namespace
 		RobotType{constants::Robominer, "robots/robominer.sprite", "ui/interface/product_robominer.png"},
 	};
 
-	const std::map<RobotTypeIndex, int> basicTaskTime{
-		{RobotTypeIndex::Dozer, 0},
-		{RobotTypeIndex::Digger, constants::DiggerTaskTime},
-		{RobotTypeIndex::Miner, constants::MinerTaskTime},
+	constexpr std::array basicTaskTime{
+		constants::DiggerTaskTime,
+		0,
+		constants::MinerTaskTime,
 	};
 
 	int getTaskTime(RobotTypeIndex robotTypeIndex, Tile& tile)
 	{
-		return std::max(1, basicTaskTime.at(robotTypeIndex) + static_cast<int>(tile.index()));
+		return std::max(1, basicTaskTime.at(static_cast<std::size_t>(robotTypeIndex)) + static_cast<int>(tile.index()));
 	}
 }
 

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -1,13 +1,23 @@
 #include "Robot.h"
 
+#include "RobotType.h"
 #include "../Constants/Numbers.h"
+#include "../Constants/Strings.h"
 #include "../Map/Tile.h"
 
 #include <NAS2D/Dictionary.h>
 
+#include <array>
+
 
 namespace
 {
+	const std::array robotTypes{
+		RobotType{constants::Robodigger, "robots/robodigger.sprite"},
+		RobotType{constants::Robodozer, "robots/robodozer.sprite"},
+		RobotType{constants::Robominer, "robots/robominer.sprite"},
+	};
+
 	const std::map<RobotTypeIndex, int> basicTaskTime{
 		{RobotTypeIndex::Dozer, 0},
 		{RobotTypeIndex::Digger, constants::DiggerTaskTime},
@@ -21,9 +31,15 @@ namespace
 }
 
 
-Robot::Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex robotTypeIndex) :
-	MapObject(spritePath, "running"),
-	mName(name),
+Robot::Robot(RobotTypeIndex robotTypeIndex) :
+	Robot{robotTypeIndex, robotTypes.at(static_cast<std::size_t>(robotTypeIndex))}
+{}
+
+
+Robot::Robot(RobotTypeIndex robotTypeIndex, const RobotType& robotType) :
+	MapObject(robotType.spritePath, "running"),
+	mRobotType{robotType},
+	mName(robotType.name),
 	mRobotTypeIndex{robotTypeIndex}
 {}
 

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -13,9 +13,9 @@
 namespace
 {
 	const std::array robotTypes{
-		RobotType{constants::Robodigger, "robots/robodigger.sprite"},
-		RobotType{constants::Robodozer, "robots/robodozer.sprite"},
-		RobotType{constants::Robominer, "robots/robominer.sprite"},
+		RobotType{constants::Robodigger, "robots/robodigger.sprite", "ui/interface/product_robodigger.png"},
+		RobotType{constants::Robodozer, "robots/robodozer.sprite", "ui/interface/product_robodozer.png"},
+		RobotType{constants::Robominer, "robots/robominer.sprite", "ui/interface/product_robominer.png"},
 	};
 
 	const std::map<RobotTypeIndex, int> basicTaskTime{

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -13,20 +13,14 @@
 namespace
 {
 	const std::array robotTypes{
-		RobotType{constants::Robodigger, "robots/robodigger.sprite", "ui/interface/product_robodigger.png"},
-		RobotType{constants::Robodozer, "robots/robodozer.sprite", "ui/interface/product_robodozer.png"},
-		RobotType{constants::Robominer, "robots/robominer.sprite", "ui/interface/product_robominer.png"},
-	};
-
-	constexpr std::array basicTaskTime{
-		constants::DiggerTaskTime,
-		0,
-		constants::MinerTaskTime,
+		RobotType{constants::Robodigger, "robots/robodigger.sprite", "ui/interface/product_robodigger.png", constants::DiggerTaskTime},
+		RobotType{constants::Robodozer, "robots/robodozer.sprite", "ui/interface/product_robodozer.png", 0},
+		RobotType{constants::Robominer, "robots/robominer.sprite", "ui/interface/product_robominer.png", constants::MinerTaskTime},
 	};
 
 	int getTaskTime(RobotTypeIndex robotTypeIndex, Tile& tile)
 	{
-		return std::max(1, basicTaskTime.at(static_cast<std::size_t>(robotTypeIndex)) + static_cast<int>(tile.index()));
+		return std::max(1, Robot::robotType(robotTypeIndex).basicTaskTime + static_cast<int>(tile.index()));
 	}
 }
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -22,6 +22,8 @@ class Robot : public MapObject
 public:
 	using TaskCompleteDelegate = NAS2D::Delegate<void(Robot&)>;
 
+	static const RobotType& robotType(RobotTypeIndex robotTypeIndex);
+
 public:
 	Robot(RobotTypeIndex robotTypeIndex);
 	Robot(RobotTypeIndex robotTypeIndex, const RobotType& robotType);

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -28,6 +28,7 @@ public:
 	Robot(RobotTypeIndex robotTypeIndex);
 	Robot(RobotTypeIndex robotTypeIndex, const RobotType& robotType);
 
+	const RobotType& robotType() const;
 	const std::string& name() const override;
 
 	bool isDead() const;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -12,6 +12,7 @@ namespace NAS2D
 	class Dictionary;
 }
 
+struct RobotType;
 class Tile;
 class TileMap;
 
@@ -22,7 +23,8 @@ public:
 	using TaskCompleteDelegate = NAS2D::Delegate<void(Robot&)>;
 
 public:
-	Robot(const std::string& name, const std::string& spritePath, RobotTypeIndex robotTypeIndex);
+	Robot(RobotTypeIndex robotTypeIndex);
+	Robot(RobotTypeIndex robotTypeIndex, const RobotType& robotType);
 
 	const std::string& name() const override;
 
@@ -58,6 +60,7 @@ protected:
 	virtual void onTaskComplete(TileMap& tileMap) = 0;
 
 private:
+	const RobotType& mRobotType;
 	const std::string& mName;
 	const RobotTypeIndex mRobotTypeIndex;
 	int mFuelCellAge = 0;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -61,7 +61,6 @@ protected:
 
 private:
 	const RobotType& mRobotType;
-	const std::string& mName;
 	const RobotTypeIndex mRobotTypeIndex;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;

--- a/appOPHD/MapObjects/RobotType.h
+++ b/appOPHD/MapObjects/RobotType.h
@@ -8,4 +8,5 @@ struct RobotType
 	std::string name;
 	std::string spritePath;
 	std::string imagePath;
+	int basicTaskTime;
 };

--- a/appOPHD/MapObjects/RobotType.h
+++ b/appOPHD/MapObjects/RobotType.h
@@ -7,4 +7,5 @@ struct RobotType
 {
 	std::string name;
 	std::string spritePath;
+	std::string imagePath;
 };

--- a/appOPHD/MapObjects/RobotType.h
+++ b/appOPHD/MapObjects/RobotType.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+
+struct RobotType
+{
+	std::string name;
+	std::string spritePath;
+};

--- a/appOPHD/MapObjects/Robots/Robodigger.cpp
+++ b/appOPHD/MapObjects/Robots/Robodigger.cpp
@@ -8,7 +8,7 @@
 
 
 Robodigger::Robodigger() :
-	Robot(constants::Robodigger, "robots/robodigger.sprite", RobotTypeIndex::Digger),
+	Robot(RobotTypeIndex::Digger),
 	mDirection(Direction::Down)
 {
 }

--- a/appOPHD/MapObjects/Robots/Robodozer.cpp
+++ b/appOPHD/MapObjects/Robots/Robodozer.cpp
@@ -5,7 +5,7 @@
 
 
 Robodozer::Robodozer() :
-	Robot(constants::Robodozer, "robots/robodozer.sprite", RobotTypeIndex::Dozer)
+	Robot(RobotTypeIndex::Dozer)
 {
 }
 

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -14,7 +14,7 @@
 
 
 Robominer::Robominer() :
-	Robot(constants::Robominer, "robots/robominer.sprite", RobotTypeIndex::Miner)
+	Robot(RobotTypeIndex::Miner)
 {
 }
 

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -10,6 +10,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
+#include <array>
 #include <algorithm>
 
 
@@ -20,13 +21,13 @@ namespace
 {
 	const NAS2D::Image& robotImage(RobotTypeIndex robotTypeIndex)
 	{
-		static const std::map<RobotTypeIndex, const Image*> robotImages
+		static const std::array robotImages
 		{
-			{RobotTypeIndex::Digger, &imageCache.load(Robot::robotType(RobotTypeIndex::Digger).imagePath)},
-			{RobotTypeIndex::Dozer, &imageCache.load(Robot::robotType(RobotTypeIndex::Dozer).imagePath)},
-			{RobotTypeIndex::Miner, &imageCache.load(Robot::robotType(RobotTypeIndex::Miner).imagePath)}
+			&imageCache.load(Robot::robotType(RobotTypeIndex::Digger).imagePath),
+			&imageCache.load(Robot::robotType(RobotTypeIndex::Dozer).imagePath),
+			&imageCache.load(Robot::robotType(RobotTypeIndex::Miner).imagePath),
 		};
-		return *robotImages.at(robotTypeIndex);
+		return *robotImages.at(static_cast<std::size_t>(robotTypeIndex));
 	}
 }
 

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -5,6 +5,7 @@
 #include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../MapObjects/Robot.h"
+#include "../MapObjects/RobotType.h"
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -21,9 +22,9 @@ namespace
 	{
 		static const std::map<RobotTypeIndex, const Image*> robotImages
 		{
-			{RobotTypeIndex::Digger, &imageCache.load("ui/interface/product_robodigger.png")},
-			{RobotTypeIndex::Dozer, &imageCache.load("ui/interface/product_robodozer.png")},
-			{RobotTypeIndex::Miner, &imageCache.load("ui/interface/product_robominer.png")}
+			{RobotTypeIndex::Digger, &imageCache.load(Robot::robotType(RobotTypeIndex::Digger).imagePath)},
+			{RobotTypeIndex::Dozer, &imageCache.load(Robot::robotType(RobotTypeIndex::Dozer).imagePath)},
+			{RobotTypeIndex::Miner, &imageCache.load(Robot::robotType(RobotTypeIndex::Miner).imagePath)}
 		};
 		return *robotImages.at(robotTypeIndex);
 	}

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -305,6 +305,7 @@
     <ClInclude Include="MapObjects\Robots\Robominer.h" />
     <ClInclude Include="MapObjects\Robot.h" />
     <ClInclude Include="MapObjects\Robots.h" />
+    <ClInclude Include="MapObjects\RobotType.h" />
     <ClInclude Include="MapObjects\RobotTypeIndex.h" />
     <ClInclude Include="MapObjects\Structure.h" />
     <ClInclude Include="MapObjects\StructureClass.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -434,6 +434,9 @@
     <ClInclude Include="MapObjects\Robots.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
+    <ClInclude Include="MapObjects\RobotType.h">
+      <Filter>Header Files\MapObjects</Filter>
+    </ClInclude>
     <ClInclude Include="MapObjects\RobotTypeIndex.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>


### PR DESCRIPTION
Add `RobotType` struct similar to the `StructureType` struct.

This helps simplify `Robot` construction. Potentially we may want to add additional constructors to support creating `Robot` instances from saved game data, rather than creating default `Robot` instances, and then modifying properties based on saved game data.

We may want to pass a `Tile&` or `MapCoordinate` to `Robot` constructors when loading saved game data.

Related:
- PR #1957
- Issue #1795
- Issue #1723
