### PR TITLE
Convert `ConnectorDir` to `enum class`

### DIFF
--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -4,8 +4,8 @@
 #include "Map/TileMap.h"
 #include "MapObjects/Structure.h"
 
-#include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumDirection.h>
+#include <libOPHD/DirectionOffset.h>
 
 #include <libOPHD/Map/MapCoordinate.h>
 

--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -4,6 +4,7 @@
 #include "Map/TileMap.h"
 #include "MapObjects/Structure.h"
 
+#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumDirection.h>
 #include <libOPHD/DirectionOffset.h>
 

--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -21,18 +21,18 @@ using namespace NAS2D;
  */
 static bool checkSourceTubeAlignment(Structure* src, Direction direction)
 {
-	if (src->connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION || src->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL)
+	if (src->connectorDirection() == ConnectorDir::Intersection || src->connectorDirection() == ConnectorDir::Vertical)
 	{
 		return true;
 	}
 	else if (direction == Direction::East || direction == Direction::West)
 	{
-		if (src->connectorDirection() == ConnectorDir::CONNECTOR_EAST_WEST)
+		if (src->connectorDirection() == ConnectorDir::EastWest)
 			return true;
 	}
 	else if (direction == Direction::North || direction == Direction::South)
 	{
-		if (src->connectorDirection() == ConnectorDir::CONNECTOR_NORTH_SOUTH)
+		if (src->connectorDirection() == ConnectorDir::NorthSouth)
 			return true;
 	}
 
@@ -51,21 +51,21 @@ static bool validConnection(Structure* src, Structure* dst, Direction direction)
 	}
 	if (direction == Direction::Up || direction == Direction::Down)
 	{
-		return src->isConnector() && src->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL;
+		return src->isConnector() && src->connectorDirection() == ConnectorDir::Vertical;
 	}
 	else if (dst->isConnector())
 	{
-		if (dst->connectorDirection() == ConnectorDir::CONNECTOR_INTERSECTION || dst->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL)
+		if (dst->connectorDirection() == ConnectorDir::Intersection || dst->connectorDirection() == ConnectorDir::Vertical)
 		{
 			return !src->isConnector() || checkSourceTubeAlignment(src, direction);
 		}
 		else if (direction == Direction::East || direction == Direction::West)
 		{
-			return dst->connectorDirection() == ConnectorDir::CONNECTOR_EAST_WEST;
+			return dst->connectorDirection() == ConnectorDir::EastWest;
 		}
 		else if (direction == Direction::North || direction == Direction::South)
 		{
-			return dst->connectorDirection() == ConnectorDir::CONNECTOR_NORTH_SOUTH;
+			return dst->connectorDirection() == ConnectorDir::NorthSouth;
 		}
 	}
 	else

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -495,7 +495,7 @@ NAS2D::Dictionary Structure::getDataDict() const
 		{"disabled_reason", static_cast<int>(mDisabledReason)},
 		{"idle_reason", static_cast<int>(mIdleReason)},
 		{"type", static_cast<std::size_t>(mStructureId)},
-		{"direction", mConnectorDirection},
+		{"direction", static_cast<int>(mConnectorDirection)},
 		{"integrity", mIntegrity},
 		{"pop0", mPopulationAvailable.workers},
 		{"pop1", mPopulationAvailable.scientists},

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -10,6 +10,7 @@
 
 #include "../UI/StringTable.h"
 
