### PR TITLE
Add `structureIdToClass` function

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -1,5 +1,6 @@
 #include "Structure.h"
 
+#include "StructureClass.h"
 #include "StructureIdToClass.h"
 
 #include "../StructureCatalog.h"

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -1,5 +1,7 @@
 #include "Structure.h"
 
+#include "StructureIdToClass.h"
+
 #include "../StructureCatalog.h"
 #include "../Constants/Strings.h"
 #include "../Map/Tile.h"
@@ -73,21 +75,21 @@ std::vector<StructureClass> allStructureClasses()
 }
 
 
-Structure::Structure(StructureClass structureClass, StructureID id, Tile& tile) :
+Structure::Structure(StructureID id, Tile& tile) :
 	MapObject(StructureCatalog::getType(id).spritePath, constants::StructureStateConstruction),
 	mStructureType(StructureCatalog::getType(id)),
 	mStructureId(id),
-	mStructureClass(structureClass),
+	mStructureClass(structureIdToClass(id)),
 	mTile{tile}
 {
 }
 
 
-Structure::Structure(StructureClass structureClass, StructureID id, Tile& tile, const std::string& initialAction) :
+Structure::Structure(StructureID id, Tile& tile, const std::string& initialAction) :
 	MapObject(StructureCatalog::getType(id).spritePath, initialAction),
 	mStructureType(StructureCatalog::getType(id)),
 	mStructureId(id),
-	mStructureClass(structureClass),
+	mStructureClass(structureIdToClass(id)),
 	mTile{tile}
 {
 }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -39,8 +39,8 @@ enum class StructureState
 class Structure : public MapObject
 {
 public:
-	Structure(StructureClass structureClass, StructureID id, Tile& tile);
-	Structure(StructureClass structureClass, StructureID id, Tile& tile, const std::string& initialAction);
+	Structure(StructureID id, Tile& tile);
+	Structure(StructureID id, Tile& tile, const std::string& initialAction);
 
 	~Structure() override = default;
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "StructureClass.h"
-
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/EnumIdleReason.h>
@@ -17,6 +15,7 @@ namespace NAS2D
 }
 
 
+enum class StructureClass;
 struct StructureType;
 struct MapCoordinate;
 class Tile;

--- a/appOPHD/MapObjects/StructureIdToClass.cpp
+++ b/appOPHD/MapObjects/StructureIdToClass.cpp
@@ -1,0 +1,66 @@
+#include "StructureIdToClass.h"
+
+#include "StructureClass.h"
+
+#include <array>
+#include <string>
+#include <stdexcept>
+
+
+namespace
+{
+	constexpr auto structureIdToClassTable = std::array{
+		StructureClass::Undefined, // SID_NONE
+		StructureClass::FoodProduction, // SID_AGRIDOME
+		StructureClass::Tube, // SID_AIR_SHAFT
+		StructureClass::Lander, // SID_CARGO_LANDER
+		StructureClass::LifeSupport, // SID_CHAP
+		StructureClass::Lander, // SID_COLONIST_LANDER
+		StructureClass::Command, // SID_COMMAND_CENTER
+		StructureClass::Commercial, // SID_COMMERCIAL
+		StructureClass::Communication, // SID_COMM_TOWER
+		StructureClass::EnergyProduction, // SID_FUSION_REACTOR
+		StructureClass::Laboratory, // SID_HOT_LABORATORY
+		StructureClass::Laboratory, // SID_LABORATORY
+		StructureClass::MedicalCenter, // SID_MEDICAL_CENTER
+		StructureClass::Mine, // SID_MINE_FACILITY
+		StructureClass::Undefined, // SID_MINE_SHAFT
+		StructureClass::Nursery, // SID_NURSERY
+		StructureClass::Park, // SID_PARK
+		StructureClass::RecreationCenter, // SID_RECREATION_CENTER
+		StructureClass::Residence, // SID_RED_LIGHT_DISTRICT
+		StructureClass::Residence, // SID_RESIDENCE
+		StructureClass::Road, // SID_ROAD
+		StructureClass::RobotCommand, // SID_ROBOT_COMMAND
+		StructureClass::Factory, // SID_SEED_FACTORY
+		StructureClass::Lander, // SID_SEED_LANDER
+		StructureClass::EnergyProduction, // SID_SEED_POWER
+		StructureClass::Smelter, // SID_SEED_SMELTER
+		StructureClass::Smelter, // SID_SMELTER
+		StructureClass::EnergyProduction, // SID_SOLAR_PANEL1
+		StructureClass::EnergyProduction, // SID_SOLAR_PLANT
+		StructureClass::Storage, // SID_STORAGE_TANKS
+		StructureClass::Factory, // SID_SURFACE_FACTORY
+		StructureClass::SurfacePolice, // SID_SURFACE_POLICE
+		StructureClass::Tube, // SID_TUBE
+		StructureClass::Factory, // SID_UNDERGROUND_FACTORY
+		StructureClass::UndergroundPolice, // SID_UNDERGROUND_POLICE
+		StructureClass::University, // SID_UNIVERSITY
+		StructureClass::Warehouse, // SID_WAREHOUSE
+		StructureClass::Recycling, // SID_RECYCLING
+		StructureClass::Maintenance, // SID_MAINTENANCE_FACILITY
+	};
+
+
+	static_assert(structureIdToClassTable.size() == StructureID::SID_COUNT);
+}
+
+
+StructureClass structureIdToClass(StructureID id) {
+	const auto structureTypeIndex = static_cast<std::size_t>(id);
+	if (structureTypeIndex >= structureIdToClassTable.size())
+	{
+		throw std::runtime_error("Unknown StructureID type: " + std::to_string(structureTypeIndex));
+	}
+	return structureIdToClassTable.at(structureTypeIndex);
+}

