### PR TITLE
Remove `using namespace` in UI/Reports

### DIFF
--- a/appOPHD/UI/Reports/FactoryReport.cpp
+++ b/appOPHD/UI/Reports/FactoryReport.cpp
@@ -23,9 +23,6 @@
 #include <array>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	constexpr auto viewFilterButtonSize = NAS2D::Vector{104, 26};
@@ -42,7 +39,7 @@ namespace
 
 	const NAS2D::Image& productImage(ProductType productType)
 	{
-		static const std::map<ProductType, const Image*> productImages{
+		static const std::map<ProductType, const NAS2D::Image*> productImages{
 			{ProductType::PRODUCT_DIGGER, &imageCache.load("ui/interface/product_robodigger.png")},
 			{ProductType::PRODUCT_DOZER, &imageCache.load("ui/interface/product_robodozer.png")},
 			{ProductType::PRODUCT_MINER, &imageCache.load("ui/interface/product_robominer.png")},
@@ -103,7 +100,7 @@ FactoryReport::FactoryReport(TakeMeThereDelegate takeMeThereHandler) :
 	add(btnShowDisabled, viewFilterOriginRow2 + viewFilterSpacing * 2);
 	btnShowDisabled.type(Button::Type::Toggle);
 
-	const auto positionX = Utility<Renderer>::get().size().x - 110;
+	const auto positionX = NAS2D::Utility<NAS2D::Renderer>::get().size().x - 110;
 	add(btnIdle, {positionX, 35});
 	btnIdle.type(Button::Type::Toggle);
 
@@ -166,7 +163,7 @@ void FactoryReport::fillLists()
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : NAS2D::Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		lstFactoryList.addItem(factory);
 	}
@@ -190,7 +187,7 @@ void FactoryReport::fillFactoryList(ProductType type)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : NAS2D::Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (factory->productType() == type)
 		{
@@ -209,7 +206,7 @@ void FactoryReport::fillFactoryList(bool surface)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : NAS2D::Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (surface && (factory->name() == constants::SurfaceFactory || factory->name() == constants::SeedFactory))
 		{
@@ -232,7 +229,7 @@ void FactoryReport::fillFactoryList(StructureState state)
 {
 	selectedFactory = nullptr;
 	lstFactoryList.clear();
-	for (auto* factory : Utility<StructureManager>::get().getStructures<Factory>())
+	for (auto* factory : NAS2D::Utility<StructureManager>::get().getStructures<Factory>())
 	{
 		if (factory->state() == state)
 		{
@@ -448,7 +445,7 @@ void FactoryReport::onProductFilterSelectionChange()
 }
 
 
-void FactoryReport::drawDetailPane(Renderer& renderer) const
+void FactoryReport::drawDetailPane(NAS2D::Renderer& renderer) const
 {
 	const auto startPoint = detailPanelRect.position;
 	renderer.drawImage(*factoryImage, startPoint + NAS2D::Vector{0, 25});
@@ -489,7 +486,7 @@ void FactoryReport::drawDetailPane(Renderer& renderer) const
 }
 
 
-void FactoryReport::drawProductPane(Renderer& renderer) const
+void FactoryReport::drawProductPane(NAS2D::Renderer& renderer) const
 {
 	const auto originLeft = detailPanelRect.position + NAS2D::Vector{0, 180};
 	renderer.drawText(fontBigBold, "Production", originLeft, constants::PrimaryTextColor);
@@ -530,7 +527,7 @@ void FactoryReport::drawProductPane(Renderer& renderer) const
 void FactoryReport::update()
 {
 	ControlContainer::update();
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	draw(renderer);
 }
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -28,9 +28,6 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	std::string getStructureDescription(const Structure& structure)
@@ -466,7 +463,7 @@ void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::P
 void MineReport::update()
 {
 	ControlContainer::update();
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	draw(renderer);
 }
 

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -25,13 +25,12 @@ extern NAS2D::Point<int> MOUSE_COORDS;	// <-- Yuck, really need to find a better
 										// poll mouse position. Might make sense to add a
 										// method to NAS2D::EventHandler for that.
 
-using namespace NAS2D;
 
 namespace
 {
-	constexpr Vector<int> LabTypeIconSize{32, 32};
-	constexpr Vector<int> CategoryIconSize{64, 64};
-	constexpr Vector<int> TopicIconSize{128, 128};
+	constexpr NAS2D::Vector<int> LabTypeIconSize{32, 32};
+	constexpr NAS2D::Vector<int> CategoryIconSize{64, 64};
+	constexpr NAS2D::Vector<int> TopicIconSize{128, 128};
 	constexpr auto MarginSize = 10;
 
 	constexpr NAS2D::Rectangle<int> HotLabIconRect = {{32, 224}, LabTypeIconSize};
@@ -60,17 +59,17 @@ namespace
 		return itemsToAdd;
 	}
 
-	void drawDetailsHeaderSeparator(NAS2D::Renderer& renderer, const Rectangle<int>& area)
+	void drawDetailsHeaderSeparator(NAS2D::Renderer& renderer, const NAS2D::Rectangle<int>& area)
 	{
-		const Point<int> lineStartPoint{area.crossYPoint() + Vector<int>{0, SectionPadding.y}};
-		const Point<int> lineEndPoint{area.endPoint() + Vector<int>{0, SectionPadding.y}};
+		const NAS2D::Point<int> lineStartPoint{area.crossYPoint() + NAS2D::Vector<int>{0, SectionPadding.y}};
+		const NAS2D::Point<int> lineEndPoint{area.endPoint() + NAS2D::Vector<int>{0, SectionPadding.y}};
 		renderer.drawLine(lineStartPoint, lineEndPoint, constants::PrimaryTextColor);
 	}
 
-	Rectangle<int> getCategorySlice(const int imageWidth, const int iconIndex)
+	NAS2D::Rectangle<int> getCategorySlice(const int imageWidth, const int iconIndex)
 	{
 		const int columns = imageWidth / CategoryIconSize.x;
-		const Point<int> sliceStartPosition
+		const NAS2D::Point<int> sliceStartPosition
 		{
 			(iconIndex % columns) * CategoryIconSize.x,
 			(iconIndex / columns) * CategoryIconSize.y
@@ -79,7 +78,7 @@ namespace
 		return {sliceStartPosition, CategoryIconSize};
 	}
 
-	Point<int> getIconTextureCoords(const Technology& tech, const int textureWidth)
+	NAS2D::Point<int> getIconTextureCoords(const Technology& tech, const int textureWidth)
 	{
 		const auto columns = textureWidth / TopicIconSize.x;
 
@@ -158,7 +157,7 @@ void ResearchReport::refresh()
 	setSectionRects();
 	setIconPositions();
 
-	mCategoryHeaderTextPosition = {area().position + Vector<int>{SectionPadding.x * 3 + CategoryIconSize.x, SectionPadding.y}};
+	mCategoryHeaderTextPosition = {area().position + NAS2D::Vector<int>{SectionPadding.x * 3 + CategoryIconSize.x, SectionPadding.y}};
 
 	lstResearchTopics.area(mResearchTopicArea);
 
@@ -169,7 +168,7 @@ void ResearchReport::refresh()
 
 void ResearchReport::update()
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	draw(renderer);
 	ControlContainer::update();
 }
@@ -236,10 +235,10 @@ void ResearchReport::setIconPositions()
 {
 	const auto startPoint{mTopicDetailsHeaderArea.startPoint()};
 
-	mHotLabIconPosition = {startPoint + Vector<int>{0, fontBigBold.height() + SectionPadding.y}};
-	mStdLabIconPosition = {startPoint + Vector<int>{(area().size.x - startPoint.x) / 2, fontBigBold.height() + SectionPadding.y}};
-	mStdLabTextPosition = {mStdLabIconPosition + Vector<int>{LabTypeIconSize.x + SectionPadding.x, LabTypeIconSize.y / 2 - fontMedium.height() / 2}};
-	mHotLabTextPosition = {mHotLabIconPosition + Vector<int>{LabTypeIconSize.x + SectionPadding.x, LabTypeIconSize.y / 2 - fontMedium.height() / 2}};
+	mHotLabIconPosition = {startPoint + NAS2D::Vector<int>{0, fontBigBold.height() + SectionPadding.y}};
+	mStdLabIconPosition = {startPoint + NAS2D::Vector<int>{(area().size.x - startPoint.x) / 2, fontBigBold.height() + SectionPadding.y}};
+	mStdLabTextPosition = {mStdLabIconPosition + NAS2D::Vector<int>{LabTypeIconSize.x + SectionPadding.x, LabTypeIconSize.y / 2 - fontMedium.height() / 2}};
+	mHotLabTextPosition = {mHotLabIconPosition + NAS2D::Vector<int>{LabTypeIconSize.x + SectionPadding.x, LabTypeIconSize.y / 2 - fontMedium.height() / 2}};
 }
 
 
@@ -270,7 +269,7 @@ void ResearchReport::setSectionRects()
 	
 	mTopicDetailsHeaderArea =
 	{
-		area().position + Vector<int>{SectionPadding.x * 2 + mResearchTopicArea.endPoint().x, SectionPadding.y},
+		area().position + NAS2D::Vector<int>{SectionPadding.x * 2 + mResearchTopicArea.endPoint().x, SectionPadding.y},
 		{
 			area().size.x - mResearchTopicArea.endPoint().x - SectionPadding.x * 3,
 			100
@@ -283,7 +282,7 @@ void ResearchReport::setSectionRects()
 		mTopicDetailsHeaderArea.crossYPoint().y + SectionPadding.y * 2
 	};
 
-	const Point<int> topicDetailStart{mTopicDetailsIconPosition + Vector<int>{0, TopicIconSize.y + SectionPadding.y}};
+	const NAS2D::Point<int> topicDetailStart{mTopicDetailsIconPosition + NAS2D::Vector<int>{0, TopicIconSize.y + SectionPadding.y}};
 	mTopicDetailsArea =
 	{
 		topicDetailStart,
@@ -315,7 +314,7 @@ void ResearchReport::adjustCategoryIconSpacing()
 
 void ResearchReport::checkForLabAvailability()
 {
-	auto& mgr = Utility<StructureManager>::get();
+	auto& mgr = NAS2D::Utility<StructureManager>::get();
 	mLabsAvailable = {mgr.countInState<Laboratory>(StructureState::Operational), mgr.countInState<HotLaboratory>(StructureState::Operational)};
 }
 
@@ -324,7 +323,7 @@ void ResearchReport::processCategories()
 {
 	for (const auto& category : mTechCatalog->categories())
 	{
-		const Rectangle<int> sliceRect{getCategorySlice(imageCategoryIcons.size().x, category.icon_index)};
+		const NAS2D::Rectangle<int> sliceRect{getCategorySlice(imageCategoryIcons.size().x, category.icon_index)};
 		mCategoryPanels.emplace_back(CategoryPanel{{}, sliceRect, category.name, false});
 	}
 
@@ -382,7 +381,7 @@ void ResearchReport::drawCategories(NAS2D::Renderer& renderer) const
 {
 	for (const auto& panel : mCategoryPanels)
 	{
-		const auto panelRect = Rectangle<int>::Create(
+		const auto panelRect = NAS2D::Rectangle<int>::Create(
 			panel.rect.position - CategorySelectorPadding,
 			panel.rect.endPoint() + CategorySelectorPadding);
 
@@ -408,8 +407,8 @@ void ResearchReport::drawCategoryHeader(NAS2D::Renderer& renderer) const
 
 void ResearchReport::drawVerticalSectionSpacer(NAS2D::Renderer& renderer, const int startX) const
 {
-	const Point<int> start{startX, area().position.y + SectionPadding.y};
-	const Point<int> end{startX, area().position.y + area().size.y - SectionPadding.y};
+	const NAS2D::Point<int> start{startX, area().position.y + SectionPadding.y};
+	const NAS2D::Point<int> end{startX, area().position.y + area().size.y - SectionPadding.y};
 	renderer.drawLine(start, end, constants::PrimaryColor);
 }
 

--- a/appOPHD/UI/Reports/SatellitesReport.cpp
+++ b/appOPHD/UI/Reports/SatellitesReport.cpp
@@ -7,9 +7,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 SatellitesReport::SatellitesReport(TakeMeThereDelegate takeMeThereHandler) :
 	mTakeMeThereHandler{takeMeThereHandler},
 	fontMedium{fontCache.load(constants::FontPrimary, constants::FontPrimaryMedium)},
@@ -53,7 +50,7 @@ void SatellitesReport::refresh()
 
 void SatellitesReport::update()
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	draw(renderer);
 	ControlContainer::update();
 }
@@ -66,7 +63,7 @@ void SatellitesReport::onResize()
 
 void SatellitesReport::draw(NAS2D::Renderer& renderer) const
 {
-	renderer.drawImage(imageNotImplemented, area().startPoint() + Vector<int>{10, 10});
-	renderer.drawText(fontBigBold, "Satellites Report", area().startPoint() + Vector<int>{148, 10}, constants::PrimaryTextColor);
-	renderer.drawText(fontMedium, "This panel intentionally left blank.", area().startPoint() + Vector<int>{148, 20 + fontBigBold.height()}, constants::PrimaryTextColor);
+	renderer.drawImage(imageNotImplemented, area().startPoint() + NAS2D::Vector<int>{10, 10});
+	renderer.drawText(fontBigBold, "Satellites Report", area().startPoint() + NAS2D::Vector<int>{148, 10}, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, "This panel intentionally left blank.", area().startPoint() + NAS2D::Vector<int>{148, 20 + fontBigBold.height()}, constants::PrimaryTextColor);
 }

--- a/appOPHD/UI/Reports/SpaceportsReport.cpp
+++ b/appOPHD/UI/Reports/SpaceportsReport.cpp
@@ -6,7 +6,6 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/Renderer/Renderer.h>
 
-using namespace NAS2D;
 
 SpaceportsReport::SpaceportsReport(TakeMeThereDelegate takeMeThereHandler) :
 	mTakeMeThereHandler{takeMeThereHandler},
@@ -51,7 +50,7 @@ void SpaceportsReport::refresh()
 
 void SpaceportsReport::update()
 {
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	draw(renderer);
 	ControlContainer::update();
 }
@@ -64,7 +63,7 @@ void SpaceportsReport::onResize()
 
 void SpaceportsReport::draw(NAS2D::Renderer& renderer) const
 {
-	renderer.drawImage(imageNotImplemented, area().startPoint() + Vector<int>{10, 10});
-	renderer.drawText(fontBigBold, "Spaceports Report", area().startPoint() + Vector<int>{148, 10}, constants::PrimaryTextColor);
-	renderer.drawText(fontMedium, "This panel intentionally left blank.", area().startPoint() + Vector<int>{148, 20 + fontBigBold.height()}, constants::PrimaryTextColor);
+	renderer.drawImage(imageNotImplemented, area().startPoint() + NAS2D::Vector<int>{10, 10});
+	renderer.drawText(fontBigBold, "Spaceports Report", area().startPoint() + NAS2D::Vector<int>{148, 10}, constants::PrimaryTextColor);
+	renderer.drawText(fontMedium, "This panel intentionally left blank.", area().startPoint() + NAS2D::Vector<int>{148, 20 + fontBigBold.height()}, constants::PrimaryTextColor);
 }

--- a/appOPHD/UI/Reports/WarehouseReport.cpp
+++ b/appOPHD/UI/Reports/WarehouseReport.cpp
@@ -21,9 +21,6 @@
 class Structure;
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	constexpr auto filterButtonSectionOffset = NAS2D::Vector{10, 10};
@@ -36,7 +33,7 @@ namespace
 	template <typename Predicate>
 	std::vector<Warehouse*> selectWarehouses(const Predicate& predicate)
 	{
-		const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
+		const auto& warehouses = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 
 		std::vector<Warehouse*> output;
 		std::copy_if(warehouses.begin(), warehouses.end(), std::back_inserter(output), predicate);
@@ -87,19 +84,19 @@ WarehouseReport::WarehouseReport(TakeMeThereDelegate takeMeThereHandler) :
 
 	btnTakeMeThere.size({140, 30});
 
-	Utility<EventHandler>::get().mouseDoubleClick().connect({this, &WarehouseReport::onDoubleClick});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseDoubleClick().connect({this, &WarehouseReport::onDoubleClick});
 
 	fillLists();
 
 	add(btnTakeMeThere, {10, 10});
 	add(lstStructures, structureListBoxOffset);
-	add(lstProducts, {Utility<Renderer>::get().center().x + 10, 173});
+	add(lstProducts, {NAS2D::Utility<NAS2D::Renderer>::get().center().x + 10, 173});
 }
 
 
 WarehouseReport::~WarehouseReport()
 {
-	Utility<EventHandler>::get().mouseDoubleClick().disconnect({this, &WarehouseReport::onDoubleClick});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseDoubleClick().disconnect({this, &WarehouseReport::onDoubleClick});
 }
 
 
@@ -148,7 +145,7 @@ void WarehouseReport::computeTotalWarehouseCapacity()
 	int capacityTotal = 0;
 	int capacityAvailable = 0;
 
-	const auto& warehouses = Utility<StructureManager>::get().getStructures<Warehouse>();
+	const auto& warehouses = NAS2D::Utility<StructureManager>::get().getStructures<Warehouse>();
 	for (const auto* warehouse : warehouses)
 	{
 		if (warehouse->operational())
@@ -220,10 +217,10 @@ void WarehouseReport::fillListDisabled()
 }
 
 
-void WarehouseReport::onDoubleClick(MouseButton button, NAS2D::Point<int> position)
+void WarehouseReport::onDoubleClick(NAS2D::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!visible()) { return; }
-	if (button != MouseButton::Left) { return; }
+	if (button != NAS2D::MouseButton::Left) { return; }
 
 	if (lstStructures.area().contains(position) && selectedWarehouse())
 	{
@@ -238,11 +235,11 @@ void WarehouseReport::onResize()
 
 	lstStructures.size({(mRect.size.x / 2) - 20, mRect.position.y + mRect.size.y - lstStructures.position().y - 10});
 	lstProducts.area({
-		{Utility<Renderer>::get().center().x + 10, lstProducts.position().y},
+		{NAS2D::Utility<NAS2D::Renderer>::get().center().x + 10, lstProducts.position().y},
 		{(mRect.size.x / 2) - 20, mRect.size.y - 184}
 	});
 
-	btnTakeMeThere.position({Utility<Renderer>::get().size().x - 150, position().y + 35});
+	btnTakeMeThere.position({NAS2D::Utility<NAS2D::Renderer>::get().size().x - 150, position().y + 35});
 }
 
 
@@ -337,7 +334,7 @@ void WarehouseReport::onStructureSelectionChange()
 	setVisibility();
 }
 
-void WarehouseReport::drawLeftPanel(Renderer& renderer) const
+void WarehouseReport::drawLeftPanel(NAS2D::Renderer& renderer) const
 {
 	const auto textLineSpacing = infoSectionHeight / 3;
 	const auto textOrigin = position() + infoSectionOffset;
@@ -364,7 +361,7 @@ void WarehouseReport::drawLeftPanel(Renderer& renderer) const
 }
 
 
-void WarehouseReport::drawRightPanel(Renderer& renderer) const
+void WarehouseReport::drawRightPanel(NAS2D::Renderer& renderer) const
 {
 	const auto* warehouse = selectedWarehouse();
 	if (!warehouse) { return; }
@@ -378,7 +375,7 @@ void WarehouseReport::drawRightPanel(Renderer& renderer) const
 void WarehouseReport::update()
 {
 	ControlContainer::update();
-	auto& renderer = Utility<Renderer>::get();
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	draw(renderer);
 }
 


### PR DESCRIPTION
Removing `using namespace` increases consistency between the header files and implementation files.

Related:
- PR #2017