+#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/MapObjects/StructureType.h>

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -93,7 +93,7 @@ Structure::Structure(StructureID id, Tile& tile, const std::string& initialActio
 	mStructureClass{structureIdToClass(id)},
 	mTile{tile},
 	mStructureState{StructureState::UnderConstruction},
-	mConnectorDirection{ConnectorDir::CONNECTOR_INTERSECTION},
+	mConnectorDirection{ConnectorDir::Intersection},
 	mDisabledReason{DisabledReason::None},
 	mIdleReason{IdleReason::None}
 {

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/MapObject.h>
 #include <libOPHD/Population/PopulationRequirements.h>
@@ -13,6 +12,7 @@ namespace NAS2D
 
 
 enum class StructureID;
+enum class ConnectorDir;
 enum class DisabledReason;
 enum class IdleReason;
 enum class StructureClass;

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -13,7 +13,7 @@ AirShaft::AirShaft(Tile& tile) :
 		(tile.depth() == 0) ? constants::StructureStateOperational : constants::StructureStateOperationalUg,
 	}
 {
-	connectorDirection(ConnectorDir::CONNECTOR_VERTICAL);
+	connectorDirection(ConnectorDir::Vertical);
 
 	state(StructureState::Operational);
 }

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -4,6 +4,7 @@
 #include "../../Map/Tile.h"
 
 #include <libOPHD/EnumStructureID.h>
+#include <libOPHD/EnumConnectorDir.h>
 
 
 AirShaft::AirShaft(Tile& tile) :

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -23,11 +23,11 @@ Tube::Tube(Tile& tile, ConnectorDir dir) :
 const std::string& Tube::getAnimationName(ConnectorDir dir, bool underground)
 {
 	return *(
-		(dir == ConnectorDir::CONNECTOR_INTERSECTION) ?
+		(dir == ConnectorDir::Intersection) ?
 			(underground ? &constants::UgTubeIntersection : &constants::AgTubeIntersection) :
-		(dir == ConnectorDir::CONNECTOR_EAST_WEST) ?
+		(dir == ConnectorDir::EastWest) ?
 			(underground ? &constants::UgTubeRight : &constants::AgTubeRight) :
-		(dir == ConnectorDir::CONNECTOR_NORTH_SOUTH) ?
+		(dir == ConnectorDir::NorthSouth) ?
 			(underground ? &constants::UgTubelLeft : &constants::AgTubeLeft) :
 		throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter."));
 }

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -4,6 +4,7 @@
 #include "../../Constants/Strings.h"
 
 #include <libOPHD/EnumStructureID.h>
+#include <libOPHD/EnumConnectorDir.h>
 
 #include <stdexcept>
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -762,7 +762,7 @@ void MapViewState::changeViewDepth(int depth)
 
 void MapViewState::insertTube(Tile& tile, ConnectorDir dir)
 {
-	if (dir == ConnectorDir::CONNECTOR_VERTICAL)
+	if (dir == ConnectorDir::Vertical)
 	{
 		throw std::runtime_error("MapViewState::insertTube() called with invalid ConnectorDir parameter.");
 	}
@@ -1084,12 +1084,12 @@ void MapViewState::placeRobodigger(Tile& tile)
 	{
 		if (!tile.isSurface())
 		{
-			if (tile.hasStructure() && tile.structure()->connectorDirection() != ConnectorDir::CONNECTOR_VERTICAL) // Air shaft
+			if (tile.hasStructure() && tile.structure()->connectorDirection() != ConnectorDir::Vertical) // Air shaft
 			{
 				doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertStructureInWay);
 				return;
 			}
-			else if (tile.hasStructure() && tile.structure()->connectorDirection() == ConnectorDir::CONNECTOR_VERTICAL && tile.depth() == mTileMap->maxDepth())
+			else if (tile.hasStructure() && tile.structure()->connectorDirection() == ConnectorDir::Vertical && tile.depth() == mTileMap->maxDepth())
 			{
 				doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertMaxDigDepth);
 				return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -41,6 +41,7 @@
 #include "../UI/MiniMap.h"
 
 #include <libOPHD/EnumDifficulty.h>
+#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/MeanSolarDistance.h>
 #include <libOPHD/ProductCatalog.h>

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -27,7 +27,6 @@
 #include "../UI/RobotDeploymentSummary.h"
 #include "../UI/CheatMenu.h"
 
-#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/PlanetAttributes.h>
 #include <libOPHD/StorableResources.h>
 
@@ -65,6 +64,7 @@ namespace NAS2D
 
 enum class Difficulty;
 enum class Direction;
+enum class ConnectorDir;
 enum class StructureID;
 enum class RobotTypeIndex;
 

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -20,6 +20,7 @@
 #include "../MapObjects/Structures/Warehouse.h"
 
 #include <libOPHD/DirectionOffset.h>
+#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -142,7 +142,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& direction : DirectionClockwise4)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		structureManager.addStructure(*new Tube(tile, ConnectorDir::CONNECTOR_INTERSECTION), tile);
+		structureManager.addStructure(*new Tube(tile, ConnectorDir::Intersection), tile);
 	}
 
 	constexpr std::array initialStructures{

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -121,20 +121,20 @@ bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnector
 	Structure* structure = tile.structure();
 	const auto connectorDirection = structure->connectorDirection();
 
-	if (sourceConnectorDir == ConnectorDir::CONNECTOR_INTERSECTION)
+	if (sourceConnectorDir == ConnectorDir::Intersection)
 	{
-		return (connectorDirection == ConnectorDir::CONNECTOR_INTERSECTION || connectorDirection == ConnectorDir::CONNECTOR_VERTICAL) ||
+		return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::Vertical) ||
 			((dir == Direction::East || dir == Direction::West) ?
-				(connectorDirection == ConnectorDir::CONNECTOR_EAST_WEST) :
-				(connectorDirection == ConnectorDir::CONNECTOR_NORTH_SOUTH));
+				(connectorDirection == ConnectorDir::EastWest) :
+				(connectorDirection == ConnectorDir::NorthSouth));
 	}
-	else if (sourceConnectorDir == ConnectorDir::CONNECTOR_EAST_WEST && (dir == Direction::East || dir == Direction::West))
+	else if (sourceConnectorDir == ConnectorDir::EastWest && (dir == Direction::East || dir == Direction::West))
 	{
-		return (connectorDirection == ConnectorDir::CONNECTOR_INTERSECTION || connectorDirection == ConnectorDir::CONNECTOR_EAST_WEST || connectorDirection == ConnectorDir::CONNECTOR_VERTICAL);
+		return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::EastWest || connectorDirection == ConnectorDir::Vertical);
 	}
-	else if (sourceConnectorDir == ConnectorDir::CONNECTOR_NORTH_SOUTH && (dir == Direction::North || dir == Direction::South))
+	else if (sourceConnectorDir == ConnectorDir::NorthSouth && (dir == Direction::North || dir == Direction::South))
 	{
-		return (connectorDirection == ConnectorDir::CONNECTOR_INTERSECTION || connectorDirection == ConnectorDir::CONNECTOR_NORTH_SOUTH || connectorDirection == ConnectorDir::CONNECTOR_VERTICAL);
+		return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::NorthSouth || connectorDirection == ConnectorDir::Vertical);
 	}
 
 	return false;
