### PR TITLE
Add `robotCommandCapacity` field

### DIFF
--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -5,6 +5,8 @@
 #include "MapObjects/Robots.h"
 #include "MapObjects/Structures/CommandCenter.h"
 
+#include <libOPHD/MapObjects/StructureType.h>
+
 #include <NAS2D/Utility.h>
 #include <NAS2D/ParserHelper.h>
 #include <NAS2D/Xml/XmlElement.h>
@@ -250,13 +252,11 @@ void RobotPool::update()
 	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
 	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().structureList(StructureClass::RobotCommand);
 
-	// 3 for the first command center
 	int totalRobotCommandCapacity = 0;
-	if (commandCenters.size() > 0) { totalRobotCommandCapacity += 3; }
-	// the 10 per robot command facility
+	if (commandCenters.size() > 0) { totalRobotCommandCapacity += commandCenters[0]->type().robotCommandCapacity; }
 	for (const auto* structure : robotCommands)
 	{
-		if (structure->operational()) { totalRobotCommandCapacity += 10; }
+		if (structure->operational()) { totalRobotCommandCapacity += structure->type().robotCommandCapacity; }
 	}
 
 	mRobotControlMax = static_cast<std::size_t>(totalRobotCommandCapacity);

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -254,9 +254,9 @@ void RobotPool::update()
 	std::size_t maxRobots = 0;
 	if (commandCenters.size() > 0) { maxRobots += 3; }
 	// the 10 per robot command facility
-	for (std::size_t s = 0; s < robotCommands.size(); ++s)
+	for (const auto* structure : robotCommands)
 	{
-		if (robotCommands[s]->operational()) { maxRobots += 10; }
+		if (structure->operational()) { maxRobots += 10; }
 	}
 
 	mRobotControlMax = maxRobots;

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -251,7 +251,7 @@ void RobotPool::update()
 	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().structureList(StructureClass::RobotCommand);
 
 	// 3 for the first command center
-	std::size_t totalRobotCommandCapacity = 0;
+	int totalRobotCommandCapacity = 0;
 	if (commandCenters.size() > 0) { totalRobotCommandCapacity += 3; }
 	// the 10 per robot command facility
 	for (const auto* structure : robotCommands)
@@ -259,7 +259,7 @@ void RobotPool::update()
 		if (structure->operational()) { totalRobotCommandCapacity += 10; }
 	}
 
-	mRobotControlMax = totalRobotCommandCapacity;
+	mRobotControlMax = static_cast<std::size_t>(totalRobotCommandCapacity);
 	mRobotControlCount = robotControlCount(mDiggers) + robotControlCount(mDozers) + robotControlCount(mMiners);
 }
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -251,15 +251,15 @@ void RobotPool::update()
 	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().structureList(StructureClass::RobotCommand);
 
 	// 3 for the first command center
-	std::size_t maxRobots = 0;
-	if (commandCenters.size() > 0) { maxRobots += 3; }
+	std::size_t totalRobotCommandCapacity = 0;
+	if (commandCenters.size() > 0) { totalRobotCommandCapacity += 3; }
 	// the 10 per robot command facility
 	for (const auto* structure : robotCommands)
 	{
-		if (structure->operational()) { maxRobots += 10; }
+		if (structure->operational()) { totalRobotCommandCapacity += 10; }
 	}
 
-	mRobotControlMax = maxRobots;
+	mRobotControlMax = totalRobotCommandCapacity;
 	mRobotControlCount = robotControlCount(mDiggers) + robotControlCount(mDozers) + robotControlCount(mMiners);
 }
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -249,14 +249,23 @@ std::size_t RobotPool::getAvailableCount(RobotTypeIndex robotTypeIndex) const
 
 void RobotPool::update()
 {
-	const auto& commandCenters = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
-	const auto& robotCommands = NAS2D::Utility<StructureManager>::get().structureList(StructureClass::RobotCommand);
+	const auto& structureManager = NAS2D::Utility<StructureManager>::get();
+	const auto& structures = structureManager.allStructures();
 
 	int totalRobotCommandCapacity = 0;
-	if (commandCenters.size() > 0) { totalRobotCommandCapacity += commandCenters[0]->type().robotCommandCapacity; }
-	for (const auto* structure : robotCommands)
+	for (const auto* structure : structures)
 	{
 		if (structure->operational()) { totalRobotCommandCapacity += structure->type().robotCommandCapacity; }
+	}
+
+	// Special case hack to allow robot use during initial colony deploy
+	if (totalRobotCommandCapacity == 0)
+	{
+		const auto& commandCenters = structureManager.getStructures<CommandCenter>();
+		if (commandCenters.size() > 0)
+		{
+			totalRobotCommandCapacity += commandCenters[0]->type().robotCommandCapacity;
+		}
 	}
 
 	mRobotControlMax = static_cast<std::size_t>(totalRobotCommandCapacity);

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -111,7 +111,7 @@ namespace
 		const auto& structuresElement = *document.firstChildElement("Structures");
 
 		const auto requiredFields = std::vector<std::string>{"Name", "ImagePath"};
-		const auto optionalFields = std::vector<std::string>{"TurnsToBuild", "MaxAge", "RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "SolarEnergyProduced", "FoodProduced", "FoodStorageCapacity", "RawOreStorageCapacity", "OreStorageCapacity", "CommRange", "PoliceRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
+		const auto optionalFields = std::vector<std::string>{"TurnsToBuild", "MaxAge", "RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "SolarEnergyProduced", "FoodProduced", "FoodStorageCapacity", "RawOreStorageCapacity", "OreStorageCapacity", "RobotCommandCapacity", "CommRange", "PoliceRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
 
 		std::vector<StructureType> loadedStructureTypes;
 		for (const auto* structureElement = structuresElement.firstChildElement(); structureElement; structureElement = structureElement->nextSiblingElement())
@@ -138,6 +138,7 @@ namespace
 				dictionary.get<int>("FoodStorageCapacity", 0),
 				dictionary.get<int>("RawOreStorageCapacity", 0),
 				dictionary.get<int>("OreStorageCapacity", 0),
+				dictionary.get<int>("RobotCommandCapacity", 0),
 				dictionary.get<int>("CommRange", 0),
 				dictionary.get<int>("PoliceRange", 0),
 				dictionary.get<int>("IntegrityDecayRate", 1),

--- a/libOPHD/MapObjects/StructureType.h
+++ b/libOPHD/MapObjects/StructureType.h
@@ -23,6 +23,7 @@ struct StructureType
 	int foodStorageCapacity{0};
 	int rawOreStorageCapacity{0};
 	int oreStorageCapacity{0};
+	int robotCommandCapacity{0};
 	int commRange{0};
 	int policeRange{0};
 	int integrityDecayRate{1};


### PR DESCRIPTION
Add `robotCommandCapacity` field to `StructureType`, and use it to replace hardcoded constants.

Related:
- Issue #1723
- PR https://github.com/OutpostUniverse/ophd-assets/pull/30
- PR #2025
- PR #2026
