### PR TITLE
Fix possible seg fault removing mine

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -961,6 +961,9 @@ void MapViewState::placeRobodozer(Tile& tile)
 
 		mMineOperationsWindow.hide();
 
+		const auto* mineFacility = dynamic_cast<MineFacility*>(tile.structure());
+		NAS2D::Utility<std::map<const MineFacility*, Route>>::get().erase(mineFacility);
+
 		const auto tilePosition = tile.xy();
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 		for (int i = 0; i <= mTileMap->maxDepth(); ++i)

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -961,8 +961,6 @@ void MapViewState::placeRobodozer(Tile& tile)
 
 		mMineOperationsWindow.hide();
 		const auto tilePosition = tile.xy();
-		mTileMap->removeOreDepositLocation(tilePosition);
-		tile.placeOreDeposit(nullptr);
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 		for (int i = 0; i <= mTileMap->maxDepth(); ++i)
 		{
@@ -972,6 +970,8 @@ void MapViewState::placeRobodozer(Tile& tile)
 				structureManager.removeStructure(*mineShaftTile.structure());
 			}
 		}
+		mTileMap->removeOreDepositLocation(tilePosition);
+		tile.placeOreDeposit(nullptr);
 	}
 	else if (tile.hasStructure())
 	{

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -967,7 +967,10 @@ void MapViewState::placeRobodozer(Tile& tile)
 		for (int i = 0; i <= mTileMap->maxDepth(); ++i)
 		{
 			auto& mineShaftTile = mTileMap->getTile({tilePosition, i});
-			structureManager.removeStructure(*mineShaftTile.structure());
+			if (mineShaftTile.hasStructure())
+			{
+				structureManager.removeStructure(*mineShaftTile.structure());
+			}
 		}
 	}
 	else if (tile.hasStructure())

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -963,10 +963,11 @@ void MapViewState::placeRobodozer(Tile& tile)
 		const auto tilePosition = tile.xy();
 		mTileMap->removeOreDepositLocation(tilePosition);
 		tile.placeOreDeposit(nullptr);
+		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 		for (int i = 0; i <= mTileMap->maxDepth(); ++i)
 		{
 			auto& mineShaftTile = mTileMap->getTile({tilePosition, i});
-			NAS2D::Utility<StructureManager>::get().removeStructure(*mineShaftTile.structure());
+			structureManager.removeStructure(*mineShaftTile.structure());
 		}
 	}
 	else if (tile.hasStructure())

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -960,6 +960,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 		}
 
 		mMineOperationsWindow.hide();
+
 		const auto tilePosition = tile.xy();
 		auto& structureManager = NAS2D::Utility<StructureManager>::get();
 		for (int i = 0; i <= mTileMap->maxDepth(); ++i)


### PR DESCRIPTION
Fix possible segmentation fault when bulldozing a `MineFacility` caused by missing `MineShaft` instances at depth `2` due to corrupt data from an earlier bug.

We also needed to remove the `MineFacility` entry from the `routeTable`, which was causing invalid accesses that were flagged by `valgrind`. Without `valgrind` these would have been silent errors that could have caused unknown problems at some point in the future.

Closes #2031

Related:
- Issue #2301
- Issue #1349
- PR #1361
