### PR TITLE
Separate header for `StructureState` enum

### DIFF
--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -157,7 +157,7 @@ float Tile::movementCost() const
 	{
 		Structure& road = *structure();
 
-		if (road.state() != StructureState::Operational)
+		if (!road.operational())
 		{
 			return constants::RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 1.0f;
 		}

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -125,6 +125,12 @@ const MapCoordinate& Structure::xyz() const
 }
 
 
+bool Structure::disabled() const
+{
+	return mStructureState == StructureState::Disabled;
+}
+
+
 /**
  * Sets a Disabled state for the Structure.
  */
@@ -136,6 +142,12 @@ void Structure::disable(DisabledReason reason)
 	mDisabledReason = reason;
 	mIdleReason = IdleReason::None;
 	disabledStateSet();
+}
+
+
+bool Structure::operational() const
+{
+	return mStructureState == StructureState::Operational;
 }
 
 
@@ -158,6 +170,12 @@ void Structure::enable()
 }
 
 
+bool Structure::isIdle() const
+{
+	return mStructureState == StructureState::Idle;
+}
+
+
 /**
 * Sets idle state of the Structure.
 */
@@ -173,6 +191,18 @@ void Structure::idle(IdleReason reason)
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = reason;
 	state(StructureState::Idle);
+}
+
+
+bool Structure::destroyed() const
+{
+	return mStructureState == StructureState::Destroyed;
+}
+
+
+bool Structure::underConstruction() const
+{
+	return mStructureState == StructureState::UnderConstruction;
 }
 
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -1,5 +1,6 @@
 #include "Structure.h"
 
+#include "StructureState.h"
 #include "StructureClass.h"
 #include "StructureIdToClass.h"
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "StructureState.h"
-
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/MapObject.h>
 #include <libOPHD/Population/PopulationRequirements.h>
@@ -18,6 +16,7 @@ enum class ConnectorDir;
 enum class DisabledReason;
 enum class IdleReason;
 enum class StructureClass;
+enum class StructureState;
 struct StructureType;
 struct MapCoordinate;
 class Tile;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -46,21 +46,21 @@ public:
 	bool connected() const { return mConnected; }
 	void connected(bool value) { mConnected = value; }
 
-	bool disabled() const { return mStructureState == StructureState::Disabled; }
+	bool disabled() const;
 	void disable(DisabledReason);
 	DisabledReason disabledReason() const { return mDisabledReason; }
 
-	bool operational() const { return mStructureState == StructureState::Operational; }
+	bool operational() const;
 	void enable();
 
-	bool isIdle() const { return mStructureState == StructureState::Idle; }
+	bool isIdle() const;
 	void idle(IdleReason);
 	IdleReason idleReason() const { return mIdleReason; }
 
-	bool destroyed() const { return mStructureState == StructureState::Destroyed; }
+	bool destroyed() const;
 	void destroy();
 
-	bool underConstruction() const { return mStructureState == StructureState::UnderConstruction; }
+	bool underConstruction() const;
 
 	void forceIdle(bool force);
 	bool forceIdle() const { return mForcedIdle; }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -22,9 +22,6 @@ class Tile;
 class StringTable;
 
 