@@ -153,10 +153,10 @@ bool checkStructurePlacement(Tile& tile, Direction dir)
 	}
 
 	const auto connectorDirection = structure->connectorDirection();
-	return (connectorDirection == ConnectorDir::CONNECTOR_INTERSECTION || connectorDirection == ConnectorDir::CONNECTOR_VERTICAL) ||
+	return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::Vertical) ||
 		((dir == Direction::East || dir == Direction::West) ?
-			(connectorDirection == ConnectorDir::CONNECTOR_EAST_WEST) :
-			(connectorDirection == ConnectorDir::CONNECTOR_NORTH_SOUTH));
+			(connectorDirection == ConnectorDir::EastWest) :
+			(connectorDirection == ConnectorDir::NorthSouth));
 }
 
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -24,6 +24,7 @@
 
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumDirection.h>
+#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/MapObjects/StructureType.h>
 

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumProductType.h>
-
 #include <libOPHD/Map/MapCoordinate.h>
 
 #include <cstddef>
@@ -24,6 +22,7 @@ class Warehouse;
 struct StorableResources;
 enum class StructureID;
 enum class Direction;
+enum class ConnectorDir;
 
 CommandCenter& firstCc();
 bool isCcPlaced();

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -78,15 +78,15 @@ namespace
 
 
 	const std::vector<IconGridItem> SurfaceTubes = {
-		{constants::AgTubeIntersection, 110, ConnectorDir::CONNECTOR_INTERSECTION},
-		{constants::AgTubeRight, 112, ConnectorDir::CONNECTOR_EAST_WEST},
-		{constants::AgTubeLeft, 111, ConnectorDir::CONNECTOR_NORTH_SOUTH},
+		{constants::AgTubeIntersection, 110, static_cast<int>(ConnectorDir::CONNECTOR_INTERSECTION)},
+		{constants::AgTubeRight, 112, static_cast<int>(ConnectorDir::CONNECTOR_EAST_WEST)},
+		{constants::AgTubeLeft, 111, static_cast<int>(ConnectorDir::CONNECTOR_NORTH_SOUTH)},
 	};
 
 	const std::vector<IconGridItem> UndergroundTubes = {
-		{constants::UgTubeIntersection, 113, ConnectorDir::CONNECTOR_INTERSECTION},
-		{constants::UgTubeRight, 115, ConnectorDir::CONNECTOR_EAST_WEST},
-		{constants::UgTubelLeft, 114, ConnectorDir::CONNECTOR_NORTH_SOUTH},
+		{constants::UgTubeIntersection, 113, static_cast<int>(ConnectorDir::CONNECTOR_INTERSECTION)},
+		{constants::UgTubeRight, 115, static_cast<int>(ConnectorDir::CONNECTOR_EAST_WEST)},
+		{constants::UgTubelLeft, 114, static_cast<int>(ConnectorDir::CONNECTOR_NORTH_SOUTH)},
 	};
 
 

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -78,15 +78,15 @@ namespace
 
 
 	const std::vector<IconGridItem> SurfaceTubes = {
-		{constants::AgTubeIntersection, 110, static_cast<int>(ConnectorDir::CONNECTOR_INTERSECTION)},
-		{constants::AgTubeRight, 112, static_cast<int>(ConnectorDir::CONNECTOR_EAST_WEST)},
-		{constants::AgTubeLeft, 111, static_cast<int>(ConnectorDir::CONNECTOR_NORTH_SOUTH)},
+		{constants::AgTubeIntersection, 110, static_cast<int>(ConnectorDir::Intersection)},
+		{constants::AgTubeRight, 112, static_cast<int>(ConnectorDir::EastWest)},
+		{constants::AgTubeLeft, 111, static_cast<int>(ConnectorDir::NorthSouth)},
 	};
 
 	const std::vector<IconGridItem> UndergroundTubes = {
-		{constants::UgTubeIntersection, 113, static_cast<int>(ConnectorDir::CONNECTOR_INTERSECTION)},
-		{constants::UgTubeRight, 115, static_cast<int>(ConnectorDir::CONNECTOR_EAST_WEST)},
-		{constants::UgTubelLeft, 114, static_cast<int>(ConnectorDir::CONNECTOR_NORTH_SOUTH)},
+		{constants::UgTubeIntersection, 113, static_cast<int>(ConnectorDir::Intersection)},
+		{constants::UgTubeRight, 115, static_cast<int>(ConnectorDir::EastWest)},
+		{constants::UgTubelLeft, 114, static_cast<int>(ConnectorDir::NorthSouth)},
 	};
 
 

