### PR TITLE
Add ability to read optional `StorableResources` with default

### DIFF
--- a/appOPHD/IOHelper.cpp
+++ b/appOPHD/IOHelper.cpp
@@ -7,14 +7,20 @@
 #include <NAS2D/ParserHelper.h>
 
 
-StorableResources readResourcesOptional(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName)
+StorableResources readResourcesOptional(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName, const StorableResources& defaultValue)
 {
 	const auto* childElement = parentElement.firstChildElement(subElementName);
 	if (!childElement) {
-		return {};
+		return defaultValue;
 	}
 
 	return readResources(*childElement);
+}
+
+
+StorableResources readResourcesOptional(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName)
+{
+	return readResourcesOptional(parentElement, subElementName, {});
 }
 
 

--- a/appOPHD/IOHelper.h
+++ b/appOPHD/IOHelper.h
@@ -6,6 +6,7 @@
 struct StorableResources;
 
 
+StorableResources readResourcesOptional(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName, const StorableResources& defaultValue);
 StorableResources readResourcesOptional(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName);
 StorableResources readResources(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName);
 StorableResources readResources(const NAS2D::Xml::XmlElement& element);


### PR DESCRIPTION
Potentially this may be useful to move `structureRecycleValueTable` hardcoded values to a data file, perhaps using the `buildCost` as a default value.

Of course there may end up being other ways to get rid of the hardcoded data. Perhaps a certain number of free structures can be placed. Then the build cost can be set to give the appropriate recycled amount.

Related:
- Issue #1723
