### PR TITLE
Add `Renderer&` parameter to sub-`draw` methods

### DIFF
--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -165,10 +165,8 @@ void DetailMap::draw(NAS2D::Renderer& renderer) const
 }
 
 
-void DetailMap::drawGrid() const
+void DetailMap::drawGrid(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	const auto viewSize = mMapView.viewSize();
 	const auto incrementY = NAS2D::Vector{-TileSize.x, TileSize.y};
 	const auto leftEdge = mOriginPixelPosition + incrementY * viewSize / 2;

--- a/appOPHD/UI/DetailMap.h
+++ b/appOPHD/UI/DetailMap.h
@@ -28,7 +28,7 @@ public:
 	void draw(NAS2D::Renderer& renderer) const override;
 
 protected:
-	void drawGrid() const;
+	void drawGrid(NAS2D::Renderer& renderer) const;
 
 private:
 	MapView& mMapView;

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -204,10 +204,10 @@ void FactoryProduction::factory(Factory* newFactory)
 }
 
 
-void FactoryProduction::drawClientArea() const
+void FactoryProduction::drawClientArea(NAS2D::Renderer& renderer) const
 {
 	auto stringTable = factoryProductionStringTable(mProductCost, mFactory->productionTurnsCompleted());
 	stringTable.position(mProductGrid.area().crossXPoint() + NAS2D::Vector{constants::Margin, 0});
 	stringTable.computeRelativeCellPositions();
-	stringTable.draw(Utility<Renderer>::get());
+	stringTable.draw(renderer);
 }

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -13,6 +13,7 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <algorithm>
+#include <stdexcept>
 
 
 using namespace NAS2D;

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -9,7 +9,6 @@
 
 #include <libOPHD/ProductCatalog.h>
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <algorithm>

--- a/appOPHD/UI/FactoryProduction.h
+++ b/appOPHD/UI/FactoryProduction.h
@@ -26,7 +26,7 @@ public:
 
 	void hide() override;
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 protected:
 	void onProductSelectionChange(const IconGridItem*);

--- a/appOPHD/UI/GameOverDialog.cpp
+++ b/appOPHD/UI/GameOverDialog.cpp
@@ -2,7 +2,6 @@
 
 #include "../Cache.h"
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 

--- a/appOPHD/UI/GameOverDialog.cpp
+++ b/appOPHD/UI/GameOverDialog.cpp
@@ -20,10 +20,8 @@ GameOverDialog::GameOverDialog(ClickDelegate clickHandler) :
 }
 
 
