### PR TITLE
Forward declare `StructureID`

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <libOPHD/EnumConnectorDir.h>
-#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/MapObject.h>
 #include <libOPHD/Population/PopulationRequirements.h>
@@ -13,6 +12,7 @@ namespace NAS2D
 }
 
 
+enum class StructureID;
 enum class DisabledReason;
 enum class IdleReason;
 enum class StructureClass;

--- a/appOPHD/MapObjects/StructureIdToClass.cpp
+++ b/appOPHD/MapObjects/StructureIdToClass.cpp
@@ -2,6 +2,8 @@
 
 #include "StructureClass.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 #include <array>
 #include <string>
 #include <stdexcept>

--- a/appOPHD/MapObjects/StructureIdToClass.h
+++ b/appOPHD/MapObjects/StructureIdToClass.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <libOPHD/EnumStructureID.h>
 
-
+enum class StructureID;
 enum class StructureClass;
 
 

--- a/appOPHD/MapObjects/Structures/Agridome.cpp
+++ b/appOPHD/MapObjects/Structures/Agridome.cpp
@@ -1,5 +1,6 @@
 #include "Agridome.h"
 
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumIdleReason.h>
 
 #include <algorithm>

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -3,6 +3,8 @@
 #include "../../Constants/Strings.h"
 #include "../../Map/Tile.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 AirShaft::AirShaft(Tile& tile) :
 	Structure{

--- a/appOPHD/MapObjects/Structures/CargoLander.cpp
+++ b/appOPHD/MapObjects/Structures/CargoLander.cpp
@@ -1,7 +1,8 @@
 #include "CargoLander.h"
 
-
 #include "../../Map/Tile.h"
+
+#include <libOPHD/EnumStructureID.h>
 
 
 CargoLander::CargoLander(Tile& tile) :

--- a/appOPHD/MapObjects/Structures/ColonistLander.cpp
+++ b/appOPHD/MapObjects/Structures/ColonistLander.cpp
@@ -1,7 +1,8 @@
 #include "ColonistLander.h"
 
-
 #include "../../Map/Tile.h"
+
+#include <libOPHD/EnumStructureID.h>
 
 
 ColonistLander::ColonistLander(Tile& tile) :

--- a/appOPHD/MapObjects/Structures/CommTower.cpp
+++ b/appOPHD/MapObjects/Structures/CommTower.cpp
@@ -4,6 +4,8 @@
 
 #include "../../UI/StringTable.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 CommTower::CommTower(Tile& tile) :
 	Structure{StructureID::SID_COMM_TOWER, tile}

--- a/appOPHD/MapObjects/Structures/CommandCenter.cpp
+++ b/appOPHD/MapObjects/Structures/CommandCenter.cpp
@@ -1,5 +1,7 @@
 #include "CommandCenter.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 CommandCenter::CommandCenter(Tile& tile) :
 	FoodProduction{StructureID::SID_COMMAND_CENTER, tile}

--- a/appOPHD/MapObjects/Structures/HotLaboratory.h
+++ b/appOPHD/MapObjects/Structures/HotLaboratory.h
@@ -2,6 +2,8 @@
 
 #include "ResearchFacility.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class HotLaboratory : public ResearchFacility
 {

--- a/appOPHD/MapObjects/Structures/Laboratory.h
+++ b/appOPHD/MapObjects/Structures/Laboratory.h
@@ -2,6 +2,8 @@
 
 #include "ResearchFacility.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class Laboratory : public ResearchFacility
 {

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -2,6 +2,7 @@
 
 #include "../../States/MapViewStateHelper.h"
 
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/StorableResources.h>
 

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -4,6 +4,7 @@
 #include "../../Constants/Strings.h"
 #include "../../Map/Tile.h"
 
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/OreDeposit.h>

--- a/appOPHD/MapObjects/Structures/MineShaft.h
+++ b/appOPHD/MapObjects/Structures/MineShaft.h
@@ -2,6 +2,8 @@
 
 #include "../Structure.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class MineShaft : public Structure
 {

--- a/appOPHD/MapObjects/Structures/Recycling.cpp
+++ b/appOPHD/MapObjects/Structures/Recycling.cpp
@@ -4,6 +4,8 @@
 
 #include "../../UI/StringTable.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 namespace
 {

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -2,6 +2,8 @@
 
 #include "../../UI/StringTable.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 #include <algorithm>
 
 

--- a/appOPHD/MapObjects/Structures/Road.h
+++ b/appOPHD/MapObjects/Structures/Road.h
@@ -2,6 +2,8 @@
 
 #include "../Structure.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class TileMap;
 

--- a/appOPHD/MapObjects/Structures/SeedFactory.h
+++ b/appOPHD/MapObjects/Structures/SeedFactory.h
@@ -2,6 +2,8 @@
 
 #include "Factory.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class SeedFactory : public Factory
 {

--- a/appOPHD/MapObjects/Structures/SeedLander.cpp
+++ b/appOPHD/MapObjects/Structures/SeedLander.cpp
@@ -2,6 +2,8 @@
 
 #include "../../Map/Tile.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 SeedLander::SeedLander(Tile& tile) :
 	Structure{StructureID::SID_SEED_LANDER, tile}

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -4,6 +4,8 @@
 
 #include "../../UI/StringTable.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 StorageTanks::StorageTanks(Tile& tile) :
 	Structure{StructureID::SID_STORAGE_TANKS, tile}

--- a/appOPHD/MapObjects/Structures/SurfaceFactory.h
+++ b/appOPHD/MapObjects/Structures/SurfaceFactory.h
@@ -2,6 +2,8 @@
 
 #include "Factory.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class SurfaceFactory : public Factory
 {

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -3,6 +3,8 @@
 #include "../../Map/Tile.h"
 #include "../../Constants/Strings.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 #include <stdexcept>
 
 

--- a/appOPHD/MapObjects/Structures/UndergroundFactory.h
+++ b/appOPHD/MapObjects/Structures/UndergroundFactory.h
@@ -2,6 +2,8 @@
 
 #include "Factory.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class UndergroundFactory : public Factory
 {

--- a/appOPHD/MapObjects/Structures/Warehouse.h
+++ b/appOPHD/MapObjects/Structures/Warehouse.h
@@ -4,6 +4,8 @@
 
 #include "../../ProductPool.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 class Warehouse : public Structure
 {

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -28,7 +28,6 @@
 #include "../UI/CheatMenu.h"
 
 #include <libOPHD/EnumConnectorDir.h>
-#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/PlanetAttributes.h>
 #include <libOPHD/StorableResources.h>
 
@@ -66,6 +65,7 @@ namespace NAS2D
 
 enum class Difficulty;
 enum class Direction;
+enum class StructureID;
 enum class RobotTypeIndex;
 
 class Structure;

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -24,6 +24,7 @@
 
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumDirection.h>
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/Utility.h>

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -11,7 +11,6 @@
 
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumProductType.h>
-#include <libOPHD/EnumStructureID.h>
 
 #include <libOPHD/Map/MapCoordinate.h>
 
@@ -23,6 +22,7 @@ class TileMap;
 class CommandCenter;
 class Warehouse;
 struct StorableResources;
+enum class StructureID;
 enum class Direction;
 
 CommandCenter& firstCc();

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -28,6 +28,7 @@
 
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumDirection.h>
+#include <libOPHD/EnumStructureID.h>
 
 #include <libOPHD/Map/MapCoordinate.h>
 #include <libOPHD/MapObjects/StructureType.h>

--- a/appOPHD/States/StructureTracker.cpp
+++ b/appOPHD/States/StructureTracker.cpp
@@ -1,5 +1,7 @@
 #include "StructureTracker.h"
 
+#include <libOPHD/EnumStructureID.h>
+
 
 namespace
 {

--- a/appOPHD/States/StructureTracker.h
+++ b/appOPHD/States/StructureTracker.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <libOPHD/EnumStructureID.h>
-
 #include <vector>
+
+
+enum class StructureID;
 
 
 class StructureTracker

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -4,6 +4,7 @@
 #include "IOHelper.h"
 #include "Constants/Strings.h"
 
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/MapObjects/StructureType.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/XmlSerializer.h>

--- a/appOPHD/StructureCatalog.h
+++ b/appOPHD/StructureCatalog.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <libOPHD/EnumStructureID.h>
-
 #include <string>
 
 
+enum class StructureID;
 class Structure;
 class Tile;
 struct StructureType;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -3,8 +3,6 @@
 #include "MapObjects/StructureClass.h"
 #include "MapObjects/StructureTypeToClass.h"
 
-#include <libOPHD/EnumStructureID.h>
-
 #include <map>
 #include <vector>
 
@@ -17,6 +15,7 @@ namespace NAS2D
 	}
 }
 
+enum class StructureID;
 enum class StructureState;
 class Tile;
 class TileMap;

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -6,6 +6,7 @@
 #include "../MapObjects/RobotTypeIndex.h"
 #include "../StructureCatalog.h"
 
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/MapObjects/StructureType.h>
 

--- a/appOPHD/UI/MapObjectPicker.h
+++ b/appOPHD/UI/MapObjectPicker.h
@@ -2,8 +2,6 @@
 
 #include "IconGrid.h"
 
-#include <libOPHD/EnumStructureID.h>
-
 #include <libControls/ControlContainer.h>
 
 #include <NAS2D/Signal/Delegate.h>
@@ -11,6 +9,7 @@
 #include <vector>
 
 
+enum class StructureID;
 enum class RobotTypeIndex;
 enum class InsertMode;
 struct StorableResources;


### PR DESCRIPTION
Use forward declares for `StructureID` to reduce transitive includes of `EnumStructureID.h`.

This reduces the impact of `EnumStructureID.h` from 95 files down to 41 files.

Related:
- PR #1991
- Issue #319
- Issue #1573
