### PR TITLE
Tube constructor default `Intersection`

### DIFF
--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -10,6 +10,12 @@
 #include <stdexcept>
 
 
+Tube::Tube(Tile& tile) :
+	Tube{tile, ConnectorDir::Intersection}
+{
+}
+
+
 Tube::Tube(Tile& tile, ConnectorDir dir) :
 	Structure{
 		StructureID::Tube,

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -6,6 +6,7 @@
 class Tube : public Structure
 {
 public:
+	Tube(Tile& tile);
 	Tube(Tile& tile, ConnectorDir dir);
 
 private:

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -157,9 +157,8 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& [direction, structureId] : initialStructures)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		auto* structure = StructureCatalog::create(structureId, tile);
-		structureManager.addStructure(*structure, tile);
-		structures.push_back(structure);
+		auto& structure = structureManager.create(structureId, tile);
+		structures.push_back(&structure);
 	}
 
 	auto& seedFactory = *dynamic_cast<SeedFactory*>(structures[2]);

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -143,7 +143,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& direction : DirectionClockwise4)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		structureManager.addStructure(*new Tube(tile, ConnectorDir::Intersection), tile);
+		structureManager.addStructure(*new Tube(tile), tile);
 	}
 
 	constexpr std::array initialStructures{

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -143,7 +143,7 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 	for (const auto& direction : DirectionClockwise4)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
-		structureManager.addStructure(*new Tube(tile), tile);
+		structureManager.create(StructureID::Tube, tile);
 	}
 
 	constexpr std::array initialStructures{

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -374,9 +374,10 @@ Structure* StructureCatalog::create(StructureID id, Tile& tile)
 			structure = new Warehouse(tile);
 			break;
 
-
 		case StructureID::Tube:
+			structure = new Tube(tile);
 			break;
+
 
 		case StructureID::None:
 			break;


### PR DESCRIPTION
Add `Tube` constructor taking only a `Tile&` parameter, which sets the `connectorDirection` to `Intersection`. Use new `Tube` constructor in `StructureCatalog::create`. Use `StructureManager::create` when creating initial base on `SeedLander` deploy.

Related:
- Issue #1795
- Issue #1740
- Issue #1989
