### PR TITLE
Refactor misc - Add header parameter names

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -149,8 +149,6 @@ public:
 	virtual NAS2D::Dictionary getDataDict() const;
 
 protected:
-	friend class StructureCatalog;
-
 	void activate();
 
 	virtual void disabledStateSet() {}

--- a/appOPHD/UI/DetailMap.h
+++ b/appOPHD/UI/DetailMap.h
@@ -22,7 +22,7 @@ public:
 	Tile& mouseTile();
 
 	void onMouseMove(NAS2D::Point<int> position);
-	void resize(NAS2D::Vector<int>);
+	void resize(NAS2D::Vector<int> size);
 
 	void update() override;
 	void draw(NAS2D::Renderer& renderer) const override;

--- a/appOPHD/UI/FactoryListBox.h
+++ b/appOPHD/UI/FactoryListBox.h
@@ -28,7 +28,7 @@ public:
 	FactoryListBox(SelectionChangedDelegate selectionChangedHandler = {});
 
 	void addItem(Factory* factory);
-	void setSelected(Factory*);
+	void setSelected(Factory* factory);
 
 	Factory* selectedFactory();
 

--- a/appOPHD/UI/FactoryProduction.h
+++ b/appOPHD/UI/FactoryProduction.h
@@ -29,7 +29,7 @@ public:
 	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 protected:
-	void onProductSelectionChange(const IconGridItem*);
+	void onProductSelectionChange(const IconGridItem* item);
 	void onClearSelection();
 	void onApply();
 	void onOkay();

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -19,11 +19,6 @@
 using namespace NAS2D;
 
 
-FileIo::FileIo(FileLoadDelegate fileLoadHandler) :
-	FileIo{fileLoadHandler, FileSaveDelegate{}}
-{}
-
-
 FileIo::FileIo(FileLoadDelegate fileLoadHandler, FileSaveDelegate fileSaveHandler) :
 	Window{"File I/O"},
 	mFileLoadHandler{fileLoadHandler},

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -19,15 +19,15 @@
 using namespace NAS2D;
 
 
-FileIo::FileIo(FileLoadDelegate fileLoadDelegate) :
-	FileIo{fileLoadDelegate, FileSaveDelegate{}}
+FileIo::FileIo(FileLoadDelegate fileLoadHandler) :
+	FileIo{fileLoadHandler, FileSaveDelegate{}}
 {}
 
 
-FileIo::FileIo(FileLoadDelegate fileLoadDelegate, FileSaveDelegate fileSaveDelegate) :
+FileIo::FileIo(FileLoadDelegate fileLoadHandler, FileSaveDelegate fileSaveHandler) :
 	Window{"File I/O"},
-	mFileLoadDelegate{fileLoadDelegate},
-	mFileSaveDelegate{fileSaveDelegate},
+	mFileLoadHandler{fileLoadHandler},
+	mFileSaveHandler{fileSaveHandler},
 	mMode{FileOperation::Load},
 	mOpenSaveFolder{"Open Save Folder", {this, &FileIo::onOpenFolder}},
 	mCancel{"Cancel", {this, &FileIo::onClose}},
@@ -196,12 +196,12 @@ void FileIo::onFileIo()
 {
 	if(mMode == FileOperation::Save)
 	{
-		if(mFileSaveDelegate) { mFileSaveDelegate(mFileName.text()); }
+		if(mFileSaveHandler) { mFileSaveHandler(mFileName.text()); }
 	}
 
 	if(mMode == FileOperation::Load)
 	{
-		mFileLoadDelegate(mFileName.text());
+		mFileLoadHandler(mFileName.text());
 	}
 	mFileName.clear();
 	mFileOperation.enabled(false);

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -24,7 +24,7 @@ public:
 	using FileLoadDelegate = NAS2D::Delegate<void(const std::string&)>;
 	using FileSaveDelegate = NAS2D::Delegate<void(const std::string&)>;
 
-	FileIo(FileLoadDelegate, FileSaveDelegate = {});
+	FileIo(FileLoadDelegate fileLoadHandler, FileSaveDelegate fileSaveHandler = {});
 	~FileIo() override;
 
 	void showOpen(const std::string& directory);

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -24,8 +24,7 @@ public:
 	using FileLoadDelegate = NAS2D::Delegate<void(const std::string&)>;
 	using FileSaveDelegate = NAS2D::Delegate<void(const std::string&)>;
 
-	FileIo(FileLoadDelegate);
-	FileIo(FileLoadDelegate, FileSaveDelegate);
+	FileIo(FileLoadDelegate, FileSaveDelegate = {});
 	~FileIo() override;
 
 	void showOpen(const std::string& directory);

--- a/appOPHD/UI/FileIo.h
+++ b/appOPHD/UI/FileIo.h
@@ -51,8 +51,8 @@ protected:
 	void onFileDelete();
 
 private:
-	FileLoadDelegate mFileLoadDelegate;
-	FileSaveDelegate mFileSaveDelegate;
+	FileLoadDelegate mFileLoadHandler;
+	FileSaveDelegate mFileSaveHandler;
 
 	FileOperation mMode;
 

--- a/appOPHD/UI/IconGrid.h
+++ b/appOPHD/UI/IconGrid.h
@@ -42,7 +42,7 @@ public:
 	IconGrid(Delegate selectionChangedHandler, const std::string& filePath, int iconSize, int margin, bool showTooltip = false);
 	~IconGrid() override;
 
-	void addItem(const IconGridItem&);
+	void addItem(const IconGridItem& item);
 	void sort();
 	void clear();
 	bool isEmpty() const { return mIconItemList.empty(); }

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -46,9 +46,9 @@ MajorEventAnnouncement::AnnouncementType MajorEventAnnouncement::colonyShipCrash
 }
 
 
