### PR TITLE
Refactor `Structure` creation to use `Tile&` parameters

### DIFF
--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -6,7 +6,7 @@
 
 CargoLander::CargoLander(Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_CARGO_LANDER},
-	mTile{&tile}
+	mTile{tile}
 {
 	enable();
 }
@@ -23,6 +23,6 @@ void CargoLander::think()
 	if (age() == turnsToBuild())
 	{
 		if (mDeployHandler) { mDeployHandler(); }
-		mTile->bulldoze();
+		mTile.bulldoze();
 	}
 }

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -4,9 +4,9 @@
 #include "../../Map/Tile.h"
 
 
-CargoLander::CargoLander(Tile* tile) :
+CargoLander::CargoLander(Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_CARGO_LANDER},
-	mTile{tile}
+	mTile{&tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/CargoLander.h
+++ b/appOPHD/MapObjects/Structures/CargoLander.h
@@ -13,7 +13,7 @@ class CargoLander : public Structure
 public:
 	using DeployDelegate = NAS2D::Delegate<void()>;
 
-	CargoLander(Tile* tile);
+	CargoLander(Tile& tile);
 
 	void deployHandler(DeployDelegate newDeployHandler);
 

--- a/appOPHD/MapObjects/Structures/CargoLander.h
+++ b/appOPHD/MapObjects/Structures/CargoLander.h
@@ -27,5 +27,5 @@ private:
 
 private:
 	DeployDelegate mDeployHandler;
-	Tile* mTile = nullptr;
+	Tile* mTile;
 };

--- a/appOPHD/MapObjects/Structures/CargoLander.h
+++ b/appOPHD/MapObjects/Structures/CargoLander.h
@@ -27,5 +27,5 @@ private:
 
 private:
 	DeployDelegate mDeployHandler;
-	Tile* mTile;
+	Tile& mTile;
 };

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -6,7 +6,7 @@
 
 ColonistLander::ColonistLander(Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_COLONIST_LANDER},
-	mTile{&tile}
+	mTile{tile}
 {
 	enable();
 }
@@ -23,6 +23,6 @@ void ColonistLander::think()
 	if (age() == turnsToBuild())
 	{
 		if (mDeployHandler) { mDeployHandler(); }
-		mTile->bulldoze();
+		mTile.bulldoze();
 	}
 }

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -4,9 +4,9 @@
 #include "../../Map/Tile.h"
 
 
-ColonistLander::ColonistLander(Tile* tile) :
+ColonistLander::ColonistLander(Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_COLONIST_LANDER},
-	mTile{tile}
+	mTile{&tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/ColonistLander.h
+++ b/appOPHD/MapObjects/Structures/ColonistLander.h
@@ -24,5 +24,5 @@ protected:
 private:
 	DeployDelegate mDeployHandler;
 
-	Tile* mTile;
+	Tile& mTile;
 };

--- a/appOPHD/MapObjects/Structures/ColonistLander.h
+++ b/appOPHD/MapObjects/Structures/ColonistLander.h
@@ -14,7 +14,7 @@ public:
 	using DeployDelegate = NAS2D::Delegate<void()>;
 
 public:
-	ColonistLander(Tile* tile);
+	ColonistLander(Tile& tile);
 
 	void deployHandler(DeployDelegate newDeployHandler);
 

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -24,9 +24,9 @@ namespace
 }
 
 
-MineFacility::MineFacility(Tile* tile) :
+MineFacility::MineFacility(Tile& tile) :
 	Structure{StructureClass::Mine, StructureID::SID_MINE_FACILITY},