--- a/libOPHD/EnumConnectorDir.h
+++ b/libOPHD/EnumConnectorDir.h
@@ -12,5 +12,5 @@ enum class ConnectorDir
 	Intersection = 1,
 	EastWest,
 	NorthSouth,
-	Vertical // Functions as an intersection
+	Vertical, // Functions as an intersection
 };

--- a/libOPHD/EnumConnectorDir.h
+++ b/libOPHD/EnumConnectorDir.h
@@ -4,13 +4,13 @@
 /**
  * Connector Direction.
  *
- * \note	CONNECTOR_INTERSECTION is intentionally set to '1' to prevent
+ * \note	Intersection is intentionally set to '1' to prevent
  *			breaking changes with save files.
  */
 enum class ConnectorDir
 {
-	CONNECTOR_INTERSECTION = 1,
-	CONNECTOR_EAST_WEST,
-	CONNECTOR_NORTH_SOUTH,
-	CONNECTOR_VERTICAL // Functions as an intersection
+	Intersection = 1,
+	EastWest,
+	NorthSouth,
+	Vertical // Functions as an intersection
 };

--- a/libOPHD/EnumConnectorDir.h
+++ b/libOPHD/EnumConnectorDir.h
@@ -7,7 +7,7 @@
  * \note	CONNECTOR_INTERSECTION is intentionally set to '1' to prevent
  *			breaking changes with save files.
  */
-enum ConnectorDir
+enum class ConnectorDir
 {
 	CONNECTOR_INTERSECTION = 1,
 	CONNECTOR_EAST_WEST,


### PR DESCRIPTION
Convert `ConnectorDir` to `enum class`, drop the "CONNECTOR_" value name prefix, rename value names to CamelCase, and use forward declares to reduce transitive header includes.

This reduces the transitive header include impact from 88 files down to 8 files.

Related:
- Issue #319
- Issue #1573
