### PR TITLE
Add `Tile&` field to `Robot`

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -74,10 +74,11 @@ void Robot::startTask(Tile& tile)
 }
 
 
-void Robot::startTask(Tile& /*tile*/, int turns)
+void Robot::startTask(Tile& tile, int turns)
 {
 	if (turns < 1) { throw std::runtime_error("Robot task time must be at least 1 turn"); }
 	mTurnsToCompleteTask = turns;
+	mTile = &tile;
 }
 
 

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -70,11 +70,11 @@ bool Robot::isDead() const
 
 void Robot::startTask(Tile& tile)
 {
-	startTask(getTaskTime(mRobotTypeIndex, tile));
+	startTask(tile, getTaskTime(mRobotTypeIndex, tile));
 }
 
 
-void Robot::startTask(int turns)
+void Robot::startTask(Tile& /*tile*/, int turns)
 {
 	if (turns < 1) { throw std::runtime_error("Robot task time must be at least 1 turn"); }
 	mTurnsToCompleteTask = turns;

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -82,6 +82,12 @@ void Robot::startTask(Tile& tile, int turns)
 }
 
 
+bool Robot::isPlaced() const
+{
+	return mTurnsToCompleteTask > 0 && mTile;
+}
+
+
 Tile& Robot::tile()
 {
 	if (!mTile) { throw std::runtime_error("Robot must be placed"); }

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -82,6 +82,20 @@ void Robot::startTask(Tile& tile, int turns)
 }
 
 
+Tile& Robot::tile()
+{
+	if (!mTile) { throw std::runtime_error("Robot must be placed"); }
+	return *mTile;
+}
+
+
+const Tile& Robot::tile() const
+{
+	if (!mTile) { throw std::runtime_error("Robot must be placed"); }
+	return *mTile;
+}
+
+
 void Robot::taskCompleteHandler(TaskCompleteDelegate newTaskCompleteHandler)
 {
 	mTaskCompleteHandler = newTaskCompleteHandler;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -41,6 +41,9 @@ public:
 
 	virtual void abortTask(Tile& /*tile*/) {}
 
+	Tile& tile();
+	const Tile& tile() const;
+
 	void fuelCellAge(int age) { mFuelCellAge = age; }
 	int fuelCellAge() const { return mFuelCellAge; }
 	int turnsToCompleteTask() const { return mTurnsToCompleteTask; }

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -37,7 +37,7 @@ public:
 	virtual void processTurn(TileMap& tileMap);
 
 	virtual void startTask(Tile& tile);
-	void startTask(int turns);
+	void startTask(Tile& tile, int turns);
 
 	virtual void abortTask(Tile& /*tile*/) {}
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -67,6 +67,7 @@ private:
 	const RobotTypeIndex mRobotTypeIndex;
 	int mFuelCellAge = 0;
 	int mTurnsToCompleteTask = 0;
+	Tile* mTile = nullptr;
 
 	bool mIsDead = false;
 	bool mSelfDestruct = false;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -41,6 +41,7 @@ public:
 
 	virtual void abortTask(Tile& /*tile*/) {}
 
+	bool isPlaced() const;
 	Tile& tile();
 	const Tile& tile() const;
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -265,7 +265,7 @@ void RobotPool::update()
 }
 
 
-void RobotPool::insertRobotIntoTable(std::map<Robot*, Tile*>& deployedRobots, Robot& robot, Tile& tile)
+void RobotPool::insertRobotIntoTable(std::vector<Robot*>& deployedRobots, Robot& robot, Tile& tile)
 {
 	// Add pre-check for control count against max capacity, with one caveat
 	// When loading saved games a control max won't have been set yet as robots are loaded before structures
@@ -275,10 +275,10 @@ void RobotPool::insertRobotIntoTable(std::map<Robot*, Tile*>& deployedRobots, Ro
 		throw std::runtime_error("Must increase robot command capacity before placing more robots: " + std::to_string(mRobotControlCount) + " / " + std::to_string(mRobotControlMax));
 	}
 
-	auto it = deployedRobots.find(&robot);
+	auto it = std::find(deployedRobots.begin(), deployedRobots.end(), &robot);
 	if (it != deployedRobots.end()) { throw std::runtime_error("MapViewState::insertRobot(): Attempting to add a duplicate Robot* pointer."); }
 
-	deployedRobots[&robot] = &tile;
+	deployedRobots.push_back(&robot);
 	tile.mapObject(&robot);
 
 	++mRobotControlCount;

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -76,14 +76,13 @@ namespace
 	}
 
 
