### PR TITLE
Remove `using namespace` in UI

### DIFF
--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -15,9 +15,6 @@
 #include <map>
 
 
-using namespace NAS2D;
-
-
 namespace {
 	const auto TileSize = NAS2D::Vector{128, 55};
 	const auto TileDrawSize = NAS2D::Vector{128, 64};
@@ -75,7 +72,7 @@ DetailMap::DetailMap(MapView& mapView, TileMap& tileMap, const std::string& tile
 	mTileset{tilesetPath},
 	mMineBeacon{"structures/mine_beacon.png"}
 {
-	resize(Utility<Renderer>::get().size());
+	resize(NAS2D::Utility<NAS2D::Renderer>::get().size());
 }
 
 
@@ -117,7 +114,7 @@ Tile& DetailMap::mouseTile()
 
 void DetailMap::update()
 {
-	for (const auto tilePosition : PointInRectangleRange{mMapView.viewTileRect()})
+	for (const auto tilePosition : NAS2D::PointInRectangleRange{mMapView.viewTileRect()})
 	{
 		auto& tile = mTileMap.getTile({tilePosition, mMapView.currentDepth()});
 
@@ -133,7 +130,7 @@ void DetailMap::draw(NAS2D::Renderer& renderer) const
 {
 	int tsetOffset = mMapView.currentDepth() > 0 ? TileDrawSize.y : 0;
 
-	for (const auto tilePosition : PointInRectangleRange{mMapView.viewTileRect()})
+	for (const auto tilePosition : NAS2D::PointInRectangleRange{mMapView.viewTileRect()})
 	{
 		auto& tile = mTileMap.getTile({tilePosition, mMapView.currentDepth()});
 

--- a/appOPHD/UI/FactoryListBox.cpp
+++ b/appOPHD/UI/FactoryListBox.cpp
@@ -17,9 +17,6 @@
 #include <stdexcept>
 
 
-using namespace NAS2D;
-
-
 FactoryListBox::FactoryListBox(SelectionChangedDelegate selectionChangedHandler) :
 	ListBoxBase{{0, 58}, selectionChangedHandler},
 	mFont{fontCache.load(constants::FontPrimary, 12)},

--- a/appOPHD/UI/FactoryProduction.cpp
+++ b/appOPHD/UI/FactoryProduction.cpp
@@ -15,9 +15,6 @@
 #include <stdexcept>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	StringTable factoryProductionStringTable(const ProductionCost& productionCost, int turnsCompleted)
@@ -78,8 +75,8 @@ FactoryProduction::FactoryProduction() :
 
 	mProductGrid.height(chkIdle.area().endPoint().y - mProductGrid.area().position.y);
 
-	const auto buttonArea = Rectangle{mProductGrid.area().endPoint() + Vector{constants::Margin, constants::MarginTight}, {std::max(162, stringTable.area().size.x), 22}};
-	const auto buttonSize = Vector{(buttonArea.size.x - (constants::MarginTight * 2)) / 3, buttonArea.size.y};
+	const auto buttonArea = NAS2D::Rectangle{mProductGrid.area().endPoint() + NAS2D::Vector{constants::Margin, constants::MarginTight}, {std::max(162, stringTable.area().size.x), 22}};
+	const auto buttonSize = NAS2D::Vector{(buttonArea.size.x - (constants::MarginTight * 2)) / 3, buttonArea.size.y};
 	const auto buttonSpacing = buttonSize.x + constants::MarginTight;
 
 	btnClearSelection.size({mProductGrid.size().x, buttonSize.y});

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -16,9 +16,6 @@
 #include <algorithm>
 
 
-using namespace NAS2D;
-
-
 FileIo::FileIo(FileLoadDelegate fileLoadHandler, FileSaveDelegate fileSaveHandler) :
 	Window{"File I/O"},
 	mFileLoadHandler{fileLoadHandler},
@@ -31,7 +28,7 @@ FileIo::FileIo(FileLoadDelegate fileLoadHandler, FileSaveDelegate fileSaveHandle
 	mFileName{50, {this, &FileIo::onFileNameChange}},
 	mListBox{{this, &FileIo::onFileSelect}}
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseDoubleClick().connect({this, &FileIo::onDoubleClick});
 	eventHandler.keyDown().connect({this, &FileIo::onKeyDown});
 
@@ -64,7 +61,7 @@ FileIo::FileIo(FileLoadDelegate fileLoadHandler, FileSaveDelegate fileSaveHandle
 
 FileIo::~FileIo()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseDoubleClick().disconnect({this, &FileIo::onDoubleClick});
 	eventHandler.keyDown().disconnect({this, &FileIo::onKeyDown});
 }
@@ -92,9 +89,9 @@ void FileIo::showSave(const std::string& directory)
 
 void FileIo::scanDirectory(const std::string& directory)
 {
-	mScanPath = (Utility<Filesystem>::get().prefPath() / directory).string();
+	mScanPath = (NAS2D::Utility<NAS2D::Filesystem>::get().prefPath() / directory).string();
 
-	const auto& filesystem = Utility<Filesystem>::get();
+	const auto& filesystem = NAS2D::Utility<NAS2D::Filesystem>::get();
 	auto dirList = filesystem.directoryList(directory);
 	std::sort(dirList.begin(), dirList.end());
 
@@ -109,7 +106,7 @@ void FileIo::scanDirectory(const std::string& directory)
 }
 
 
-void FileIo::onDoubleClick(MouseButton /*button*/, NAS2D::Point<int> position)
+void FileIo::onDoubleClick(NAS2D::MouseButton /*button*/, NAS2D::Point<int> position)
 {
 	if (!visible()) { return; } // ignore key presses when hidden.
 
@@ -126,18 +123,18 @@ void FileIo::onDoubleClick(MouseButton /*button*/, NAS2D::Point<int> position)
 /**
  * Event handler for Key Down.
  */
-void FileIo::onKeyDown(KeyCode key, KeyModifier /*mod*/, bool /*repeat*/)
+void FileIo::onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	if (!visible()) { return; } // ignore key presses when hidden.
 
-	if (key == KeyCode::Enter || key == KeyCode::KeypadEnter)
+	if (key == NAS2D::KeyCode::Enter || key == NAS2D::KeyCode::KeypadEnter)
 	{
 		if (!mFileName.isEmpty())
 		{
 			onFileIo();
 		}
 	}
-	else if (key == KeyCode::Escape)
+	else if (key == NAS2D::KeyCode::Escape)
 	{
 		onClose();
 	}
@@ -211,7 +208,7 @@ void FileIo::onFileDelete()
 	{
 		if(doYesNoMessage(constants::WindowFileIoTitleDelete, "Are you sure you want to delete " + mFileName.text() + "?"))
 		{
-			Utility<Filesystem>::get().del(filename);
+			NAS2D::Utility<NAS2D::Filesystem>::get().del(filename);
 		}
 	}
 	catch(const std::exception& e)

--- a/appOPHD/UI/IconGrid.cpp
+++ b/appOPHD/UI/IconGrid.cpp
@@ -17,9 +17,6 @@
 #include <limits>
 
 
-using namespace NAS2D;
-
-
 const IconGrid::Index IconGrid::NoSelection{std::numeric_limits<Index>::max()};
 
 
@@ -41,7 +38,7 @@ IconGrid::IconGrid(Delegate selectionChangedHandler, const std::string& filePath
 		throw std::runtime_error("IconGrid::iconMargin must be non-negative: " + std::to_string(margin));
 	}
 
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &IconGrid::onMouseDown});
 	eventHandler.mouseMotion().connect({this, &IconGrid::onMouseMove});
 }
@@ -49,7 +46,7 @@ IconGrid::IconGrid(Delegate selectionChangedHandler, const std::string& filePath
 
 IconGrid::~IconGrid()
 {
-	auto& eventHandler = Utility<EventHandler>::get();
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect({this, &IconGrid::onMouseDown});
 	eventHandler.mouseMotion().disconnect({this, &IconGrid::onMouseMove});
 }
@@ -246,10 +243,10 @@ void IconGrid::onResize()
 }
 
 
-void IconGrid::onMouseDown(MouseButton button, NAS2D::Point<int> position)
+void IconGrid::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 {
 	if (!enabled() || !visible() || !mRect.contains(position)) { return; }
-	if (button != MouseButton::Left) { return; }
+	if (button != NAS2D::MouseButton::Left) { return; }
 
 	setSelectionInternal(positionToIndex(position));
 }

--- a/appOPHD/UI/MajorEventAnnouncement.cpp
+++ b/appOPHD/UI/MajorEventAnnouncement.cpp
@@ -9,9 +9,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 MajorEventAnnouncement::MajorEventAnnouncement() :
 	mHeader{imageCache.load("ui/interface/colony_ship_crash.png")},
 	btnClose{"Okay", {this, &MajorEventAnnouncement::onClose}}

--- a/appOPHD/UI/MineOperationsWindow.cpp
+++ b/appOPHD/UI/MineOperationsWindow.cpp
@@ -17,9 +17,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	const auto truckAvailabilityOffset = NAS2D::Vector{148, 80};

--- a/appOPHD/UI/PopulationPanel.cpp
+++ b/appOPHD/UI/PopulationPanel.cpp
@@ -22,9 +22,6 @@
 #include <array>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	static constexpr int IconSize = 32;
@@ -38,10 +35,10 @@ namespace
 
 	static const std::array moraleStringColor
 	{
-		Color::Red,
-		Color::Orange,
-		Color::Yellow,
-		Color::White,
+		NAS2D::Color::Red,
+		NAS2D::Color::Orange,
+		NAS2D::Color::Yellow,
+		NAS2D::Color::White,
 		constants::PrimaryColor
 	};
 }
@@ -123,7 +120,7 @@ void PopulationPanel::draw(NAS2D::Renderer& renderer) const
 	}
 
 	// DIVIDER LINE Between population statistics and population availability statistics
-	renderer.drawLine(position, position + NAS2D::Vector<int>{mFont.width(constants::PopulationBreakdown) + constants::Margin, 0}, Color::DarkGray);
+	renderer.drawLine(position, position + NAS2D::Vector<int>{mFont.width(constants::PopulationBreakdown) + constants::Margin, 0}, NAS2D::Color::DarkGray);
 	position.y += constants::Margin;
 
 	const std::array populationAvailabilityStatistics{
@@ -134,8 +131,8 @@ void PopulationPanel::draw(NAS2D::Renderer& renderer) const
 	for (const auto& [statisticLabel, personCount] : populationAvailabilityStatistics)
 	{
 		const auto personCountString = std::to_string(personCount);
-		const Color statusColor = personCount <= 0 ? Color::Red : Color::White;
-		renderer.drawText(mFont, statisticLabel, position, Color::White);
+		const NAS2D::Color statusColor = personCount <= 0 ? NAS2D::Color::Red : NAS2D::Color::White;
+		renderer.drawText(mFont, statisticLabel, position, NAS2D::Color::White);
 		const NAS2D::Point<int> labelPosition = {this->position().x + mPopulationPanelWidth - mFont.width(personCountString) - constants::Margin, position.y};
 		renderer.drawText(mFont, personCountString, labelPosition, statusColor);
 		position.y += fontBoldHeight + constants::Margin;
@@ -143,7 +140,7 @@ void PopulationPanel::draw(NAS2D::Renderer& renderer) const
 
 	// DIVIDER LINE Between population statistics and morale statistics
 	position = this->position() + NAS2D::Vector{mPopulationPanelWidth, constants::Margin};
-	renderer.drawLine(position, position + NAS2D::Vector<int>{0, area().size.y - 10}, Color::DarkGray);
+	renderer.drawLine(position, position + NAS2D::Vector<int>{0, area().size.y - 10}, NAS2D::Color::DarkGray);
 
 	// MORALE
 	position.x += constants::Margin;
@@ -167,7 +164,7 @@ void PopulationPanel::draw(NAS2D::Renderer& renderer) const
 	position.y += fontHeight + constants::Margin;
 
 	// DIVIDER LINE Between morale breakdown and morale change reasons
-	renderer.drawLine(position, position + NAS2D::Vector<int>{area().size.x - mPopulationPanelWidth - constants::Margin * 2, 0}, Color::DarkGray);
+	renderer.drawLine(position, position + NAS2D::Vector<int>{area().size.x - mPopulationPanelWidth - constants::Margin * 2, 0}, NAS2D::Color::DarkGray);
 
 	position.y += constants::Margin;
 

--- a/appOPHD/UI/ProductListBox.cpp
+++ b/appOPHD/UI/ProductListBox.cpp
@@ -11,9 +11,6 @@
 #include <NAS2D/Renderer/Renderer.h>
 
 
-using namespace NAS2D;
-
-
 ProductListBox::ProductListBox(SelectionChangedDelegate selectionChangedHandler) :
 	ListBoxBase{{0, 30}, selectionChangedHandler},
 	mFont{fontCache.load(constants::FontPrimary, 12)},

--- a/appOPHD/UI/ResourceBreakdownPanel.cpp
+++ b/appOPHD/UI/ResourceBreakdownPanel.cpp
@@ -13,15 +13,12 @@
 #include <array>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	constexpr std::array changeIconImageRects{
-		NAS2D::Rectangle{Point{0, 64},{8, 8}},
-		NAS2D::Rectangle{Point{16, 64},{8, 8}},
-		NAS2D::Rectangle{Point{8, 64},{8, 8}},
+		NAS2D::Rectangle{NAS2D::Point{0, 64},{8, 8}},
+		NAS2D::Rectangle{NAS2D::Point{16, 64},{8, 8}},
+		NAS2D::Rectangle{NAS2D::Point{8, 64},{8, 8}},
 	};
 }
 

--- a/appOPHD/UI/RobotInspector.cpp
+++ b/appOPHD/UI/RobotInspector.cpp
@@ -14,9 +14,6 @@
 #include <stdexcept>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	const NAS2D::Image& robotImage(RobotTypeIndex robotTypeIndex)
@@ -54,7 +51,7 @@ RobotInspector::RobotInspector() :
 		mainFont.height() + constants::Margin}
 	};
 
-	auto buttonPosition = Vector{imageWidth,  mContentRect.position.y + mContentRect.size.y + constants::Margin};
+	auto buttonPosition = NAS2D::Vector{imageWidth,  mContentRect.position.y + mContentRect.size.y + constants::Margin};
 
 	btnCancelOrders.size(buttonSize);
 	add(btnCancelOrders, buttonPosition);
@@ -102,8 +99,8 @@ void RobotInspector::onCancel()
 
 void RobotInspector::drawClientArea(NAS2D::Renderer& renderer) const
 {
-	renderer.drawImage(robotImage(mRobot->type()), position() + Vector{constants::Margin, constants::Margin + sWindowTitleBarHeight});
+	renderer.drawImage(robotImage(mRobot->type()), position() + NAS2D::Vector{constants::Margin, constants::Margin + sWindowTitleBarHeight});
 
-	const auto labelPosition = area().position + Vector{mContentRect.position.x, mContentRect.position.y};
+	const auto labelPosition = area().position + NAS2D::Vector{mContentRect.position.x, mContentRect.position.y};
 	drawLabelAndValueRightJustify(labelPosition, mContentRect.size.x, "Age", std::to_string(mRobot->fuelCellAge()));
 }

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -14,9 +14,6 @@
 #include <stdexcept>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	const std::map<DisabledReason, std::string> disabledReasonTable =
@@ -102,14 +99,14 @@ namespace
 		{
 			stringTable[{0, 3}].text = "Workers:";
 			stringTable[{1, 3}].text = std::to_string(populationAvailable.workers) + " / " + std::to_string(populationRequirements.workers);
-			stringTable[{1, 3}].textColor = populationAvailable.workers >= populationRequirements.workers ? Color::White : Color::Red;
+			stringTable[{1, 3}].textColor = populationAvailable.workers >= populationRequirements.workers ? NAS2D::Color::White : NAS2D::Color::Red;
 		}
 
 		if (populationRequirements.scientists > 0)
 		{
 			stringTable[{0, 4}].text = "Scientists:";
 			stringTable[{1, 4}].text = std::to_string(populationAvailable.scientists) + " / " + std::to_string(populationRequirements.scientists);
-			stringTable[{1, 4}].textColor = populationAvailable.scientists >= populationRequirements.scientists ? Color::White : Color::Red;
+			stringTable[{1, 4}].textColor = populationAvailable.scientists >= populationRequirements.scientists ? NAS2D::Color::White : NAS2D::Color::Red;
 		}
 
 		if (structure.hasCrime())

--- a/appOPHD/UI/StructureListBox.cpp
+++ b/appOPHD/UI/StructureListBox.cpp
@@ -12,9 +12,6 @@
 #include <stdexcept>
 
 
-using namespace NAS2D;
-
-
 StructureListBox::StructureListBox(SelectionChangedDelegate selectionChangedHandler) :
 	ListBoxBase{{0, 30}, selectionChangedHandler},
 	mFont{fontCache.load(constants::FontPrimary, 12)},

--- a/appOPHD/UI/TileInspector.cpp
+++ b/appOPHD/UI/TileInspector.cpp
@@ -14,9 +14,6 @@
 #include <sstream>
 
 
-using namespace NAS2D;
-
-
 namespace
 {
 	const auto lineSpacing = 18;
@@ -40,7 +37,7 @@ TileInspector::TileInspector() :
 	size({200, sWindowTitleBarHeight + lineSpacing * 5 + sectionSpacing + constants::Margin * 2});
 
 	btnClose.size({50, 20});
-	add(btnClose, size() - btnClose.size() - Vector{constants::Margin, constants::Margin});
+	add(btnClose, size() - btnClose.size() - NAS2D::Vector{constants::Margin, constants::Margin});
 }
 
 

--- a/appOPHD/UI/WarehouseInspector.cpp
+++ b/appOPHD/UI/WarehouseInspector.cpp
@@ -10,9 +10,6 @@
 #include <libOPHD/ProductCatalog.h>
 
 
-using namespace NAS2D;
-
-
 WarehouseInspector::WarehouseInspector() :
 	Window{constants::WindowWarehouseInspector},
 	btnClose{"Okay", {this, &WarehouseInspector::onClose}}


### PR DESCRIPTION
Removing `using namespace` increases consistency between the header files and implementation files.

Related:
- PR #2018
