### PR TITLE
Consistent formatting for `Structure` init lists

### DIFF
--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -4,7 +4,7 @@
 
 
 Agridome::Agridome() :
-	FoodProduction(StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
+	FoodProduction{StructureClass::FoodProduction, StructureID::SID_AGRIDOME}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -3,7 +3,8 @@
 #include <algorithm>
 
 
-Agridome::Agridome() : FoodProduction(StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
+Agridome::Agridome() :
+	FoodProduction(StructureClass::FoodProduction, StructureID::SID_AGRIDOME)
 {
 }
 

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -4,10 +4,12 @@
 #include "../../Constants/Strings.h"
 
 
-AirShaft::AirShaft() : Structure(
-	constants::StructureStateOperational,
-	StructureClass::Tube,
-	StructureID::SID_AIR_SHAFT)
+AirShaft::AirShaft() :
+	Structure(
+		constants::StructureStateOperational,
+		StructureClass::Tube,
+		StructureID::SID_AIR_SHAFT
+	)
 {
 	connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);
 

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -5,11 +5,11 @@
 
 
 AirShaft::AirShaft() :
-	Structure(
+	Structure{
 		constants::StructureStateOperational,
 		StructureClass::Tube,
 		StructureID::SID_AIR_SHAFT
-	)
+	}
 {
 	connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);
 

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -5,8 +5,8 @@
 
 
 CargoLander::CargoLander(Tile* tile) :
-	Structure(StructureClass::Lander, StructureID::SID_CARGO_LANDER),
-	mTile(tile)
+	Structure{StructureClass::Lander, StructureID::SID_CARGO_LANDER},
+	mTile{tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -4,9 +4,8 @@
 #include "../../Map/Tile.h"
 
 
-CargoLander::CargoLander(Tile* tile) : Structure(
-	StructureClass::Lander,
-	StructureID::SID_CARGO_LANDER),
+CargoLander::CargoLander(Tile* tile) :
+	Structure(StructureClass::Lander, StructureID::SID_CARGO_LANDER),
 	mTile(tile)
 {
 	enable();

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -5,8 +5,8 @@
 
 
 ColonistLander::ColonistLander(Tile* tile) :
-	Structure(StructureClass::Lander, StructureID::SID_COLONIST_LANDER),
-	mTile(tile)
+	Structure{StructureClass::Lander, StructureID::SID_COLONIST_LANDER},
+	mTile{tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -4,9 +4,8 @@
 #include "../../Map/Tile.h"
 
 
-ColonistLander::ColonistLander(Tile* tile) : Structure(
-	StructureClass::Lander,
-	StructureID::SID_COLONIST_LANDER),
+ColonistLander::ColonistLander(Tile* tile) :
+	Structure(StructureClass::Lander, StructureID::SID_COLONIST_LANDER),
 	mTile(tile)
 {
 	enable();

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -5,9 +5,8 @@
 #include "../../UI/StringTable.h"
 
 
-CommTower::CommTower() : Structure(
-	StructureClass::Communication,
-	StructureID::SID_COMM_TOWER)
+CommTower::CommTower() :
+	Structure(StructureClass::Communication, StructureID::SID_COMM_TOWER)
 {
 }
 

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -6,7 +6,7 @@
 
 
 CommTower::CommTower() :
-	Structure(StructureClass::Communication, StructureID::SID_COMM_TOWER)
+	Structure{StructureClass::Communication, StructureID::SID_COMM_TOWER}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/CommandCenter.cpp
+++ b/appOPHD/MapObjects/Structures/CommandCenter.cpp
@@ -1,9 +1,8 @@
 #include "CommandCenter.h"
 
 
-CommandCenter::CommandCenter() : FoodProduction(
-	StructureClass::Command,
-	StructureID::SID_COMMAND_CENTER)
+CommandCenter::CommandCenter() :
+	FoodProduction(StructureClass::Command, StructureID::SID_COMMAND_CENTER)
 {
 }
 

--- a/appOPHD/MapObjects/Structures/CommandCenter.cpp
+++ b/appOPHD/MapObjects/Structures/CommandCenter.cpp
@@ -2,7 +2,7 @@
 
 
 CommandCenter::CommandCenter() :
-	FoodProduction(StructureClass::Command, StructureID::SID_COMMAND_CENTER)
+	FoodProduction{StructureClass::Command, StructureID::SID_COMMAND_CENTER}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -60,7 +60,7 @@ const ProductionCost& productCost(ProductType productType)
 
 
 Factory::Factory(StructureID id, std::vector<ProductType> products) :
-	Structure(StructureClass::Factory, id),
+	Structure{StructureClass::Factory, id},
 	mAvailableProducts{std::move(products)}
 {
 	assertNoDuplicates(mAvailableProducts);

--- a/appOPHD/MapObjects/Structures/FoodProduction.cpp
+++ b/appOPHD/MapObjects/Structures/FoodProduction.cpp
@@ -6,7 +6,7 @@
 
 
 FoodProduction::FoodProduction(StructureClass structureClass, StructureID id) :
-	Structure(structureClass, id)
+	Structure{structureClass, id}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/FusionReactor.h
+++ b/appOPHD/MapObjects/Structures/FusionReactor.h
@@ -9,9 +9,8 @@ constexpr int FusionReactorBaseProduction = 1000;
 class FusionReactor : public PowerStructure
 {
 public:
-	FusionReactor() : PowerStructure(
-		StructureClass::EnergyProduction,
-		StructureID::SID_FUSION_REACTOR)
+	FusionReactor() :
+		PowerStructure(StructureClass::EnergyProduction, StructureID::SID_FUSION_REACTOR)
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/FusionReactor.h
+++ b/appOPHD/MapObjects/Structures/FusionReactor.h
@@ -10,7 +10,7 @@ class FusionReactor : public PowerStructure
 {
 public:
 	FusionReactor() :
-		PowerStructure(StructureClass::EnergyProduction, StructureID::SID_FUSION_REACTOR)
+		PowerStructure{StructureClass::EnergyProduction, StructureID::SID_FUSION_REACTOR}
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/HotLaboratory.h
+++ b/appOPHD/MapObjects/Structures/HotLaboratory.h
@@ -6,9 +6,8 @@
 class HotLaboratory : public ResearchFacility
 {
 public:
-	HotLaboratory() : ResearchFacility(
-		StructureClass::Laboratory,
-		StructureID::SID_HOT_LABORATORY)
+	HotLaboratory() :
+		ResearchFacility(StructureClass::Laboratory, StructureID::SID_HOT_LABORATORY)
 	{
 		maxScientistsAllowed(3);
 		hotPointsPerScientist(1.0f);

--- a/appOPHD/MapObjects/Structures/HotLaboratory.h
+++ b/appOPHD/MapObjects/Structures/HotLaboratory.h
@@ -7,7 +7,7 @@ class HotLaboratory : public ResearchFacility
 {
 public:
 	HotLaboratory() :
-		ResearchFacility(StructureClass::Laboratory, StructureID::SID_HOT_LABORATORY)
+		ResearchFacility{StructureClass::Laboratory, StructureID::SID_HOT_LABORATORY}
 	{
 		maxScientistsAllowed(3);
 		hotPointsPerScientist(1.0f);

--- a/appOPHD/MapObjects/Structures/Laboratory.h
+++ b/appOPHD/MapObjects/Structures/Laboratory.h
@@ -6,9 +6,8 @@
 class Laboratory : public ResearchFacility
 {
 public:
-	Laboratory() : ResearchFacility(
-		StructureClass::Laboratory,
-		StructureID::SID_LABORATORY)
+	Laboratory() :
+		ResearchFacility(StructureClass::Laboratory, StructureID::SID_LABORATORY)
 	{
 		maxScientistsAllowed(3);
 		regularPointsPerScientist(1);

--- a/appOPHD/MapObjects/Structures/Laboratory.h
+++ b/appOPHD/MapObjects/Structures/Laboratory.h
@@ -7,7 +7,7 @@ class Laboratory : public ResearchFacility
 {
 public:
 	Laboratory() :
-		ResearchFacility(StructureClass::Laboratory, StructureID::SID_LABORATORY)
+		ResearchFacility{StructureClass::Laboratory, StructureID::SID_LABORATORY}
 	{
 		maxScientistsAllowed(3);
 		regularPointsPerScientist(1);

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -16,7 +16,7 @@ namespace
 
 
 MaintenanceFacility::MaintenanceFacility() :
-	Structure(StructureClass::Maintenance, StructureID::SID_MAINTENANCE_FACILITY),
+	Structure{StructureClass::Maintenance, StructureID::SID_MAINTENANCE_FACILITY},
 	mMaterialsLevel{0},
 	mMaintenancePersonnel{MinimumPersonnel},
 	mAssignedPersonnel{0},

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -16,10 +16,7 @@ namespace
 
 
 MaintenanceFacility::MaintenanceFacility() :
-	Structure(
-		StructureClass::Maintenance,
-		StructureID::SID_MAINTENANCE_FACILITY
-	),
+	Structure(StructureClass::Maintenance, StructureID::SID_MAINTENANCE_FACILITY),
 	mMaterialsLevel{0},
 	mMaintenancePersonnel{MinimumPersonnel},
 	mAssignedPersonnel{0},

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -25,8 +25,8 @@ namespace
 
 
 MineFacility::MineFacility(Tile* tile) :
-	Structure(StructureClass::Mine, StructureID::SID_MINE_FACILITY),
-	mOreDeposit(tile->oreDeposit())
+	Structure{StructureClass::Mine, StructureID::SID_MINE_FACILITY},
+	mOreDeposit{tile->oreDeposit()}
 {
 	if (mOreDeposit == nullptr)
 	{

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -25,10 +25,7 @@ namespace
 
 
 MineFacility::MineFacility(Tile* tile) :
-	Structure(
-		StructureClass::Mine,
-		StructureID::SID_MINE_FACILITY
-	),
+	Structure(StructureClass::Mine, StructureID::SID_MINE_FACILITY),
 	mOreDeposit(tile->oreDeposit())
 {
 	if (mOreDeposit == nullptr)

--- a/appOPHD/MapObjects/Structures/MineShaft.h
+++ b/appOPHD/MapObjects/Structures/MineShaft.h
@@ -6,9 +6,8 @@
 class MineShaft : public Structure
 {
 public:
-	MineShaft() : Structure(
-		StructureClass::Undefined,
-		StructureID::SID_MINE_SHAFT)
+	MineShaft() :
+		Structure(StructureClass::Undefined, StructureID::SID_MINE_SHAFT)
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/MineShaft.h
+++ b/appOPHD/MapObjects/Structures/MineShaft.h
@@ -7,7 +7,7 @@ class MineShaft : public Structure
 {
 public:
 	MineShaft() :
-		Structure(StructureClass::Undefined, StructureID::SID_MINE_SHAFT)
+		Structure{StructureClass::Undefined, StructureID::SID_MINE_SHAFT}
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -7,7 +7,7 @@
 
 
 OreRefining::OreRefining(StructureClass structureClass, StructureID id) :
-	Structure(structureClass, id)
+	Structure{structureClass, id}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/PowerStructure.cpp
+++ b/appOPHD/MapObjects/Structures/PowerStructure.cpp
@@ -6,7 +6,7 @@
 
 
 PowerStructure::PowerStructure(StructureClass structureClass, StructureID id) :
-	Structure(structureClass, id)
+	Structure{structureClass, id}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -12,9 +12,8 @@ namespace
 }
 
 
-Recycling::Recycling() : Structure(
-	StructureClass::Recycling,
-	StructureID::SID_RECYCLING)
+Recycling::Recycling() :
+	Structure(StructureClass::Recycling, StructureID::SID_RECYCLING)
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -13,7 +13,7 @@ namespace
 
 
 Recycling::Recycling() :
-	Structure(StructureClass::Recycling, StructureID::SID_RECYCLING)
+	Structure{StructureClass::Recycling, StructureID::SID_RECYCLING}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/ResearchFacility.cpp
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.cpp
@@ -7,7 +7,7 @@
 
 
 ResearchFacility::ResearchFacility(StructureClass structureClass, StructureID id) :
-	Structure(structureClass, id)
+	Structure{structureClass, id}
 {}
 
 

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -12,9 +12,8 @@ namespace
 }
 
 
-Residence::Residence() : Structure(
-	StructureClass::Residence,
-	StructureID::SID_RESIDENCE)
+Residence::Residence() :
+	Structure(StructureClass::Residence, StructureID::SID_RESIDENCE)
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -13,7 +13,7 @@ namespace
 
 
 Residence::Residence() :
-	Structure(StructureClass::Residence, StructureID::SID_RESIDENCE)
+	Structure{StructureClass::Residence, StructureID::SID_RESIDENCE}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Road.h
+++ b/appOPHD/MapObjects/Structures/Road.h
@@ -10,7 +10,7 @@ class Road : public Structure
 {
 public:
 	Road() :
-		Structure(StructureClass::Road, StructureID::SID_ROAD)
+		Structure{StructureClass::Road, StructureID::SID_ROAD}
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/Road.h
+++ b/appOPHD/MapObjects/Structures/Road.h
@@ -9,9 +9,8 @@ class TileMap;
 class Road : public Structure
 {
 public:
-	Road() : Structure(
-		StructureClass::Road,
-		StructureID::SID_ROAD)
+	Road() :
+		Structure(StructureClass::Road, StructureID::SID_ROAD)
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/SeedFactory.h
+++ b/appOPHD/MapObjects/Structures/SeedFactory.h
@@ -7,7 +7,7 @@ class SeedFactory : public Factory
 {
 public:
 	SeedFactory() :
-		Factory(
+		Factory{
 			StructureID::SID_SEED_FACTORY,
 			{
 				ProductType::PRODUCT_DIGGER,
@@ -15,7 +15,7 @@ public:
 				ProductType::PRODUCT_MINER,
 				ProductType::PRODUCT_TRUCK,
 			}
-		)
+		}
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/SeedFactory.h
+++ b/appOPHD/MapObjects/Structures/SeedFactory.h
@@ -7,15 +7,15 @@ class SeedFactory : public Factory
 {
 public:
 	SeedFactory() :
-	Factory(
-		StructureID::SID_SEED_FACTORY,
-		{
-			ProductType::PRODUCT_DIGGER,
-			ProductType::PRODUCT_DOZER,
-			ProductType::PRODUCT_MINER,
-			ProductType::PRODUCT_TRUCK,
-		}
-	)
+		Factory(
+			StructureID::SID_SEED_FACTORY,
+			{
+				ProductType::PRODUCT_DIGGER,
+				ProductType::PRODUCT_DOZER,
+				ProductType::PRODUCT_MINER,
+				ProductType::PRODUCT_TRUCK,
+			}
+		)
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/SeedLander.cpp
+++ b/appOPHD/MapObjects/Structures/SeedLander.cpp
@@ -4,10 +4,7 @@
 
 
 SeedLander::SeedLander(const Tile* tile) :
-	Structure{
-		StructureClass::Lander,
-		StructureID::SID_SEED_LANDER
-	},
+	Structure{StructureClass::Lander, StructureID::SID_SEED_LANDER},
 	mPosition{tile->xy()}
 {
 	enable();

--- a/appOPHD/MapObjects/Structures/SeedPower.h
+++ b/appOPHD/MapObjects/Structures/SeedPower.h
@@ -9,7 +9,7 @@ class SeedPower : public PowerStructure
 {
 public:
 	SeedPower() :
-		PowerStructure(StructureClass::EnergyProduction, StructureID::SID_SEED_POWER)
+		PowerStructure{StructureClass::EnergyProduction, StructureID::SID_SEED_POWER}
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/SeedPower.h
+++ b/appOPHD/MapObjects/Structures/SeedPower.h
@@ -8,9 +8,8 @@ const int SeedPowerProduction = 50;
 class SeedPower : public PowerStructure
 {
 public:
-	SeedPower() : PowerStructure(
-		StructureClass::EnergyProduction,
-		StructureID::SID_SEED_POWER)
+	SeedPower() :
+		PowerStructure(StructureClass::EnergyProduction, StructureID::SID_SEED_POWER)
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/SolarPanelArray.cpp
+++ b/appOPHD/MapObjects/Structures/SolarPanelArray.cpp
@@ -10,11 +10,7 @@ namespace
 
 
 SolarPanelArray::SolarPanelArray() :
-	PowerStructure
-	{
-		StructureClass::EnergyProduction,
-		StructureID::SID_SOLAR_PANEL1
-	}
+	PowerStructure{StructureClass::EnergyProduction, StructureID::SID_SOLAR_PANEL1}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/SolarPlant.cpp
+++ b/appOPHD/MapObjects/Structures/SolarPlant.cpp
@@ -10,11 +10,7 @@ namespace
 
 
 SolarPlant::SolarPlant() :
-	PowerStructure
-	{
-		StructureClass::EnergyProduction,
-		StructureID::SID_SOLAR_PLANT
-	}
+	PowerStructure{StructureClass::EnergyProduction, StructureID::SID_SOLAR_PLANT}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -5,9 +5,8 @@
 #include "../../UI/StringTable.h"
 
 
-StorageTanks::StorageTanks() : Structure(
-	StructureClass::Storage,
-	StructureID::SID_STORAGE_TANKS)
+StorageTanks::StorageTanks() :
+	Structure(StructureClass::Storage, StructureID::SID_STORAGE_TANKS)
 {
 }
 

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -6,7 +6,7 @@
 
 
 StorageTanks::StorageTanks() :
-	Structure(StructureClass::Storage, StructureID::SID_STORAGE_TANKS)
+	Structure{StructureClass::Storage, StructureID::SID_STORAGE_TANKS}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/appOPHD/MapObjects/Structures/SurfaceFactory.h
@@ -7,7 +7,7 @@ class SurfaceFactory : public Factory
 {
 public:
 	SurfaceFactory() :
-		Factory(
+		Factory{
 			StructureID::SID_SURFACE_FACTORY,
 			{
 				ProductType::PRODUCT_DIGGER,
@@ -15,7 +15,7 @@ public:
 				ProductType::PRODUCT_MINER,
 				ProductType::PRODUCT_TRUCK,
 			}
-		)
+		}
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/appOPHD/MapObjects/Structures/SurfaceFactory.h
@@ -7,15 +7,15 @@ class SurfaceFactory : public Factory
 {
 public:
 	SurfaceFactory() :
-	Factory(
-		StructureID::SID_SURFACE_FACTORY,
-		{
-			ProductType::PRODUCT_DIGGER,
-			ProductType::PRODUCT_DOZER,
-			ProductType::PRODUCT_MINER,
-			ProductType::PRODUCT_TRUCK,
-		}
-	)
+		Factory(
+			StructureID::SID_SURFACE_FACTORY,
+			{
+				ProductType::PRODUCT_DIGGER,
+				ProductType::PRODUCT_DOZER,
+				ProductType::PRODUCT_MINER,
+				ProductType::PRODUCT_TRUCK,
+			}
+		)
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -9,7 +9,8 @@ Tube::Tube(ConnectorDir dir, bool underground) :
 	Structure(
 		getAnimationName(dir, underground),
 		StructureClass::Tube,
-		StructureID::SID_TUBE)
+		StructureID::SID_TUBE
+	)
 {
 	connectorDirection(dir);
 	state(StructureState::Operational);

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -6,11 +6,11 @@
 
 
 Tube::Tube(ConnectorDir dir, bool underground) :
-	Structure(
+	Structure{
 		getAnimationName(dir, underground),
 		StructureClass::Tube,
 		StructureID::SID_TUBE
-	)
+	}
 {
 	connectorDirection(dir);
 	state(StructureState::Operational);

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -7,7 +7,7 @@ class UndergroundFactory : public Factory
 {
 public:
 	UndergroundFactory() :
-		Factory(
+		Factory{
 			StructureID::SID_UNDERGROUND_FACTORY,
 			{
 				// Need to be replaced by non robot/surface goods
@@ -15,7 +15,7 @@ public:
 				ProductType::PRODUCT_CLOTHING,
 				ProductType::PRODUCT_MEDICINE,
 			}
-		)
+		}
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -7,15 +7,15 @@ class UndergroundFactory : public Factory
 {
 public:
 	UndergroundFactory() :
-	Factory(
-		StructureID::SID_UNDERGROUND_FACTORY,
-		{
-			// Need to be replaced by non robot/surface goods
-			// Produces luxuries, clothing, or medicine
-			ProductType::PRODUCT_CLOTHING,
-			ProductType::PRODUCT_MEDICINE,
-		}
-	)
+		Factory(
+			StructureID::SID_UNDERGROUND_FACTORY,
+			{
+				// Need to be replaced by non robot/surface goods
+				// Produces luxuries, clothing, or medicine
+				ProductType::PRODUCT_CLOTHING,
+				ProductType::PRODUCT_MEDICINE,
+			}
+		)
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/Warehouse.h
+++ b/appOPHD/MapObjects/Structures/Warehouse.h
@@ -8,9 +8,8 @@
 class Warehouse : public Structure
 {
 public:
-	Warehouse() : Structure(
-		StructureClass::Warehouse,
-		StructureID::SID_WAREHOUSE)
+	Warehouse() :
+		Structure(StructureClass::Warehouse, StructureID::SID_WAREHOUSE)
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/Warehouse.h
+++ b/appOPHD/MapObjects/Structures/Warehouse.h
@@ -9,7 +9,7 @@ class Warehouse : public Structure
 {
 public:
 	Warehouse() :
-		Structure(StructureClass::Warehouse, StructureID::SID_WAREHOUSE)
+		Structure{StructureClass::Warehouse, StructureID::SID_WAREHOUSE}
 	{
 	}
 


### PR DESCRIPTION
Refactor `Structure` init lists, so they all use a consistency formatting style, and use braces `{}` for parameters.

Related:
- Issue #1795
- Issue #1804
