### PR TITLE
Improve `TextField` cursor apparent responsiveness

### DIFF
--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -140,19 +140,19 @@ void TextField::update()
 
 void TextField::updateScrollPosition()
 {
-	const auto cursorX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
+	const auto cursorVirtualPixelX = mFont.width(std::string_view{mText}.substr(0, mCursorCharacterIndex));
 	const auto viewWidth = mRect.size.x - fieldPadding * 2;
 
 	// Check if cursor is after visible area
-	if (mScrollOffsetPixelX <= cursorX - viewWidth)
+	if (mScrollOffsetPixelX <= cursorVirtualPixelX - viewWidth)
 	{
-		mScrollOffsetPixelX = cursorX - viewWidth;
+		mScrollOffsetPixelX = cursorVirtualPixelX - viewWidth;
 	}
 
 	// Check if cursor is before visible area
-	if (mScrollOffsetPixelX >= cursorX)
+	if (mScrollOffsetPixelX >= cursorVirtualPixelX)
 	{
-		mScrollOffsetPixelX = cursorX - viewWidth / 2;
+		mScrollOffsetPixelX = cursorVirtualPixelX - viewWidth / 2;
 	}
 
 	if (mScrollOffsetPixelX < 0)
@@ -160,7 +160,7 @@ void TextField::updateScrollPosition()
 		mScrollOffsetPixelX = 0;
 	}
 
-	mCursorOffsetPixelX = cursorX - mScrollOffsetPixelX;
+	mCursorOffsetPixelX = cursorVirtualPixelX - mScrollOffsetPixelX;
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -160,7 +160,7 @@ void TextField::updateScrollPosition()
 		mScrollOffsetPixelX = 0;
 	}
 
-	mCursorPixelX = mRect.position.x + fieldPadding + cursorX - mScrollOffsetPixelX;
+	mCursorPixelX = cursorX - mScrollOffsetPixelX;
 }
 
 
@@ -188,8 +188,8 @@ void TextField::drawCursor(NAS2D::Renderer& renderer) const
 	{
 		if (mShowCursor)
 		{
-			const auto startPosition = NAS2D::Point{mCursorPixelX, mRect.position.y + fieldPadding};
-			const auto endPosition = NAS2D::Point{mCursorPixelX, mRect.position.y + mRect.size.y - fieldPadding - 1};
+			const auto startPosition = mRect.position + NAS2D::Vector{mCursorPixelX + fieldPadding, fieldPadding};
+			const auto endPosition = mRect.position + NAS2D::Vector{mCursorPixelX + fieldPadding, mRect.size.y - fieldPadding - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);
 			renderer.drawLine(startPosition, endPosition, NAS2D::Color::White);
 		}

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -161,6 +161,10 @@ void TextField::updateScrollPosition()
 	}
 
 	mCursorOffsetPixelX = cursorVirtualPixelX - mScrollOffsetPixelX;
+
+	// Show cursor immediately at new position (responsiveness)
+	mCursorBlinkTimer.reset();
+	mShowCursor = true;
 }
 
 

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -201,6 +201,17 @@ void TextField::drawCursor(NAS2D::Renderer& renderer) const
 }
 
 
+void TextField::onVisibilityChange(bool visible)
+{
+	if (visible)
+	{
+		// Show cursor immediately (responsiveness)
+		mCursorBlinkTimer.reset();
+		mShowCursor = true;
+	}
+}
+
+
 void TextField::onMouseDown(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 {
 	hasFocus(mRect.contains(position)); // This is a very useful check, should probably include this in all controls.

--- a/libControls/TextField.cpp
+++ b/libControls/TextField.cpp
@@ -160,7 +160,7 @@ void TextField::updateScrollPosition()
 		mScrollOffsetPixelX = 0;
 	}
 
-	mCursorPixelX = cursorX - mScrollOffsetPixelX;
+	mCursorOffsetPixelX = cursorX - mScrollOffsetPixelX;
 }
 
 
@@ -188,8 +188,8 @@ void TextField::drawCursor(NAS2D::Renderer& renderer) const
 	{
 		if (mShowCursor)
 		{
-			const auto startPosition = mRect.position + NAS2D::Vector{mCursorPixelX + fieldPadding, fieldPadding};
-			const auto endPosition = mRect.position + NAS2D::Vector{mCursorPixelX + fieldPadding, mRect.size.y - fieldPadding - 1};
+			const auto startPosition = mRect.position + NAS2D::Vector{mCursorOffsetPixelX + fieldPadding, fieldPadding};
+			const auto endPosition = mRect.position + NAS2D::Vector{mCursorOffsetPixelX + fieldPadding, mRect.size.y - fieldPadding - 1};
 			renderer.drawLine(startPosition + NAS2D::Vector{1, 1}, endPosition + NAS2D::Vector{1, 1}, NAS2D::Color::Black);
 			renderer.drawLine(startPosition, endPosition, NAS2D::Color::White);
 		}

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -91,7 +91,7 @@ private:
 
 	NAS2D::Timer mCursorBlinkTimer;
 	std::size_t mCursorCharacterIndex = 0;
-	int mCursorPixelX = 0;
+	int mCursorOffsetPixelX = 0;
 	int mScrollOffsetPixelX = 0;
 
 	bool mEditable = true;

--- a/libControls/TextField.h
+++ b/libControls/TextField.h
@@ -74,6 +74,7 @@ protected:
 	void draw(NAS2D::Renderer& renderer) const override;
 	void drawCursor(NAS2D::Renderer& renderer) const;
 
+	void onVisibilityChange(bool visible) override;
 	virtual void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	virtual void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onTextInput(const std::string& newTextInput);


### PR DESCRIPTION
Fix `TextField` so text cursor is initially visible in an empty `TextField`, and improve apparent responsiveness when updating scroll position, and when `TextField` first becomes visible.

The `TextField` sometimes gave a sense of lag when updating the text cursor position, which was caused by it blinking out of visibility during the update, so the new position was not seen until the next blink cycle. By resetting the blink cycle upon a text cursor move, so the text cursor is immediately visible at the new position, it appears much more responsive.

Additionally, when the `TextField` first comes into view, it may be long after it was created, so the initial text cursor blink period will have already elapsed, causing it to be hidden initially. By resetting the text cursor blinking when becoming visible, we can ensure the text cursor is drawn for the initial blink period, which gives a more responsive feel during the initial show.

Related:
- Issue #1754
