### PR TITLE
Add `RouteFinder` class and isolate `MicroPather`

### DIFF
--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -126,8 +126,8 @@ bool routeObstructed(Route& route)
 
 
 RouteFinder::RouteFinder(TileMap& tileMap) :
-	mTileMap{tileMap},
-	mPathSolver{std::make_unique<micropather::MicroPather>(&mTileMap, 250, 6, false)}
+	mTileMapGraph{std::make_unique<TileMapGraph>(tileMap)},
+	mPathSolver{std::make_unique<micropather::MicroPather>(mTileMapGraph.get(), 250, 6, false)}
 {
 }
 

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -2,6 +2,7 @@
 
 #include "Route.h"
 #include "Tile.h"
+#include "TileMap.h"
 #include "../StructureManager.h"
 #include "../MapObjects/Structures/OreRefining.h"
 #include "../MicroPather/micropather.h"
@@ -68,4 +69,22 @@ bool routeObstructed(Route& route)
 	}
 
 	return false;
+}
+
+
+RouteFinder::RouteFinder(TileMap& tileMap) :
+	mTileMap{tileMap},
+	mPathSolver{std::make_unique<micropather::MicroPather>(&mTileMap, 250, 6, false)}
+{
+}
+
+
+RouteFinder::~RouteFinder()
+{
+}
+
+
+Route RouteFinder::findLowestCostRoute(const Structure* mineFacility, const std::vector<OreRefining*>& smelters)
+{
+	return ::findLowestCostRoute(mPathSolver.get(), mineFacility, smelters);
 }

--- a/appOPHD/Map/RouteFinder.h
+++ b/appOPHD/Map/RouteFinder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 
 namespace micropather
@@ -12,7 +13,22 @@ namespace micropather
 struct Route;
 class Structure;
 class OreRefining;
+class TileMap;
 
 
 Route findLowestCostRoute(micropather::MicroPather* solver, const Structure* mineFacility, const std::vector<OreRefining*>& smelters);
 bool routeObstructed(Route& route);
+
+
+class RouteFinder
+{
+public:
+	RouteFinder(TileMap& tileMap);
+	~RouteFinder();
+
+	Route findLowestCostRoute(const Structure* mineFacility, const std::vector<OreRefining*>& smelters);
+
+private:
+	TileMap& mTileMap;
+	std::unique_ptr<micropather::MicroPather> mPathSolver;
+};

--- a/appOPHD/Map/RouteFinder.h
+++ b/appOPHD/Map/RouteFinder.h
@@ -14,6 +14,7 @@ struct Route;
 class Structure;
 class OreRefining;
 class TileMap;
+class TileMapGraph;
 
 
 Route findLowestCostRoute(micropather::MicroPather* solver, const Structure* mineFacility, const std::vector<OreRefining*>& smelters);
@@ -29,6 +30,6 @@ public:
 	Route findLowestCostRoute(const Structure* mineFacility, const std::vector<OreRefining*>& smelters);
 
 private:
