### PR TITLE
Have `TileMap` own `OreDeposit`

### DIFF
--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -109,8 +109,18 @@ void Tile::removeMapObject()
 
 void Tile::placeOreDeposit(OreDeposit* oreDeposit)
 {
-	delete mOreDeposit;
+	if (mOreDeposit)
+	{
+		throw std::runtime_error("Attempting to set OreDeposit on a tile where it's already set");
+	}
 	mOreDeposit = oreDeposit;
+}
+
+
+void Tile::removeOreDeposit()
+{
+	delete mOreDeposit;
+	mOreDeposit = nullptr;
 }
 
 

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -50,11 +50,6 @@ Tile& Tile::operator=(Tile&& other) noexcept
 }
 
 
-Tile::~Tile()
-{
-}
-
-
 bool Tile::isSurface() const
 {
 	return mPosition.z == 0;

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -21,35 +21,6 @@ Tile::Tile(const MapCoordinate& position, TerrainType index) :
 {}
 
 
-Tile::Tile(Tile&& other) noexcept :
-	mIndex{other.mIndex},
-	mPosition{other.mPosition},
-	mMapObject{other.mMapObject},
-	mOreDeposit{other.mOreDeposit},
-	mOverlay{other.mOverlay},
-	mExcavated{other.mExcavated}
-{
-	other.mMapObject = nullptr;
-	other.mOreDeposit = nullptr;
-}
-
-
-Tile& Tile::operator=(Tile&& other) noexcept
-{
-	mIndex = other.mIndex;
-	mPosition = other.mPosition;
-	mMapObject = other.mMapObject;
-	mOreDeposit = other.mOreDeposit;
-	mOverlay = other.mOverlay;
-	mExcavated = other.mExcavated;
-
-	other.mMapObject = nullptr;
-	other.mOreDeposit = nullptr;
-
-	return *this;
-}
-
-
 bool Tile::isSurface() const
 {
 	return mPosition.z == 0;

--- a/appOPHD/Map/Tile.cpp
+++ b/appOPHD/Map/Tile.cpp
@@ -52,7 +52,6 @@ Tile& Tile::operator=(Tile&& other) noexcept
 
 Tile::~Tile()
 {
-	delete mOreDeposit;
 }
 
 
@@ -119,7 +118,6 @@ void Tile::placeOreDeposit(OreDeposit* oreDeposit)
 
 void Tile::removeOreDeposit()
 {
-	delete mOreDeposit;
 	mOreDeposit = nullptr;
 }
 

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -69,6 +69,7 @@ public:
 	const OreDeposit* oreDeposit() const { return mOreDeposit; }
 	OreDeposit* oreDeposit() { return mOreDeposit; }
 	void placeOreDeposit(OreDeposit*);
+	void removeOreDeposit();
 
 	void overlay(Overlay overlay) { mOverlay = overlay; }
 	Overlay overlay() const { return mOverlay; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -28,10 +28,6 @@ public:
 public:
 	Tile();
 	Tile(const MapCoordinate& position, TerrainType);
-	Tile(const Tile&) = delete;
-	Tile& operator=(const Tile&) = delete;
-	Tile(Tile&&) noexcept;
-	Tile& operator=(Tile&&) noexcept;
 
 	TerrainType index() const { return mIndex; }
 	void index(TerrainType index) { mIndex = index; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -32,7 +32,6 @@ public:
 	Tile& operator=(const Tile&) = delete;
 	Tile(Tile&&) noexcept;
 	Tile& operator=(Tile&&) noexcept;
-	~Tile();
 
 	TerrainType index() const { return mIndex; }
 	void index(TerrainType index) { mIndex = index; }

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -130,7 +130,7 @@ void TileMap::removeOreDepositLocation(const NAS2D::Point<int>& pt)
 	}
 
 	mOreDepositLocations.erase(find(mOreDepositLocations.begin(), mOreDepositLocations.end(), pt));
-	tile.placeOreDeposit(nullptr);
+	tile.removeOreDeposit();
 }
 
 

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -112,6 +112,13 @@ TileMap::TileMap(const std::string& mapPath, int maxDepth) :
 
 TileMap::~TileMap()
 {
+	for (const auto& oreDepositLocation : mOreDepositLocations)
+	{
+		auto& tile = getTile({oreDepositLocation, 0});
+		const auto* oreDeposit = tile.oreDeposit();
+		tile.removeOreDeposit();
+		delete oreDeposit;
+	}
 }
 
 
@@ -130,7 +137,9 @@ void TileMap::removeOreDepositLocation(const NAS2D::Point<int>& pt)
 	}
 
 	mOreDepositLocations.erase(find(mOreDepositLocations.begin(), mOreDepositLocations.end(), pt));
+	auto* oreDeposit = tile.oreDeposit();
 	tile.removeOreDeposit();
+	delete oreDeposit;
 }
 
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -975,7 +975,6 @@ void MapViewState::placeRobodozer(Tile& tile)
 			}
 		}
 		mTileMap->removeOreDepositLocation(tilePosition);
-		tile.placeOreDeposit(nullptr);
 	}
 	else if (tile.hasStructure())
 	{


### PR DESCRIPTION
Have `TileMap` own `OreDeposit`, so uses of `new`/`delete` are paired in `TileMap`, and so `Tile` is no longer responsible for any object lifetime.

Potentially we can have `TileMap` own a `std::vector<OreDeposit>` and avoid using `new`/`delete`, though there are still a few blockers for that, such as `OreDeposit` having an implicitly deleted copy constructor, which is needed for use with `std::vector`.

Noticed this during recent work that involve removing mines from the game.

Related:
- Issue #480
- PR #2030
- PR #2029
- Issue #1723
- PR #2032