### PR TITLE
Use `static_cast` for enum class `StructureID`

### DIFF
--- a/appOPHD/MapObjects/StructureIdToClass.cpp
+++ b/appOPHD/MapObjects/StructureIdToClass.cpp
@@ -52,7 +52,7 @@ namespace
 	};
 
 
-	static_assert(structureIdToClassTable.size() == StructureID::SID_COUNT);
+	static_assert(structureIdToClassTable.size() == static_cast<std::size_t>(StructureID::SID_COUNT));
 }
 
 

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -62,6 +62,7 @@ namespace
 		constants::MaintenanceFacility
 	};
 
+	constexpr auto structureIdCount = static_cast<std::size_t>(StructureID::SID_COUNT);
 
 	/**	Currently set at 90% but this should probably be
 	 *	lowered for actual gameplay with modifiers to improve efficiency. */
@@ -143,9 +144,9 @@ namespace
 
 	void verifyStructureTypeOrder()
 	{
-		if (structureTypes.size() != StructureID::SID_COUNT)
+		if (structureTypes.size() != structureIdCount)
 		{
-			throw std::runtime_error("Unexpected number of StructureType entries: Read: " + std::to_string(structureTypes.size()) + " Expected: " + std::to_string(StructureID::SID_COUNT));
+			throw std::runtime_error("Unexpected number of StructureType entries: Read: " + std::to_string(structureTypes.size()) + " Expected: " + std::to_string(structureIdCount));
 		}
 
 		for (std::size_t i = 0; i < structureTypes.size(); ++i)

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -375,7 +375,7 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 
 	if (!structure)
 	{
-		throw std::runtime_error("StructureCatalog::create(): Unsupported structure type: " + std::to_string(id));
+		throw std::runtime_error("StructureCatalog::create(): Unsupported structure type: " + std::to_string(static_cast<std::size_t>(id)));
 	}
 
 	return structure;


### PR DESCRIPTION
Add explicit `static_cast` for `StructureID` values that would be needed when converting from `enum` to `enum class`.

A few easy changes that were noticed while doing work on `StructureCatalog`.

Related:
- Issue #319
- PR #1979
