### PR TITLE
Refactor `Structure` constructors and reduce enum includes

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -9,6 +9,8 @@
 
 #include "../UI/StringTable.h"
 
+#include <libOPHD/EnumDisabledReason.h>
+#include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/MapObjects/StructureType.h>
 #include <libOPHD/RandomNumberGenerator.h>
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -77,11 +77,7 @@ std::vector<StructureClass> allStructureClasses()
 
 
 Structure::Structure(StructureID id, Tile& tile) :
-	MapObject(StructureCatalog::getType(id).spritePath, constants::StructureStateConstruction),
-	mStructureType(StructureCatalog::getType(id)),
-	mStructureId(id),
-	mStructureClass(structureIdToClass(id)),
-	mTile{tile}
+	Structure{id, tile, constants::StructureStateConstruction}
 {
 }
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -83,10 +83,10 @@ Structure::Structure(StructureID id, Tile& tile) :
 
 
 Structure::Structure(StructureID id, Tile& tile, const std::string& initialAction) :
-	MapObject(StructureCatalog::getType(id).spritePath, initialAction),
-	mStructureType(StructureCatalog::getType(id)),
-	mStructureId(id),
-	mStructureClass(structureIdToClass(id)),
+	MapObject{StructureCatalog::getType(id).spritePath, initialAction},
+	mStructureType{StructureCatalog::getType(id)},
+	mStructureId{id},
+	mStructureClass{structureIdToClass(id)},
 	mTile{tile}
 {
 }

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -87,7 +87,11 @@ Structure::Structure(StructureID id, Tile& tile, const std::string& initialActio
 	mStructureType{StructureCatalog::getType(id)},
 	mStructureId{id},
 	mStructureClass{structureIdToClass(id)},
-	mTile{tile}
+	mTile{tile},
+	mStructureState{StructureState::UnderConstruction},
+	mConnectorDirection{ConnectorDir::CONNECTOR_INTERSECTION},
+	mDisabledReason{DisabledReason::None},
+	mIdleReason{IdleReason::None}
 {
 }
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <libOPHD/EnumConnectorDir.h>
-#include <libOPHD/EnumDisabledReason.h>
-#include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/MapObject.h>
@@ -15,6 +13,8 @@ namespace NAS2D
 }
 
 
+enum class DisabledReason;
+enum class IdleReason;
 enum class StructureClass;
 struct StructureType;
 struct MapCoordinate;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -177,7 +177,7 @@ private:
 
 protected:
 	const StructureType& mStructureType;
-	const StructureID mStructureId{StructureID::SID_NONE};
+	const StructureID mStructureId;
 	const StructureClass mStructureClass;
 	Tile& mTile;
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -185,16 +185,16 @@ protected:
 	int mCrimeRate{0};
 	int mIntegrity{100};
 
-	StructureState mStructureState{StructureState::UnderConstruction};
-	ConnectorDir mConnectorDirection{ConnectorDir::CONNECTOR_INTERSECTION};
+	StructureState mStructureState;
+	ConnectorDir mConnectorDirection;
 
 	PopulationRequirements mPopulationAvailable{}; /**< Determine how many of each type of population required was actually supplied to the structure. */
 
 	StorableResources mProductionPool; /**< Resource pool used for production. */
 	StorableResources mStoragePool; /**< Resource storage pool. */
 
-	DisabledReason mDisabledReason{DisabledReason::None};
-	IdleReason mIdleReason{IdleReason::None};
+	DisabledReason mDisabledReason;
+	IdleReason mIdleReason;
 
 	bool mConnected{false};
 	bool mForcedIdle{false}; /**< Indicates that the Structure was manually set to Idle by the user and should remain that way until the user says otherwise. */

--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -1,5 +1,7 @@
 #include "Agridome.h"
 
+#include <libOPHD/EnumIdleReason.h>
+
 #include <algorithm>
 
 

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -2,6 +2,7 @@
 
 #include "../../States/MapViewStateHelper.h" // yuck
 
+#include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/ProductionCost.h>
 
 #include <NAS2D/Dictionary.h>

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -2,6 +2,7 @@
 
 #include "../../States/MapViewStateHelper.h"
 
+#include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/StorableResources.h>
 
 #include <algorithm>

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -4,6 +4,7 @@
 #include "../../Constants/Strings.h"
 #include "../../Map/Tile.h"
 
+#include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -5,6 +5,8 @@
 
 #include "../../UI/StringTable.h"
 
+#include <libOPHD/EnumIdleReason.h>
+
 
 OreRefining::OreRefining(StructureID id, Tile& tile) :
 	Structure{id, tile}

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -20,6 +20,7 @@
 #include "../MapObjects/Structures/Warehouse.h"
 
 #include <libOPHD/DirectionOffset.h>
+#include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <NAS2D/Utility.h>

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -30,6 +30,7 @@
 
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumMoraleIndex.h>
+#include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/Population/MoraleChangeEntry.h>
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -18,6 +18,7 @@
 
 #include "States/MapViewStateHelper.h" // <-- For removeRefinedResources()
 
+#include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/Population/PopulationPool.h>
 
 #include <NAS2D/ParserHelper.h>

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -7,6 +7,9 @@
 #include "StringTable.h"
 #include "TextRender.h"
 
+#include <libOPHD/EnumDisabledReason.h>
+#include <libOPHD/EnumIdleReason.h>
+
 #include <NAS2D/Utility.h>
 
 #include <algorithm>


### PR DESCRIPTION
Noticed delegated constructors could reduce repetition in `Structure`, and using the constructor init-list for `enum` values meant forward declares could be used to reduce transitive includes.

Noticed this after recent work to add `MapCoordinate` to `Structure`, and use a more data focused approach to `StructureClass`.

Related:
- Issue #1573
- Issue #1795
- Issue #1723