-void MajorEventAnnouncement::announcement(AnnouncementType a)
+void MajorEventAnnouncement::announcement(AnnouncementType announcementType)
 {
-	switch (a)
+	switch (announcementType)
 	{
 	case AnnouncementType::ColonyShipCrash:
 		mMessage = "Colony ship deorbited and crashed.";

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -13,7 +13,8 @@ using namespace NAS2D;
 
 
 MajorEventAnnouncement::MajorEventAnnouncement() :
-	mHeader{imageCache.load("ui/interface/colony_ship_crash.png")}
+	mHeader{imageCache.load("ui/interface/colony_ship_crash.png")},
+	btnClose{"Okay", {this, &MajorEventAnnouncement::onClose}}
 {
 	position({0, 0});
 	size({522, 340});

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -35,5 +35,5 @@ protected:
 private:
 	const NAS2D::Image& mHeader;
 	std::string mMessage;
-	Button btnClose{"Okay", {this, &MajorEventAnnouncement::onClose}};
+	Button btnClose;
 };

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -3,13 +3,14 @@
 #include <libControls/Window.h>
 #include <libControls/Button.h>
 
+
 class WindowStack;
 struct ColonyShipLanders;
+
 
 class MajorEventAnnouncement : public Window
 {
 public:
-
 	enum class AnnouncementType
 	{
 		ColonyShipCrash,

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -29,7 +29,7 @@ public:
 private:
 	void onClose();
 
-	MajorEventAnnouncement::AnnouncementType colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipLanders);
+	AnnouncementType colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipLanders);
 
 	const NAS2D::Image& mHeader;
 	std::string mMessage;

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -20,16 +20,16 @@ public:
 
 	MajorEventAnnouncement();
 
-	void announcement(AnnouncementType a);
+	void announcement(AnnouncementType announcementType);
 
-	void onColonyShipCrash(WindowStack&, const ColonyShipLanders&);
+	void onColonyShipCrash(WindowStack& windowStack, const ColonyShipLanders& colonyShipLanders);
 
 	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
 private:
 	void onClose();
 
-	MajorEventAnnouncement::AnnouncementType colonyShipCrashAnnouncement(const ColonyShipLanders&);
+	MajorEventAnnouncement::AnnouncementType colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipLanders);
 
 	const NAS2D::Image& mHeader;
 	std::string mMessage;

--- a/appOPHD/UI/MajorEventAnnouncement.h
+++ b/appOPHD/UI/MajorEventAnnouncement.h
@@ -27,11 +27,12 @@ public:
 
 	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
-private:
+protected:
 	void onClose();
 
 	AnnouncementType colonyShipCrashAnnouncement(const ColonyShipLanders& colonyShipLanders);
 
+private:
 	const NAS2D::Image& mHeader;
 	std::string mMessage;
 	Button btnClose{"Okay", {this, &MajorEventAnnouncement::onClose}};

--- a/appOPHD/UI/MapObjectPicker.h
+++ b/appOPHD/UI/MapObjectPicker.h
@@ -45,9 +45,9 @@ public:
 	using ControlContainer::update;
 
 protected:
-	void onStructuresSelectionChange(const IconGridItem*);
-	void onConnectionsSelectionChange(const IconGridItem*);
-	void onRobotsSelectionChange(const IconGridItem*);
+	void onStructuresSelectionChange(const IconGridItem* item);
+	void onConnectionsSelectionChange(const IconGridItem* item);
+	void onRobotsSelectionChange(const IconGridItem* item);
 	void onMouseWheel(NAS2D::Vector<int> changeAmount);
 	void onResize() override;
 

--- a/appOPHD/UI/NotificationArea.h
+++ b/appOPHD/UI/NotificationArea.h
@@ -62,7 +62,7 @@ protected:
 	NAS2D::Rectangle<int> notificationRect(std::size_t index) const;
 	std::size_t notificationIndex(NAS2D::Point<int> pixelPosition);
 
-	void onMouseDown(NAS2D::MouseButton, NAS2D::Point<int> position);
+	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 private:

--- a/appOPHD/UI/NotificationWindow.h
+++ b/appOPHD/UI/NotificationWindow.h
@@ -20,7 +20,7 @@ public:
 public:
 	NotificationWindow(TakeMeThereDelegate takeMeThereHandler);
 
-	void notification(const NotificationArea::Notification&);
+	void notification(const NotificationArea::Notification& notification);
 
 	void drawClientArea(NAS2D::Renderer& renderer) const override;
 

--- a/appOPHD/UI/NotificationWindow.h
+++ b/appOPHD/UI/NotificationWindow.h
@@ -24,11 +24,12 @@ public:
 
 	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
-private:
+protected:
 	void onVisibilityChange(bool isVisible) override;
 	void onOkayClicked();
 	void onTakeMeThereClicked();
 
+private:
 	const NAS2D::Image& mIcons;
 
 	NotificationArea::Notification mNotification;

--- a/appOPHD/UI/RobotInspector.h
+++ b/appOPHD/UI/RobotInspector.h
@@ -12,7 +12,7 @@ class RobotInspector : public Window
 public:
 	RobotInspector();
 
-	void focusOnRobot(Robot*);
+	void focusOnRobot(Robot* robot);
 	const Robot* focusedRobot() const { return mRobot; }
 
 	void drawClientArea(NAS2D::Renderer& renderer) const override;

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -103,9 +103,9 @@ void StructureListBox::clear()
 }
 
 
