### PR TITLE
Remove method `StructureManager::tileFromStructure`

### DIFF
--- a/appOPHD/Map/Connections.cpp
+++ b/appOPHD/Map/Connections.cpp
@@ -2,14 +2,12 @@
 
 #include "Tile.h"
 #include "TileMap.h"
-#include "../StructureManager.h"
 #include "../MapObjects/Structures/Road.h"
 #include "../Constants/Numbers.h"
 
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/Map/MapCoordinate.h>
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Math/Point.h>
 
 
@@ -69,7 +67,7 @@ namespace
 
 std::string roadAnimationName(const Road& road, const TileMap& tileMap)
 {
-	const auto tileLocation = NAS2D::Utility<StructureManager>::get().tileFromStructure(&road).xy();
+	const auto tileLocation = road.xyz().xy;
 	const auto surroundingTiles = getSurroundingRoads(tileMap, tileLocation);
 	return roadAnimationName(road.integrity(), surroundingTiles);
 }

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -3,14 +3,11 @@
 #include "Route.h"
 #include "Tile.h"
 #include "TileMap.h"
-#include "../StructureManager.h"
 #include "../MapObjects/Structures/OreRefining.h"
 #include "../MicroPather/micropather.h"
 
 #include <libOPHD/EnumTerrainType.h>
 #include <libOPHD/DirectionOffset.h>
-
-#include <NAS2D/Utility.h>
 
 #include <cmath>
 
