### PR TITLE
Convert `StructureID` to `enum class`

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -494,7 +494,7 @@ NAS2D::Dictionary Structure::getDataDict() const
 		{"forced_idle", mForcedIdle},
 		{"disabled_reason", static_cast<int>(mDisabledReason)},
 		{"idle_reason", static_cast<int>(mIdleReason)},
-		{"type", mStructureId},
+		{"type", static_cast<std::size_t>(mStructureId)},
 		{"direction", mConnectorDirection},
 		{"integrity", mIntegrity},
 		{"pop0", mPopulationAvailable.workers},

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -268,6 +268,9 @@ MapViewState::~MapViewState()
  */
 void MapViewState::initialize()
 {
+	StructureCatalog::init("StructureTypes.xml");
+	ProductCatalog::init("factory_products.xml");
+
 	// UI
 	initUi();
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
@@ -275,9 +278,6 @@ void MapViewState::initialize()
 	setCursor(PointerType::Normal);
 
 	mPopulationPool.population(&mPopulation);
-
-	StructureCatalog::init("StructureTypes.xml");
-	ProductCatalog::init("factory_products.xml");
 
 	if (mLoadingExisting)
 	{

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -119,7 +119,7 @@ void MapViewState::initUi()
 	mBtnTogglePoliceOverlay.type(Button::Type::Toggle);
 
 	// Initial Structures
-	mStructures.addItem({constants::SeedLander, 0, StructureID::SID_SEED_LANDER});
+	mMapObjectPicker.addStructure(StructureID::SID_SEED_LANDER);
 
 	// tooltip control sizes
 	constexpr auto hudHeight = constants::ResourceIconSize + constants::MarginTight * 2;
@@ -281,8 +281,8 @@ void MapViewState::populateStructureMenu()
 		mMapObjectPicker.setTubesAboveGround();
 
 		// Special case code, not thrilled with this
-		if (mColonyShip.colonistLanders() > 0) { mStructures.addItem({constants::ColonistLander, 2, StructureID::SID_COLONIST_LANDER}); }
-		if (mColonyShip.cargoLanders() > 0) { mStructures.addItem({constants::CargoLander, 1, StructureID::SID_CARGO_LANDER}); }
+		if (mColonyShip.colonistLanders() > 0) { mMapObjectPicker.addStructure(StructureID::SID_COLONIST_LANDER); }
+		if (mColonyShip.cargoLanders() > 0) { mMapObjectPicker.addStructure(StructureID::SID_CARGO_LANDER); }
 	}
 	else
 	{

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -72,6 +72,12 @@ namespace
 	std::vector<StorableResources> recycleValueTable;
 
 
+	std::size_t typeIndex(StructureID id)
+	{
+		return static_cast<std::size_t>(id);
+	}
+
+
 	/**
 	 * Fills out the recycle value for all structures.
 	 */
@@ -86,13 +92,13 @@ namespace
 
 		// Set recycling values for landers and automatically built structures.
 		// Resources: {Common Metals, Common Minerals, Rare Metals, Rare Minerals}
-		structureRecycleValueTable[StructureID::SID_MINE_FACILITY] = {15, 10, 5, 5};
-		structureRecycleValueTable[StructureID::SID_CARGO_LANDER] = {15, 10, 5, 5};
-		structureRecycleValueTable[StructureID::SID_COLONIST_LANDER] = {15, 10, 5, 5};
-		structureRecycleValueTable[StructureID::SID_SEED_LANDER] = {10, 5, 5, 5};
-		structureRecycleValueTable[StructureID::SID_SEED_FACTORY] = {15, 10, 5, 5};
-		structureRecycleValueTable[StructureID::SID_SEED_POWER] = {15, 10, 5, 5};
-		structureRecycleValueTable[StructureID::SID_SEED_SMELTER] = {15, 10, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_MINE_FACILITY)] = {15, 10, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_CARGO_LANDER)] = {15, 10, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_COLONIST_LANDER)] = {15, 10, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_SEED_LANDER)] = {10, 5, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_SEED_FACTORY)] = {15, 10, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_SEED_POWER)] = {15, 10, 5, 5};
+		structureRecycleValueTable[typeIndex(StructureID::SID_SEED_SMELTER)] = {15, 10, 5, 5};
 
 		return structureRecycleValueTable;
 	}

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -194,6 +194,10 @@ const StructureType& StructureCatalog::getType(StructureID id)
 
 const StructureType& StructureCatalog::getType(std::size_t structureTypeIndex)
 {
+	if (structureTypeIndex >= structureTypes.size())
+	{
+		throw std::runtime_error("StructureCatalog::getType called with invalid index: " + std::to_string(structureTypeIndex) + " of " + std::to_string(structureTypes.size()));
+	}
 	return structureTypes.at(structureTypeIndex);
 }
 

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -154,6 +154,12 @@ void MapObjectPicker::setTubesUnderGround()
 }
 
 
+void MapObjectPicker::addStructure(StructureID structureId)
+{
+	mStructures.addItem(idToIconGridItem(structureId));
+}
+
+
 bool MapObjectPicker::isInserting() const
 {
 	return mInsertMode != InsertMode::None;

--- a/appOPHD/UI/MapObjectPicker.h
+++ b/appOPHD/UI/MapObjectPicker.h
@@ -32,6 +32,8 @@ public:
 	void setTubesAboveGround();
 	void setTubesUnderGround();
 
+	void addStructure(StructureID structureId);
+
 	bool isInserting() const;
 	bool isInsertingStructure() const;
 	bool isInsertingRobot() const;

--- a/libOPHD/EnumStructureID.h
+++ b/libOPHD/EnumStructureID.h
@@ -8,7 +8,7 @@
  *			the structure Class code which is used to group like structures into
  *			lists for structure updates.
  */
-enum StructureID
+enum class StructureID
 {
 	SID_NONE,
 


### PR DESCRIPTION
Convert `StructureID` to `enum class`.

Improve bounds check exception message in `StructureCatalog::getType`. Move `StructureCatalog::init` call earlier, so we can do lookup earlier without triggers a bounds check exception. Allow single `StructureID` values to be added to the `MapObjectPicker`, which can be used for the Lander special cases. Add `static_cast` to the few remaining places where implicit `StructureID` to `int` conversions were being done. Mark `StructureID` as `enum class`.

Related:
- Issue #319