-void StructureListBox::add(Structure* s, std::string stateDescription)
+void StructureListBox::add(Structure* structure, std::string stateDescription)
 {
-	mItems.emplace_back(StructureListBoxItem{s->name(), s, std::move(stateDescription)});
+	mItems.emplace_back(StructureListBoxItem{structure->name(), structure, std::move(stateDescription)});
 	updateScrollLayout();
 }
 

--- a/appOPHD/UI/StructureListBox.h
+++ b/appOPHD/UI/StructureListBox.h
@@ -26,7 +26,7 @@ public:
 	StructureListBox(SelectionChangedDelegate selectionChangedHandler = {});
 
 	void addItem(Structure* structure, std::string stateDescription = std::string{});
-	void setSelected(const Structure*);
+	void setSelected(const Structure* structure);
 
 	const Structure* selectedStructure() const;
 	Structure* selectedStructure();
@@ -36,7 +36,7 @@ public:
 	void clear();
 
 protected:
-	void add(Structure* s, std::string stateDescription);
+	void add(Structure* structure, std::string stateDescription);
 
 	virtual std::size_t count() const override;
 

--- a/appOPHD/UI/WarehouseInspector.cpp
+++ b/appOPHD/UI/WarehouseInspector.cpp
@@ -24,9 +24,9 @@ WarehouseInspector::WarehouseInspector() :
 }
 
 
-void WarehouseInspector::warehouse(const Warehouse* w)
+void WarehouseInspector::warehouse(const Warehouse* warehouse)
 {
-	mWarehouse = w;
+	mWarehouse = warehouse;
 }
 
 

--- a/appOPHD/UI/WarehouseInspector.h
+++ b/appOPHD/UI/WarehouseInspector.h
@@ -15,7 +15,7 @@ class WarehouseInspector : public Window
 public:
 	WarehouseInspector();
 
-	void warehouse(const Warehouse* w);
+	void warehouse(const Warehouse* warehouse);
 
 	void hide() override;
 	void drawClientArea(NAS2D::Renderer& renderer) const override;

--- a/appOPHD/UI/WarehouseInspector.h
+++ b/appOPHD/UI/WarehouseInspector.h
@@ -20,9 +20,10 @@ public:
 	void hide() override;
 	void drawClientArea(NAS2D::Renderer& renderer) const override;
 
-private:
+protected:
 	void onClose();
 
+private:
 	const Warehouse* mWarehouse = nullptr;
 	Button btnClose;
 };

--- a/libControls/Button.cpp
+++ b/libControls/Button.cpp
@@ -207,5 +207,3 @@ void Button::draw(NAS2D::Renderer& renderer) const
 		renderer.drawBoxFilled(mRect, NAS2D::Color{125, 125, 125, 100});
 	}
 }
-
-


### PR DESCRIPTION
A bit of misc refactoring to increase code consistency, though mostly adding parameter names to header files.

Also removes unnecessary use of `friend`, adjust blank lines, rename a few parameters and fields, use default parameters to eliminate constructor overloads, remove unnecessary prefix, use constructor init-list to initialize field default values.
