### PR TITLE
Add `structureIconTable` to simplify `MapObjectPicker` use

### DIFF
--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -45,10 +45,10 @@
 
 namespace
 {
-	const std::map<std::string, IconGridItem> StructureItemFromString =
+	const std::map<std::string, StructureID> StructureIdFromString =
 	{
-		{"SID_FUSION_REACTOR", {constants::FusionReactor, 21, StructureID::SID_FUSION_REACTOR}},
-		{"SID_SOLAR_PLANT", {constants::SolarPlant, 10, StructureID::SID_SOLAR_PLANT}}
+		{"SID_FUSION_REACTOR", StructureID::SID_FUSION_REACTOR},
+		{"SID_SOLAR_PLANT", StructureID::SID_SOLAR_PLANT}
 	};
 
 	// Length of "honeymoon period" of no crime/morale updates after landing, in turns
@@ -629,8 +629,8 @@ void MapViewState::updateResearch()
 	{
 		for (const auto& unlock : tech->unlocks)
 		{
-			const auto& structureItem = StructureItemFromString.at(unlock.value);
-			mStructureTracker.addUnlockedSurfaceStructure(structureItem);
+			const auto structureId = StructureIdFromString.at(unlock.value);
+			mStructureTracker.addUnlockedSurfaceStructure(structureId);
 		}
 	}
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -39,18 +39,6 @@
 extern NAS2D::Point<int> MOUSE_COORDS;
 
 
-namespace
-{
-	void fillList(IconGrid& grid, const std::vector<IconGridItem>& itemList)
-	{
-		for (const auto& item : itemList)
-		{
-			grid.addItem(item);
-		}
-	}
-}
-
-
 /**
  * Sets up the user interface elements
  *
@@ -290,7 +278,7 @@ void MapViewState::populateStructureMenu()
 	else if (mMapView->isSurface())
 	{
 		mMapObjectPicker.setStructureIds(mStructureTracker.availableSurfaceStructures());
-		fillList(mConnections, mStructureTracker.surfaceTubes());
+		mMapObjectPicker.setTubesAboveGround();
 
 		// Special case code, not thrilled with this
 		if (mColonyShip.colonistLanders() > 0) { mStructures.addItem({constants::ColonistLander, 2, StructureID::SID_COLONIST_LANDER}); }
@@ -299,7 +287,7 @@ void MapViewState::populateStructureMenu()
 	else
 	{
 		mMapObjectPicker.setStructureIds(mStructureTracker.availableUndergroundStructures());
-		fillList(mConnections, mStructureTracker.undergroundTubes());
+		mMapObjectPicker.setTubesUnderGround();
 	}
 
 	updateStructuresAvailability();

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -284,12 +284,12 @@ void MapViewState::populateStructureMenu()
 	{
 		if (mMapView->isSurface())
 		{
-			mStructures.addItem({constants::SeedLander, 0, StructureID::SID_SEED_LANDER});
+			mMapObjectPicker.setStructureIds({StructureID::SID_SEED_LANDER});
 		}
 	}
 	else if (mMapView->isSurface())
 	{
-		fillList(mStructures, mStructureTracker.availableSurfaceStructures());
+		mMapObjectPicker.setStructureIds(mStructureTracker.availableSurfaceStructures());
 		fillList(mConnections, mStructureTracker.surfaceTubes());
 
 		// Special case code, not thrilled with this
@@ -298,7 +298,7 @@ void MapViewState::populateStructureMenu()
 	}
 	else
 	{
-		fillList(mStructures, mStructureTracker.availableUndergroundStructures());
+		mMapObjectPicker.setStructureIds(mStructureTracker.availableUndergroundStructures());
 		fillList(mConnections, mStructureTracker.undergroundTubes());
 	}
 

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -1,10 +1,5 @@
 #include "StructureTracker.h"
 
-#include "../Constants/Strings.h"
-#include "../UI/IconGrid.h"
-
-#include <libOPHD/EnumConnectorDir.h>
-
 
 namespace
 {
@@ -39,18 +34,6 @@ namespace
 		StructureID::SID_UNIVERSITY,
 	};
 
-	const std::vector<IconGridItem> SurfaceTubes = {
-		{constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION},
-		{constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_EAST_WEST},
-		{constants::AgTubeLeft, 111, ConnectorDir::CONNECTOR_NORTH_SOUTH},
-	};
-
-	const std::vector<IconGridItem> UndergroundTubes = {
-		{constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION},
-		{constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_EAST_WEST},
-		{constants::UgTubelLeft, 114, ConnectorDir::CONNECTOR_NORTH_SOUTH},
-	};
-
 
 	void addItemToList(StructureID structureId, std::vector<StructureID>& list)
 	{
@@ -71,18 +54,6 @@ StructureTracker::StructureTracker() :
 	mAvailableSurfaceStructures{DefaultAvailableSurfaceStructures},
 	mAvailableUndergroundStructures{DefaultAvailableUndergroundStructures}
 {
-}
-
-
-const std::vector<IconGridItem>& StructureTracker::surfaceTubes() const
-{
-	return SurfaceTubes;
-}
-
-
-const std::vector<IconGridItem>& StructureTracker::undergroundTubes() const
-{
-	return UndergroundTubes;
 }
 
 

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -4,40 +4,39 @@
 #include "../UI/IconGrid.h"
 
 #include <libOPHD/EnumConnectorDir.h>
-#include <libOPHD/EnumStructureID.h>
 
 
 namespace
 {
-	const std::vector<IconGridItem> DefaultAvailableSurfaceStructures = {
-		{constants::Agridome, 5, StructureID::SID_AGRIDOME},
-		{constants::Chap, 3, StructureID::SID_CHAP},
-		{constants::CommTower, 22, StructureID::SID_COMM_TOWER},
-		{constants::HotLaboratory, 18, StructureID::SID_HOT_LABORATORY},
-		{constants::MaintenanceFacility, 54, StructureID::SID_MAINTENANCE_FACILITY},
-		{constants::Recycling, 16, StructureID::SID_RECYCLING},
-		{constants::Road, 24, StructureID::SID_ROAD},
-		{constants::RobotCommand, 14, StructureID::SID_ROBOT_COMMAND},
-		{constants::Smelter, 4, StructureID::SID_SMELTER},
-		{constants::SolarPanel1, 33, StructureID::SID_SOLAR_PANEL1},
-		{constants::StorageTanks, 8, StructureID::SID_STORAGE_TANKS},
-		{constants::SurfaceFactory, 11, StructureID::SID_SURFACE_FACTORY},
-		{constants::SurfacePolice, 23, StructureID::SID_SURFACE_POLICE},
-		{constants::Warehouse, 9, StructureID::SID_WAREHOUSE},
+	const std::vector<StructureID> DefaultAvailableSurfaceStructures = {
+		StructureID::SID_AGRIDOME,
+		StructureID::SID_CHAP,
+		StructureID::SID_COMM_TOWER,
+		StructureID::SID_HOT_LABORATORY,
+		StructureID::SID_MAINTENANCE_FACILITY,
+		StructureID::SID_RECYCLING,
+		StructureID::SID_ROAD,
+		StructureID::SID_ROBOT_COMMAND,
+		StructureID::SID_SMELTER,
+		StructureID::SID_SOLAR_PANEL1,
+		StructureID::SID_STORAGE_TANKS,
+		StructureID::SID_SURFACE_FACTORY,
+		StructureID::SID_SURFACE_POLICE,
+		StructureID::SID_WAREHOUSE,
 	};
 
-	const std::vector<IconGridItem> DefaultAvailableUndergroundStructures = {
-		{constants::Laboratory, 58, StructureID::SID_LABORATORY},
-		{constants::Park, 75, StructureID::SID_PARK},
-		{constants::UndergroundPolice, 61, StructureID::SID_UNDERGROUND_POLICE},
-		{constants::RecreationCenter, 73, StructureID::SID_RECREATION_CENTER},
-		{constants::Residence, 55, StructureID::SID_RESIDENCE},
-		{constants::UndergroundFactory, 69, StructureID::SID_UNDERGROUND_FACTORY},
-		{constants::MedicalCenter, 62, StructureID::SID_MEDICAL_CENTER},
-		{constants::Nursery, 77, StructureID::SID_NURSERY},
-		{constants::Commercial, 66, StructureID::SID_COMMERCIAL},
-		{constants::RedLightDistrict, 76, StructureID::SID_RED_LIGHT_DISTRICT},
-		{constants::University, 63, StructureID::SID_UNIVERSITY},
+	const std::vector<StructureID> DefaultAvailableUndergroundStructures = {
+		StructureID::SID_LABORATORY,
+		StructureID::SID_PARK,
+		StructureID::SID_UNDERGROUND_POLICE,
+		StructureID::SID_RECREATION_CENTER,
+		StructureID::SID_RESIDENCE,
+		StructureID::SID_UNDERGROUND_FACTORY,
+		StructureID::SID_MEDICAL_CENTER,
+		StructureID::SID_NURSERY,
+		StructureID::SID_COMMERCIAL,
+		StructureID::SID_RED_LIGHT_DISTRICT,
+		StructureID::SID_UNIVERSITY,
 	};
 
 	const std::vector<IconGridItem> SurfaceTubes = {
@@ -53,17 +52,17 @@ namespace
 	};
 
 
-	void addItemToList(const IconGridItem& structureItem, std::vector<IconGridItem>& list)
+	void addItemToList(StructureID structureId, std::vector<StructureID>& list)
 	{
 		for (const auto& item : list)
 		{
-			if (item.meta == structureItem.meta)
+			if (item == structureId)
 			{
 				return;
 			}
 		}
 
-		list.push_back(structureItem);
+		list.push_back(structureId);
 	}
 }
 
@@ -87,25 +86,25 @@ const std::vector<IconGridItem>& StructureTracker::undergroundTubes() const
 }
 
 
-const std::vector<IconGridItem>& StructureTracker::availableSurfaceStructures() const
+const std::vector<StructureID>& StructureTracker::availableSurfaceStructures() const
 {
 	return mAvailableSurfaceStructures;
 }
 
 
-const std::vector<IconGridItem>& StructureTracker::availableUndergroundStructures() const
+const std::vector<StructureID>& StructureTracker::availableUndergroundStructures() const
 {
 	return mAvailableUndergroundStructures;
 }
 
 
-void StructureTracker::addUnlockedSurfaceStructure(const IconGridItem& structureItem)
+void StructureTracker::addUnlockedSurfaceStructure(StructureID structureId)
 {
-	addItemToList(structureItem, mAvailableSurfaceStructures);
+	addItemToList(structureId, mAvailableSurfaceStructures);
 }
 
 
-void StructureTracker::addUnlockedUndergroundStructure(const IconGridItem& structureItem)
+void StructureTracker::addUnlockedUndergroundStructure(StructureID structureId)
 {
-	addItemToList(structureItem, mAvailableUndergroundStructures);
+	addItemToList(structureId, mAvailableUndergroundStructures);
 }

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -5,16 +5,10 @@
 #include <vector>
 
 
-struct IconGridItem;
-
-
 class StructureTracker
 {
 public:
 	StructureTracker();
-
-	const std::vector<IconGridItem>& surfaceTubes() const;
-	const std::vector<IconGridItem>& undergroundTubes() const;
 
 	const std::vector<StructureID>& availableSurfaceStructures() const;
 	const std::vector<StructureID>& availableUndergroundStructures() const;

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <libOPHD/EnumStructureID.h>
+
 #include <vector>
 
 
@@ -14,13 +16,13 @@ public:
 	const std::vector<IconGridItem>& surfaceTubes() const;
 	const std::vector<IconGridItem>& undergroundTubes() const;
 
-	const std::vector<IconGridItem>& availableSurfaceStructures() const;
-	const std::vector<IconGridItem>& availableUndergroundStructures() const;
+	const std::vector<StructureID>& availableSurfaceStructures() const;
+	const std::vector<StructureID>& availableUndergroundStructures() const;
 
-	void addUnlockedSurfaceStructure(const IconGridItem& structureItem);
-	void addUnlockedUndergroundStructure(const IconGridItem& structureItem);
+	void addUnlockedSurfaceStructure(StructureID structureId);
+	void addUnlockedUndergroundStructure(StructureID structureId);
 
 private:
-	std::vector<IconGridItem> mAvailableSurfaceStructures;
-	std::vector<IconGridItem> mAvailableUndergroundStructures;
+	std::vector<StructureID> mAvailableSurfaceStructures;
+	std::vector<StructureID> mAvailableUndergroundStructures;
 };

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -3,6 +3,9 @@
 #include "../States/MapViewStateHelper.h"
 #include "../Constants/UiConstants.h"
 #include "../MapObjects/RobotTypeIndex.h"
+#include "../StructureCatalog.h"
+
+#include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/Utility.h>
 #include <NAS2D/EventHandler.h>
@@ -58,6 +61,17 @@ namespace
 	};
 
 	static_assert(structureIconTable.size() == static_cast<std::size_t>(StructureID::SID_COUNT));
+
+
+	IconGridItem idToIconGridItem(StructureID structureId)
+	{
+		const auto index = StructureCatalog::typeIndex(structureId);
+		return {
+			StructureCatalog::getType(index).name,
+			structureIconTable.at(index),
+			static_cast<int>(index),
+		};
+	}
 }
 
 
@@ -90,6 +104,16 @@ MapObjectPicker::~MapObjectPicker()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseWheel().disconnect({this, &MapObjectPicker::onMouseWheel});
+}
+
+
+void MapObjectPicker::setStructureIds(const std::vector<StructureID>& structureIds)
+{
+	mStructures.clear();
+	for (const auto structureId : structureIds)
+	{
+		mStructures.addItem(idToIconGridItem(structureId));
+	}
 }
 
 

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -1,10 +1,12 @@
 #include "MapObjectPicker.h"
 
 #include "../States/MapViewStateHelper.h"
+#include "../Constants/Strings.h"
 #include "../Constants/UiConstants.h"
 #include "../MapObjects/RobotTypeIndex.h"
 #include "../StructureCatalog.h"
 
+#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/Utility.h>
@@ -72,6 +74,29 @@ namespace
 			static_cast<int>(index),
 		};
 	}
+
+
+	const std::vector<IconGridItem> SurfaceTubes = {
+		{constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION},
+		{constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_EAST_WEST},
+		{constants::AgTubeLeft, 111, ConnectorDir::CONNECTOR_NORTH_SOUTH},
+	};
+
+	const std::vector<IconGridItem> UndergroundTubes = {
+		{constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION},
+		{constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_EAST_WEST},
+		{constants::UgTubelLeft, 114, ConnectorDir::CONNECTOR_NORTH_SOUTH},
+	};
+
+
+	void setTubes(IconGrid& tubesGrid, const std::vector<IconGridItem>& items)
+	{
+		tubesGrid.clear();
+		for (const auto& item : items)
+		{
+			tubesGrid.addItem(item);
+		}
+	}
 }
 
 
@@ -114,6 +139,18 @@ void MapObjectPicker::setStructureIds(const std::vector<StructureID>& structureI
 	{
 		mStructures.addItem(idToIconGridItem(structureId));
 	}
+}
+
+
+void MapObjectPicker::setTubesAboveGround()
+{
+	setTubes(mConnections, SurfaceTubes);
+}
+
+
+void MapObjectPicker::setTubesUnderGround()
+{
+	setTubes(mConnections, UndergroundTubes);
 }
 
 

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -8,6 +8,59 @@
 #include <NAS2D/EventHandler.h>
 
 
+#include <array>
+
+
+namespace
+{
+	constexpr auto NotSet = int{54};
+
+	constexpr auto structureIconTable = std::array{
+		NotSet, // SID_NONE
+		5, // SID_AGRIDOME
+		NotSet, // SID_AIR_SHAFT
+		1, // SID_CARGO_LANDER
+		3, // SID_CHAP
+		2, // SID_COLONIST_LANDER
+		NotSet, // SID_COMMAND_CENTER
+		66, // SID_COMMERCIAL
+		22, // SID_COMM_TOWER
+		21, // SID_FUSION_REACTOR
+		18, // SID_HOT_LABORATORY
+		58, // SID_LABORATORY
+		62, // SID_MEDICAL_CENTER
+		NotSet, // SID_MINE_FACILITY
+		NotSet, // SID_MINE_SHAFT
+		77, // SID_NURSERY
+		75, // SID_PARK
+		73, // SID_RECREATION_CENTER
+		76, // SID_RED_LIGHT_DISTRICT
+		55, // SID_RESIDENCE
+		24, // SID_ROAD
+		14, // SID_ROBOT_COMMAND
+		98, // SID_SEED_FACTORY
+		0, // SID_SEED_LANDER
+		98, // SID_SEED_POWER
+		98, // SID_SEED_SMELTER
+		4, // SID_SMELTER
+		33, // SID_SOLAR_PANEL1
+		10, // SID_SOLAR_PLANT
+		8, // SID_STORAGE_TANKS
+		11, // SID_SURFACE_FACTORY
+		23, // SID_SURFACE_POLICE
+		110, // SID_TUBE
+		69, // SID_UNDERGROUND_FACTORY
+		61, // SID_UNDERGROUND_POLICE
+		63, // SID_UNIVERSITY
+		9, // SID_WAREHOUSE
+		16, // SID_RECYCLING
+		54, // SID_MAINTENANCE_FACILITY
+	};
+
+	static_assert(structureIconTable.size() == static_cast<std::size_t>(StructureID::SID_COUNT));
+}
+
+
 enum class InsertMode
 {
 	None,

--- a/appOPHD/UI/MapObjectPicker.h
+++ b/appOPHD/UI/MapObjectPicker.h
@@ -53,9 +53,9 @@ protected:
 public:
 	const SelectionChangedDelegate mSelectionChangedHandler;
 	const StorableResources& mResourcesCount;
-	InsertMode mInsertMode; /**< What's being inserted into the TileMap if anything. */
-	StructureID mCurrentStructure; /**< Structure being placed. */
-	RobotTypeIndex mCurrentRobot; /**< Robot being placed. */
+	InsertMode mInsertMode;
+	StructureID mCurrentStructure;
+	RobotTypeIndex mCurrentRobot;
 	IconGrid mStructures;
 	IconGrid mRobots;
 	IconGrid mConnections;

--- a/appOPHD/UI/MapObjectPicker.h
+++ b/appOPHD/UI/MapObjectPicker.h
@@ -29,6 +29,8 @@ public:
 	IconGrid& robots() { return mRobots; }
 
 	void setStructureIds(const std::vector<StructureID>& structureIds);
+	void setTubesAboveGround();
+	void setTubesUnderGround();
 
 	bool isInserting() const;
 	bool isInsertingStructure() const;

--- a/appOPHD/UI/MapObjectPicker.h
+++ b/appOPHD/UI/MapObjectPicker.h
@@ -8,6 +8,8 @@
 
 #include <NAS2D/Signal/Delegate.h>
 
+#include <vector>
+
 
 enum class RobotTypeIndex;
 enum class InsertMode;
@@ -25,6 +27,8 @@ public:
 	IconGrid& structures() { return mStructures; }
 	IconGrid& tubes() { return mConnections; }
 	IconGrid& robots() { return mRobots; }
+
+	void setStructureIds(const std::vector<StructureID>& structureIds);
 
 	bool isInserting() const;
 	bool isInsertingStructure() const;


### PR DESCRIPTION
Add a `structureIconTable` to allow `MapObjectPicker` to have items set using only a `StructureID` rather than a full `IconGridItem`.

This simplifies many of the uses of `StructureID`, so we have a `std::vector<StructureID>`, rather than implicit conversions of `StructureID` values to `int` when building a `std::vector<IconGridItem>`.

Related:
- Issue #319
- Issue #650
- Issue #1989