### PR TITLE
Refactor `CheatCode` processing in `CheatMenu`

### DIFF
--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -177,7 +177,7 @@ private:
 
 	void pullRobotFromFactory(ProductType pt, Factory& factory);
 	void onFactoryProductionComplete(Factory& factory);
-	void onCheatCodeEntry(const std::string& cheatCode);
+	void onCheatCodeEntry(CheatMenu::CheatCode cheatCode);
 
 	void onMineFacilityExtend(MineFacility* mf);
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -549,10 +549,9 @@ void MapViewState::onTurns()
 	nextTurn();
 }
 
-void MapViewState::onCheatCodeEntry(const std::string& cheatCode)
+void MapViewState::onCheatCodeEntry(CheatMenu::CheatCode cheatCode)
 {
-	CheatMenu::CheatCode code = CheatMenu::stringToCheatCode(cheatCode);
-	switch(code)
+	switch(cheatCode)
 	{
 		case CheatMenu::CheatCode::Invalid:
 			return;

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <map>
 
 
 namespace

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -64,7 +64,7 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 
 void CheatMenu::onOkay()
 {
-	if (mCheatHandler) { mCheatHandler(txtCheatCode.text()); }
+	if (mCheatHandler) { mCheatHandler(stringToCheatCode(txtCheatCode.text())); }
 	txtCheatCode.clear();
 	hide();
 	// Transfer focus back to text field (from "Okay" button)

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -10,19 +10,6 @@
 
 namespace
 {
-	enum class CheatCode
-	{
-		AddResources,
-		AddFood,
-		AddRobots,
-		AddChildren,
-		AddStudents,
-		AddWorkers,
-		AddScientists,
-		AddRetired,
-		Invalid
-	};
-
 	const std::map<std::string, CheatMenu::CheatCode>& cheatCodeTable =
 	{
 		{"goldrush", CheatMenu::CheatCode::AddResources },         // Add 1000 of each resource.

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -39,6 +39,19 @@ namespace
 	};
 
 	const auto maxCheatLength = std::ranges::max(std::views::transform(std::views::keys(cheatCodeTable), &std::string::size));
+
+
+	CheatMenu::CheatCode stringToCheatCode(const std::string& cheatCode)
+	{
+		try
+		{
+			return stringToEnum(cheatCodeTable, cheatCode);
+		}
+		catch (const std::runtime_error&)
+		{
+			return CheatMenu::CheatCode::Invalid;
+		}
+	}
 }
 
 
@@ -69,17 +82,4 @@ void CheatMenu::onOkay()
 	hide();
 	// Transfer focus back to text field (from "Okay" button)
 	bringToFront(&txtCheatCode);
-}
-
-
-CheatMenu::CheatCode CheatMenu::stringToCheatCode(const std::string& cheatCode)
-{
-	try
-	{
-		return stringToEnum(cheatCodeTable, cheatCode);
-	}
-	catch (const std::runtime_error&)
-	{
-		return CheatCode::Invalid;
-	}
 }

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <string>
 #include <map>
 
 

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -30,7 +30,7 @@ public:
 		Invalid
 	};
 
-	using CheatDelegate = NAS2D::Delegate<void(const std::string&)>;
+	using CheatDelegate = NAS2D::Delegate<void(CheatCode)>;
 
 	CheatMenu(CheatDelegate cheatHandler);
 

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -26,7 +26,7 @@ public:
 		RemoveWorkers,
 		RemoveScientists,
 		RemoveRetired,
-		Invalid
+		Invalid,
 	};
 
 	using CheatDelegate = NAS2D::Delegate<void(CheatCode)>;

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -34,6 +34,7 @@ public:
 
 	CheatMenu(CheatDelegate cheatHandler);
 
+protected:
 	void onOkay();
 
 	static CheatMenu::CheatCode stringToCheatCode(const std::string& cheatCode);

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -37,8 +37,6 @@ public:
 protected:
 	void onOkay();
 
-	static CheatMenu::CheatCode stringToCheatCode(const std::string& cheatCode);
-
 private:
 	CheatDelegate mCheatHandler;
 

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -7,7 +7,6 @@
 
 #include <NAS2D/Signal/Delegate.h>
 
-#include <map>
 
 class CheatMenu : public Window
 {


### PR DESCRIPTION
Refactor `CheatCode` processing in `CheatMenu` to make cheat strings an internal detail.

This should make certain future changes to `CheatMenu` a little easier to accomplish, such as allowing `Enter` to submit cheat codes, or removing cheat code processing from `MapViewState`.

Related:
- Issue #1754
- Issue #650
