### PR TITLE
Refactor `Tube` constructor to take `Tile&`

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -81,7 +81,7 @@ Structure::Structure(StructureClass structureClass, StructureID id) :
 }
 
 
-Structure::Structure(const std::string& initialAction, StructureClass structureClass, StructureID id) :
+Structure::Structure(StructureClass structureClass, StructureID id, const std::string& initialAction) :
 	MapObject(StructureCatalog::getType(id).spritePath, initialAction),
 	mStructureType(StructureCatalog::getType(id)),
 	mStructureId(id),

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -38,7 +38,7 @@ class Structure : public MapObject
 {
 public:
 	Structure(StructureClass structureClass, StructureID id);
-	Structure(const std::string& initialAction, StructureClass structureClass, StructureID id);
+	Structure(StructureClass structureClass, StructureID id, const std::string& initialAction);
 
 	~Structure() override = default;
 

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -6,9 +6,9 @@
 
 AirShaft::AirShaft() :
 	Structure{
-		constants::StructureStateOperational,
 		StructureClass::Tube,
-		StructureID::SID_AIR_SHAFT
+		StructureID::SID_AIR_SHAFT,
+		constants::StructureStateOperational,
 	}
 {
 	connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -1,15 +1,16 @@
 #include "Tube.h"
 
+#include "../../Map/Tile.h"
 #include "../../Constants/Strings.h"
 
 #include <stdexcept>
 
 
-Tube::Tube(ConnectorDir dir, bool underground) :
+Tube::Tube(Tile& tile, ConnectorDir dir) :
 	Structure{
 		StructureClass::Tube,
 		StructureID::SID_TUBE,
-		getAnimationName(dir, underground),
+		getAnimationName(dir, tile.depth() != 0),
 	}
 {
 	connectorDirection(dir);

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -7,9 +7,9 @@
 
 Tube::Tube(ConnectorDir dir, bool underground) :
 	Structure{
-		getAnimationName(dir, underground),
 		StructureClass::Tube,
-		StructureID::SID_TUBE
+		StructureID::SID_TUBE,
+		getAnimationName(dir, underground),
 	}
 {
 	connectorDirection(dir);

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -3,10 +3,13 @@
 #include "../Structure.h"
 
 
+class Tile;
+
+
 class Tube : public Structure
 {
 public:
-	Tube(ConnectorDir dir, bool underground);
+	Tube(Tile& tile, ConnectorDir dir);
 
 private:
 	static const std::string& getAnimationName(ConnectorDir dir, bool underground);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -760,14 +760,14 @@ void MapViewState::changeViewDepth(int depth)
 }
 
 
-void MapViewState::insertTube(ConnectorDir dir, int depth, Tile& tile)
+void MapViewState::insertTube(ConnectorDir dir, Tile& tile)
 {
 	if (dir == ConnectorDir::CONNECTOR_VERTICAL)
 	{
 		throw std::runtime_error("MapViewState::insertTube() called with invalid ConnectorDir parameter.");
 	}
 
-	NAS2D::Utility<StructureManager>::get().addStructure(*new Tube(dir, depth != 0), tile);
+	NAS2D::Utility<StructureManager>::get().addStructure(*new Tube(dir, tile.depth() != 0), tile);
 }
 
 
@@ -782,7 +782,7 @@ void MapViewState::placeTubes(Tile& tile, ConnectorDir connectorDirection)
 
 	if (validTubeConnection(*mTileMap, tile.xyz(), connectorDirection))
 	{
-		insertTube(connectorDirection, mMapView->currentDepth(), tile);
+		insertTube(connectorDirection, tile);
 
 		// FIXME: Naive approach -- will be slow with larger colonies.
 		updateConnectedness();

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -760,7 +760,7 @@ void MapViewState::changeViewDepth(int depth)
 }
 
 
-void MapViewState::insertTube(ConnectorDir dir, Tile& tile)
+void MapViewState::insertTube(Tile& tile, ConnectorDir dir)
 {
 	if (dir == ConnectorDir::CONNECTOR_VERTICAL)
 	{
@@ -782,7 +782,7 @@ void MapViewState::placeTubes(Tile& tile, ConnectorDir connectorDirection)
 
 	if (validTubeConnection(*mTileMap, tile.xyz(), connectorDirection))
 	{
-		insertTube(connectorDirection, tile);
+		insertTube(tile, connectorDirection);
 
 		// FIXME: Naive approach -- will be slow with larger colonies.
 		updateConnectedness();

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -767,7 +767,7 @@ void MapViewState::insertTube(Tile& tile, ConnectorDir dir)
 		throw std::runtime_error("MapViewState::insertTube() called with invalid ConnectorDir parameter.");
 	}
 
-	NAS2D::Utility<StructureManager>::get().addStructure(*new Tube(dir, tile.depth() != 0), tile);
+	NAS2D::Utility<StructureManager>::get().addStructure(*new Tube(tile, dir), tile);
 }
 
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -158,7 +158,7 @@ private:
 	void onDeployColonistLander();
 	void onDeploySeedLander(NAS2D::Point<int> point);
 	void insertSeedLander(NAS2D::Point<int> point);
-	void insertTube(ConnectorDir dir, Tile& tile);
+	void insertTube(Tile& tile, ConnectorDir dir);
 
 	void placeTubes(Tile& tile, ConnectorDir connectorDirection);
 	void placeStructure(Tile& tile, StructureID structureID);

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -158,7 +158,7 @@ private:
 	void onDeployColonistLander();
 	void onDeploySeedLander(NAS2D::Point<int> point);
 	void insertSeedLander(NAS2D::Point<int> point);
-	void insertTube(ConnectorDir dir, int depth, Tile& tile);
+	void insertTube(ConnectorDir dir, Tile& tile);
 
 	void placeTubes(Tile& tile, ConnectorDir connectorDirection);
 	void placeStructure(Tile& tile, StructureID structureID);

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -141,7 +141,8 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	// Place initial tubes
 	for (const auto& direction : DirectionClockwise4)
 	{
-		structureManager.addStructure(*new Tube(ConnectorDir::CONNECTOR_INTERSECTION, false), mTileMap->getTile({point + direction, 0}));
+		auto& tile = mTileMap->getTile({point + direction, 0});
+		structureManager.addStructure(*new Tube(ConnectorDir::CONNECTOR_INTERSECTION, false), tile);
 	}
 
 	constexpr std::array initialStructures{

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -142,7 +142,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& direction : DirectionClockwise4)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		structureManager.addStructure(*new Tube(ConnectorDir::CONNECTOR_INTERSECTION, false), tile);
+		structureManager.addStructure(*new Tube(tile, ConnectorDir::CONNECTOR_INTERSECTION), tile);
 	}
 
 	constexpr std::array initialStructures{

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -413,7 +413,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 		if (structureId == StructureID::SID_TUBE)
 		{
 			ConnectorDir connectorDir = static_cast<ConnectorDir>(direction);
-			insertTube(connectorDir, mapCoordinate.z, mTileMap->getTile(mapCoordinate));
+			insertTube(connectorDir, mTileMap->getTile(mapCoordinate));
 			continue; // FIXME: ugly
 		}
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -413,7 +413,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 		if (structureId == StructureID::SID_TUBE)
 		{
 			ConnectorDir connectorDir = static_cast<ConnectorDir>(direction);
-			insertTube(connectorDir, mTileMap->getTile(mapCoordinate));
+			insertTube(mTileMap->getTile(mapCoordinate), connectorDir);
 			continue; // FIXME: ugly
 		}
 


### PR DESCRIPTION
Refactor `Tube` constructor to take a `Tile&` and use that to replace the `bool` parameter.

Eventually all `Structure` derived classes will take a `Tile&` in their constructor. Might as well make use of it now to simplify the parameter list, and ease the future transition.

----

Re-order `Structure` constructor parameters so `initialAction` is last. This makes the first two parameters consistent with the other `Structure` constructor overload.

----

Related:
- Issue #1795
