### PR TITLE
Refactor `CrimeRateUpdate` to not use `overlay`

### DIFF
--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -24,7 +24,7 @@ namespace
 	};
 
 
-	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, Structure* structure)
+	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, const Structure* structure)
 	{
 		const auto& structureTile = structure->tile();
 

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -24,9 +24,9 @@ namespace
 	};
 
 
-	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, const Structure* structure)
+	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, const Structure& structure)
 	{
-		const auto& structureTile = structure->tile();
+		const auto& structureTile = structure.tile();
 
 		for (const auto& tile : policeOverlays[static_cast<std::size_t>(structureTile.depth())])
 		{
@@ -65,7 +65,7 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 
 	for (auto* structure : structuresWithCrime)
 	{
-		int crimeRateChange = isProtectedByPolice(policeOverlays, structure) ? -1 : 1;
+		int crimeRateChange = isProtectedByPolice(policeOverlays, *structure) ? -1 : 1;
 		structure->increaseCrimeRate(crimeRateChange);
 
 		// Crime Rate of 0% means no crime

--- a/appOPHD/States/CrimeRateUpdate.cpp
+++ b/appOPHD/States/CrimeRateUpdate.cpp
@@ -3,6 +3,7 @@
 #include "../Map/Tile.h"
 #include "../MapObjects/Structure.h"
 #include "../StructureManager.h"
+#include "../States/MapViewStateHelper.h"
 
 #include <libOPHD/EnumDifficulty.h>
 #include <libOPHD/RandomNumberGenerator.h>
@@ -24,18 +25,31 @@ namespace
 	};
 
 
-	bool isProtectedByPolice(const std::vector<std::vector<Tile*>>& policeOverlays, const Structure& structure)
+	std::vector<const Structure*> activePoliceStations()
 	{
-		const auto& structureTile = structure.tile();
-
-		for (const auto& tile : policeOverlays[static_cast<std::size_t>(structureTile.depth())])
+		std::vector<const Structure*> policeStations;
+		const auto& structureManager = NAS2D::Utility<StructureManager>::get();
+		for (const auto* structure : structureManager.allStructures())
 		{
-			if (tile->xy() == structureTile.xy())
+			if (structure->operational() && structure->isPolice())
+			{
+				policeStations.push_back(structure);
+			}
+		}
+		return policeStations;
+	}
+
+
+	bool isProtectedByPolice(const std::vector<const Structure*>& policeStations, const Structure& structure)
+	{
+		const auto& position = structure.xyz();
+		for (const auto* policeStation : policeStations)
+		{
+			if (isPointInRangeSameZ(position, policeStation->xyz(), policeStation->policeRange()))
 			{
 				return true;
 			}
 		}
-
 		return false;
 	}
 }
@@ -47,7 +61,7 @@ CrimeRateUpdate::CrimeRateUpdate(const Difficulty& difficulty) :
 }
 
 
-void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverlays)
+void CrimeRateUpdate::update()
 {
 	mMeanCrimeRate = 0;
 	mStructuresCommittingCrimes.clear();
@@ -63,9 +77,10 @@ void CrimeRateUpdate::update(const std::vector<std::vector<Tile*>>& policeOverla
 
 	double accumulatedCrime{0};
 
+	const auto& policeStations = activePoliceStations();
 	for (auto* structure : structuresWithCrime)
 	{
-		int crimeRateChange = isProtectedByPolice(policeOverlays, *structure) ? -1 : 1;
+		int crimeRateChange = isProtectedByPolice(policeStations, *structure) ? -1 : 1;
 		structure->increaseCrimeRate(crimeRateChange);
 
 		// Crime Rate of 0% means no crime

--- a/appOPHD/States/CrimeRateUpdate.h
+++ b/appOPHD/States/CrimeRateUpdate.h
@@ -6,7 +6,6 @@
 enum class Difficulty;
 struct MoraleChangeEntry;
 class Structure;
-class Tile;
 
 
 class CrimeRateUpdate
@@ -14,7 +13,7 @@ class CrimeRateUpdate
 public:
 	CrimeRateUpdate(const Difficulty& difficulty);
 
-	void update(const std::vector<std::vector<Tile*>>& policeOverlays);
+	void update();
 
 	int meanCrimeRate() const;
 	std::vector<MoraleChangeEntry> moraleChanges() const;

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -101,6 +101,12 @@ bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int dist
 }
 
 
+bool isPointInRangeSameZ(MapCoordinate point1, MapCoordinate point2, int distance)
+{
+	return (point1.z == point2.z) && isPointInRange(point1.xy, point2.xy, distance);
+}
+
+
 /**
  * Checks to see if a given tube connection is valid.
  */

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -31,6 +31,7 @@ bool isInCcRange(NAS2D::Point<int> position);
 
 bool isInCommRange(NAS2D::Point<int> position);
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);
+bool isPointInRangeSameZ(MapCoordinate point1, MapCoordinate point2, int distance);
 
 bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile& tile, Direction dir);

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -672,7 +672,7 @@ void MapViewState::nextTurn()
 
 	if (isMoraleEnabled)
 	{
-		mCrimeRateUpdate.update(mPoliceOverlays);
+		mCrimeRateUpdate.update();
 		auto structuresCommittingCrimes = mCrimeRateUpdate.structuresCommittingCrimes();
 		mCrimeExecution.executeCrimes(structuresCommittingCrimes);
 	}


### PR DESCRIPTION
Update `CrimeRateUpdate` so it directly uses a list of active police stations, rather than using an overlay tile list.

Rather than search an overlay list, search through a list of active police stations and range check against each. There will be a lot fewer entries in the active police stations collection than tiles in the overlay collection. It may actually be faster and take less memory to use the police station collection.

Additionally, the overlay list was more of a user interface object, which the core game engine shouldn't really know about. It's a bit odd to use it for both purposes.

Related:
- Issue #1815
- Issue #1814
- Issue #1422
- Issue #650
