### PR TITLE
Isolate access to `MapObject` picking fields

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -700,15 +700,15 @@ void MapViewState::onClickMap()
 	if (!mDetailMap->isMouseOverTile()) { return; }
 	Tile& tile = mDetailMap->mouseTile();
 
-	if (mInsertMode == InsertMode::Structure)
+	if (isInsertingStructure())
 	{
 		placeStructure(tile, mCurrentStructure);
 	}
-	else if (mInsertMode == InsertMode::Robot)
+	else if (isInsertingRobot())
 	{
 		placeRobot(tile, mCurrentRobot);
 	}
-	else if (mInsertMode == InsertMode::Tube)
+	else if (isInsertingTube())
 	{
 		/** FIXME: This is a kludge that only works because all of the tube structures are listed alphabetically.
 		* Should instead take advantage of the updated meta data in the IconGridItem.

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -702,11 +702,11 @@ void MapViewState::onClickMap()
 
 	if (isInsertingStructure())
 	{
-		placeStructure(tile, mCurrentStructure);
+		placeStructure(tile, selectedStructureId());
 	}
 	else if (isInsertingRobot())
 	{
-		placeRobot(tile, mCurrentRobot);
+		placeRobot(tile, selectedRobotIndex());
 	}
 	else if (isInsertingTube())
 	{

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -225,6 +225,7 @@ private:
 	bool isInsertingStructure() const;
 	bool isInsertingRobot() const;
 	bool isInsertingTube() const;
+	StructureID selectedStructureId() const;
 	void clearBuildMode();
 	void clearSelections();
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -222,6 +222,7 @@ private:
 
 	// UI MANAGEMENT FUNCTIONS
 	bool isInserting() const;
+	bool isInsertingStructure() const;
 	bool isInsertingRobot() const;
 	void clearBuildMode();
 	void clearSelections();

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -226,6 +226,7 @@ private:
 	bool isInsertingRobot() const;
 	bool isInsertingTube() const;
 	StructureID selectedStructureId() const;
+	RobotTypeIndex selectedRobotIndex() const;
 	void clearBuildMode();
 	void clearSelections();
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -224,6 +224,7 @@ private:
 	bool isInserting() const;
 	bool isInsertingStructure() const;
 	bool isInsertingRobot() const;
+	bool isInsertingTube() const;
 	void clearBuildMode();
 	void clearSelections();
 

--- a/appOPHD/States/MapViewStateMapObjectPicker.cpp
+++ b/appOPHD/States/MapViewStateMapObjectPicker.cpp
@@ -10,6 +10,12 @@ bool MapViewState::isInserting() const
 }
 
 
+bool MapViewState::isInsertingStructure() const
+{
+	return mInsertMode == InsertMode::Structure;
+}
+
+
 bool MapViewState::isInsertingRobot() const
 {
 	return mInsertMode == InsertMode::Robot;

--- a/appOPHD/States/MapViewStateMapObjectPicker.cpp
+++ b/appOPHD/States/MapViewStateMapObjectPicker.cpp
@@ -22,6 +22,12 @@ bool MapViewState::isInsertingRobot() const
 }
 
 
+bool MapViewState::isInsertingTube() const
+{
+	return mInsertMode == InsertMode::Tube;
+}
+
+
 void MapViewState::clearBuildMode()
 {
 	mInsertMode = InsertMode::None;

--- a/appOPHD/States/MapViewStateMapObjectPicker.cpp
+++ b/appOPHD/States/MapViewStateMapObjectPicker.cpp
@@ -34,6 +34,12 @@ StructureID MapViewState::selectedStructureId() const
 }
 
 
+RobotTypeIndex MapViewState::selectedRobotIndex() const
+{
+	return mCurrentRobot;
+}
+
+
 void MapViewState::clearBuildMode()
 {
 	mInsertMode = InsertMode::None;

--- a/appOPHD/States/MapViewStateMapObjectPicker.cpp
+++ b/appOPHD/States/MapViewStateMapObjectPicker.cpp
@@ -28,6 +28,12 @@ bool MapViewState::isInsertingTube() const
 }
 
 
+StructureID MapViewState::selectedStructureId() const
+{
+	return mCurrentStructure;
+}
+
+
 void MapViewState::clearBuildMode()
 {
 	mInsertMode = InsertMode::None;


### PR DESCRIPTION
Isolate access to `MapObject` picking fields so the map object picking code can be split from `MapViewState`.

These fields won't be accessible from outside of the split off object, other than through accessor methods. By switching to accessor methods now, we make it easier to split `MapViewState` later.

Related:
- Issue #650