--- a/appOPHD/MapObjects/StructureIdToClass.h
+++ b/appOPHD/MapObjects/StructureIdToClass.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <libOPHD/EnumStructureID.h>
+
+
+enum class StructureClass;
+
+
+StructureClass structureIdToClass(StructureID id);

--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -4,7 +4,7 @@
 
 
 Agridome::Agridome(Tile& tile) :
-	FoodProduction{StructureClass::FoodProduction, StructureID::SID_AGRIDOME, tile}
+	FoodProduction{StructureID::SID_AGRIDOME, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -6,7 +6,6 @@
 
 AirShaft::AirShaft(Tile& tile) :
 	Structure{
-		StructureClass::Tube,
 		StructureID::SID_AIR_SHAFT,
 		tile,
 		constants::StructureStateOperational,

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -5,7 +5,7 @@
 
 
 CargoLander::CargoLander(Tile& tile) :
-	Structure{StructureClass::Lander, StructureID::SID_CARGO_LANDER, tile}
+	Structure{StructureID::SID_CARGO_LANDER, tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -5,7 +5,7 @@
 
 
 ColonistLander::ColonistLander(Tile& tile) :
-	Structure{StructureClass::Lander, StructureID::SID_COLONIST_LANDER, tile}
+	Structure{StructureID::SID_COLONIST_LANDER, tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -6,7 +6,7 @@
 
 
 CommTower::CommTower(Tile& tile) :
-	Structure{StructureClass::Communication, StructureID::SID_COMM_TOWER, tile}
+	Structure{StructureID::SID_COMM_TOWER, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/CommandCenter.cpp
+++ b/appOPHD/MapObjects/Structures/CommandCenter.cpp
@@ -2,7 +2,7 @@
 
 
 CommandCenter::CommandCenter(Tile& tile) :
-	FoodProduction{StructureClass::Command, StructureID::SID_COMMAND_CENTER, tile}
+	FoodProduction{StructureID::SID_COMMAND_CENTER, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -60,7 +60,7 @@ const ProductionCost& productCost(ProductType productType)
 
 
 Factory::Factory(StructureID id, std::vector<ProductType> products, Tile& tile) :
-	Structure{StructureClass::Factory, id, tile},
+	Structure{id, tile},
 	mAvailableProducts{std::move(products)}
 {
 	assertNoDuplicates(mAvailableProducts);

--- a/appOPHD/MapObjects/Structures/FoodProduction.cpp
+++ b/appOPHD/MapObjects/Structures/FoodProduction.cpp
@@ -5,8 +5,8 @@
 #include <algorithm>
 
 
-FoodProduction::FoodProduction(StructureClass structureClass, StructureID id, Tile& tile) :
-	Structure{structureClass, id, tile}
+FoodProduction::FoodProduction(StructureID id, Tile& tile) :
+	Structure{id, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/FoodProduction.h
+++ b/appOPHD/MapObjects/Structures/FoodProduction.h
@@ -11,7 +11,7 @@
 class FoodProduction : public Structure
 {
 public:
-	FoodProduction(StructureClass structureClass, StructureID id, Tile& tile);
+	FoodProduction(StructureID id, Tile& tile);
 
 	StringTable createInspectorViewTable() const override;
 

--- a/appOPHD/MapObjects/Structures/FusionReactor.h
+++ b/appOPHD/MapObjects/Structures/FusionReactor.h
@@ -10,7 +10,7 @@ class FusionReactor : public PowerStructure
 {
 public:
 	FusionReactor(Tile& tile) :
-		PowerStructure{StructureClass::EnergyProduction, StructureID::SID_FUSION_REACTOR, tile}
+		PowerStructure{StructureID::SID_FUSION_REACTOR, tile}
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/HotLaboratory.h
+++ b/appOPHD/MapObjects/Structures/HotLaboratory.h
@@ -7,7 +7,7 @@ class HotLaboratory : public ResearchFacility
 {
 public:
 	HotLaboratory(Tile& tile) :
-		ResearchFacility{StructureClass::Laboratory, StructureID::SID_HOT_LABORATORY, tile}
+		ResearchFacility{StructureID::SID_HOT_LABORATORY, tile}
 	{
 		maxScientistsAllowed(3);
 		hotPointsPerScientist(1.0f);

--- a/appOPHD/MapObjects/Structures/Laboratory.h
+++ b/appOPHD/MapObjects/Structures/Laboratory.h
@@ -7,7 +7,7 @@ class Laboratory : public ResearchFacility
 {
 public:
 	Laboratory(Tile& tile) :
-		ResearchFacility{StructureClass::Laboratory, StructureID::SID_LABORATORY, tile}
+		ResearchFacility{StructureID::SID_LABORATORY, tile}
 	{
 		maxScientistsAllowed(3);
 		regularPointsPerScientist(1);

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -16,7 +16,7 @@ namespace
 
 
 MaintenanceFacility::MaintenanceFacility(Tile& tile) :
-	Structure{StructureClass::Maintenance, StructureID::SID_MAINTENANCE_FACILITY, tile},
+	Structure{StructureID::SID_MAINTENANCE_FACILITY, tile},
 	mMaterialsLevel{0},
 	mMaintenancePersonnel{MinimumPersonnel},
 	mAssignedPersonnel{0},

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -25,7 +25,7 @@ namespace
 
 
 MineFacility::MineFacility(Tile& tile) :
-	Structure{StructureClass::Mine, StructureID::SID_MINE_FACILITY, tile},
+	Structure{StructureID::SID_MINE_FACILITY, tile},
 	mOreDeposit{tile.oreDeposit()}
 {
 	if (mOreDeposit == nullptr)

--- a/appOPHD/MapObjects/Structures/MineShaft.h
+++ b/appOPHD/MapObjects/Structures/MineShaft.h
@@ -7,7 +7,7 @@ class MineShaft : public Structure
 {
 public:
 	MineShaft(Tile& tile) :
-		Structure{StructureClass::Undefined, StructureID::SID_MINE_SHAFT, tile}
+		Structure{StructureID::SID_MINE_SHAFT, tile}
 	{
 	}
 };

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -6,8 +6,8 @@
 #include "../../UI/StringTable.h"
 
 
-OreRefining::OreRefining(StructureClass structureClass, StructureID id, Tile& tile) :
-	Structure{structureClass, id, tile}
+OreRefining::OreRefining(StructureID id, Tile& tile) :
+	Structure{id, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/OreRefining.h
+++ b/appOPHD/MapObjects/Structures/OreRefining.h
@@ -13,7 +13,7 @@
 class OreRefining : public Structure
 {
 public:
-	OreRefining(StructureClass structureClass, StructureID id, Tile& tile);
+	OreRefining(StructureID id, Tile& tile);
 
 	StringTable createInspectorViewTable() const override;
 

--- a/appOPHD/MapObjects/Structures/PowerStructure.cpp
+++ b/appOPHD/MapObjects/Structures/PowerStructure.cpp
@@ -5,8 +5,8 @@
 #include "../../UI/StringTable.h"
 
 
-PowerStructure::PowerStructure(StructureClass structureClass, StructureID id, Tile& tile) :
-	Structure{structureClass, id, tile}
+PowerStructure::PowerStructure(StructureID id, Tile& tile) :
+	Structure{id, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/PowerStructure.h
+++ b/appOPHD/MapObjects/Structures/PowerStructure.h
@@ -11,7 +11,7 @@
 class PowerStructure : public Structure
 {
 public:
-	PowerStructure(StructureClass structureClass, StructureID id, Tile& tile);
+	PowerStructure(StructureID id, Tile& tile);
 
 	StringTable createInspectorViewTable() const override;
 

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -13,7 +13,7 @@ namespace
 
 
 Recycling::Recycling(Tile& tile) :
-	Structure{StructureClass::Recycling, StructureID::SID_RECYCLING, tile}
+	Structure{StructureID::SID_RECYCLING, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/ResearchFacility.cpp
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.cpp
@@ -6,8 +6,8 @@
 #include <cmath>
 
 
-ResearchFacility::ResearchFacility(StructureClass structureClass, StructureID id, Tile& tile) :
-	Structure{structureClass, id, tile}
+ResearchFacility::ResearchFacility(StructureID id, Tile& tile) :
+	Structure{id, tile}
 {}
 
 

--- a/appOPHD/MapObjects/Structures/ResearchFacility.h
+++ b/appOPHD/MapObjects/Structures/ResearchFacility.h
@@ -6,7 +6,7 @@
 class ResearchFacility : public Structure
 {
 public:
-	ResearchFacility(StructureClass structureClass, StructureID id, Tile& tile);
+	ResearchFacility(StructureID id, Tile& tile);
 
 	StringTable createInspectorViewTable() const override;
 

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -13,7 +13,7 @@ namespace
 
 
 Residence::Residence(Tile& tile) :
-	Structure{StructureClass::Residence, StructureID::SID_RESIDENCE, tile}
+	Structure{StructureID::SID_RESIDENCE, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Road.h
+++ b/appOPHD/MapObjects/Structures/Road.h
@@ -10,7 +10,7 @@ class Road : public Structure
 {
 public:
 	Road(Tile& tile) :
-		Structure{StructureClass::Road, StructureID::SID_ROAD, tile}
+		Structure{StructureID::SID_ROAD, tile}
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/SeedLander.cpp
+++ b/appOPHD/MapObjects/Structures/SeedLander.cpp
@@ -4,7 +4,7 @@
 
 
 SeedLander::SeedLander(Tile& tile) :
-	Structure{StructureClass::Lander, StructureID::SID_SEED_LANDER, tile}
+	Structure{StructureID::SID_SEED_LANDER, tile}
 {
 	enable();
 }

--- a/appOPHD/MapObjects/Structures/SeedPower.h
+++ b/appOPHD/MapObjects/Structures/SeedPower.h
@@ -9,7 +9,7 @@ class SeedPower : public PowerStructure
 {
 public:
 	SeedPower(Tile& tile) :
-		PowerStructure{StructureClass::EnergyProduction, StructureID::SID_SEED_POWER, tile}
+		PowerStructure{StructureID::SID_SEED_POWER, tile}
 	{
 	}
 

--- a/appOPHD/MapObjects/Structures/SolarPanelArray.cpp
+++ b/appOPHD/MapObjects/Structures/SolarPanelArray.cpp
@@ -10,7 +10,7 @@ namespace
 
 
 SolarPanelArray::SolarPanelArray(Tile& tile) :
-	PowerStructure{StructureClass::EnergyProduction, StructureID::SID_SOLAR_PANEL1, tile}
+	PowerStructure{StructureID::SID_SOLAR_PANEL1, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/SolarPlant.cpp
+++ b/appOPHD/MapObjects/Structures/SolarPlant.cpp
@@ -10,7 +10,7 @@ namespace
 
 
 SolarPlant::SolarPlant(Tile& tile) :
-	PowerStructure{StructureClass::EnergyProduction, StructureID::SID_SOLAR_PLANT, tile}
+	PowerStructure{StructureID::SID_SOLAR_PLANT, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -6,7 +6,7 @@
 
 
 StorageTanks::StorageTanks(Tile& tile) :
-	Structure{StructureClass::Storage, StructureID::SID_STORAGE_TANKS, tile}
+	Structure{StructureID::SID_STORAGE_TANKS, tile}
 {
 }
 

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -8,7 +8,6 @@
 
 Tube::Tube(Tile& tile, ConnectorDir dir) :
 	Structure{
-		StructureClass::Tube,
 		StructureID::SID_TUBE,
 		tile,
 		getAnimationName(dir, tile.depth() != 0),

--- a/appOPHD/MapObjects/Structures/Warehouse.h
+++ b/appOPHD/MapObjects/Structures/Warehouse.h
@@ -9,7 +9,7 @@ class Warehouse : public Structure
 {
 public:
 	Warehouse(Tile& tile) :
-		Structure{StructureClass::Warehouse, StructureID::SID_WAREHOUSE, tile}
+		Structure{StructureID::SID_WAREHOUSE, tile}
 	{
 	}
 

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -220,7 +220,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_CHAP:
-			structure = new Structure(StructureClass::LifeSupport, StructureID::SID_CHAP, tile);
+			structure = new Structure(StructureID::SID_CHAP, tile);
 			break;
 
 		case StructureID::SID_COLONIST_LANDER:
@@ -232,7 +232,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_COMMERCIAL:
-			structure = new Structure(StructureClass::Commercial, StructureID::SID_COMMERCIAL, tile);
+			structure = new Structure(StructureID::SID_COMMERCIAL, tile);
 			break;
 
 		case StructureID::SID_COMM_TOWER:
@@ -256,7 +256,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_MEDICAL_CENTER:
-			structure = new Structure(StructureClass::MedicalCenter, StructureID::SID_MEDICAL_CENTER, tile);
+			structure = new Structure(StructureID::SID_MEDICAL_CENTER, tile);
 			break;
 
 		case StructureID::SID_MINE_FACILITY:
@@ -268,11 +268,11 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_NURSERY:
-			structure = new Structure(StructureClass::Nursery, StructureID::SID_NURSERY, tile);
+			structure = new Structure(StructureID::SID_NURSERY, tile);
 			break;
 
 		case StructureID::SID_PARK:
-			structure = new Structure(StructureClass::Park, StructureID::SID_PARK, tile);
+			structure = new Structure(StructureID::SID_PARK, tile);
 			break;
 
 		case StructureID::SID_ROAD:
@@ -280,15 +280,15 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_SURFACE_POLICE:
-			structure = new Structure(StructureClass::SurfacePolice, StructureID::SID_SURFACE_POLICE, tile);
+			structure = new Structure(StructureID::SID_SURFACE_POLICE, tile);
 			break;
 
 		case StructureID::SID_UNDERGROUND_POLICE:
-			structure = new Structure(StructureClass::UndergroundPolice, StructureID::SID_UNDERGROUND_POLICE, tile);
+			structure = new Structure(StructureID::SID_UNDERGROUND_POLICE, tile);
 			break;
 
 		case StructureID::SID_RECREATION_CENTER:
-			structure = new Structure(StructureClass::RecreationCenter, StructureID::SID_RECREATION_CENTER, tile);
+			structure = new Structure(StructureID::SID_RECREATION_CENTER, tile);
 			break;
 
 		case StructureID::SID_RECYCLING:
@@ -296,7 +296,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_RED_LIGHT_DISTRICT:
-			structure = new Structure(StructureClass::Residence, StructureID::SID_RED_LIGHT_DISTRICT, tile);
+			structure = new Structure(StructureID::SID_RED_LIGHT_DISTRICT, tile);
 			break;
 
 		case StructureID::SID_RESIDENCE:
@@ -304,7 +304,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_ROBOT_COMMAND:
-			structure = new Structure(StructureClass::RobotCommand, StructureID::SID_ROBOT_COMMAND, tile);
+			structure = new Structure(StructureID::SID_ROBOT_COMMAND, tile);
 			break;
 
 		case StructureID::SID_SEED_FACTORY:
@@ -320,11 +320,11 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_SEED_SMELTER:
-			structure = new OreRefining(StructureClass::Smelter, StructureID::SID_SEED_SMELTER, tile);
+			structure = new OreRefining(StructureID::SID_SEED_SMELTER, tile);
 			break;
 
 		case StructureID::SID_SMELTER:
-			structure = new OreRefining(StructureClass::Smelter, StructureID::SID_SMELTER, tile);
+			structure = new OreRefining(StructureID::SID_SMELTER, tile);
 			break;
 
 		case StructureID::SID_SOLAR_PANEL1:
@@ -348,7 +348,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			break;
 
 		case StructureID::SID_UNIVERSITY:
-			structure = new Structure(StructureClass::University, StructureID::SID_UNIVERSITY, tile);
+			structure = new Structure(StructureID::SID_UNIVERSITY, tile);
 			break;
 
 		case StructureID::SID_WAREHOUSE:

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MapObjects/StructureClass.h"
 #include "MapObjects/StructureTypeToClass.h"
 
 #include <libOPHD/EnumStructureID.h>

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -196,6 +196,7 @@
     <ClCompile Include="MapObjects\Robots\Robodozer.cpp" />
     <ClCompile Include="MapObjects\Robots\Robominer.cpp" />
     <ClCompile Include="MapObjects\Structure.cpp" />
+    <ClCompile Include="MapObjects\StructureIdToClass.cpp" />
     <ClCompile Include="MapObjects\Structures\Agridome.cpp" />
     <ClCompile Include="MapObjects\Structures\AirShaft.cpp" />
     <ClCompile Include="MapObjects\Structures\CargoLander.cpp" />
@@ -309,6 +310,7 @@
     <ClInclude Include="MapObjects\RobotTypeIndex.h" />
     <ClInclude Include="MapObjects\Structure.h" />
     <ClInclude Include="MapObjects\StructureClass.h" />
+    <ClInclude Include="MapObjects\StructureIdToClass.h" />
     <ClInclude Include="MapObjects\Structures.h" />
     <ClInclude Include="MapObjects\StructureTypeToClass.h" />
     <ClInclude Include="MapObjects\Structures\Agridome.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="MapObjects\Structure.cpp">
       <Filter>Source Files\MapObjects</Filter>
     </ClCompile>
+    <ClCompile Include="MapObjects\StructureIdToClass.cpp">
+      <Filter>Source Files\MapObjects</Filter>
+    </ClCompile>
     <ClCompile Include="MapObjects\Structures\Agridome.cpp">
       <Filter>Source Files\MapObjects\Structures</Filter>
     </ClCompile>
@@ -444,6 +447,9 @@
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
     <ClInclude Include="MapObjects\StructureClass.h">
+      <Filter>Header Files\MapObjects</Filter>
+    </ClInclude>
+    <ClInclude Include="MapObjects\StructureIdToClass.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
     <ClInclude Include="MapObjects\Structures.h">


### PR DESCRIPTION
Add `structureIdToClass` function to convert `StructureID` values to `StructureClass` values.

Rather than define individual class types in the various `Structure` derived files, or spread through `StructureCatalog::create`, we define a central lookup table to convert from `StructureID` values to `StructureClass` values.

Potentially we could load the data table from an external file, though I suspect we'll eventually get rid of `StructureClass` and instead check for non-zero properties on an associated `StructureType`, rather than some predefined class. One of the limitations of a predefined class is it presupposes which combinations of attributes are allowed. Consider how both the `CommandCenter` and `Agridome` can store food, which makes it a bit difficult to define which `StructureClass` it should be assigned.

Related:
- Issue #1723
- Issue #1795