-	TileMap& mTileMap;
+	std::unique_ptr<TileMapGraph> mTileMapGraph;
 	std::unique_ptr<micropather::MicroPather> mPathSolver;
 };

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -275,39 +275,6 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 }
 
 
-/**
- * Implements MicroPather interface.
- *
- * \warning	Assumes stateStart and stateEnd are never nullptr.
- */
-float TileMap::LeastCostEstimate(void* stateStart, void* stateEnd)
-{
-	return sqrtf(static_cast<float>((static_cast<Tile*>(stateEnd)->xy() - static_cast<Tile*>(stateStart)->xy()).lengthSquared()));
-}
-
-
-void TileMap::AdjacentCost(void* state, std::vector<micropather::StateCost>* adjacent)
-{
-	auto& tile = *static_cast<Tile*>(state);
-	const auto tilePosition = tile.xy();
-
-	for (const auto& offset : DirectionClockwise4)
-	{
-		const auto position = tilePosition + offset;
-		if (!NAS2D::Rectangle{{0, 0}, mSizeInTiles}.contains(position))
-		{
-			continue;
-		}
-
-		auto& adjacentTile = getTile({position, 0});
-		float cost = adjacentTile.movementCost();
-
-		micropather::StateCost nodeCost = {&adjacentTile, cost};
-		adjacent->push_back(nodeCost);
-	}
-}
-
-
 bool TileMap::isTileBlockedByOreDeposit(const Tile& tile) const
 {
 	return getTile({tile.xy(), 0}).hasOreDeposit();

--- a/appOPHD/Map/TileMap.h
+++ b/appOPHD/Map/TileMap.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../MicroPather/micropather.h"
-
 #include <NAS2D/Math/Vector.h>
 
 #include <string>
@@ -24,7 +22,7 @@ struct MapCoordinate;
 class Tile;
 
 
-class TileMap : public micropather::Graph
+class TileMap
 {
 public:
 	using OreDepositYields = std::array<int, 3>; // {low, med, high}
@@ -33,7 +31,7 @@ public:
 	TileMap(const std::string& mapPath, int maxDepth);
 	TileMap(const TileMap&) = delete;
 	TileMap& operator=(const TileMap&) = delete;
-	~TileMap() override;
+	~TileMap();
 
 	NAS2D::Vector<int> size() const { return mSizeInTiles; }
 	int maxDepth() const { return mMaxDepth; }
@@ -48,12 +46,6 @@ public:
 
 	void serialize(NAS2D::Xml::XmlElement* element);
 	void deserialize(NAS2D::Xml::XmlElement* element);
-
-
-	/** MicroPather public interface implementation. */
-	float LeastCostEstimate(void* stateStart, void* stateEnd) override;
-	void AdjacentCost(void* state, std::vector<micropather::StateCost>* adjacent) override;
-	void PrintStateInfo(void* /*state*/) override {}
 
 	bool isTileBlockedByOreDeposit(const Tile&) const;
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -16,6 +16,7 @@
 #include "../StructureManager.h"
 
 #include "../Map/Route.h"
+#include "../Map/RouteFinder.h"
 #include "../Map/Tile.h"
 #include "../Map/TileMap.h"
 #include "../Map/MapView.h"
@@ -300,7 +301,7 @@ void MapViewState::initialize()
 	eventHandler.mouseMotion().connect({this, &MapViewState::onMouseMove});
 	eventHandler.mouseWheel().connect({this, &MapViewState::onMouseWheel});
 
-	mPathSolver = std::make_unique<micropather::MicroPather>(mTileMap.get(), 250, 6, false);
+	mPathSolver = std::make_unique<RouteFinder>(*mTileMap);
 }
 
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -64,17 +64,13 @@ namespace NAS2D
 	template <typename BaseType> struct Point;
 }
 
-namespace micropather
-{
-	class MicroPather;
-}
-
 enum class Direction;
 enum class RobotTypeIndex;
 
 class Structure;
 class Tile;
 class TileMap;
+class RouteFinder;
 class MapView;
 class DetailMap;
 class MiniMap;
@@ -314,7 +310,7 @@ private:
 	Population mPopulation;
 
 	// ROUTING
-	std::unique_ptr<micropather::MicroPather> mPathSolver;
+	std::unique_ptr<RouteFinder> mPathSolver;
 
 	bool mLoadingExisting = false;
 	NAS2D::Xml::XmlDocument* mExistingToLoad = nullptr; 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -17,6 +17,7 @@
 #include "../StructureCatalog.h"
 #include "../StructureManager.h"
 #include "../Map/Route.h"
+#include "../Map/RouteFinder.h"
 #include "../Map/TileMap.h"
 #include "../Map/MapView.h"
 #include "../MapObjects/Robots.h"
@@ -270,7 +271,7 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 	mDetailMap = std::make_unique<DetailMap>(*mMapView, *mTileMap, mPlanetAttributes.tilesetPath);
 	mNavControl = std::make_unique<NavControl>(*mMapView);
 
-	mPathSolver = std::make_unique<micropather::MicroPather>(mTileMap.get(), 250, 6, false);
+	mPathSolver = std::make_unique<RouteFinder>(*mTileMap);
 	auto& routeTable = NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
 	routeTable.clear();
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -270,7 +270,7 @@ void MapViewState::findMineRoutes()
 
 		if (findNewRoute)
 		{
-			auto newRoute = findLowestCostRoute(mPathSolver.get(), mineFacility, smelterList);
+			auto newRoute = mPathSolver->findLowestCostRoute(mineFacility, smelterList);
 
 			if (newRoute.isEmpty()) { continue; } // give up and move on to the next mine facility.
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -38,6 +38,8 @@
 
 #include <vector>
 #include <algorithm>
+#include <cfloat>
+
 
 namespace
 {


### PR DESCRIPTION
Add `RouteFinder` class to wrap uses of `MicroPather` and remove `micropather::Graph` base class from `TileMap`.

This effectively limits `include` visibility of `MicroPather` related code to just `RouteFinder.cpp`. Previously it impacted 15 translation units in `appOPHD`, and is now down to just 1.

Related:
- Issue #1846
