### PR TITLE
Incorporate location display as part of `NotificationWindow`

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1083,7 +1083,7 @@ void MapViewState::placeRobodigger(Tile& tile)
 		const auto position = tile.xy();
 		mNotificationArea.push({
 			"Mine destroyed",
-			"Digger destroyed a Mine at " + NAS2D::stringFrom(position) + ".",
+			"Digger destroyed a Mine.",
 			tile.xyz(),
 			NotificationArea::NotificationType::Information});
 		mTileMap->removeOreDepositLocation(position);

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -25,7 +25,6 @@
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <NAS2D/Utility.h>
-#include <NAS2D/StringFrom.h>
 
 #include <stdexcept>
 #include <array>
@@ -218,7 +217,7 @@ void MapViewState::onRobotSelfDestruct(const Robot& robot)
 	const auto& position = robot.mapCoordinate();
 	mNotificationArea.push({
 		"Robot Self-Destructed",
-		robot.name() + " self destructed at " + NAS2D::stringFrom(position.xy) + ".",
+		robot.name() + " self destructed.",
 		position,
 		NotificationArea::NotificationType::Critical
 	});
@@ -230,7 +229,7 @@ void MapViewState::onRobotBreakDown(const Robot& robot)
 	const auto& position = robot.mapCoordinate();
 	mNotificationArea.push({
 		"Robot Broke Down",
-		robot.name() + " has broken down at " + NAS2D::stringFrom(position.xy) + ". It will not be able to complete its task and will be removed from your inventory.",
+		robot.name() + " has broken down. It will not be able to complete its task and will be removed from your inventory.",
 		position,
 		NotificationArea::NotificationType::Critical
 	});
@@ -242,7 +241,7 @@ void MapViewState::onRobotTaskComplete(const Robot& robot)
 	const auto& position = robot.mapCoordinate();
 	mNotificationArea.push({
 		"Robot Task Completed",
-		robot.name() + " completed its task at " + NAS2D::stringFrom(position.xy) + ".",
+		robot.name() + " completed its task.",
 		position,
 		NotificationArea::NotificationType::Success
 	});
@@ -254,7 +253,7 @@ void MapViewState::onRobotTaskCancel(const Robot& robot)
 	const auto& position = robot.mapCoordinate();
 	mNotificationArea.push({
 		"Robot Task Canceled",
-		robot.name() + " canceled its task at " + NAS2D::stringFrom(position.xy) + ".",
+		robot.name() + " canceled its task.",
 		position,
 		NotificationArea::NotificationType::Information
 	});

--- a/appOPHD/UI/NotificationWindow.cpp
+++ b/appOPHD/UI/NotificationWindow.cpp
@@ -2,6 +2,9 @@
 
 #include "../Cache.h"
 
+#include <NAS2D/StringFrom.h>
+#include <NAS2D/Renderer/Renderer.h>
+
 
 NotificationWindow::NotificationWindow(TakeMeThereDelegate takeMeThereHandler):
 	mIcons{imageCache.load("ui/icons.png")},
@@ -55,4 +58,12 @@ void NotificationWindow::drawClientArea(NAS2D::Renderer& renderer) const
 {
 	const auto iconLocation = position() + NAS2D::Vector{10, 30};
 	drawNotificationIcon(renderer, iconLocation, mNotification.type, mIcons);
+
+	if (mNotification.hasMapCoordinate())
+	{
+		const auto& font = getDefaultFont();
+		const auto textPosition = btnTakeMeThere.position() + NAS2D::Vector{2, -font.height() - 2};
+		const auto text = "At location: " + NAS2D::stringFrom(mNotification.position.xy);
+		renderer.drawText(font, text, textPosition);
+	}
 }


### PR DESCRIPTION
Coordinates will now be displayed for any notification with an associated location. There will no longer be a need to include the location as part of the `Notification` message.

----

Updated `NotificationWindow`:
<img width="304" height="225" alt="image" src="https://github.com/user-attachments/assets/0b44d10b-731c-4d64-92b2-19417837e4c5" />

----

Related:
- PR #2039
- Issue #1335
- Issue #1754
