### PR TITLE
Move robot command capacity to `StructureManager`

### DIFF
--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -219,13 +219,9 @@ void RobotPool::update()
 	int totalRobotCommandCapacity = mStructureManager.totalRobotCommandCapacity();
 
 	// Special case hack to allow robot use during initial colony deploy
-	if (totalRobotCommandCapacity == 0)
+	if (totalRobotCommandCapacity == 0 && mStructureManager.hasCommandCenter())
 	{
-		const auto& commandCenters = mStructureManager.getStructures<CommandCenter>();
-		if (commandCenters.size() > 0)
-		{
-			totalRobotCommandCapacity += commandCenters[0]->type().robotCommandCapacity;
-		}
+		totalRobotCommandCapacity += mStructureManager.firstCc().type().robotCommandCapacity;
 	}
 
 	mRobotControlMax = static_cast<std::size_t>(totalRobotCommandCapacity);

--- a/appOPHD/RobotPool.cpp
+++ b/appOPHD/RobotPool.cpp
@@ -216,13 +216,7 @@ std::size_t RobotPool::getAvailableCount(RobotTypeIndex robotTypeIndex) const
 
 void RobotPool::update()
 {
-	const auto& structures = mStructureManager.allStructures();
-
-	int totalRobotCommandCapacity = 0;
-	for (const auto* structure : structures)
-	{
-		if (structure->operational()) { totalRobotCommandCapacity += structure->type().robotCommandCapacity; }
-	}
+	int totalRobotCommandCapacity = mStructureManager.totalRobotCommandCapacity();
 
 	// Special case hack to allow robot use during initial colony deploy
 	if (totalRobotCommandCapacity == 0)

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -473,6 +473,22 @@ int StructureManager::totalFoodStorageCapacity() const
 }
 
 
+int StructureManager::totalRobotCommandCapacity() const
+{
+	int totalRobotCommandCapacity = 0;
+
+	for (const auto* structure : allStructures())
+	{
+		if (structure->operational())
+		{
+			totalRobotCommandCapacity += structure->type().robotCommandCapacity;
+		}
+	}
+
+	return totalRobotCommandCapacity;
+}
+
+
 void StructureManager::assignColonistsToResidences(PopulationPool& population)
 {
 	int populationCount = population.size();

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -253,6 +253,12 @@ StructureList StructureManager::activePoliceStations() const
 }
 
 
+bool StructureManager::hasCommandCenter() const
+{
+	return !getStructures<CommandCenter>().empty();
+}
+
+
 CommandCenter& StructureManager::firstCc() const
 {
 	const auto& ccList = getStructures<CommandCenter>();

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -78,6 +78,7 @@ public:
 
 	StructureList activePoliceStations() const;
 
+	bool hasCommandCenter() const;
 	CommandCenter& firstCc() const;
 	std::vector<MapCoordinate> operationalCommandCenterPositions() const;
 	bool isInCcRange(NAS2D::Point<int> position) const;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -121,6 +121,7 @@ public:
 
 	int totalRefinedOreStorageCapacity() const;
 	int totalFoodStorageCapacity() const;
+	int totalRobotCommandCapacity() const;
 
 	void assignColonistsToResidences(PopulationPool&);
 	void assignScientistsToResearchFacilities(PopulationPool&);


### PR DESCRIPTION
Robot command capacity depends on current operational structures and their `robotCommandCapacity` values.

Related:
- Issue #1335
- PR #2047
- PR #2045
