### PR TITLE
Refactor `Tile` `MapObject` pointer uses

### DIFF
--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -53,7 +53,7 @@ namespace
 			return FLT_MAX;
 		}
 
-		if (!tile.empty() && tile.hasStructure() && tile.structure()->isRoad())
+		if (tile.hasMapObject() && tile.hasStructure() && tile.structure()->isRoad())
 		{
 			Structure& road = *tile.structure();
 
@@ -71,7 +71,7 @@ namespace
 			}
 		}
 
-		if (!tile.empty() && (!tile.hasStructure() || (!tile.structure()->isMineFacility() && !tile.structure()->isSmelter())))
+		if (tile.hasMapObject() && (!tile.hasStructure() || (!tile.structure()->isMineFacility() && !tile.structure()->isSmelter())))
 		{
 			return FLT_MAX;
 		}

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -53,7 +53,7 @@ namespace
 			return FLT_MAX;
 		}
 
-		if (tile.hasMapObject() && tile.hasStructure() && tile.structure()->isRoad())
+		if (tile.hasStructure() && tile.structure()->isRoad())
 		{
 			Structure& road = *tile.structure();
 

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -47,9 +47,8 @@ public:
 
 	bool isImpassable() const;
 
-	void mapObject(MapObject*);
 	MapObject* mapObject() const { return mMapObject; }
-
+	void mapObject(MapObject*);
 	void removeMapObject();
 
 	bool hasOreDeposit() const { return mOreDeposit != nullptr; }

--- a/appOPHD/Map/Tile.h
+++ b/appOPHD/Map/Tile.h
@@ -52,9 +52,8 @@ public:
 
 	void removeMapObject();
 
-	bool empty() const { return mMapObject == nullptr; }
-
 	bool hasOreDeposit() const { return mOreDeposit != nullptr; }
+	bool hasMapObject() const { return mMapObject != nullptr; }
 	bool hasStructure() const { return structure() != nullptr; }
 	bool hasRobot() const { return robot() != nullptr; }
 

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -223,7 +223,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 			auto& tile = getTile({point, depth});
 			if (
 				((depth > 0 && tile.excavated()) || tile.isBulldozed()) &&
-				(tile.empty() && !tile.hasOreDeposit())
+				(!tile.hasMapObject() && !tile.hasOreDeposit())
 			)
 			{
 				tiles->linkEndChild(

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -281,9 +281,9 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 }
 
 
-bool TileMap::hasOreDeposit(const Tile& tile) const
+bool TileMap::hasOreDeposit(const MapCoordinate& mapCoordinate) const
 {
-	return getTile({tile.xy(), 0}).hasOreDeposit();
+	return getTile({mapCoordinate.xy, 0}).hasOreDeposit();
 }
 
 

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -281,7 +281,7 @@ void TileMap::deserialize(NAS2D::Xml::XmlElement* element)
 }
 
 
-bool TileMap::isTileBlockedByOreDeposit(const Tile& tile) const
+bool TileMap::hasOreDeposit(const Tile& tile) const
 {
 	return getTile({tile.xy(), 0}).hasOreDeposit();
 }

--- a/appOPHD/Map/TileMap.cpp
+++ b/appOPHD/Map/TileMap.cpp
@@ -223,7 +223,7 @@ void TileMap::serialize(NAS2D::Xml::XmlElement* element)
 			auto& tile = getTile({point, depth});
 			if (
 				((depth > 0 && tile.excavated()) || tile.isBulldozed()) &&
-				(tile.empty() && tile.oreDeposit() == nullptr)
+				(tile.empty() && !tile.hasOreDeposit())
 			)
 			{
 				tiles->linkEndChild(

--- a/appOPHD/Map/TileMap.h
+++ b/appOPHD/Map/TileMap.h
@@ -47,7 +47,7 @@ public:
 	void serialize(NAS2D::Xml::XmlElement* element);
 	void deserialize(NAS2D::Xml::XmlElement* element);
 
-	bool isTileBlockedByOreDeposit(const Tile&) const;
+	bool hasOreDeposit(const Tile&) const;
 
 private:
 	std::size_t linearSize() const;

--- a/appOPHD/Map/TileMap.h
+++ b/appOPHD/Map/TileMap.h
@@ -47,7 +47,7 @@ public:
 	void serialize(NAS2D::Xml::XmlElement* element);
 	void deserialize(NAS2D::Xml::XmlElement* element);
 
-	bool hasOreDeposit(const Tile&) const;
+	bool hasOreDeposit(const MapCoordinate& mapCoordinate) const;
 
 private:
 	std::size_t linearSize() const;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -811,7 +811,7 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 		return;
 	}
 
-	if (mTileMap->hasOreDeposit(tile))
+	if (mTileMap->hasOreDeposit(tile.xyz()))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOreDepositInWay);
 		return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -631,7 +631,7 @@ void MapViewState::onMapObjectSelectionChanged()
 void MapViewState::onInspect(const MapCoordinate& tilePosition, bool inspectModifier)
 {
 	auto& tile = mTileMap->getTile(tilePosition);
-	if (tile.empty())
+	if (!tile.hasMapObject())
 	{
 		onInspectTile(tile);
 	}
@@ -1070,7 +1070,7 @@ void MapViewState::placeRobodigger(Tile& tile)
 	}
 
 	// Check for obstructions underneath the digger location.
-	if (tile.depth() != mTileMap->maxDepth() && !mTileMap->getTile({tile.xy(), tile.depth() + 1}).empty())
+	if (tile.depth() != mTileMap->maxDepth() && mTileMap->getTile({tile.xy(), tile.depth() + 1}).hasMapObject())
 	{
 		doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertDiggerBlockedBelow);
 		return;
@@ -1090,7 +1090,7 @@ void MapViewState::placeRobodigger(Tile& tile)
 	}
 
 	// Die if tile is occupied or not excavated.
