### PR TITLE
Use `GraphWalker` function `hasConnectorDirection`

### DIFF
--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -14,6 +14,23 @@
 using namespace NAS2D;
 
 
+static bool canConnect(Structure& src, Structure& dst, Direction direction)
+{
+	const auto srcConnectorDir = src.connectorDirection();
+	const auto dstConnectorDir = dst.connectorDirection();
+
+	// At least one end must be a Tube as Structures don't connect to each other
+	if (!src.isConnector() && !dst.isConnector()) { return false; }
+
+	// Only follow directions that are valid for source connector
+	if (!hasConnectorDirection(srcConnectorDir, direction)) { return false; }
+
+	// Check if destination can receive a connection from the given direction
+	// (Relies on symmetry of connector directions)
+	return hasConnectorDirection(dstConnectorDir, direction);
+}
+
+
 bool hasConnectorDirection(ConnectorDir srcConnectorDir, Direction direction)
 {
 	if (srcConnectorDir == ConnectorDir::Vertical)
@@ -34,23 +51,6 @@ bool hasConnectorDirection(ConnectorDir srcConnectorDir, Direction direction)
 	}
 
 	return false;
-}
-
-
-static bool canConnect(Structure& src, Structure& dst, Direction direction)
-{
-	const auto srcConnectorDir = src.connectorDirection();
-	const auto dstConnectorDir = dst.connectorDirection();
-
-	// At least one end must be a Tube as Structures don't connect to each other
-	if (!src.isConnector() && !dst.isConnector()) { return false; }
-
-	// Only follow directions that are valid for source connector
-	if (!hasConnectorDirection(srcConnectorDir, direction)) { return false; }
-
-	// Check if destination can receive a connection from the given direction
-	// (Relies on symmetry of connector directions)
-	return hasConnectorDirection(dstConnectorDir, direction);
 }
 
 

--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -14,7 +14,7 @@
 using namespace NAS2D;
 
 
-static bool hasConnectorDirection(ConnectorDir srcConnectorDir, Direction direction)
+bool hasConnectorDirection(ConnectorDir srcConnectorDir, Direction direction)
 {
 	if (srcConnectorDir == ConnectorDir::Vertical)
 	{

--- a/appOPHD/GraphWalker.cpp
+++ b/appOPHD/GraphWalker.cpp
@@ -14,20 +14,23 @@
 using namespace NAS2D;
 
 
-static bool canConnect(Structure& src, Structure& dst, Direction direction)
+namespace
 {
-	const auto srcConnectorDir = src.connectorDirection();
-	const auto dstConnectorDir = dst.connectorDirection();
+	bool canConnect(Structure& src, Structure& dst, Direction direction)
+	{
+		const auto srcConnectorDir = src.connectorDirection();
+		const auto dstConnectorDir = dst.connectorDirection();
 
-	// At least one end must be a Tube as Structures don't connect to each other
-	if (!src.isConnector() && !dst.isConnector()) { return false; }
+		// At least one end must be a Tube as Structures don't connect to each other
+		if (!src.isConnector() && !dst.isConnector()) { return false; }
 
-	// Only follow directions that are valid for source connector
-	if (!hasConnectorDirection(srcConnectorDir, direction)) { return false; }
+		// Only follow directions that are valid for source connector
+		if (!hasConnectorDirection(srcConnectorDir, direction)) { return false; }
 
-	// Check if destination can receive a connection from the given direction
-	// (Relies on symmetry of connector directions)
-	return hasConnectorDirection(dstConnectorDir, direction);
+		// Check if destination can receive a connection from the given direction
+		// (Relies on symmetry of connector directions)
+		return hasConnectorDirection(dstConnectorDir, direction);
+	}
 }
 
 

--- a/appOPHD/GraphWalker.h
+++ b/appOPHD/GraphWalker.h
@@ -3,9 +3,13 @@
 #include <vector>
 
 
+enum class ConnectorDir;
+enum class Direction;
 struct MapCoordinate;
 class TileMap;
 
+
+bool hasConnectorDirection(ConnectorDir srcConnectorDir, Direction direction);
 
 void walkGraph(const std::vector<MapCoordinate>& positions, TileMap& tileMap);
 void walkGraph(const MapCoordinate& position, TileMap& tileMap);

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -13,6 +13,7 @@
 #include "../Constants/Strings.h"
 #include "../StructureCatalog.h"
 #include "../StructureManager.h"
+#include "../GraphWalker.h"
 #include "../Map/Tile.h"
 #include "../Map/TileMap.h"
 
@@ -122,23 +123,12 @@ bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnector
 	Structure* structure = tile.structure();
 	const auto connectorDirection = structure->connectorDirection();
 
-	if (sourceConnectorDir == ConnectorDir::Intersection)
-	{
-		return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::Vertical) ||
-			((dir == Direction::East || dir == Direction::West) ?
-				(connectorDirection == ConnectorDir::EastWest) :
-				(connectorDirection == ConnectorDir::NorthSouth));
-	}
-	else if (sourceConnectorDir == ConnectorDir::EastWest && (dir == Direction::East || dir == Direction::West))
-	{
-		return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::EastWest || connectorDirection == ConnectorDir::Vertical);
-	}
-	else if (sourceConnectorDir == ConnectorDir::NorthSouth && (dir == Direction::North || dir == Direction::South))
-	{
-		return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::NorthSouth || connectorDirection == ConnectorDir::Vertical);
-	}
+	// Only follow directions that are valid for source connector
+	if (!hasConnectorDirection(sourceConnectorDir, dir)) { return false; }
 
-	return false;
+	// Check if destination can receive a connection from the given direction
+	// (Relies on symmetry of connector directions)
+	return hasConnectorDirection(connectorDirection, dir);
 }
 
 
@@ -153,11 +143,8 @@ bool checkStructurePlacement(Tile& tile, Direction dir)
 		return false;
 	}
 
-	const auto connectorDirection = structure->connectorDirection();
-	return (connectorDirection == ConnectorDir::Intersection || connectorDirection == ConnectorDir::Vertical) ||
-		((dir == Direction::East || dir == Direction::West) ?
-			(connectorDirection == ConnectorDir::EastWest) :
-			(connectorDirection == ConnectorDir::NorthSouth));
+	// Rely on symmetry of connector direction for back connection
+	return hasConnectorDirection(structure->connectorDirection(), dir);
 }
 
 


### PR DESCRIPTION
Use `GraphWalker` function `hasConnectorDirection` to implement `Structure` and `Tube` placement checks in `MapViewStateHelper`.

Related:
- PR #2000
- Issue #1999
- Issue #1740