-	mOreDeposit{tile->oreDeposit()}
+	mOreDeposit{tile.oreDeposit()}
 {
 	if (mOreDeposit == nullptr)
 	{

--- a/appOPHD/MapObjects/Structures/MineFacility.h
+++ b/appOPHD/MapObjects/Structures/MineFacility.h
@@ -16,7 +16,7 @@ public:
 	using ExtensionCompleteDelegate = NAS2D::Delegate<void(MineFacility*)>;
 
 public:
-	MineFacility(Tile* tile);
+	MineFacility(Tile& tile);
 
 	void maxDepth(int depth);
 

--- a/appOPHD/MapObjects/Structures/SeedLander.cpp
+++ b/appOPHD/MapObjects/Structures/SeedLander.cpp
@@ -3,7 +3,7 @@
 #include "../../Map/Tile.h"
 
 
-SeedLander::SeedLander(const Tile& tile) :
+SeedLander::SeedLander(Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_SEED_LANDER},
 	mTile{tile}
 {

--- a/appOPHD/MapObjects/Structures/SeedLander.cpp
+++ b/appOPHD/MapObjects/Structures/SeedLander.cpp
@@ -3,9 +3,9 @@
 #include "../../Map/Tile.h"
 
 
-SeedLander::SeedLander(const Tile* tile) :
+SeedLander::SeedLander(const Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_SEED_LANDER},
-	mPosition{tile->xy()}
+	mPosition{tile.xy()}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/SeedLander.cpp
+++ b/appOPHD/MapObjects/Structures/SeedLander.cpp
@@ -5,7 +5,7 @@
 
 SeedLander::SeedLander(const Tile& tile) :
 	Structure{StructureClass::Lander, StructureID::SID_SEED_LANDER},
-	mPosition{tile.xy()}
+	mTile{tile}
 {
 	enable();
 }
@@ -21,6 +21,6 @@ void SeedLander::think()
 {
 	if (age() == turnsToBuild())
 	{
-		if (mDeployHandler) { mDeployHandler(mPosition); }
+		if (mDeployHandler) { mDeployHandler(mTile.xy()); }
 	}
 }

--- a/appOPHD/MapObjects/Structures/SeedLander.h
+++ b/appOPHD/MapObjects/Structures/SeedLander.h
@@ -16,7 +16,7 @@ public:
 
 public:
 	SeedLander() = delete;
-	SeedLander(const Tile& tile);
+	SeedLander(Tile& tile);
 
 	void deployHandler(DeployDelegate newDeployHandler);
 
@@ -25,5 +25,5 @@ protected:
 
 private:
 	DeployDelegate mDeployHandler;
-	const Tile& mTile;
+	Tile& mTile;
 };

--- a/appOPHD/MapObjects/Structures/SeedLander.h
+++ b/appOPHD/MapObjects/Structures/SeedLander.h
@@ -25,5 +25,5 @@ protected:
 
 private:
 	DeployDelegate mDeployHandler;
-	NAS2D::Point<int> mPosition;
+	const Tile& mTile;
 };

--- a/appOPHD/MapObjects/Structures/SeedLander.h
+++ b/appOPHD/MapObjects/Structures/SeedLander.h
@@ -16,7 +16,7 @@ public:
 
 public:
 	SeedLander() = delete;
-	SeedLander(const Tile* tile);
+	SeedLander(const Tile& tile);
 
 	void deployHandler(DeployDelegate newDeployHandler);
 

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -155,7 +155,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& [direction, structureId] : initialStructures)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		auto* structure = StructureCatalog::create(structureId, &tile);
+		auto* structure = StructureCatalog::create(structureId, tile);
 		structureManager.addStructure(*structure, tile);
 		structures.push_back(structure);
 	}

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -155,7 +155,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& [direction, structureId] : initialStructures)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		auto* structure = StructureCatalog::create(structureId);
+		auto* structure = StructureCatalog::create(structureId, &tile);
 		structureManager.addStructure(*structure, tile);
 		structures.push_back(structure);
 	}

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -154,8 +154,9 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	std::vector<Structure*> structures;
 	for (const auto& [direction, structureId] : initialStructures)
 	{
+		auto& tile = mTileMap->getTile({point + direction, 0});
 		auto* structure = StructureCatalog::create(structureId);
-		structureManager.addStructure(*structure, mTileMap->getTile({point + direction, 0}));
+		structureManager.addStructure(*structure, tile);
 		structures.push_back(structure);
 	}
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -417,7 +417,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			continue; // FIXME: ugly
 		}
 
