### PR TITLE
Use `isRoad()` to reduce reliance on `StructureID` values

### DIFF
--- a/appOPHD/Map/Connections.cpp
+++ b/appOPHD/Map/Connections.cpp
@@ -50,7 +50,7 @@ namespace
 			const auto& tile = tileMap.getTile(surfacePosition);
 			if (!tile.hasStructure()) { continue; }
 
-			surroundingTiles[i] = tile.structure()->structureId() == StructureID::SID_ROAD;
+			surroundingTiles[i] = tile.structure()->isRoad();
 		}
 		return surroundingTiles;
 	}

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -175,7 +175,7 @@ void MaintenanceFacility::repairStructure(Structure* structure)
 		++mAssignedPersonnel;
 		structure->integrity(100);
 
-		if (structure->structureId() == StructureID::SID_ROAD)
+		if (structure->isRoad())
 		{
 			structure->rebuild();
 		}


### PR DESCRIPTION
Related:
- Issue #319
