### PR TITLE
Update `data` submodule for updated `ProductTypes.xml` format

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -270,7 +270,7 @@ MapViewState::~MapViewState()
 void MapViewState::initialize()
 {
 	StructureCatalog::init("StructureTypes.xml");
-	ProductCatalog::init("factory_products.xml");
+	ProductCatalog::init("ProductTypes.xml");
 
 	// UI
 	initUi();

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -11,14 +11,9 @@ namespace
 {
 	ProductCatalog::Product parseProduct(const NAS2D::Xml::XmlElement* node)
 	{
-		NAS2D::Dictionary dictionary{};
-		for (const auto* element = node->firstChildElement(); element; element = element->nextSiblingElement())
-		{
-			dictionary.set(element->value(), element->getText());
-		}
+		const auto dictionary = NAS2D::attributesToDictionary(*node);
 
 		const auto requiredFields = std::vector<std::string>{"id", "name", "description"};
-
 		NAS2D::reportMissingOrUnexpected(dictionary.keys(), requiredFields, {});
 
 		return {


### PR DESCRIPTION
Use attributes to store `Product` data, and rename file to `ProductTypes.xml`. This makes the data file consistent with the format and name scheme used by `StructureTypes.xml`.

Related:
- PR https://github.com/OutpostUniverse/ophd-assets/pull/25
- Issue #2005
