### PR TITLE
Consolidate `SeedLander` deploy loops

### DIFF
--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -161,9 +161,11 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 		structures.push_back(&structure);
 	}
 
-	auto& seedFactory = *dynamic_cast<SeedFactory*>(structures[2]);
-	seedFactory.resourcePool(&mResourcesCount);
-	seedFactory.productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
+	if (auto* seedFactory = dynamic_cast<SeedFactory*>(structures[2]))
+	{
+		seedFactory->resourcePool(&mResourcesCount);
+		seedFactory->productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
+	}
 
 	mRobotPool.addRobot(RobotTypeIndex::Dozer).taskCompleteHandler({this, &MapViewState::onDozerTaskComplete});
 	mRobotPool.addRobot(RobotTypeIndex::Digger).taskCompleteHandler({this, &MapViewState::onDiggerTaskComplete});

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -153,18 +153,16 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 		std::tuple{DirectionSouthEast, StructureID::SeedSmelter},
 	};
 
-	std::vector<Structure*> structures;
 	for (const auto& [direction, structureId] : initialStructures)
 	{
 		auto& tile = mTileMap->getTile({point + direction, 0});
 		auto& structure = structureManager.create(structureId, tile);
-		structures.push_back(&structure);
-	}
 
-	if (auto* seedFactory = dynamic_cast<SeedFactory*>(structures[2]))
-	{
-		seedFactory->resourcePool(&mResourcesCount);
-		seedFactory->productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
+		if (auto* seedFactory = dynamic_cast<SeedFactory*>(&structure))
+		{
+			seedFactory->resourcePool(&mResourcesCount);
+			seedFactory->productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
+		}
 	}
 
 	mRobotPool.addRobot(RobotTypeIndex::Dozer).taskCompleteHandler({this, &MapViewState::onDozerTaskComplete});

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -139,14 +139,11 @@ void MapViewState::onDeploySeedLander(NAS2D::Point<int> point)
 
 	auto& structureManager = NAS2D::Utility<StructureManager>::get();
 
-	// Place initial tubes
-	for (const auto& direction : DirectionClockwise4)
-	{
-		auto& tile = mTileMap->getTile({point + direction, 0});
-		structureManager.create(StructureID::Tube, tile);
-	}
-
 	constexpr std::array initialStructures{
+		std::tuple{DirectionNorth, StructureID::Tube},
+		std::tuple{DirectionSouth, StructureID::Tube},
+		std::tuple{DirectionWest, StructureID::Tube},
+		std::tuple{DirectionEast, StructureID::Tube},
 		std::tuple{DirectionNorthWest, StructureID::SeedPower},
 		std::tuple{DirectionNorthEast, StructureID::CommandCenter},
 		std::tuple{DirectionSouthWest, StructureID::SeedFactory},


### PR DESCRIPTION
Consolidate `SeedLander` deploy loops so both tubes and structures are created by the same loop.

Now that `StructureCatalog::create` can create a `Tube`, we can use a single loop to create everything. Additionally, the code is made more robust in case the `SeedFactory` changes position in the `initialStructures` collection, or even if the number of `SeedFactory` structures changes.

Related:
- PR #2001
- Issue #1795
