### PR TITLE
Update `Structure` attributes relating to type

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -309,6 +309,7 @@ bool Structure::isOreStore() const { return mStructureType.oreStorageCapacity > 
 bool Structure::isComms() const { return mStructureType.commRange > 0; }
 bool Structure::isPolice() const { return mStructureType.policeRange > 0; }
 bool Structure::isLander() const { return mStructureClass == StructureClass::Lander; }
+bool Structure::isPark() const { return mStructureClass == StructureClass::Park; }
 bool Structure::isMaintenance() const { return mStructureClass == StructureClass::Maintenance; }
 bool Structure::isConnector() const { return mStructureClass == StructureClass::Tube; }
 bool Structure::isRoad() const { return mStructureClass == StructureClass::Road; }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -137,6 +137,7 @@ public:
 	bool isComms() const;
 	bool isPolice() const;
 	bool isLander() const;
+	bool isPark() const;
 	bool isMaintenance() const;
 	bool isConnector() const;
 	bool isRoad() const;


### PR DESCRIPTION
Use `StructureType` attributes to determine if a `Structure` has an attribute, whenever possible, rather than use the `StructureClass`, and expand the list of attributes that can be checked.

Related:
- Issue #319
- Issue #1723
- Issue #1804