### PR TITLE
Remove redundant `deleteMapObject()` calls

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1038,7 +1038,6 @@ void MapViewState::placeRobodozer(Tile& tile)
 		updateStructuresAvailability();
 
 		NAS2D::Utility<StructureManager>::get().removeStructure(*structure);
-		tile.deleteMapObject();
 		updateConnectedness();
 	}
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -470,7 +470,6 @@ void MapViewState::onDiggerSelectionDialog(Direction direction, Tile& tile)
 	if (tile.depth() > 0 && direction == Direction::Down)
 	{
 		NAS2D::Utility<StructureManager>::get().removeStructure(*tile.structure());
-		tile.deleteMapObject();
 		updateConnectedness();
 	}
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -203,7 +203,7 @@ void StructureManager::removeStructure(Structure& structure)
 		mDeployedStructures.erase(tileTableIt);
 	}
 
-	if (!isFoundStructureTable || !isFoundTileTable)
+	if (!isFoundStructureTable && !isFoundTileTable)
 	{
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}


### PR DESCRIPTION
These calls immediately follow `removeStructure` which internally calls `deleteMapObject()`. The second call is simply ignored, since the `mMapObject` pointer was already set to `nullptr`, so the call to `delete` does nothing.

Noticed this during some recent work that involved `StructureManager`, which really should be the object responsible for `Structure` lifetime.

Related:
- Issue #1723