-void GameOverDialog::drawClientArea() const
+void GameOverDialog::drawClientArea(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	const auto& font = Control::getDefaultFont();

--- a/appOPHD/UI/GameOverDialog.h
+++ b/appOPHD/UI/GameOverDialog.h
@@ -14,7 +14,7 @@ public:
 public:
 	GameOverDialog(ClickDelegate clickHandler);
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 private:
 	const NAS2D::Image& mHeader;

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -6,7 +6,6 @@
 
 #include <libControls/WindowStack.h>
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -75,10 +75,8 @@ void MajorEventAnnouncement::onColonyShipCrash(WindowStack& windowStack, const C
 }
 
 
-void MajorEventAnnouncement::drawClientArea() const
+void MajorEventAnnouncement::drawClientArea(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	renderer.drawImage(mHeader, position() + NAS2D::Vector{5, 25});
 
 	const auto& font = Control::getDefaultFont();

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -24,7 +24,7 @@ public:
 
 	void onColonyShipCrash(WindowStack&, const ColonyShipLanders&);
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 private:
 	void onClose();

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -14,7 +14,6 @@
 
 #include <libControls/LoadRectangleSkin.h>
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -132,10 +132,8 @@ void MineOperationsWindow::updateTruckAvailability()
 }
 
 
-void MineOperationsWindow::drawClientArea() const
+void MineOperationsWindow::drawClientArea(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	const auto origin = mRect.position;
 	renderer.drawImage(mUiIcon, origin + NAS2D::Vector{10, 30});
 

--- a/appOPHD/UI/MineOperationsWindow.h
+++ b/appOPHD/UI/MineOperationsWindow.h
@@ -22,7 +22,7 @@ public:
 
 	void updateTruckAvailability();
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 	void hide() override;
 
 protected:

--- a/appOPHD/UI/NotificationArea.cpp
+++ b/appOPHD/UI/NotificationArea.cpp
@@ -38,9 +38,8 @@ namespace
 }
 
 
-void drawNotificationIcon(NAS2D::Point<int> position, NotificationArea::NotificationType type, const NAS2D::Image& icons)
+void drawNotificationIcon(NAS2D::Renderer& renderer, NAS2D::Point<int> position, NotificationArea::NotificationType type, const NAS2D::Image& icons)
 {
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	const auto& iconDrawParameters = NotificationIconDrawParameters.at(type);
 	renderer.drawSubImage(icons, position, {{160, 64}, {32, 32}}, iconDrawParameters.color);
 	renderer.drawSubImage(icons, position, iconDrawParameters.iconRect, NAS2D::Color::Normal);
@@ -137,7 +136,7 @@ void NotificationArea::draw(NAS2D::Renderer& renderer) const
 	for (auto& notification : mNotificationList)
 	{
 		const auto& rect = notificationRect(count);
-		drawNotificationIcon(rect.position, notification.type, mIcons);
+		drawNotificationIcon(renderer, rect.position, notification.type, mIcons);
 
 		if (mNotificationIndex == count)
 		{

--- a/appOPHD/UI/NotificationArea.h
+++ b/appOPHD/UI/NotificationArea.h
@@ -74,4 +74,4 @@ private:
 	NotificationClickedDelegate mNotificationClickedHandler;
 };
 
-void drawNotificationIcon(NAS2D::Point<int> position, NotificationArea::NotificationType type, const NAS2D::Image& icons);
+void drawNotificationIcon(NAS2D::Renderer& renderer, NAS2D::Point<int> position, NotificationArea::NotificationType type, const NAS2D::Image& icons);

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -51,8 +51,8 @@ void NotificationWindow::onTakeMeThereClicked()
 }
 
 
-void NotificationWindow::drawClientArea(NAS2D::Renderer& /*renderer*/) const
+void NotificationWindow::drawClientArea(NAS2D::Renderer& renderer) const
 {
 	const auto iconLocation = position() + NAS2D::Vector{10, 30};
-	drawNotificationIcon(iconLocation, mNotification.type, mIcons);
+	drawNotificationIcon(renderer, iconLocation, mNotification.type, mIcons);
 }

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -51,7 +51,7 @@ void NotificationWindow::onTakeMeThereClicked()
 }
 
 
-void NotificationWindow::drawClientArea() const
+void NotificationWindow::drawClientArea(NAS2D::Renderer& /*renderer*/) const
 {
 	const auto iconLocation = position() + NAS2D::Vector{10, 30};
 	drawNotificationIcon(iconLocation, mNotification.type, mIcons);

--- a/appOPHD/UI/NotificationWindow.h
+++ b/appOPHD/UI/NotificationWindow.h
@@ -22,7 +22,7 @@ public:
 
 	void notification(const NotificationArea::Notification&);
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 private:
 	void onVisibilityChange(bool isVisible) override;

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -327,22 +327,18 @@ void MineReport::onRemoveTruck()
 }
 
 
-void MineReport::drawMineFacilityPane(const NAS2D::Point<int>& origin) const
+void MineReport::drawMineFacilityPane(NAS2D::Renderer& renderer, const NAS2D::Point<int>& origin) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	renderer.drawImage(mineFacilityImage, origin);
 	const auto text = mSelectedFacility ? getStructureDescription(*mSelectedFacility) : "";
 	renderer.drawText(fontBigBold, text, origin + NAS2D::Vector{0, -33}, constants::PrimaryTextColor);
 
-	drawStatusPane(origin + NAS2D::Vector{138, 0});
+	drawStatusPane(renderer, origin + NAS2D::Vector{138, 0});
 }
 
 
-void MineReport::drawStatusPane(const NAS2D::Point<int>& origin) const
+void MineReport::drawStatusPane(NAS2D::Renderer& renderer, const NAS2D::Point<int>& origin) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	renderer.drawText(fontMediumBold, "Status", origin, constants::PrimaryTextColor);
 
 	const auto& mineFacility = *mSelectedFacility;
@@ -421,10 +417,8 @@ void MineReport::drawStatusPane(const NAS2D::Point<int>& origin) const
 }
 
 
