### PR TITLE
Remove duplicate copy of `InsertMode` enum

### DIFF
--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -83,15 +83,6 @@ class FileIo;
 class ColonyShip;
 
 
-enum class InsertMode
-{
-	None,
-	Robot,
-	Tube,
-	Structure
-};
-
-
 class MapViewState : public Wrapper
 {
 public:


### PR DESCRIPTION
It seems the copy was made in commit 2dbacdf780236bbd75e32ac98fef2d3320d04cbb, but the original was left in place. The intention was to move the enum to the new location.

Related:
- PR #1988
- Issue #650