-	NAS2D::Dictionary robotToDictionary(RobotPool::RobotTileTable& robotTileTable, Robot& robot)
+	NAS2D::Dictionary robotToDictionary(RobotPool::RobotTileTable& /*robotTileTable*/, Robot& robot)
 	{
 		NAS2D::Dictionary dictionary = robot.getDataDict();
 
-		const auto it = robotTileTable.find(&robot);
-		if (it != robotTileTable.end())
+		if (robot.isPlaced())
 		{
-			const auto& tile = *it->second;
+			const auto& tile = robot.tile();
 			const auto position = tile.xy();
 			dictionary += NAS2D::Dictionary{{
 				{"x", position.x},

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -76,7 +76,7 @@ namespace
 	}
 
 
-	NAS2D::Dictionary robotToDictionary(RobotPool::RobotTileTable& /*robotTileTable*/, Robot& robot)
+	NAS2D::Dictionary robotToDictionary(Robot& robot)
 	{
 		NAS2D::Dictionary dictionary = robot.getDataDict();
 
@@ -285,13 +285,13 @@ void RobotPool::insertRobotIntoTable(RobotTileTable& robotMap, Robot& robot, Til
 }
 
 
-NAS2D::Xml::XmlElement* RobotPool::writeRobots(RobotTileTable& robotMap)
+NAS2D::Xml::XmlElement* RobotPool::writeRobots()
 {
 	auto* robots = new NAS2D::Xml::XmlElement("robots");
 
 	for (auto robot : mRobots)
 	{
-		auto dictionary = robotToDictionary(robotMap, *robot);
+		auto dictionary = robotToDictionary(*robot);
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -265,7 +265,7 @@ void RobotPool::update()
 }
 
 
-void RobotPool::insertRobotIntoTable(RobotTileTable& robotMap, Robot& robot, Tile& tile)
+void RobotPool::insertRobotIntoTable(std::map<Robot*, Tile*>& robotMap, Robot& robot, Tile& tile)
 {
 	// Add pre-check for control count against max capacity, with one caveat
 	// When loading saved games a control max won't have been set yet as robots are loaded before structures

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -265,7 +265,7 @@ void RobotPool::update()
 }
 
 
-void RobotPool::insertRobotIntoTable(std::map<Robot*, Tile*>& robotMap, Robot& robot, Tile& tile)
+void RobotPool::insertRobotIntoTable(std::map<Robot*, Tile*>& deployedRobots, Robot& robot, Tile& tile)
 {
 	// Add pre-check for control count against max capacity, with one caveat
 	// When loading saved games a control max won't have been set yet as robots are loaded before structures
@@ -275,10 +275,10 @@ void RobotPool::insertRobotIntoTable(std::map<Robot*, Tile*>& robotMap, Robot& r
 		throw std::runtime_error("Must increase robot command capacity before placing more robots: " + std::to_string(mRobotControlCount) + " / " + std::to_string(mRobotControlMax));
 	}
 
-	auto it = robotMap.find(&robot);
-	if (it != robotMap.end()) { throw std::runtime_error("MapViewState::insertRobot(): Attempting to add a duplicate Robot* pointer."); }
+	auto it = deployedRobots.find(&robot);
+	if (it != deployedRobots.end()) { throw std::runtime_error("MapViewState::insertRobot(): Attempting to add a duplicate Robot* pointer."); }
 
-	robotMap[&robot] = &tile;
+	deployedRobots[&robot] = &tile;
 	tile.mapObject(&robot);
 
 	++mRobotControlCount;

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -30,7 +30,6 @@ public:
 	using DiggerList = std::list<Robodigger>;
 	using DozerList = std::list<Robodozer>;
 	using MinerList = std::list<Robominer>;
-	using RobotTileTable = std::map<Robot*, Tile*>;
 
 public:
 	RobotPool();
@@ -59,7 +58,7 @@ public:
 
 	void clear();
 	void erase(Robot* robot);
-	void insertRobotIntoTable(RobotTileTable& robotMap, Robot& robot, Tile& tile);
+	void insertRobotIntoTable(std::map<Robot*, Tile*>& robotMap, Robot& robot, Tile& tile);
 
 	std::size_t robotControlMax() const { return mRobotControlMax; }
 	std::size_t currentControlCount() const { return mRobotControlCount; }

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -66,7 +66,7 @@ public:
 
 	const RobotList& robots() const { return mRobots; }
 
-	NAS2D::Xml::XmlElement* writeRobots(RobotTileTable& robotMap);
+	NAS2D::Xml::XmlElement* writeRobots();
 
 private:
 	DiggerList mDiggers;

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <vector>
 #include <list>
-#include <map>
 
 
 enum class RobotTypeIndex;
@@ -58,7 +57,7 @@ public:
 
 	void clear();
 	void erase(Robot* robot);
-	void insertRobotIntoTable(std::map<Robot*, Tile*>& deployedRobots, Robot& robot, Tile& tile);
+	void insertRobotIntoTable(std::vector<Robot*>& deployedRobots, Robot& robot, Tile& tile);
 
 	std::size_t robotControlMax() const { return mRobotControlMax; }
 	std::size_t currentControlCount() const { return mRobotControlCount; }

--- a/appOPHD/RobotPool.h
+++ b/appOPHD/RobotPool.h
@@ -58,7 +58,7 @@ public:
 
 	void clear();
 	void erase(Robot* robot);
-	void insertRobotIntoTable(std::map<Robot*, Tile*>& robotMap, Robot& robot, Tile& tile);
+	void insertRobotIntoTable(std::map<Robot*, Tile*>& deployedRobots, Robot& robot, Tile& tile);
 
 	std::size_t robotControlMax() const { return mRobotControlMax; }
 	std::size_t currentControlCount() const { return mRobotControlCount; }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -232,7 +232,7 @@ MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetA
 	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth() + 1)},
 	mResourceInfoBar{mResourcesCount, mPopulation, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
-	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, planetAttributes.mapImagePath)},
+	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mDeployedRobots, planetAttributes.mapImagePath)},
 	mDetailMap{std::make_unique<DetailMap>(*mMapView, *mTileMap, planetAttributes.tilesetPath)},
 	mNavControl{std::make_unique<NavControl>(*mMapView)}
 {
@@ -1039,7 +1039,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 
 	auto& robot = mRobotPool.getDozer();
 	robot.startTask(tile);
-	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
+	mRobotPool.insertRobotIntoTable(mDeployedRobots, robot, tile);
 
 	if (!mRobotPool.robotAvailable(RobotTypeIndex::Dozer))
 	{
@@ -1149,7 +1149,7 @@ void MapViewState::placeRobominer(Tile& tile)
 
 	auto& robot = mRobotPool.getMiner();
 	robot.startTask(tile);
-	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
+	mRobotPool.insertRobotIntoTable(mDeployedRobots, robot, tile);
 
 	if (!mRobotPool.robotAvailable(RobotTypeIndex::Miner))
 	{
@@ -1235,8 +1235,8 @@ void MapViewState::insertSeedLander(NAS2D::Point<int> point)
  */
 void MapViewState::updateRobots()
 {
-	auto robot_it = mRobotList.begin();
-	while (robot_it != mRobotList.end())
+	auto robot_it = mDeployedRobots.begin();
+	while (robot_it != mDeployedRobots.end())
 	{
 		auto& robot = *robot_it->first;
 		auto& tile = robot.tile();
@@ -1273,7 +1273,7 @@ void MapViewState::updateRobots()
 			if (mRobotInspector.focusedRobot() == &robot) { mRobotInspector.hide(); }
 
 			mRobotPool.erase(&robot);
-			robot_it = mRobotList.erase(robot_it);
+			robot_it = mDeployedRobots.erase(robot_it);
 		}
 		else if (robot.idle())
 		{
@@ -1288,7 +1288,7 @@ void MapViewState::updateRobots()
 					NotificationArea::NotificationType::Success
 				});
 			}
-			robot_it = mRobotList.erase(robot_it);
+			robot_it = mDeployedRobots.erase(robot_it);
 
 			if (robot.taskCanceled())
 			{
@@ -1370,7 +1370,7 @@ void MapViewState::updatePoliceOverlay()
  */
 void MapViewState::scrubRobotList()
 {
-	for (auto it : mRobotList)
+	for (auto it : mDeployedRobots)
 	{
 		it.second->removeMapObject();
 	}

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1239,7 +1239,7 @@ void MapViewState::updateRobots()
 	while (robot_it != mRobotList.end())
 	{
 		auto robot = robot_it->first;
-		auto tile = robot_it->second;
+		auto tile = &robot->tile();
 
 		robot->processTurn(*mTileMap);
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1238,7 +1238,7 @@ void MapViewState::updateRobots()
 	auto robot_it = mDeployedRobots.begin();
 	while (robot_it != mDeployedRobots.end())
 	{
-		auto& robot = *robot_it->first;
+		auto& robot = **robot_it;
 		auto& tile = robot.tile();
 
 		robot.processTurn(*mTileMap);
@@ -1370,9 +1370,9 @@ void MapViewState::updatePoliceOverlay()
  */
 void MapViewState::scrubRobotList()
 {
-	for (auto it : mDeployedRobots)
+	for (auto* robot : mDeployedRobots)
 	{
-		it.second->removeMapObject();
+		robot->tile().removeMapObject();
 	}
 }
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1239,11 +1239,11 @@ void MapViewState::updateRobots()
 	while (robot_it != mRobotList.end())
 	{
 		auto robot = robot_it->first;
-		auto tile = &robot->tile();
+		auto& tile = robot->tile();
 
 		robot->processTurn(*mTileMap);
 
-		const auto& position = tile->xyz();
+		const auto& position = tile.xyz();
 
 		pushAgingRobotMessage(robot, position, mNotificationArea);
 
@@ -1262,12 +1262,12 @@ void MapViewState::updateRobots()
 			{
 				const auto text = "Your " + robot->name() + " at location " + NAS2D::stringFrom(position.xy) + " has broken down. It will not be able to complete its task and will be removed from your inventory.";
 				mNotificationArea.push({"Robot Broke Down", text, position, NotificationArea::NotificationType::Critical});
-				robot->abortTask(*tile);
+				robot->abortTask(tile);
 			}
 
-			if (tile->mapObject() == robot)
+			if (tile.mapObject() == robot)
 			{
-				tile->removeMapObject();
+				tile.removeMapObject();
 			}
 
 			if (mRobotInspector.focusedRobot() == robot) { mRobotInspector.hide(); }
@@ -1277,14 +1277,14 @@ void MapViewState::updateRobots()
 		}
 		else if (robot->idle())
 		{
-			if (tile->mapObject() == robot)
+			if (tile.mapObject() == robot)
 			{
-				tile->removeMapObject();
+				tile.removeMapObject();
 
 				mNotificationArea.push({
 					"Robot Task Completed",
-					robot->name() + " completed its task at " + NAS2D::stringFrom(tile->xy()) + ".",
-					tile->xyz(),
+					robot->name() + " completed its task at " + NAS2D::stringFrom(tile.xy()) + ".",
+					tile.xyz(),
 					NotificationArea::NotificationType::Success
 				});
 			}
@@ -1292,14 +1292,14 @@ void MapViewState::updateRobots()
 
 			if (robot->taskCanceled())
 			{
-				robot->abortTask(*tile);
+				robot->abortTask(tile);
 				populateRobotMenu();
 				robot->reset();
 
 				mNotificationArea.push({
 					"Robot Task Canceled",
-					robot->name() + " canceled its task at " + NAS2D::stringFrom(tile->xy()) + ".",
-					tile->xyz(),
+					robot->name() + " canceled its task at " + NAS2D::stringFrom(tile.xy()) + ".",
+					tile.xyz(),
 					NotificationArea::NotificationType::Information
 				});
 			}

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1238,67 +1238,67 @@ void MapViewState::updateRobots()
 	auto robot_it = mRobotList.begin();
 	while (robot_it != mRobotList.end())
 	{
-		auto robot = robot_it->first;
-		auto& tile = robot->tile();
+		auto& robot = *robot_it->first;
+		auto& tile = robot.tile();
 
-		robot->processTurn(*mTileMap);
+		robot.processTurn(*mTileMap);
 
 		const auto& position = tile.xyz();
 
-		pushAgingRobotMessage(robot, position, mNotificationArea);
+		pushAgingRobotMessage(&robot, position, mNotificationArea);
 
-		if (robot->isDead())
+		if (robot.isDead())
 		{
-			if (robot->selfDestruct())
+			if (robot.selfDestruct())
 			{
 				mNotificationArea.push({
 					"Robot Self-Destructed",
-					robot->name() + " at location " + NAS2D::stringFrom(position.xy) + " self destructed.",
+					robot.name() + " at location " + NAS2D::stringFrom(position.xy) + " self destructed.",
 					position,
 					NotificationArea::NotificationType::Critical
 				});
 			}
-			else if (robot->type() != RobotTypeIndex::Miner)
+			else if (robot.type() != RobotTypeIndex::Miner)
 			{
-				const auto text = "Your " + robot->name() + " at location " + NAS2D::stringFrom(position.xy) + " has broken down. It will not be able to complete its task and will be removed from your inventory.";
+				const auto text = "Your " + robot.name() + " at location " + NAS2D::stringFrom(position.xy) + " has broken down. It will not be able to complete its task and will be removed from your inventory.";
 				mNotificationArea.push({"Robot Broke Down", text, position, NotificationArea::NotificationType::Critical});
-				robot->abortTask(tile);
+				robot.abortTask(tile);
 			}
 
-			if (tile.mapObject() == robot)
+			if (tile.mapObject() == &robot)
 			{
 				tile.removeMapObject();
 			}
 
-			if (mRobotInspector.focusedRobot() == robot) { mRobotInspector.hide(); }
+			if (mRobotInspector.focusedRobot() == &robot) { mRobotInspector.hide(); }
 
-			mRobotPool.erase(robot);
+			mRobotPool.erase(&robot);
 			robot_it = mRobotList.erase(robot_it);
 		}
-		else if (robot->idle())
+		else if (robot.idle())
 		{
-			if (tile.mapObject() == robot)
+			if (tile.mapObject() == &robot)
 			{
 				tile.removeMapObject();
 
 				mNotificationArea.push({
 					"Robot Task Completed",
-					robot->name() + " completed its task at " + NAS2D::stringFrom(tile.xy()) + ".",
+					robot.name() + " completed its task at " + NAS2D::stringFrom(tile.xy()) + ".",
 					tile.xyz(),
 					NotificationArea::NotificationType::Success
 				});
 			}
 			robot_it = mRobotList.erase(robot_it);
 
-			if (robot->taskCanceled())
+			if (robot.taskCanceled())
 			{
-				robot->abortTask(tile);
+				robot.abortTask(tile);
 				populateRobotMenu();
-				robot->reset();
+				robot.reset();
 
 				mNotificationArea.push({
 					"Robot Task Canceled",
-					robot->name() + " canceled its task at " + NAS2D::stringFrom(tile.xy()) + ".",
+					robot.name() + " canceled its task at " + NAS2D::stringFrom(tile.xy()) + ".",
 					tile.xyz(),
 					NotificationArea::NotificationType::Information
 				});

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -50,7 +50,7 @@
 
 #include <string>
 #include <memory>
-#include <map>
+#include <vector>
 
 
 namespace NAS2D
@@ -310,7 +310,7 @@ private:
 	RobotPool mRobotPool; /**< Robots that are currently available for use. */
 	PopulationPool mPopulationPool;
 
-	std::map<Robot*, Tile*> mDeployedRobots;
+	std::vector<Robot*> mDeployedRobots;
 	Population mPopulation;
 
 	// ROUTING

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -310,7 +310,7 @@ private:
 	RobotPool mRobotPool; /**< Robots that are currently available for use. */
 	PopulationPool mPopulationPool;
 
-	std::map<Robot*, Tile*> mRobotList; /**< List of active robots and their positions on the map. */
+	std::map<Robot*, Tile*> mRobotList;
 	Population mPopulation;
 
 	// ROUTING

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -310,7 +310,7 @@ private:
 	RobotPool mRobotPool; /**< Robots that are currently available for use. */
 	PopulationPool mPopulationPool;
 
-	std::map<Robot*, Tile*> mRobotList;
+	std::map<Robot*, Tile*> mDeployedRobots;
 	Population mPopulation;
 
 	// ROUTING

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -93,8 +93,6 @@ enum class InsertMode
 	Structure
 };
 
-using RobotTileTable = std::map<Robot*, Tile*>;
-
 
 class MapViewState : public Wrapper
 {
@@ -312,7 +310,7 @@ private:
 	RobotPool mRobotPool; /**< Robots that are currently available for use. */
 	PopulationPool mPopulationPool;
 
-	RobotTileTable mRobotList; /**< List of active robots and their positions on the map. */
+	std::map<Robot*, Tile*> mRobotList; /**< List of active robots and their positions on the map. */
 	Population mPopulation;
 
 	// ROUTING

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -187,13 +187,7 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
 {
 	auto& roboDigger = dynamic_cast<Robodigger&>(robot);
 	auto& tileMap = *mTileMap;
-
-	if (mRobotList.find(&roboDigger) == mRobotList.end())
-	{
-		throw std::runtime_error("MapViewState::onDiggerTaskComplete() called with a Robot not in the Robot List!");
-	}
-
-	auto& tile = *mRobotList[&roboDigger];
+	auto& tile = roboDigger.tile();
 	const auto& position = tile.xyz();
 
 	if (position.z > tileMap.maxDepth())

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -237,9 +237,7 @@ void MapViewState::onDiggerTaskComplete(Robot& robot)
  */
 void MapViewState::onMinerTaskComplete(Robot& robot)
 {
-	if (mRobotList.find(&robot) == mRobotList.end()) { throw std::runtime_error("MapViewState::onMinerTaskComplete() called with a Robot not in the Robot List!"); }
-
-	auto& robotTile = *mRobotList[&robot];
+	auto& robotTile = robot.tile();
 	auto& miner = dynamic_cast<Robominer&>(robot);
 
 	auto& mineFacility = miner.buildMine(*mTileMap, robotTile.xyz());

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -266,7 +266,7 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 	mTileMap->deserialize(root);
 	mMapView = std::make_unique<MapView>(*mTileMap);
 	mMapView->deserialize(root);
-	mMiniMap = std::make_unique<MiniMap>(*mMapView, *mTileMap, mRobotList, mPlanetAttributes.mapImagePath);
+	mMiniMap = std::make_unique<MiniMap>(*mMapView, *mTileMap, mDeployedRobots, mPlanetAttributes.mapImagePath);
 	mDetailMap = std::make_unique<DetailMap>(*mMapView, *mTileMap, mPlanetAttributes.tilesetPath);
 	mNavControl = std::make_unique<NavControl>(*mMapView);
 
@@ -343,7 +343,7 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 {
 	mRobotPool.clear();
-	mRobotList.clear();
+	mDeployedRobots.clear();
 
 	for (NAS2D::Xml::XmlElement* robotElement = element->firstChildElement(); robotElement; robotElement = robotElement->nextSiblingElement())
 	{
@@ -370,7 +370,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		{
 			auto& tile = mTileMap->getTile({{x, y}, depth});
 			robot.startTask(tile, productionTime);
-			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
+			mRobotPool.insertRobotIntoTable(mDeployedRobots, robot, tile);
 			tile.bulldoze();
 			tile.excavated(true);
 		}

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -369,7 +369,7 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 		if (productionTime > 0)
 		{
 			auto& tile = mTileMap->getTile({{x, y}, depth});
-			robot.startTask(productionTime);
+			robot.startTask(tile, productionTime);
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 			tile.bulldoze();
 			tile.excavated(true);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -169,7 +169,7 @@ void MapViewState::save(NAS2D::Xml::XmlDocument& saveGameDocument)
 	mTileMap->serialize(root);
 	mMapView->serialize(root);
 	root->linkEndChild(NAS2D::Utility<StructureManager>::get().serialize());
-	root->linkEndChild(mRobotPool.writeRobots(mRobotList));
+	root->linkEndChild(mRobotPool.writeRobots());
 	root->linkEndChild(writeResources(mResourceBreakdownPanel.previousResources(), "prev_resources"));
 	root->linkEndChild(writeResearch(mResearchTracker));
 	root->linkEndChild(NAS2D::dictionaryToAttributes("turns", {{{"count", mTurnCount}}}));

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -368,8 +368,8 @@ void MapViewState::readRobots(NAS2D::Xml::XmlElement* element)
 
 		if (productionTime > 0)
 		{
-			robot.startTask(productionTime);
 			auto& tile = mTileMap->getTile({{x, y}, depth});
+			robot.startTask(productionTime);
 			mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
 			tile.bulldoze();
 			tile.excavated(true);

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -513,7 +513,7 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 	Robodigger& robot = mRobotPool.getDigger();
 	robot.direction(direction);
 	robot.startTask(tile);
-	mRobotPool.insertRobotIntoTable(mRobotList, robot, tile);
+	mRobotPool.insertRobotIntoTable(mDeployedRobots, robot, tile);
 
 	if (direction != Direction::Down)
 	{

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -110,7 +110,7 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 
 	for (auto robotEntry : mDeployedRobots)
 	{
-		const auto robotPosition = robotEntry.second->xy();
+		const auto robotPosition = robotEntry.first->tile().xy();
 		renderer.drawPoint(robotPosition + miniMapOffset, NAS2D::Color::Cyan);
 	}
 

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -28,10 +28,10 @@ namespace
 }
 
 
-MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName) :
+MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& deployedRobots, const std::string& mapName) :
 	mMapView{mapView},
 	mTileMap{tileMap},
-	mDeployedRobots{robotList},
+	mDeployedRobots{deployedRobots},
 	mIsHeightMapVisible{false},
 	mBackgroundSatellite{mapName + MapDisplayExtension},
 	mBackgroundHeightMap{mapName + MapTerrainExtension},

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -31,7 +31,7 @@ namespace
 MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName) :
 	mMapView{mapView},
 	mTileMap{tileMap},
-	mRobotList{robotList},
+	mDeployedRobots{robotList},
 	mIsHeightMapVisible{false},
 	mBackgroundSatellite{mapName + MapDisplayExtension},
 	mBackgroundHeightMap{mapName + MapTerrainExtension},
@@ -108,7 +108,7 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 		}
 	}
 
-	for (auto robotEntry : mRobotList)
+	for (auto robotEntry : mDeployedRobots)
 	{
 		const auto robotPosition = robotEntry.second->xy();
 		renderer.drawPoint(robotPosition + miniMapOffset, NAS2D::Color::Cyan);

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -28,7 +28,7 @@ namespace
 }
 
 
-MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& deployedRobots, const std::string& mapName) :
+MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const std::vector<Robot*>& deployedRobots, const std::string& mapName) :
 	mMapView{mapView},
 	mTileMap{tileMap},
 	mDeployedRobots{deployedRobots},
@@ -108,9 +108,9 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 		}
 	}
 
-	for (auto robotEntry : mDeployedRobots)
+	for (const auto* robot : mDeployedRobots)
 	{
-		const auto robotPosition = robotEntry.first->tile().xy();
+		const auto robotPosition = robot->tile().xy();
 		renderer.drawPoint(robotPosition + miniMapOffset, NAS2D::Color::Cyan);
 	}
 

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -26,7 +26,7 @@ class MapViewState;
 class MiniMap : public Control
 {
 public:
-	MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& robotList, const std::string& mapName);
+	MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& deployedRobots, const std::string& mapName);
 
 	bool heightMapVisible() const;
 	void heightMapVisible(bool isVisible);

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -44,7 +44,7 @@ protected:
 private:
 	MapView& mMapView;
 	TileMap& mTileMap;
-	const std::map<Robot*, Tile*>& mRobotList;
+	const std::map<Robot*, Tile*>& mDeployedRobots;
 	bool mIsHeightMapVisible;
 	NAS2D::Image mBackgroundSatellite;
 	NAS2D::Image mBackgroundHeightMap;

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -7,7 +7,7 @@
 #include <NAS2D/Math/Point.h>
 #include <NAS2D/Math/Vector.h>
 
-#include <map>
+#include <vector>
 #include <string>
 
 
@@ -26,7 +26,7 @@ class MapViewState;
 class MiniMap : public Control
 {
 public:
-	MiniMap(MapView& mapView, TileMap& tileMap, const std::map<Robot*, Tile*>& deployedRobots, const std::string& mapName);
+	MiniMap(MapView& mapView, TileMap& tileMap, const std::vector<Robot*>& deployedRobots, const std::string& mapName);
 
 	bool heightMapVisible() const;
 	void heightMapVisible(bool isVisible);
@@ -44,7 +44,7 @@ protected:
 private:
 	MapView& mMapView;
 	TileMap& mTileMap;
-	const std::map<Robot*, Tile*>& mDeployedRobots;
+	const std::vector<Robot*>& mDeployedRobots;
 	bool mIsHeightMapVisible;
 	NAS2D::Image mBackgroundSatellite;
 	NAS2D::Image mBackgroundHeightMap;


### PR DESCRIPTION
Add `Tile&` field to `Robot`, and use the new field to avoid having to do lookup to find the `Tile` of a `Robot`.

Rename the `mRobotList` field of `MapViewState` and convert from `std::map` to `std::vector`. We no longer need to store the `Tile*` data, since it can be retrieved directly from a `Robot*`. Though we do still need a list of which `Robot` instances have been deployed, and the ability to iterate over them.

Related:
- Issue #1795
- PR #1958