-void MineReport::drawOreProductionPane(const NAS2D::Point<int>& origin) const
+void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::Point<int>& origin) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	renderer.drawText(fontMediumBold, "Ore Production", origin, constants::PrimaryTextColor);
 	const auto panelWidth = renderer.size().x - origin.x - 10;
 	drawLabelRightJustify(origin, panelWidth, fontMediumBold, "Haul Capacity", constants::PrimaryTextColor);
@@ -485,7 +479,7 @@ void MineReport::draw(NAS2D::Renderer& renderer) const
 
 	if (mSelectedFacility)
 	{
-		drawMineFacilityPane(startPoint + NAS2D::Vector{10, 30});
-		drawOreProductionPane(startPoint + NAS2D::Vector{10, 260});
+		drawMineFacilityPane(renderer, startPoint + NAS2D::Vector{10, 30});
+		drawOreProductionPane(renderer, startPoint + NAS2D::Vector{10, 260});
 	}
 }

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -56,9 +56,9 @@ protected:
 	void onAddTruck();
 	void onRemoveTruck();
 
-	void drawMineFacilityPane(const NAS2D::Point<int>& origin) const;
-	void drawStatusPane(const NAS2D::Point<int>& origin) const;
-	void drawOreProductionPane(const NAS2D::Point<int>& origin) const;
+	void drawMineFacilityPane(NAS2D::Renderer& renderer, const NAS2D::Point<int>& origin) const;
+	void drawStatusPane(NAS2D::Renderer& renderer, const NAS2D::Point<int>& origin) const;
+	void drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::Point<int>& origin) const;
 
 private:
 	TakeMeThereDelegate mTakeMeThereHandler;

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -60,11 +60,11 @@ namespace
 		return itemsToAdd;
 	}
 
-	void drawDetailsHeaderSeparator(const Rectangle<int>& area)
+	void drawDetailsHeaderSeparator(NAS2D::Renderer& renderer, const Rectangle<int>& area)
 	{
 		const Point<int> lineStartPoint{area.crossYPoint() + Vector<int>{0, SectionPadding.y}};
 		const Point<int> lineEndPoint{area.endPoint() + Vector<int>{0, SectionPadding.y}};
-		Utility<Renderer>::get().drawLine(lineStartPoint, lineEndPoint, constants::PrimaryTextColor);
+		renderer.drawLine(lineStartPoint, lineEndPoint, constants::PrimaryTextColor);
 	}
 
 	Rectangle<int> getCategorySlice(const int imageWidth, const int iconIndex)
@@ -430,7 +430,7 @@ void ResearchReport::drawTopicHeaderPanel(NAS2D::Renderer& renderer) const
 	renderer.drawText(fontBigBold, constants::ResearchReportTopicDetails, mTopicDetailsHeaderArea.startPoint(), constants::PrimaryTextColor);
 
 	drawTopicLabRequirements(renderer);
-	drawDetailsHeaderSeparator(mTopicDetailsHeaderArea);
+	drawDetailsHeaderSeparator(renderer, mTopicDetailsHeaderArea);
 }
 
 

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -378,10 +378,8 @@ void ResearchReport::handleTopicChanged()
 }
 
 
