### PR TITLE
Use `largeDelta` for `ScrollBar` thumb size

### DIFF
--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -120,7 +120,7 @@ int ScrollBar::largeDelta() const
 
 void ScrollBar::largeDelta(int newLargeDelta)
 {
-	mLargeDelta = newLargeDelta;
+	mLargeDelta = std::max(newLargeDelta, 1);
 	onThumbResize();
 	onThumbMove();
 }

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -255,12 +255,14 @@ void ScrollBar::onThumbResize()
 {
 	if (mScrollBarType == ScrollBarType::Vertical)
 	{
-		const auto thumbLength = std::min(mTrackRect.size.y * mRect.size.y / std::max(mMax + mRect.size.y, 1), mTrackRect.size.y);
+		const auto naturalThumbLength = mTrackRect.size.y * mRect.size.y / std::max(mMax + mRect.size.y, 1);
+		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().y, mTrackRect.size.y);
 		mThumbRect.size = {mTrackRect.size.x, thumbLength};
 	}
 	else
 	{
-		const auto thumbLength = std::min(mTrackRect.size.x * mRect.size.x / std::max(mMax + mRect.size.x, 1), mTrackRect.size.x);
+		const auto naturalThumbLength = mTrackRect.size.x * mRect.size.x / std::max(mMax + mRect.size.x, 1);
+		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().x, mTrackRect.size.x);
 		mThumbRect.size = {thumbLength, mTrackRect.size.y};
 	}
 }

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -103,9 +103,10 @@ int ScrollBar::max() const
 
 void ScrollBar::max(int newMax)
 {
-	if (mMax != newMax)
+	const auto clampedMax = std::max(newMax, 0);
+	if (mMax != clampedMax)
 	{
-		mMax = newMax;
+		mMax = clampedMax;
 		onThumbResize();
 	}
 	value(mValue); // Re-clamp to new max

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -258,13 +258,13 @@ void ScrollBar::onThumbResize()
 {
 	if (mScrollBarType == ScrollBarType::Vertical)
 	{
-		const auto naturalThumbLength = mTrackRect.size.y * mLargeDelta / std::max(mMax + mLargeDelta, 1);
+		const auto naturalThumbLength = mTrackRect.size.y * mLargeDelta / (mMax + mLargeDelta);
 		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().y, mTrackRect.size.y);
 		mThumbRect.size = {mTrackRect.size.x, thumbLength};
 	}
 	else
 	{
-		const auto naturalThumbLength = mTrackRect.size.x * mLargeDelta / std::max(mMax + mLargeDelta, 1);
+		const auto naturalThumbLength = mTrackRect.size.x * mLargeDelta / (mMax + mLargeDelta);
 		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().x, mTrackRect.size.x);
 		mThumbRect.size = {thumbLength, mTrackRect.size.y};
 	}

--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -121,6 +121,8 @@ int ScrollBar::largeDelta() const
 void ScrollBar::largeDelta(int newLargeDelta)
 {
 	mLargeDelta = newLargeDelta;
+	onThumbResize();
+	onThumbMove();
 }
 
 
@@ -255,13 +257,13 @@ void ScrollBar::onThumbResize()
 {
 	if (mScrollBarType == ScrollBarType::Vertical)
 	{
-		const auto naturalThumbLength = mTrackRect.size.y * mRect.size.y / std::max(mMax + mRect.size.y, 1);
+		const auto naturalThumbLength = mTrackRect.size.y * mLargeDelta / std::max(mMax + mLargeDelta, 1);
 		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().y, mTrackRect.size.y);
 		mThumbRect.size = {mTrackRect.size.x, thumbLength};
 	}
 	else
 	{
-		const auto naturalThumbLength = mTrackRect.size.x * mRect.size.x / std::max(mMax + mRect.size.x, 1);
+		const auto naturalThumbLength = mTrackRect.size.x * mLargeDelta / std::max(mMax + mLargeDelta, 1);
 		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().x, mTrackRect.size.x);
 		mThumbRect.size = {thumbLength, mTrackRect.size.y};
 	}


### PR DESCRIPTION
Fix `ScrollBar` display for small thumb sizes, and use `largeDelta` setting to set the thumb size.

Related:
- Issue #1944
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3063510114