-		auto& structure = *StructureCatalog::create(structureId, &tile);
+		auto& structure = *StructureCatalog::create(structureId, tile);
 
 		if (structureId == StructureID::SID_COLONIST_LANDER)
 		{

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -198,7 +198,7 @@ const StructureType& StructureCatalog::getType(std::size_t index)
  * \return	Pointer to a newly constructed Structure
  * \throw	std::runtime_error if the StructureID is unsupported/invalid
  */
-Structure* StructureCatalog::create(StructureID id, Tile* tile)
+Structure* StructureCatalog::create(StructureID id, Tile& tile)
 {
 	Structure* structure = nullptr;
 
@@ -216,7 +216,7 @@ Structure* StructureCatalog::create(StructureID id, Tile* tile)
 			break;
 
 		case StructureID::SID_CARGO_LANDER:
-			structure = new CargoLander(tile);
+			structure = new CargoLander(&tile);
 			break;
 
 		case StructureID::SID_CHAP:
@@ -224,7 +224,7 @@ Structure* StructureCatalog::create(StructureID id, Tile* tile)
 			break;
 
 		case StructureID::SID_COLONIST_LANDER:
-			structure = new ColonistLander(tile);
+			structure = new ColonistLander(&tile);
 			break;
 
 		case StructureID::SID_COMMAND_CENTER:
@@ -260,7 +260,7 @@ Structure* StructureCatalog::create(StructureID id, Tile* tile)
 			break;
 
 		case StructureID::SID_MINE_FACILITY:
-			structure = new MineFacility(tile);
+			structure = new MineFacility(&tile);
 			break;
 
 		case StructureID::SID_MINE_SHAFT:
@@ -312,7 +312,7 @@ Structure* StructureCatalog::create(StructureID id, Tile* tile)
 			break;
 
 		case StructureID::SID_SEED_LANDER:
-			structure = new SeedLander(tile);
+			structure = new SeedLander(&tile);
 			break;
 
 		case StructureID::SID_SEED_POWER:

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -216,7 +216,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_CARGO_LANDER:
-			structure = new CargoLander(&tile);
+			structure = new CargoLander(tile);
 			break;
 
 		case StructureID::SID_CHAP:
@@ -224,7 +224,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_COLONIST_LANDER:
-			structure = new ColonistLander(&tile);
+			structure = new ColonistLander(tile);
 			break;
 
 		case StructureID::SID_COMMAND_CENTER:
@@ -260,7 +260,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_MINE_FACILITY:
-			structure = new MineFacility(&tile);
+			structure = new MineFacility(tile);
 			break;
 
 		case StructureID::SID_MINE_SHAFT:
@@ -312,7 +312,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_SEED_LANDER:
-			structure = new SeedLander(&tile);
+			structure = new SeedLander(tile);
 			break;
 
 		case StructureID::SID_SEED_POWER:

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -32,7 +32,7 @@ public:
 	static const StructureType& getType(StructureID id);
 	static const StructureType& getType(std::size_t index);
 
-	static Structure* create(StructureID id, Tile* tile = nullptr);
+	static Structure* create(StructureID id, Tile* tile);
 
 	static const StorableResources& costToBuild(StructureID id);
 	static const StorableResources& recyclingValue(StructureID id);

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -32,7 +32,7 @@ public:
 	static const StructureType& getType(StructureID id);
 	static const StructureType& getType(std::size_t index);
 
-	static Structure* create(StructureID id, Tile* tile);
+	static Structure* create(StructureID id, Tile& tile);
 
 	static const StorableResources& costToBuild(StructureID id);
 	static const StorableResources& recyclingValue(StructureID id);

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -150,7 +150,7 @@ StructureManager::StructureManager() :
 
 Structure& StructureManager::create(StructureID structureId, Tile& tile)
 {
-	auto& structure = *StructureCatalog::create(structureId);
+	auto& structure = *StructureCatalog::create(structureId, &tile);
 	addStructure(structure, tile);
 	return structure;
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -150,7 +150,7 @@ StructureManager::StructureManager() :
 
 Structure& StructureManager::create(StructureID structureId, Tile& tile)
 {
-	auto& structure = *StructureCatalog::create(structureId, &tile);
+	auto& structure = *StructureCatalog::create(structureId, tile);
 	addStructure(structure, tile);
 	return structure;
 }

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -39,10 +39,10 @@ public:
 	StructureManager();
 
 	template <typename StructureType>
-	requires std::derived_from<StructureType, Structure> && std::constructible_from<StructureType, Tile*>
+	requires std::derived_from<StructureType, Structure> && std::constructible_from<StructureType, Tile&>
 	StructureType& create(Tile& tile)
 	{
-		auto& structure = *new StructureType(&tile);
+		auto& structure = *new StructureType(tile);
 		addStructure(structure, tile);
 		return structure;
 	}


### PR DESCRIPTION
Convert landers and `MineFacility` to use `Tile&` parameters instead of `Tile*`.

We eventually want every `Structure` to take a `Tile&`.

Related:
- Issue #1795
- Issue #1804
