### PR TITLE
Remove `Tile*` from deployed structures collection

### DIFF
--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -52,9 +52,9 @@ namespace
 	}
 
 
-	NAS2D::Xml::XmlElement* serializeStructure(const Structure& structure, Tile& tile)
+	NAS2D::Xml::XmlElement* serializeStructure(const Structure& structure)
 	{
-		const auto& position = tile.xyz();
+		const auto& position = structure.xyz();
 		NAS2D::Dictionary dictionary =
 		{{
 			{"x", position.xy.x},
@@ -507,7 +507,7 @@ NAS2D::Xml::XmlElement* StructureManager::serialize() const
 
 	for (auto& [structure, tile] : mStructureTileTable)
 	{
-		structures->linkEndChild(serializeStructure(*structure, *tile));
+		structures->linkEndChild(serializeStructure(*structure));
 	}
 
 	return structures;

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -161,7 +161,7 @@ Structure& StructureManager::create(StructureID structureId, Tile& tile)
  */
 void StructureManager::addStructure(Structure& structure, Tile& tile)
 {
-	if (mStructureTileTable.find(&structure) != mStructureTileTable.end())
+	if (mDeployedStructures.find(&structure) != mDeployedStructures.end())
 	{
 		throw std::runtime_error("StructureManager::addStructure(): Attempting to add a Structure that is already managed!");
 	}
@@ -171,7 +171,7 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
 		tile.removeMapObject();
 	}
 
-	mStructureTileTable[&structure] = &tile;
+	mDeployedStructures[&structure] = &tile;
 
 	mStructureLists[structure.structureClass()].push_back(&structure);
 	tile.mapObject(&structure);
@@ -195,12 +195,12 @@ void StructureManager::removeStructure(Structure& structure)
 		structures.erase(it);
 	}
 
-	const auto tileTableIt = mStructureTileTable.find(&structure);
-	const auto isFoundTileTable = tileTableIt != mStructureTileTable.end();
+	const auto tileTableIt = mDeployedStructures.find(&structure);
+	const auto isFoundTileTable = tileTableIt != mDeployedStructures.end();
 	if (isFoundTileTable)
 	{
 		tileTableIt->second->deleteMapObject();
-		mStructureTileTable.erase(tileTableIt);
+		mDeployedStructures.erase(tileTableIt);
 	}
 
 	if (!isFoundStructureTable || !isFoundTileTable)
@@ -254,8 +254,8 @@ void StructureManager::updateConnectedness(TileMap& tileMap)
 std::vector<Tile*> StructureManager::getConnectednessOverlay() const
 {
 	std::vector<Tile*> result;
-	result.reserve(mStructureTileTable.size());
-	for (const auto& [structure, tile] : mStructureTileTable)
+	result.reserve(mDeployedStructures.size());
+	for (const auto& [structure, tile] : mDeployedStructures)
 	{
 		if (structure->connected())
 		{
@@ -271,7 +271,7 @@ std::vector<Tile*> StructureManager::getConnectednessOverlay() const
  */
 void StructureManager::disconnectAll()
 {
-	for (auto& pair : mStructureTileTable)
+	for (auto& pair : mDeployedStructures)
 	{
 		pair.first->connected(false);
 	}
@@ -280,12 +280,12 @@ void StructureManager::disconnectAll()
 
 void StructureManager::dropAllStructures()
 {
-	for (auto& pair : mStructureTileTable)
+	for (auto& pair : mDeployedStructures)
 	{
 		pair.second->deleteMapObject();
 	}
 
-	mStructureTileTable.clear();
+	mDeployedStructures.clear();
 	mStructureLists = populateKeys();
 }
 
@@ -505,7 +505,7 @@ NAS2D::Xml::XmlElement* StructureManager::serialize() const
 {
 	auto* structures = new NAS2D::Xml::XmlElement("structures");
 
-	for (auto& [structure, tile] : mStructureTileTable)
+	for (auto& [structure, tile] : mDeployedStructures)
 	{
 		structures->linkEndChild(serializeStructure(*structure));
 	}

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -122,15 +122,12 @@ public:
 	NAS2D::Xml::XmlElement* serialize() const;
 
 private:
-	using StructureTileTable = std::map<Structure*, Tile*>;
-	using StructureClassTable = std::map<StructureClass, StructureList>;
-
 	void disconnectAll();
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
 
-	StructureTileTable mStructureTileTable; /**< List mapping Structures to a particular tile. */
-	StructureClassTable mStructureLists; /**< Map containing all of the structure list types available. */
+	std::map<Structure*, Tile*> mStructureTileTable; /**< List mapping Structures to a particular tile. */
+	std::map<StructureClass, StructureList> mStructureLists; /**< Map containing all of the structure list types available. */
 
 	StructureList mAgingStructures;
 	StructureList mNewlyBuiltStructures;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -126,7 +126,7 @@ private:
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
 
-	std::map<Structure*, Tile*> mDeployedStructures;
+	std::vector<Structure*> mDeployedStructures;
 	std::map<StructureClass, StructureList> mStructureLists;
 
 	StructureList mAgingStructures;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -126,8 +126,8 @@ private:
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
 
-	std::map<Structure*, Tile*> mStructureTileTable; /**< List mapping Structures to a particular tile. */
-	std::map<StructureClass, StructureList> mStructureLists; /**< Map containing all of the structure list types available. */
+	std::map<Structure*, Tile*> mStructureTileTable;
+	std::map<StructureClass, StructureList> mStructureLists;
 
 	StructureList mAgingStructures;
 	StructureList mNewlyBuiltStructures;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -126,7 +126,7 @@ private:
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
 
-	std::map<Structure*, Tile*> mStructureTileTable;
+	std::map<Structure*, Tile*> mDeployedStructures;
 	std::map<StructureClass, StructureList> mStructureLists;
 
 	StructureList mAgingStructures;


### PR DESCRIPTION
Convert `StructureManager`'s `mStructureTileTable` collection from `std::map` to `std::vector` and rename to `mDeployedStructures`.

Related:
- Issue #1795
