### PR TITLE
Add `StructureCatalog` index overloads

### DIFF
--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -399,7 +399,7 @@ const StorableResources& StructureCatalog::costToBuild(StructureID id)
  */
 const StorableResources& StructureCatalog::recyclingValue(StructureID id)
 {
-	return recycleValueTable.at(id);
+	return recyclingValue(typeIndex(id));
 }
 
 

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -178,6 +178,12 @@ std::size_t StructureCatalog::count()
 }
 
 
+std::size_t StructureCatalog::typeIndex(StructureID id)
+{
+	return static_cast<std::size_t>(id);
+}
+
+
 const StructureType& StructureCatalog::getType(StructureID id)
 {
 	return getType(static_cast<std::size_t>(id));

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -423,3 +423,9 @@ bool StructureCatalog::canBuild(StructureID id, const StorableResources& source)
 {
 	return costToBuild(id) <= source;
 }
+
+
+bool StructureCatalog::canBuild(std::size_t structureTypeIndex, const StorableResources& source)
+{
+	return costToBuild(structureTypeIndex) <= source;
+}

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -403,6 +403,12 @@ const StorableResources& StructureCatalog::recyclingValue(StructureID id)
 }
 
 
+const StorableResources& StructureCatalog::recyclingValue(std::size_t structureTypeIndex)
+{
+	return recycleValueTable.at(structureTypeIndex);
+}
+
+
 /**
  * Indicates that the source ResourcePool has enough resources to accommodate
  * the resource requirements of the specified structure.

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -381,6 +381,12 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 }
 
 
+Structure* StructureCatalog::create(std::size_t structureTypeIndex, Tile& tile)
+{
+	return create(static_cast<StructureID>(structureTypeIndex), tile);
+}
+
+
 /**
  * Gets the cost in resources required to build a given Structure.
  *

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -392,6 +392,12 @@ const StorableResources& StructureCatalog::costToBuild(StructureID id)
 }
 
 
+const StorableResources& StructureCatalog::costToBuild(std::size_t structureTypeIndex)
+{
+	return getType(structureTypeIndex).buildCost;
+}
+
+
 /**
  * Gets the recycling value of a specified structure type.
  *

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -186,7 +186,7 @@ std::size_t StructureCatalog::typeIndex(StructureID id)
 
 const StructureType& StructureCatalog::getType(StructureID id)
 {
-	return getType(static_cast<std::size_t>(id));
+	return getType(typeIndex(id));
 }
 
 

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -190,9 +190,9 @@ const StructureType& StructureCatalog::getType(StructureID id)
 }
 
 
-const StructureType& StructureCatalog::getType(std::size_t index)
+const StructureType& StructureCatalog::getType(std::size_t structureTypeIndex)
 {
-	return structureTypes.at(index);
+	return structureTypes.at(structureTypeIndex);
 }
 
 

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -28,6 +28,7 @@ public:
 	static void init(const std::string& filename);
 
 	static std::size_t count();
+	static std::size_t typeIndex(StructureID id);
 
 	static const StructureType& getType(StructureID id);
 	static const StructureType& getType(std::size_t index);

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -36,6 +36,7 @@ public:
 	static Structure* create(StructureID id, Tile& tile);
 
 	static const StorableResources& costToBuild(StructureID id);
+	static const StorableResources& costToBuild(std::size_t structureTypeIndex);
 	static const StorableResources& recyclingValue(StructureID id);
 	static const StorableResources& recyclingValue(std::size_t structureTypeIndex);
 

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -37,6 +37,7 @@ public:
 
 	static const StorableResources& costToBuild(StructureID id);
 	static const StorableResources& recyclingValue(StructureID id);
+	static const StorableResources& recyclingValue(std::size_t structureTypeIndex);
 
 	static bool canBuild(StructureID id, const StorableResources& source);
 };

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -41,4 +41,5 @@ public:
 	static const StorableResources& recyclingValue(std::size_t structureTypeIndex);
 
 	static bool canBuild(StructureID id, const StorableResources& source);
+	static bool canBuild(std::size_t structureTypeIndex, const StorableResources& source);
 };

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -31,7 +31,7 @@ public:
 	static std::size_t typeIndex(StructureID id);
 
 	static const StructureType& getType(StructureID id);
-	static const StructureType& getType(std::size_t index);
+	static const StructureType& getType(std::size_t structureTypeIndex);
 
 	static Structure* create(StructureID id, Tile& tile);
 

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -34,6 +34,7 @@ public:
 	static const StructureType& getType(std::size_t structureTypeIndex);
 
 	static Structure* create(StructureID id, Tile& tile);
+	static Structure* create(std::size_t structureTypeIndex, Tile& tile);
 
 	static const StorableResources& costToBuild(StructureID id);
 	static const StorableResources& costToBuild(std::size_t structureTypeIndex);


### PR DESCRIPTION
Add overloads taking a `structureTypeIndex` rather than a `StructureID` to `StructureCatalog`.

Having these methods available makes it more convenient to use a `structureTypeIndex` rather than a `StructureID`. Potentially this will reduce uses of `StructureID`.

Related:
- Issue #1723
- Issue #319
- Issue #1804