-void ResearchReport::drawCategories() const
+void ResearchReport::drawCategories(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	for (const auto& panel : mCategoryPanels)
 	{
 		const auto panelRect = Rectangle<int>::Create(
@@ -402,26 +400,22 @@ void ResearchReport::drawCategories() const
 }
 
 
-void ResearchReport::drawCategoryHeader() const
+void ResearchReport::drawCategoryHeader(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
 	renderer.drawText(fontBigBold, mSelectedCategory->name, mCategoryHeaderTextPosition, constants::PrimaryTextColor);
 }
 
 
-void ResearchReport::drawVerticalSectionSpacer(const int startX) const
+void ResearchReport::drawVerticalSectionSpacer(NAS2D::Renderer& renderer, const int startX) const
 {
-	auto& renderer = Utility<Renderer>::get();
-
 	const Point<int> start{startX, area().position.y + SectionPadding.y};
 	const Point<int> end{startX, area().position.y + area().size.y - SectionPadding.y};
 	renderer.drawLine(start, end, constants::PrimaryColor);
 }
 
 
-void ResearchReport::drawTopicLabRequirements() const
+void ResearchReport::drawTopicLabRequirements(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
 	renderer.drawSubImage(imageUiIcons, mStdLabIconPosition, StandardLabIconRect);
 	renderer.drawSubImage(imageUiIcons, mHotLabIconPosition, HotLabIconRect);
 	renderer.drawText(fontMedium, "0 of X", mStdLabTextPosition, constants::PrimaryTextColor);
@@ -429,33 +423,31 @@ void ResearchReport::drawTopicLabRequirements() const
 }
 
 
-void ResearchReport::drawTopicHeaderPanel() const
+void ResearchReport::drawTopicHeaderPanel(NAS2D::Renderer& renderer) const
 {
 	if (!lstResearchTopics.isItemSelected()) { return; }
 
-	auto& renderer = Utility<Renderer>::get();
 	renderer.drawText(fontBigBold, constants::ResearchReportTopicDetails, mTopicDetailsHeaderArea.startPoint(), constants::PrimaryTextColor);
 
-	drawTopicLabRequirements();
+	drawTopicLabRequirements(renderer);
 	drawDetailsHeaderSeparator(mTopicDetailsHeaderArea);
 }
 
 
-void ResearchReport::drawTopicDetailsPanel() const
+void ResearchReport::drawTopicDetailsPanel(NAS2D::Renderer& renderer) const
 {
 	if (!lstResearchTopics.isItemSelected()) { return; }
 
-	auto& renderer = Utility<Renderer>::get();
 	renderer.drawSubImage(imageTopicIcons, mTopicDetailsIconPosition, {mTopicDetailsIconUV, TopicIconSize});
 }
 
 
-void ResearchReport::draw(NAS2D::Renderer& /*renderer*/) const
+void ResearchReport::draw(NAS2D::Renderer& renderer) const
 {
-	drawCategories();
-	drawVerticalSectionSpacer(mCategoryPanels.front().rect.endPoint().x + SectionPadding.x);
-	drawCategoryHeader();
-	drawVerticalSectionSpacer((area().size.x / 3) * 2);
-	drawTopicHeaderPanel();
-	drawTopicDetailsPanel();
+	drawCategories(renderer);
+	drawVerticalSectionSpacer(renderer, mCategoryPanels.front().rect.endPoint().x + SectionPadding.x);
+	drawCategoryHeader(renderer);
+	drawVerticalSectionSpacer(renderer, (area().size.x / 3) * 2);
+	drawTopicHeaderPanel(renderer);
+	drawTopicDetailsPanel(renderer);
 }

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -62,12 +62,12 @@ private:
 	void resetResearchDetails();
 	void handleTopicChanged();
 
-	void drawCategories() const;
-	void drawCategoryHeader() const;
-	void drawVerticalSectionSpacer(const int column) const;
-	void drawTopicLabRequirements() const;
-	void drawTopicHeaderPanel() const;
-	void drawTopicDetailsPanel() const;
+	void drawCategories(NAS2D::Renderer& renderer) const;
+	void drawCategoryHeader(NAS2D::Renderer& renderer) const;
+	void drawVerticalSectionSpacer(NAS2D::Renderer& renderer, const int column) const;
+	void drawTopicLabRequirements(NAS2D::Renderer& renderer) const;
+	void drawTopicHeaderPanel(NAS2D::Renderer& renderer) const;
+	void drawTopicDetailsPanel(NAS2D::Renderer& renderer) const;
 	void draw(NAS2D::Renderer& renderer) const override;
 
 private:

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -7,7 +7,6 @@
 #include "../MapObjects/Robot.h"
 #include "../MapObjects/RobotType.h"
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 #include <array>

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <algorithm>
+#include <stdexcept>
 
 
 using namespace NAS2D;

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -100,9 +100,8 @@ void RobotInspector::onCancel()
 }
 
 
-void RobotInspector::drawClientArea() const
+void RobotInspector::drawClientArea(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = Utility<Renderer>::get();
 	renderer.drawImage(robotImage(mRobot->type()), position() + Vector{constants::Margin, constants::Margin + sWindowTitleBarHeight});
 
 	const auto labelPosition = area().position + Vector{mContentRect.position.x, mContentRect.position.y};

--- a/appOPHD/UI/RobotInspector.h
+++ b/appOPHD/UI/RobotInspector.h
@@ -15,7 +15,7 @@ public:
 	void focusOnRobot(Robot*);
 	const Robot* focusedRobot() const { return mRobot; }
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 private:
 	void onCancelOrders();

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -204,13 +204,12 @@ StringTable StructureInspector::buildSpecificStringTable(NAS2D::Point<int> posit
 }
 
 
-void StructureInspector::drawClientArea() const
+void StructureInspector::drawClientArea(NAS2D::Renderer& renderer) const
 {
 	const auto genericStructureAttributes = buildGenericStringTable();
 	const auto specificAttributeTablePosition = genericStructureAttributes.area().crossYPoint() + NAS2D::Vector{0, 20 + constants::Margin};
 	const auto specificStructureAttributes = buildSpecificStringTable(specificAttributeTablePosition);
 
-	auto& renderer = Utility<Renderer>::get();
 	genericStructureAttributes.draw(renderer);
 	specificStructureAttributes.draw(renderer);
 }

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -10,8 +10,6 @@
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/EnumIdleReason.h>
 
-#include <NAS2D/Utility.h>
-
 #include <algorithm>
 #include <stdexcept>
 

--- a/appOPHD/UI/StructureInspector.h
+++ b/appOPHD/UI/StructureInspector.h
@@ -19,7 +19,7 @@ public:
 	void showStructure(const Structure& structure);
 	void hideStructure(const Structure& structure);
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 protected:
 	void onVisibilityChange(bool visible) override;

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -44,7 +44,7 @@ TileInspector::TileInspector() :
 }
 
 
-void TileInspector::drawClientArea() const
+void TileInspector::drawClientArea(NAS2D::Renderer& /*renderer*/) const
 {
 	auto position = mRect.position + NAS2D::Vector{5, 25};
 	const auto tilePosition = mTile->xy();

--- a/appOPHD/UI/TileInspector.h
+++ b/appOPHD/UI/TileInspector.h
@@ -13,7 +13,7 @@ public:
 
 	void tile(Tile& tile) { mTile = &tile; }
 
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 protected:
 	void onVisibilityChange(bool visible) override;

--- a/appOPHD/UI/WarehouseInspector.cpp
+++ b/appOPHD/UI/WarehouseInspector.cpp
@@ -43,7 +43,7 @@ void WarehouseInspector::hide()
 }
 
 
-void WarehouseInspector::drawClientArea() const
+void WarehouseInspector::drawClientArea(NAS2D::Renderer& /*renderer*/) const
 {
 	const auto& pool = mWarehouse->products();
 

--- a/appOPHD/UI/WarehouseInspector.h
+++ b/appOPHD/UI/WarehouseInspector.h
@@ -18,7 +18,7 @@ public:
 	void warehouse(const Warehouse* w);
 
 	void hide() override;
-	void drawClientArea() const override;
+	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 private:
 	void onClose();

--- a/libControls/ComboBox.cpp
+++ b/libControls/ComboBox.cpp
@@ -1,7 +1,6 @@
 #include "ComboBox.h"
 
 #include <NAS2D/EnumMouseButton.h>
-#include <NAS2D/Utility.h>
 #include <NAS2D/StringUtils.h>
 
 #include <algorithm>

--- a/libControls/Image.cpp
+++ b/libControls/Image.cpp
@@ -1,6 +1,5 @@
 #include "Image.h"
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Image.h>
 

--- a/libControls/Label.cpp
+++ b/libControls/Label.cpp
@@ -3,8 +3,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
 
-#include <NAS2D/Utility.h>
-
 
 namespace
 {

--- a/libControls/ListBox.h
+++ b/libControls/ListBox.h
@@ -2,7 +2,6 @@
 
 #include "ListBoxBase.h"
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
 

--- a/libControls/ProgressBar.cpp
+++ b/libControls/ProgressBar.cpp
@@ -1,6 +1,5 @@
 #include "ProgressBar.h"
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Math/Rectangle.h>

--- a/libControls/Rectangle.cpp
+++ b/libControls/Rectangle.cpp
@@ -1,6 +1,5 @@
 #include "Rectangle.h"
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
 

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -1,7 +1,6 @@
 #include "TextArea.h"
 
 #include <NAS2D/StringUtils.h>
-#include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -173,7 +173,7 @@ void TextField::draw(NAS2D::Renderer& renderer) const
 
 	if (highlight()) { renderer.drawBox(mRect, NAS2D::Color::Yellow); }
 
-	drawCursor();
+	drawCursor(renderer);
 
 	const auto textDrawArea = mRect.inset(fieldPadding);
 	renderer.clipRect(textDrawArea);
@@ -182,13 +182,12 @@ void TextField::draw(NAS2D::Renderer& renderer) const
 }
 
 
-void TextField::drawCursor() const
+void TextField::drawCursor(NAS2D::Renderer& renderer) const
 {
 	if (hasFocus() && editable())
 	{
 		if (mShowCursor)
 		{
-			auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 			const auto startPosition = NAS2D::Point{mCursorPixelX, mRect.position.y + fieldPadding};
 			const auto endPosition = NAS2D::Point{mCursorPixelX, mRect.position.y + mRect.size.y - fieldPadding - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -72,7 +72,7 @@ protected:
 	void updateScrollPosition();
 
 	void draw(NAS2D::Renderer& renderer) const override;
-	void drawCursor() const;
+	void drawCursor(NAS2D::Renderer& renderer) const;
 
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -78,7 +78,7 @@ void Window::draw(NAS2D::Renderer& renderer) const
 	if (!visible()) { return; }
 
 	drawTitleBar(renderer);
-	drawClientArea();
+	drawClientArea(renderer);
 }
 
 
@@ -94,7 +94,7 @@ void Window::drawTitleBar(NAS2D::Renderer& renderer) const
 }
 
 
-void Window::drawClientArea() const
+void Window::drawClientArea(NAS2D::Renderer& /*renderer*/) const
 {
 }
 

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -94,6 +94,11 @@ void Window::drawTitleBar(NAS2D::Renderer& renderer) const
 }
 
 
+void Window::drawClientArea() const
+{
+}
+
+
 void Window::title(const std::string& title)
 {
 	mTitle = title;

--- a/libControls/Window.cpp
+++ b/libControls/Window.cpp
@@ -73,19 +73,17 @@ void Window::update()
 }
 
 
-void Window::draw(NAS2D::Renderer& /*renderer*/) const
+void Window::draw(NAS2D::Renderer& renderer) const
 {
 	if (!visible()) { return; }
 
-	drawTitleBar();
+	drawTitleBar(renderer);
 	drawClientArea();
 }
 
 
-void Window::drawTitleBar() const
+void Window::drawTitleBar(NAS2D::Renderer& renderer) const
 {
-	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
-
 	renderer.drawImage(mTitleBarLeft, mRect.position);
 	renderer.drawImageRepeated(mTitleBarCenter, NAS2D::Rectangle<int>{{mRect.position.x + 4, mRect.position.y}, {mRect.size.x - 8, sWindowTitleBarHeight}});
 	renderer.drawImage(mTitleBarRight, NAS2D::Point{mRect.position.x + mRect.size.x - 4, mRect.position.y});

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -32,7 +32,7 @@ public:
 protected:
 	void draw(NAS2D::Renderer& renderer) const override;
 	void drawTitleBar(NAS2D::Renderer& renderer) const;
-	virtual void drawClientArea() const;
+	virtual void drawClientArea(NAS2D::Renderer& renderer) const;
 
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 	void draw(NAS2D::Renderer& renderer) const override;
-	void drawTitleBar() const;
+	void drawTitleBar(NAS2D::Renderer& renderer) const;
 	virtual void drawClientArea() const {}
 
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;

--- a/libControls/Window.h
+++ b/libControls/Window.h
@@ -32,7 +32,7 @@ public:
 protected:
 	void draw(NAS2D::Renderer& renderer) const override;
 	void drawTitleBar(NAS2D::Renderer& renderer) const;
-	virtual void drawClientArea() const {}
+	virtual void drawClientArea() const;
 
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position) override;
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);


### PR DESCRIPTION
Add `Renderer&` parameters to methods called by `draw` methods.

This allows removing a lot of `Utility<Renderer>::get()` calls, and a number of includes for `Utility.h`.

Reduces impact of `Utility.h` from 43 files down to 37 files.

Related:
- Issue #1756
- Issue #1573