@@ -19,8 +16,7 @@ namespace
 {
 	std::vector<Route> findRoutes(micropather::MicroPather* solver, const Structure* mineFacility, const std::vector<OreRefining*>& smelters)
 	{
-		auto& structureManager = NAS2D::Utility<StructureManager>::get();
-		auto& start = structureManager.tileFromStructure(mineFacility);
+		auto& start = mineFacility->tile();
 
 		std::vector<Route> routeList;
 
@@ -28,7 +24,7 @@ namespace
 		{
 			if (!smelter->operational()) { continue; }
 
-			auto& end = structureManager.tileFromStructure(smelter);
+			auto& end = smelter->tile();
 
 			Route route;
 			solver->Reset();

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -105,6 +105,12 @@ const std::string& Structure::name() const
 }
 
 
+Tile& Structure::tile() const
+{
+	return mTile;
+}
+
+
 const MapCoordinate& Structure::xyz() const
 {
 	return mTile.xyz();

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -2,6 +2,7 @@
 
 #include "../StructureCatalog.h"
 #include "../Constants/Strings.h"
+#include "../Map/Tile.h"
 
 #include "../UI/StringTable.h"
 
@@ -101,6 +102,12 @@ const StructureType& Structure::type() const
 const std::string& Structure::name() const
 {
 	return mStructureType.name;
+}
+
+
+const MapCoordinate& Structure::xyz() const
+{
+	return mTile.xyz();
 }
 
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -52,6 +52,7 @@ public:
 
 	StructureID structureId() const { return mStructureId; }
 
+	Tile& tile() const;
 	const MapCoordinate& xyz() const;
 
 	bool connected() const { return mConnected; }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -18,6 +18,7 @@ namespace NAS2D
 
 
 struct StructureType;
+struct MapCoordinate;
 class Tile;
 class StringTable;
 
@@ -50,6 +51,8 @@ public:
 	StructureState state() const { return mStructureState; }
 
 	StructureID structureId() const { return mStructureId; }
+
+	const MapCoordinate& xyz() const;
 
 	bool connected() const { return mConnected; }
 	void connected(bool value) { mConnected = value; }

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -26,7 +26,7 @@ namespace
 
 	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, Structure* structure)
 	{
-		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
+		const auto& structureTile = structure->tile();
 
 		for (const auto& tile : policeOverlays[static_cast<std::size_t>(structureTile.depth())])
 		{

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -323,7 +323,7 @@ void MapViewState::onDeactivate()
 void MapViewState::focusOnStructure(const Structure* structure)
 {
 	if (!structure) { return; }
-	onTakeMeThere(NAS2D::Utility<StructureManager>::get().tileFromStructure(structure).xyz());
+	onTakeMeThere(structure->xyz());
 }
 
 
@@ -1337,7 +1337,7 @@ void MapViewState::updateCommRangeOverlay()
 		const auto commRange = structure->commRange();
 		if (commRange > 0)
 		{
-			const auto& centerTile = structureManager.tileFromStructure(structure);
+			const auto& centerTile = structure->tile();
 			fillOverlayCircle(*mTileMap, mCommRangeOverlay, centerTile, commRange);
 		}
 	}
@@ -1357,7 +1357,7 @@ void MapViewState::updatePoliceOverlay()
 		const auto policeRange = structure->policeRange();
 		if (policeRange > 0)
 		{
-			const auto& centerTile = structureManager.tileFromStructure(structure);
+			const auto& centerTile = structure->tile();
 			const auto depth = static_cast<std::size_t>(centerTile.depth());
 			fillOverlayCircle(*mTileMap, mPoliceOverlays[depth], centerTile, policeRange);
 		}

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -79,11 +79,10 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
 			else
 			{
 				factory.idle(IdleReason::FactoryInsufficientWarehouseSpace);
-				const auto& factoryPos = factory.tile();
 				mNotificationArea.push({
 					"Warehouses full",
 					"A factory has shut down due to lack of available warehouse space.",
-					factoryPos.xyz(),
+					factory.xyz(),
 					NotificationArea::NotificationType::Warning
 				});
 			}
@@ -252,8 +251,7 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 	if (mMineOperationsWindow.mineFacility() == mineFacility) { mMineOperationsWindow.mineFacility(mineFacility); }
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	auto& mineFacilityTile = mineFacility->tile();
-	auto& mineDepthTile = mTileMap->getTile({mineFacilityTile.xy(), mineFacility->oreDeposit().digDepth()});
+	auto& mineDepthTile = mTileMap->getTile({mineFacility->xyz().xy, mineFacility->oreDeposit().digDepth()});
 	structureManager.create<MineShaft>(mineDepthTile);
 	mineDepthTile.bulldoze();
 	mineDepthTile.excavated(true);
@@ -262,12 +260,10 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 
 void MapViewState::onCrimeEvent(std::string title, std::string text, const Structure& structure)
 {
-	const auto& structureTile = structure.tile();
-
 	mNotificationArea.push({
 		std::move(title),
 		std::move(text),
-		structureTile.xyz(),
+		structure.xyz(),
 		NotificationArea::NotificationType::Warning
 	});
 }

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -79,7 +79,7 @@ void MapViewState::onFactoryProductionComplete(Factory& factory)
 			else
 			{
 				factory.idle(IdleReason::FactoryInsufficientWarehouseSpace);
-				const auto& factoryPos = NAS2D::Utility<StructureManager>::get().tileFromStructure(&factory);
+				const auto& factoryPos = factory.tile();
 				mNotificationArea.push({
 					"Warehouses full",
 					"A factory has shut down due to lack of available warehouse space.",
@@ -252,7 +252,7 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 	if (mMineOperationsWindow.mineFacility() == mineFacility) { mMineOperationsWindow.mineFacility(mineFacility); }
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
-	auto& mineFacilityTile = structureManager.tileFromStructure(mineFacility);
+	auto& mineFacilityTile = mineFacility->tile();
 	auto& mineDepthTile = mTileMap->getTile({mineFacilityTile.xy(), mineFacility->oreDeposit().digDepth()});
 	structureManager.create<MineShaft>(mineDepthTile);
 	mineDepthTile.bulldoze();
@@ -262,7 +262,7 @@ void MapViewState::onMineFacilityExtend(MineFacility* mineFacility)
 
 void MapViewState::onCrimeEvent(std::string title, std::string text, const Structure& structure)
 {
-	const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(&structure);
+	const auto& structureTile = structure.tile();
 
 	mNotificationArea.push({
 		std::move(title),

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -64,7 +64,7 @@ bool isInCcRange(NAS2D::Point<int> position)
 	const auto& ccList = structureManager.getStructures<CommandCenter>();
 	for (const auto* commandCenter : ccList)
 	{
-		const auto location = structureManager.tileFromStructure(commandCenter).xy();
+		const auto location = commandCenter->xyz().xy;
 		if (isPointInRange(position, location, range))
 		{
 			return true;
@@ -85,7 +85,7 @@ bool isInCommRange(NAS2D::Point<int> position)
 	for (const auto* structure : structures)
 	{
 		const auto commRange = structure->commRange();
-		if (commRange > 0 && isPointInRange(position, structureManager.tileFromStructure(structure).xy(), commRange))
+		if (commRange > 0 && isPointInRange(position, structure->xyz().xy, commRange))
 		{
 			return true;
 		}

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -532,14 +532,12 @@ void MapViewState::checkAgingStructures()
 
 	for (const auto* structure : structures)
 	{
-		const auto& structureTile = structure->tile();
-
 		if (structure->age() == structure->maxAge() - 10)
 		{
 			mNotificationArea.push({
 				"Aging Structure",
 				structure->name() + " is getting old. You should replace it soon.",
-				structureTile.xyz(),
+				structure->xyz(),
 				NotificationArea::NotificationType::Warning});
 		}
 		else if (structure->age() == structure->maxAge() - 5)
@@ -547,7 +545,7 @@ void MapViewState::checkAgingStructures()
 			mNotificationArea.push({
 				"Aging Structure",
 				structure->name() + " is about to collapse. You should replace it right away or consider demolishing it.",
-				structureTile.xyz(),
+				structure->xyz(),
 				NotificationArea::NotificationType::Critical});
 		}
 	}
@@ -560,12 +558,10 @@ void MapViewState::checkNewlyBuiltStructures()
 
 	for (const auto* structure : structures)
 	{
-		const auto& structureTile = structure->tile();
-
 		mNotificationArea.push({
 			"Construction Finished",
 			structure->name() + " completed construction.",
-			structureTile.xyz(),
+			structure->xyz(),
 			NotificationArea::NotificationType::Success});
 	}
 }

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -532,7 +532,7 @@ void MapViewState::checkAgingStructures()
 
 	for (const auto* structure : structures)
 	{
-		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
+		const auto& structureTile = structure->tile();
 
 		if (structure->age() == structure->maxAge() - 10)
 		{
@@ -560,7 +560,7 @@ void MapViewState::checkNewlyBuiltStructures()
 
 	for (const auto* structure : structures)
 	{
-		const auto& structureTile = NAS2D::Utility<StructureManager>::get().tileFromStructure(structure);
+		const auto& structureTile = structure->tile();
 
 		mNotificationArea.push({
 			"Construction Finished",

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -243,7 +243,7 @@ std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions()
 	{
 		if (commandCenter->operational())
 		{
-			positions.push_back(tileFromStructure(commandCenter).xyz());
+			positions.push_back(commandCenter->xyz());
 		}
 	}
 	return positions;

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -232,14 +232,7 @@ StructureList StructureManager::allStructures() const
 
 Tile& StructureManager::tileFromStructure(const Structure* structure) const
 {
-	for (const auto& [keyStructure, valueTile] : mStructureTileTable)
-	{
-		if (keyStructure == structure)
-		{
-			return *valueTile;
-		}
-	}
-	throw std::runtime_error("Could not find tile for structure");
+	return structure->tile();
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -230,12 +230,6 @@ StructureList StructureManager::allStructures() const
 }
 
 
-Tile& StructureManager::tileFromStructure(const Structure* structure) const
-{
-	return structure->tile();
-}
-
-
 std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions() const
 {
 	std::vector<MapCoordinate> positions;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -72,8 +72,6 @@ public:
 	const StructureList& structureList(StructureClass structureClass) const;
 	StructureList allStructures() const;
 
-	Tile& tileFromStructure(const Structure* structure) const;
-
 	std::vector<MapCoordinate> operationalCommandCenterPositions() const;
 
 	void updateConnectedness(TileMap& tileMap);

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -75,7 +75,7 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 	{
 		if (commTower->operational())
 		{
-			const auto commTowerPosition = structureManager.tileFromStructure(commTower).xy();
+			const auto commTowerPosition = commTower->xyz().xy;
 			const auto commTowerRangeImageRect = NAS2D::Rectangle<int>{{146, 236}, {20, 20}};
 			renderer.drawSubImage(mUiIcons, commTowerPosition + miniMapOffset - commTowerRangeImageRect.size / 2, commTowerRangeImageRect);
 		}

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -35,8 +35,7 @@ namespace
 {
 	std::string getStructureDescription(const Structure& structure)
 	{
-		const auto& structureManager = NAS2D::Utility<StructureManager>::get();
-		const auto& surfaceLocation = structureManager.tileFromStructure(&structure).xy();
+		const auto& surfaceLocation = structure.xyz().xy;
 		return structure.name() + " at " + NAS2D::stringFrom(surfaceLocation);
 	}
 


### PR DESCRIPTION
Add `MapCoordinate` and `Tile` accessors to `Structure`, and remove `StructureManager::tileFromStructure` method.

As a bonus, a few includes for `StructureManager` and `Utility` were removed.

Related:
- Issue #1795
- Issue #1573
