### PR TITLE
Add product `storageSpace` attribute

### DIFF
--- a/appOPHD/ProductPool.cpp
+++ b/appOPHD/ProductPool.cpp
@@ -3,6 +3,8 @@
 #include "Constants/Numbers.h"
 #include "Constants/Strings.h"
 
+#include <libOPHD/ProductCatalog.h>
+
 #include <NAS2D/Dictionary.h>
 #include <NAS2D/ParserHelper.h>
 
@@ -12,92 +14,11 @@
 namespace
 {
 	/**
-	 * Space required to store a Product.
-	 */
-	const std::map<ProductType, int> ProductStorageSpace =
-	{
-		{ProductType::PRODUCT_DIGGER, 10},
-		{ProductType::PRODUCT_DOZER, 10},
-		{ProductType::PRODUCT_MINER, 10},
-		{ProductType::PRODUCT_EXPLORER, 10},
-		{ProductType::PRODUCT_TRUCK, 10},
-
-		{ProductType::PRODUCT_RESERVED_AG_05, 0},
-		{ProductType::PRODUCT_RESERVED_AG_06, 0},
-		{ProductType::PRODUCT_RESERVED_AG_07, 0},
-		{ProductType::PRODUCT_RESERVED_AG_08, 0},
-
-		{ProductType::PRODUCT_MAINTENANCE_PARTS, 1},
-
-		{ProductType::PRODUCT_RESERVED_AG_10, 0},
-		{ProductType::PRODUCT_RESERVED_AG_11, 0},
-		{ProductType::PRODUCT_RESERVED_AG_12, 0},
-		{ProductType::PRODUCT_RESERVED_AG_13, 0},
-		{ProductType::PRODUCT_RESERVED_AG_14, 0},
-		{ProductType::PRODUCT_RESERVED_AG_15, 0},
-		{ProductType::PRODUCT_RESERVED_AG_16, 0},
-		{ProductType::PRODUCT_RESERVED_AG_17, 0},
-		{ProductType::PRODUCT_RESERVED_AG_18, 0},
-		{ProductType::PRODUCT_RESERVED_AG_19, 0},
-
-		{ProductType::PRODUCT_RESERVED_AG_20, 0},
-		{ProductType::PRODUCT_RESERVED_AG_21, 0},
-		{ProductType::PRODUCT_RESERVED_AG_22, 0},
-		{ProductType::PRODUCT_RESERVED_AG_23, 0},
-		{ProductType::PRODUCT_RESERVED_AG_24, 0},
-		{ProductType::PRODUCT_RESERVED_AG_25, 0},
-		{ProductType::PRODUCT_RESERVED_AG_26, 0},
-		{ProductType::PRODUCT_RESERVED_AG_27, 0},
-		{ProductType::PRODUCT_RESERVED_AG_28, 0},
-		{ProductType::PRODUCT_RESERVED_AG_29, 0},
-
-		{ProductType::PRODUCT_RESERVED_AG_30, 0},
-		{ProductType::PRODUCT_RESERVED_AG_31, 0},
-
-		{ProductType::PRODUCT_CLOTHING, 1},
-		{ProductType::PRODUCT_MEDICINE, 1},
-
-		{ProductType::PRODUCT_RESERVED_UG_34, 0},
-		{ProductType::PRODUCT_RESERVED_UG_35, 0},
-		{ProductType::PRODUCT_RESERVED_UG_36, 0},
-		{ProductType::PRODUCT_RESERVED_UG_37, 0},
-		{ProductType::PRODUCT_RESERVED_UG_38, 0},
-		{ProductType::PRODUCT_RESERVED_UG_39, 0},
-
-		{ProductType::PRODUCT_RESERVED_UG_40, 0},
-		{ProductType::PRODUCT_RESERVED_UG_41, 0},
-		{ProductType::PRODUCT_RESERVED_UG_42, 0},
-		{ProductType::PRODUCT_RESERVED_UG_43, 0},
-		{ProductType::PRODUCT_RESERVED_UG_44, 0},
-		{ProductType::PRODUCT_RESERVED_UG_45, 0},
-		{ProductType::PRODUCT_RESERVED_UG_46, 0},
-		{ProductType::PRODUCT_RESERVED_UG_47, 0},
-		{ProductType::PRODUCT_RESERVED_UG_48, 0},
-		{ProductType::PRODUCT_RESERVED_UG_49, 0},
-
-		{ProductType::PRODUCT_RESERVED_UG_50, 0},
-		{ProductType::PRODUCT_RESERVED_UG_51, 0},
-		{ProductType::PRODUCT_RESERVED_UG_52, 0},
-		{ProductType::PRODUCT_RESERVED_UG_53, 0},
-		{ProductType::PRODUCT_RESERVED_UG_54, 0},
-		{ProductType::PRODUCT_RESERVED_UG_55, 0},
-		{ProductType::PRODUCT_RESERVED_UG_56, 0},
-		{ProductType::PRODUCT_RESERVED_UG_57, 0},
-		{ProductType::PRODUCT_RESERVED_UG_58, 0},
-		{ProductType::PRODUCT_RESERVED_UG_59, 0},
-
-		{ProductType::PRODUCT_RESERVED_UG_60, 0},
-		{ProductType::PRODUCT_RESERVED_UG_61, 0},
-		{ProductType::PRODUCT_RESERVED_UG_62, 0},
-		{ProductType::PRODUCT_RESERVED_UG_63, 0}
-	};
-
-	/**
 	 * Gets the amount of storage required for a given number of Products.
 	 */
 	inline int storageRequired(ProductType type, int count)
 	{
-		return ProductStorageSpace.at(type) * count;
+		return ProductCatalog::has(type) ? ProductCatalog::get(type).storageSpace * count : 0;
 	}
 
 
@@ -117,7 +38,7 @@ namespace
  */
 int storageRequiredPerUnit(ProductType type)
 {
-	return ProductStorageSpace.at(type);
+	return ProductCatalog::get(type).storageSpace;
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -3,7 +3,6 @@
 #include "Constants/Numbers.h"
 #include "GraphWalker.h"
 #include "IOHelper.h"
-#include "ProductPool.h"
 #include "StructureCatalog.h"
 #include "Map/Tile.h"
 #include "MapObjects/Structure.h"

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -19,7 +19,8 @@ namespace
 		return {
 			dictionary.get<int>("id"),
 			dictionary.get("name"),
-			dictionary.get("description")
+			dictionary.get("description"),
+			dictionary.get<int>("storageSpace"),
 		};
 	}
 }

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -13,7 +13,7 @@ namespace
 	{
 		const auto dictionary = NAS2D::attributesToDictionary(*node);
 
-		const auto requiredFields = std::vector<std::string>{"id", "name", "description"};
+		const auto requiredFields = std::vector<std::string>{"id", "name", "description", "storageSpace"};
 		NAS2D::reportMissingOrUnexpected(dictionary.keys(), requiredFields, {});
 
 		return {

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -67,6 +67,6 @@ const ProductCatalog::Product& ProductCatalog::get(ProductType type)
 	}
 	catch (std::out_of_range&)
 	{
-		throw std::runtime_error("Product type (" + std::to_string(static_cast<int>(type)) + ") not found in Product Catalogue.");
+		throw std::runtime_error("Product type not found in Product Catalogue: " + std::to_string(static_cast<int>(type)) + " of " + std::to_string(mProductTable.size()));
 	}
 }

--- a/libOPHD/ProductCatalog.h
+++ b/libOPHD/ProductCatalog.h
@@ -18,6 +18,7 @@ public:
 		int id;
 		std::string name;
 		std::string description;
+		int storageSpace;
 	};
 
 public:


### PR DESCRIPTION
Update `data` submodule for new `storageSpace` attribute in `ProductTypes.xml`, and use it to replace the hardcoded `ProductStorageSpace` table.

Related:
- Issue #2005
- PR #https://github.com/OutpostUniverse/ophd-assets/pull/26
- PR #2006
