### PR TITLE
Set focus to `TextField` on `CheatMenu` show

### DIFF
--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -66,7 +66,7 @@ void CheatMenu::onVisibilityChange(bool visible)
 {
 	if (visible)
 	{
-		bringToFront(&txtCheatCode);
+		txtCheatCode.hasFocus(true);
 	}
 }
 

--- a/appOPHD/UI/CheatMenu.cpp
+++ b/appOPHD/UI/CheatMenu.cpp
@@ -59,8 +59,15 @@ CheatMenu::CheatMenu(CheatDelegate cheatHandler) :
 	add(btnOkay, {txtCheatCode.area().endPoint().x + 6, positionY});
 
 	size({btnOkay.area().endPoint().x + 10, positionY + txtCheatCode.size().y + 10});
-	// Transfer focus to text field
-	bringToFront(&txtCheatCode);
+}
+
+
+void CheatMenu::onVisibilityChange(bool visible)
+{
+	if (visible)
+	{
+		bringToFront(&txtCheatCode);
+	}
 }
 
 
@@ -69,8 +76,6 @@ void CheatMenu::onOkay()
 	if (mCheatHandler) { mCheatHandler(stringToCheatCode(txtCheatCode.text())); }
 	txtCheatCode.clear();
 	hide();
-	// Transfer focus back to text field (from "Okay" button)
-	bringToFront(&txtCheatCode);
 }
 
 

--- a/appOPHD/UI/CheatMenu.h
+++ b/appOPHD/UI/CheatMenu.h
@@ -34,6 +34,8 @@ public:
 	CheatMenu(CheatDelegate cheatHandler);
 
 protected:
+	void onVisibilityChange(bool visible) override;
+
 	void onOkay();
 	void onEnter(TextField& textField);
 


### PR DESCRIPTION
The previous code was a bit hacked in that it attempted to predict code paths that would lead to having focus set to the `TextField` when the `CheatMenu` was shown, rather than using an event handler override that was called when the `CheatMenu` was shown.

The old code could encounter problems when clicking outside of the `CheatMenu` and using the `Escape` key to close open windows. Upon subsequent use, the `TextField` didn't get focus.

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-2975090937