-	if (!tile.empty())
+	if (tile.hasMapObject())
 	{
 		if (!tile.isSurface())
 		{

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -811,7 +811,7 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 		return;
 	}
 
-	if (mTileMap->isTileBlockedByOreDeposit(tile))
+	if (mTileMap->hasOreDeposit(tile))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOreDepositInWay);
 		return;

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -175,7 +175,7 @@ bool validStructurePlacement(TileMap& tilemap, MapCoordinate position)
  */
 bool validLanderSite(Tile& tile)
 {
-	if (!tile.empty())
+	if (tile.hasMapObject())
 	{
 		doAlertMessage(constants::AlertLanderLocation, constants::AlertLanderTileObstructed);
 		return false;

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -166,7 +166,7 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
 		throw std::runtime_error("StructureManager::addStructure(): Attempting to add a Structure that is already managed!");
 	}
 
-	if (!tile.empty())
+	if (tile.hasMapObject())
 	{
 		tile.removeMapObject();
 	}

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -144,7 +144,7 @@ void DetailMap::draw(NAS2D::Renderer& renderer) const
 			renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
 
 			// Draw a beacon on an unoccupied tile with a mine
-			if (mTileMap.hasOreDeposit(tile) && !tile.mapObject())
+			if (mTileMap.hasOreDeposit(tile.xyz()) && !tile.mapObject())
 			{
 				constexpr NAS2D::Vector<int> beaconOffsetInTile{0, -64};
 				constexpr NAS2D::Vector<int> beaconLightOffsetInTile{59, 15};

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -144,7 +144,7 @@ void DetailMap::draw(NAS2D::Renderer& renderer) const
 			renderer.drawSubImage(mTileset, position, subImageRect, overlayColor(tile.overlay(), isTileHighlighted));
 
 			// Draw a beacon on an unoccupied tile with a mine
-			if (mTileMap.isTileBlockedByOreDeposit(tile) && !tile.mapObject())
+			if (mTileMap.hasOreDeposit(tile) && !tile.mapObject())
 			{
 				constexpr NAS2D::Vector<int> beaconOffsetInTile{0, -64};
 				constexpr NAS2D::Vector<int> beaconLightOffsetInTile{59, 15};

--- a/libOPHD/MapObjects/OreDeposit.h
+++ b/libOPHD/MapObjects/OreDeposit.h
@@ -39,10 +39,6 @@ public:
 	void deserialize(NAS2D::Xml::XmlElement* element);
 
 private:
-	OreDeposit(const OreDeposit&) = delete;
-	OreDeposit& operator=(const OreDeposit&) = delete;
-
-private:
 	StorableResources mTappedReserves;
 	OreDepositYield mYield;
 	int mDigDepth{0};


### PR DESCRIPTION
A bit of refactoring of `Tile` method uses relating to `MapObject` pointers.

Notice this while preparing for the removal of `new`/`delete` for `OreDeposit` instances.

Related:
- PR #2033
- Issue #480
