### PR TITLE
Write `Robot` `MapCoordinates` with other fields

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -119,11 +119,23 @@ void Robot::taskCompleteHandler(TaskCompleteDelegate newTaskCompleteHandler)
 
 NAS2D::Dictionary Robot::getDataDict() const
 {
-	return {{
+	auto dictionary = NAS2D::Dictionary{{
 		{"type", static_cast<int>(mRobotTypeIndex)},
 		{"age", mFuelCellAge},
 		{"production", mTurnsToCompleteTask},
 	}};
+
+	if (isPlaced())
+	{
+		const auto location = mapCoordinate();
+		dictionary += NAS2D::Dictionary{{
+			{"x", location.xy.x},
+			{"y", location.xy.y},
+			{"depth", location.z},
+		}};
+	}
+
+	return dictionary;
 }
 
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -76,12 +76,6 @@ namespace
 		}
 		return controlCounter;
 	}
-
-
-	NAS2D::Dictionary robotToDictionary(Robot& robot)
-	{
-		return robot.getDataDict();
-	}
 }
 
 
@@ -287,7 +281,7 @@ NAS2D::Xml::XmlElement* RobotPool::writeRobots()
 
 	for (auto robot : mRobots)
 	{
-		auto dictionary = robotToDictionary(*robot);
+		auto dictionary = robot->getDataDict();
 		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
 	}
 

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -281,8 +281,7 @@ NAS2D::Xml::XmlElement* RobotPool::writeRobots()
 
 	for (auto robot : mRobots)
 	{
-		auto dictionary = robot->getDataDict();
-		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", dictionary));
+		robots->linkEndChild(NAS2D::dictionaryToAttributes("robot", robot->getDataDict()));
 	}
 
 	return robots;

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -80,19 +80,7 @@ namespace
 
 	NAS2D::Dictionary robotToDictionary(Robot& robot)
 	{
-		NAS2D::Dictionary dictionary = robot.getDataDict();
-
-		if (robot.isPlaced())
-		{
-			const auto mapCoordinate = robot.mapCoordinate();
-			dictionary += NAS2D::Dictionary{{
-				{"x", mapCoordinate.xy.x},
-				{"y", mapCoordinate.xy.y},
-				{"depth", mapCoordinate.z},
-			}};
-		}
-
-		return dictionary;
+		return robot.getDataDict();
 	}
 }
 


### PR DESCRIPTION
Noticed this while looking at `RobotPool` code.

Related:
- Issue #1335