-/**
- * State of an individual Structure.
- */
 enum class StructureState
 {
 	UnderConstruction,

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "StructureState.h"
+
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/MapObjects/MapObject.h>
 #include <libOPHD/Population/PopulationRequirements.h>
@@ -20,16 +22,6 @@ struct StructureType;
 struct MapCoordinate;
 class Tile;
 class StringTable;
-
-
-enum class StructureState
-{
-	UnderConstruction,
-	Operational,
-	Idle,
-	Disabled,
-	Destroyed
-};
 
 
 class Structure : public MapObject

--- a/appOPHD/MapObjects/StructureState.h
+++ b/appOPHD/MapObjects/StructureState.h
@@ -1,0 +1,11 @@
+#pragma once
+
+
+enum class StructureState
+{
+	UnderConstruction,
+	Operational,
+	Idle,
+	Disabled,
+	Destroyed
+};

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -1,7 +1,8 @@
 #include "AirShaft.h"
 
-#include "../../Constants/Strings.h"
+#include "../StructureState.h"
 #include "../../Map/Tile.h"
+#include "../../Constants/Strings.h"
 
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumConnectorDir.h>

--- a/appOPHD/MapObjects/Structures/Factory.cpp
+++ b/appOPHD/MapObjects/Structures/Factory.cpp
@@ -128,7 +128,7 @@ void Factory::updateProduction()
 	 * \fixme	Most of these can be combined into a single
 	 *			compound conditional statement.
 	 */
-	if (state() != StructureState::Operational)
+	if (!operational())
 	{
 		return;
 	}

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -1,5 +1,6 @@
 #include "Tube.h"
 
+#include "../StructureState.h"
 #include "../../Map/Tile.h"
 #include "../../Constants/Strings.h"
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -12,6 +12,7 @@
 #include "../Map/RouteFinder.h"
 #include "../Map/TileMap.h"
 
+#include "../MapObjects/StructureState.h"
 #include "../MapObjects/Structures/CommandCenter.h"
 #include "../MapObjects/Structures/Factory.h"
 #include "../MapObjects/Structures/MineFacility.h"

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -8,7 +8,7 @@
 #include "Map/Tile.h"
 #include "MapObjects/Structure.h"
 #include "MapObjects/Robot.h"
-
+#include "MapObjects/StructureState.h"
 #include "MapObjects/Structures/FoodProduction.h"
 #include "MapObjects/Structures/MaintenanceFacility.h"
 #include "MapObjects/Structures/MineFacility.h"

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -3,6 +3,7 @@
 #include "ProgressBar.h"
 #include "StructureColor.h"
 
+#include "../MapObjects/StructureState.h"
 #include "../MapObjects/Structures/Factory.h"
 
 #include "../Cache.h"

--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -8,7 +8,7 @@
 #include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 #include "../../StructureManager.h"
-
+#include "../../MapObjects/StructureState.h"
 #include "../../MapObjects/Structures/SurfaceFactory.h"
 #include "../../MapObjects/Structures/SeedFactory.h"
 #include "../../MapObjects/Structures/UndergroundFactory.h"

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -4,7 +4,7 @@
 #include "../../Constants/UiConstants.h"
 #include "../../Cache.h"
 #include "../../StructureManager.h"
-
+#include "../../MapObjects/StructureState.h"
 #include "../../MapObjects/Structures/HotLaboratory.h"
 #include "../../MapObjects/Structures/Laboratory.h"
 

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -49,7 +49,7 @@ namespace
 	{
 		const auto& productPool = warehouse.products();
 
-		if (warehouse.state() != StructureState::Operational) { return warehouse.stateDescription(); }
+		if (!warehouse.operational()) { return warehouse.stateDescription(); }
 		else if (productPool.empty()) { return constants::WarehouseEmpty; }
 		else if (productPool.atCapacity()) { return constants::WarehouseFull; }
 		else if (!productPool.empty() && !productPool.atCapacity()) { return constants::WarehouseVacancy; }

--- a/appOPHD/UI/StructureColor.cpp
+++ b/appOPHD/UI/StructureColor.cpp
@@ -1,6 +1,6 @@
 #include "StructureColor.h"
 
-#include "../MapObjects/Structure.h"
+#include "../MapObjects/StructureState.h"
 
 #include <map>
 

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -309,6 +309,7 @@
     <ClInclude Include="MapObjects\StructureClass.h" />
     <ClInclude Include="MapObjects\StructureIdToClass.h" />
     <ClInclude Include="MapObjects\Structures.h" />
+    <ClInclude Include="MapObjects\StructureState.h" />
     <ClInclude Include="MapObjects\StructureTypeToClass.h" />
     <ClInclude Include="MapObjects\Structures\Agridome.h" />
     <ClInclude Include="MapObjects\Structures\AirShaft.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -446,6 +446,9 @@
     <ClInclude Include="MapObjects\Structures.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>
+    <ClInclude Include="MapObjects\StructureState.h">
+      <Filter>Header Files\MapObjects</Filter>
+    </ClInclude>
     <ClInclude Include="MapObjects\StructureTypeToClass.h">
       <Filter>Header Files\MapObjects</Filter>
     </ClInclude>


### PR DESCRIPTION
Split `StructureState` enum to it's own header file, and minimize includes for `Structure` when only `StructureState` is needed.

Use forward declares to reduce includes for new `StructureState` header file too.

Related:
- Issue #1573
