### PR TITLE
Reduce `ProductType` header uses

### DIFF
--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -62,6 +62,8 @@ const ProductionCost& productCost(ProductType productType)
 
 Factory::Factory(StructureID id, std::vector<ProductType> products, Tile& tile) :
 	Structure{id, tile},
+	mProduct{ProductType::PRODUCT_NONE},
+	mProductWaiting{ProductType::PRODUCT_NONE},
 	mAvailableProducts{std::move(products)}
 {
 	assertNoDuplicates(mAvailableProducts);

--- a/appOPHD/MapObjects/Structures/Factory.h
+++ b/appOPHD/MapObjects/Structures/Factory.h
@@ -70,8 +70,8 @@ private:
 	int mTurnsCompleted = 0;
 	int mTurnsToComplete = 0;
 
-	ProductType mProduct = ProductType::PRODUCT_NONE;
-	ProductType mProductWaiting = ProductType::PRODUCT_NONE; /**< Product that is waiting to be pulled from the factory. */
+	ProductType mProduct;
+	ProductType mProductWaiting; /**< Product that is waiting to be pulled from the factory. */
 
 	ProductionTypeList mAvailableProducts; /**< List of products that the Factory can produce. */
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -130,7 +130,7 @@ void FactoryListBox::drawItem(NAS2D::Renderer& renderer, NAS2D::Rectangle<int> d
 	renderer.drawText(mFontBold, factory.name(), drawArea.position + NAS2D::Vector{64, 29 - mFontBold.height() / 2}, structureTextColor);
 	if (productType != ProductType::PRODUCT_NONE)
 	{
-		renderer.drawText(mFont, ProductCatalog::get(productType).Name, drawArea.crossXPoint() + NAS2D::Vector{-112, 19 - mFontBold.height() / 2}, structureTextColor);
+		renderer.drawText(mFont, ProductCatalog::get(productType).name, drawArea.crossXPoint() + NAS2D::Vector{-112, 19 - mFontBold.height() / 2}, structureTextColor);
 		drawProgressBar(
 			factory.productionTurnsCompleted(),
 			factory.productionTurnsToComplete(),

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -193,7 +193,7 @@ void FactoryProduction::factory(Factory* newFactory)
 
 	for (std::size_t i = 0; i < ptlist.size(); ++i)
 	{
-		mProductGrid.addItem({ProductCatalog::get(ptlist[i]).Name, ptlist[i], ptlist[i]});
+		mProductGrid.addItem({ProductCatalog::get(ptlist[i]).name, ptlist[i], ptlist[i]});
 	}
 
 	if (mFactory->productType() == ProductType::PRODUCT_NONE) { mProductGrid.clearSelection(); }

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -45,7 +45,7 @@ void ProductListBox::productPool(const ProductPool& pool)
 		if (productCount > 0)
 		{
 			mItems.emplace_back(ProductListBoxItem{
-				ProductCatalog::has(productType) ? ProductCatalog::get(productType).Name : "Invalid product type",
+				ProductCatalog::has(productType) ? ProductCatalog::get(productType).name : "Invalid product type",
 				productCount,
 				productCount * pool.productStorageRequirement(productType),
 				pool.capacity()

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -79,7 +79,8 @@ FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
 	cboFilterByProduct{{this, &FactoryReport::onProductFilterSelectionChange}},
 	lstFactoryList{{this, &FactoryReport::onListSelectionChange}},
 	lstProducts{{this, &FactoryReport::onProductSelectionChange}},
-	mTxtProductDescription{constants::PrimaryTextColor}
+	mTxtProductDescription{constants::PrimaryTextColor},
+	selectedProductType{ProductType::PRODUCT_NONE}
 {
 	add(lstFactoryList, {10, viewFilterOriginRow2.y + viewFilterButtonSize.y + 10});
 

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -423,7 +423,7 @@ void FactoryReport::onListSelectionChange()
 	{
 		for (auto item : selectedFactory->productList())
 		{
-			lstProducts.add(ProductCatalog::get(item).Name, static_cast<int>(item));
+			lstProducts.add(ProductCatalog::get(item).name, static_cast<int>(item));
 		}
 	}
 	lstProducts.selectIf([productType = selectedFactory->productType()](const auto& item){ return item.userData == productType; });
@@ -436,7 +436,7 @@ void FactoryReport::onListSelectionChange()
 void FactoryReport::onProductSelectionChange()
 {
 	selectedProductType = lstProducts.isItemSelected() ? static_cast<ProductType>(lstProducts.selected().userData) : ProductType::PRODUCT_NONE;
-	mTxtProductDescription.text(productTypeInRange(selectedProductType) ? ProductCatalog::get(selectedProductType).Description : "");
+	mTxtProductDescription.text(productTypeInRange(selectedProductType) ? ProductCatalog::get(selectedProductType).description : "");
 }
 
 
@@ -499,7 +499,7 @@ void FactoryReport::drawProductPane(Renderer& renderer) const
 	if (selectedProductType != ProductType::PRODUCT_NONE)
 	{
 		const auto productImagePosition = NAS2D::Point{originRight.x, lstProducts.position().y};
-		renderer.drawText(fontBigBold, ProductCatalog::get(selectedProductType).Name, originRight, constants::PrimaryTextColor);
+		renderer.drawText(fontBigBold, ProductCatalog::get(selectedProductType).name, originRight, constants::PrimaryTextColor);
 		renderer.drawImage(productImage(selectedProductType), productImagePosition);
 		mTxtProductDescription.draw(renderer);
 	}
@@ -509,7 +509,7 @@ void FactoryReport::drawProductPane(Renderer& renderer) const
 	const auto progressTextPosition = originRight + NAS2D::Vector{0, mRect.size.y - originRight.y - 115};
 	const auto buildingProductNamePosition = progressTextPosition + NAS2D::Vector{0, 35};
 	renderer.drawText(fontBigBold, "Progress", progressTextPosition, constants::PrimaryTextColor);
-	renderer.drawText(fontMedium, "Building " + ProductCatalog::get(selectedFactory->productType()).Name, buildingProductNamePosition, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, "Building " + ProductCatalog::get(selectedFactory->productType()).name, buildingProductNamePosition, constants::PrimaryTextColor);
 
 	const auto progressBarPosition = buildingProductNamePosition + NAS2D::Vector{0, fontMedium.height()};
 	const auto progressBarSize = NAS2D::Vector{mRect.size.x - originRight.x - 10, 30};

--- a/appOPHD/UI/Reports/FactoryReport.h
+++ b/appOPHD/UI/Reports/FactoryReport.h
@@ -108,5 +108,5 @@ private:
 	TextArea mTxtProductDescription;
 
 	Factory* selectedFactory = nullptr;
-	ProductType selectedProductType = ProductType::PRODUCT_NONE;
+	ProductType selectedProductType;
 };

--- a/appOPHD/UI/WarehouseInspector.cpp
+++ b/appOPHD/UI/WarehouseInspector.cpp
@@ -65,7 +65,7 @@ void WarehouseInspector::drawClientArea(NAS2D::Renderer& /*renderer*/) const
 		if (pool.count(productType) == 0) { continue; }
 		if (storageRequiredPerUnit(productType) == 0) { continue; }
 
-		drawLabelAndValueLeftJustify(position, labelWidth, ProductCatalog::get(productType).Name + ":", std::to_string(pool.count(productType)));
+		drawLabelAndValueLeftJustify(position, labelWidth, ProductCatalog::get(productType).name + ":", std::to_string(pool.count(productType)));
 
 		position.y += 15;
 	}

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -52,7 +52,7 @@ void ProductCatalog::init(const std::string& filename)
 			throw std::runtime_error("Duplicate ProductID in data file: ID = " + std::to_string(product.Id) + ", Name = " + product.Name + ", filename = " + filename);
 		}
 
-		mProductTable[productId] = product;
+		mProductTable.try_emplace(productId, product);
 	}
 }
 

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -45,11 +45,11 @@ void ProductCatalog::init(const std::string& filename)
 	for (const auto* node = rootElement->firstChildElement(ProductElement); node; node = node->nextSiblingElement(ProductElement))
 	{
 		const auto product = parseProduct(node);
-		const auto productId = static_cast<ProductType>(product.Id);
+		const auto productId = static_cast<ProductType>(product.id);
 
 		if (mProductTable.find(productId) != mProductTable.end())
 		{
-			throw std::runtime_error("Duplicate ProductID in data file: ID = " + std::to_string(product.Id) + ", Name = " + product.Name + ", filename = " + filename);
+			throw std::runtime_error("Duplicate ProductID in data file: ID = " + std::to_string(product.id) + ", Name = " + product.name + ", filename = " + filename);
 		}
 
 		mProductTable.try_emplace(productId, product);

--- a/libOPHD/ProductCatalog.h
+++ b/libOPHD/ProductCatalog.h
@@ -15,9 +15,9 @@ class ProductCatalog
 public:
 	struct Product
 	{
-		int Id;
-		std::string Name;
-		std::string Description;
+		int id;
+		std::string name;
+		std::string description;
 	};
 
 public:

--- a/libOPHD/ProductCatalog.h
+++ b/libOPHD/ProductCatalog.h
@@ -15,9 +15,9 @@ class ProductCatalog
 public:
 	struct Product
 	{
-		int Id{ProductType::PRODUCT_NONE};
-		std::string Name{};
-		std::string Description{};
+		int Id;
+		std::string Name;
+		std::string Description;
 	};
 
 public:


### PR DESCRIPTION
Reduce `ProductType` header uses and rename `Product` fields to lowerCamelCase.

Prefer using `std::map::try_emplace` over `std::map::operator[]`, as it won't try to default initialize a new entry before assigning to it. This avoids warnings about `Product` fields not being initialized when the default values are removed.

Related:
- Issue #319
