### PR TITLE
Add `makefile` targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -358,6 +358,10 @@ cppclean:
 cppinclude:
 	cppinclude --show_details=false --report_limit=30
 
+.PHONY: cppinclude-detailed
+cppinclude-detailed:
+	cppinclude
+
 .PHONY: format
 format:
 	@clang-format --version

--- a/makefile
+++ b/makefile
@@ -269,6 +269,10 @@ ophd: $(ophd_OUTPUT)
 run: $(ophd_OUTPUT)
 	$(RunPrefix) $(ophd_OUTPUT) $(OPHD_RUN_FLAGS)
 
+.PHONY: valgrind
+valgrind: $(ophd_OUTPUT)
+	valgrind $(RunPrefix) $(ophd_OUTPUT) $(OPHD_RUN_FLAGS)
+
 
 ## Compile rules ##
 

--- a/makefile
+++ b/makefile
@@ -356,7 +356,7 @@ cppclean:
 
 .PHONY: cppinclude
 cppinclude:
-	cppinclude
+	cppinclude --show_details=false --report_limit=30
 
 .PHONY: format
 format:


### PR DESCRIPTION
Add `makefile` targets for commonly run commands.

The `valgrind` target is useful for debugging crash bugs. Meanwhile the `cppinclude` updates are useful for looking into and improving build times.

Related:
- Issue #1573
