### PR TITLE
Redefine `OreStorageCapacity` limit as per ore type

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -299,7 +299,7 @@ int Structure::foodStorageCapacity() const
 	return mStructureType.foodStorageCapacity;
 }
 
-int Structure::storageCapacity() const
+int Structure::refinedOreStorageCapacity() const
 {
 	return mStructureType.oreStorageCapacity;
 }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -94,7 +94,7 @@ public:
 	int energyProduced() const;
 	int foodProduced() const;
 	int foodStorageCapacity() const;
-	int storageCapacity() const;
+	int refinedOreStorageCapacity() const;
 	int commRange() const;
 	int policeRange() const;
 

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -75,7 +75,7 @@ StorableResources OreRefining::storageCapacities() const
  */
 int OreRefining::individualMaterialCapacity() const
 {
-	return storageCapacity() / 4;
+	return storageCapacity();
 }
 
 

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -71,10 +71,10 @@ StringTable OreRefining::createInspectorViewTable() const
 StorableResources OreRefining::storageCapacities() const
 {
 	return {
-		storageCapacity(),
-		storageCapacity(),
-		storageCapacity(),
-		storageCapacity(),
+		refinedOreStorageCapacity(),
+		refinedOreStorageCapacity(),
+		refinedOreStorageCapacity(),
+		refinedOreStorageCapacity(),
 	};
 }
 
@@ -109,7 +109,7 @@ void OreRefining::updateProduction()
 
 	auto& stored = storage();
 	auto total = stored + converted;
-	auto capped = total.cap(storageCapacity());
+	auto capped = total.cap(refinedOreStorageCapacity());
 	auto overflow = total - capped;
 
 	stored = capped;
@@ -135,5 +135,5 @@ void OreRefining::updateProduction()
 
 std::string OreRefining::writeStorageAmount(int storageAmount) const
 {
-	return std::to_string(storageAmount) + " / " + std::to_string(storageCapacity());
+	return std::to_string(storageAmount) + " / " + std::to_string(refinedOreStorageCapacity());
 }

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -7,6 +7,14 @@
 
 #include <libOPHD/EnumIdleReason.h>
 
+#include <array>
+
+
+namespace
+{
+	std::array<int, 4> OreConversionDivisor{2, 2, 3, 3};
+}
+
 
 OreRefining::OreRefining(StructureID id, Tile& tile) :
 	Structure{id, tile}

--- a/appOPHD/MapObjects/Structures/OreRefining.cpp
+++ b/appOPHD/MapObjects/Structures/OreRefining.cpp
@@ -63,19 +63,11 @@ StringTable OreRefining::createInspectorViewTable() const
 StorableResources OreRefining::storageCapacities() const
 {
 	return {
-		individualMaterialCapacity(),
-		individualMaterialCapacity(),
-		individualMaterialCapacity(),
-		individualMaterialCapacity(),
+		storageCapacity(),
+		storageCapacity(),
+		storageCapacity(),
+		storageCapacity(),
 	};
-}
-
-/**
- * Capacity of an individual type of refined resource
- */
-int OreRefining::individualMaterialCapacity() const
-{
-	return storageCapacity();
 }
 
 
@@ -109,7 +101,7 @@ void OreRefining::updateProduction()
 
 	auto& stored = storage();
 	auto total = stored + converted;
-	auto capped = total.cap(individualMaterialCapacity());
+	auto capped = total.cap(storageCapacity());
 	auto overflow = total - capped;
 
 	stored = capped;
@@ -135,5 +127,5 @@ void OreRefining::updateProduction()
 
 std::string OreRefining::writeStorageAmount(int storageAmount) const
 {
-	return std::to_string(storageAmount) + " / " + std::to_string(individualMaterialCapacity());
+	return std::to_string(storageAmount) + " / " + std::to_string(storageCapacity());
 }

--- a/appOPHD/MapObjects/Structures/OreRefining.h
+++ b/appOPHD/MapObjects/Structures/OreRefining.h
@@ -22,11 +22,6 @@ protected:
 
 	StorableResources storageCapacities() const;
 
-	/**
-	 * Capacity of an individual type of refined resource
-	 */
-	int individualMaterialCapacity() const;
-
 	void think() override;
 
 	virtual void updateProduction();

--- a/appOPHD/MapObjects/Structures/OreRefining.h
+++ b/appOPHD/MapObjects/Structures/OreRefining.h
@@ -2,8 +2,6 @@
 
 #include "../Structure.h"
 
-#include <array>
-
 
 /**
  * Virtual class for structures whose primary purpose is ore processing
@@ -18,8 +16,6 @@ public:
 	StringTable createInspectorViewTable() const override;
 
 protected:
-	std::array<int, 4> OreConversionDivisor{2, 2, 3, 3};
-
 	StorableResources storageCapacities() const;
 
 	void think() override;

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -29,7 +29,7 @@ StringTable StorageTanks::createInspectorViewTable() const
 	stringTable.setColumnText(
 		1,
 		{
-			std::to_string(storage().total()) + " / " + std::to_string(storageCapacity() * 4),
+			std::to_string(storage().total()) + " / " + std::to_string(refinedOreStorageCapacity() * 4),
 			std::to_string(storage().resources[0]),
 			std::to_string(storage().resources[1]),
 			std::to_string(storage().resources[2]),

--- a/appOPHD/MapObjects/Structures/StorageTanks.cpp
+++ b/appOPHD/MapObjects/Structures/StorageTanks.cpp
@@ -29,7 +29,7 @@ StringTable StorageTanks::createInspectorViewTable() const
 	stringTable.setColumnText(
 		1,
 		{
-			std::to_string(storage().total()) + " / " + std::to_string(storageCapacity()),
+			std::to_string(storage().total()) + " / " + std::to_string(storageCapacity() * 4),
 			std::to_string(storage().resources[0]),
 			std::to_string(storage().resources[1]),
 			std::to_string(storage().resources[2]),

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -382,7 +382,7 @@ StorableResources addRefinedResources(StorableResources resourcesToAdd)
 		auto& storageTanksResources = structure->storage();
 
 		auto newResources = storageTanksResources + resourcesToAdd;
-		auto capped = newResources.cap(structure->storageCapacity());
+		auto capped = newResources.cap(structure->refinedOreStorageCapacity());
 
 		storageTanksResources = capped;
 		resourcesToAdd = newResources - capped;

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -382,7 +382,7 @@ StorableResources addRefinedResources(StorableResources resourcesToAdd)
 		auto& storageTanksResources = structure->storage();
 
 		auto newResources = storageTanksResources + resourcesToAdd;
-		auto capped = newResources.cap(structure->storageCapacity() / 4);
+		auto capped = newResources.cap(structure->storageCapacity());
 
 		storageTanksResources = capped;
 		resourcesToAdd = newResources - capped;


### PR DESCRIPTION
Rather than divide the defined value by 4 to get a per ore type value, just define the field as being per ore type.

Related:
- PR #https://github.com/OutpostUniverse/ophd-assets/pull/28
- Issue #1723
