### PR TITLE
Split structures element processing

### DIFF
--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -600,94 +600,94 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 {
 	for (auto* structure : structures)
 	{
-		updateStructure(resources, population, structure);
+		updateStructure(resources, population, *structure);
 	}
 }
 
 
-void StructureManager::updateStructure(const StorableResources& resources, PopulationPool& population, Structure* structure)
+void StructureManager::updateStructure(const StorableResources& resources, PopulationPool& population, Structure& structure)
 {
-	structure->processTurn();
+	structure.processTurn();
 
-	if (structure->ages() && (structure->age() >= structure->maxAge() - 10))
+	if (structure.ages() && (structure.age() >= structure.maxAge() - 10))
 	{
-		mAgingStructures.push_back(structure);
+		mAgingStructures.push_back(&structure);
 	}
 
-	if (structure->age() == structure->turnsToBuild())
+	if (structure.age() == structure.turnsToBuild())
 	{
-		mNewlyBuiltStructures.push_back(structure);
+		mNewlyBuiltStructures.push_back(&structure);
 	}
 
-	if (structure->hasCrime() && !structure->underConstruction())
+	if (structure.hasCrime() && !structure.underConstruction())
 	{
-		mStructuresWithCrime.push_back(structure);
+		mStructuresWithCrime.push_back(&structure);
 	}
 
 	// State Check
 	// ASSUMPTION:	Construction sites are considered self sufficient until they are
 	//				completed and connected to the rest of the colony.
-	if (structure->underConstruction() || structure->destroyed())
+	if (structure.underConstruction() || structure.destroyed())
 	{
 		return;
 	}
 
-	if (structure->disabled() && structure->disabledReason() == DisabledReason::StructuralIntegrity)
+	if (structure.disabled() && structure.disabledReason() == DisabledReason::StructuralIntegrity)
 	{
 		return;
 	}
 
 	// Connection Check
-	if (!structure->connected() && !structure->selfSustained())
+	if (!structure.connected() && !structure.selfSustained())
 	{
-		structure->disable(DisabledReason::Disconnected);
+		structure.disable(DisabledReason::Disconnected);
 		return;
 	}
 
 	// CHAP Check
-	if (structure->requiresCHAP() && !CHAPAvailable())
+	if (structure.requiresCHAP() && !CHAPAvailable())
 	{
-		structure->disable(DisabledReason::Chap);
+		structure.disable(DisabledReason::Chap);
 		return;
 	}
 
 	// Population Check
-	const auto& populationRequired = structure->populationRequirements();
-	auto& populationAvailable = structure->populationAvailable();
+	const auto& populationRequired = structure.populationRequirements();
+	auto& populationAvailable = structure.populationAvailable();
 
 	populationAvailable = fillPopulationRequirements(population, populationRequired);
 
 	if ((populationAvailable.workers < populationRequired.workers) ||
 		(populationAvailable.scientists < populationRequired.scientists))
 	{
-		structure->disable(DisabledReason::Population);
+		structure.disable(DisabledReason::Population);
 		return;
 	}
 
-	if (structure->energyRequirement() > totalEnergyAvailable())
+	if (structure.energyRequirement() > totalEnergyAvailable())
 	{
-		structure->disable(DisabledReason::Energy);
+		structure.disable(DisabledReason::Energy);
 		return;
 	}
 
 	// Check that enough resources are available for input.
-	if (!structure->isIdle() && !(resources >= structure->resourcesIn()))
+	if (!structure.isIdle() && !(resources >= structure.resourcesIn()))
 	{
-		structure->disable(DisabledReason::RefinedResources);
+		structure.disable(DisabledReason::RefinedResources);
 		return;
 	}
 
-	structure->enable();
+	structure.enable();
 
-	if (structure->operational())
+	if (structure.operational())
 	{
 		population.usePopulation(populationRequired);
 
-		auto consumed = structure->resourcesIn();
+		auto consumed = structure.resourcesIn();
 		removeRefinedResources(consumed);
 
-		mTotalEnergyUsed += structure->energyRequirement();
+		mTotalEnergyUsed += structure.energyRequirement();
 
-		structure->think();
+		structure.think();
 	}
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -600,6 +600,13 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 {
 	for (auto* structure : structures)
 	{
+		updateStructure(resources, population, structure);
+	}
+}
+
+
+void StructureManager::updateStructure(const StorableResources& resources, PopulationPool& population, Structure* structure)
+{
 		structure->processTurn();
 
 		if (structure->ages() && (structure->age() >= structure->maxAge() - 10))
@@ -622,26 +629,26 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 		//				completed and connected to the rest of the colony.
 		if (structure->underConstruction() || structure->destroyed())
 		{
-			continue;
+			return;
 		}
 
 		if (structure->disabled() && structure->disabledReason() == DisabledReason::StructuralIntegrity)
 		{
-			continue;
+			return;
 		}
 
 		// Connection Check
 		if (!structure->connected() && !structure->selfSustained())
 		{
 			structure->disable(DisabledReason::Disconnected);
-			continue;
+			return;
 		}
 
 		// CHAP Check
 		if (structure->requiresCHAP() && !CHAPAvailable())
 		{
 			structure->disable(DisabledReason::Chap);
-			continue;
+			return;
 		}
 
 		// Population Check
@@ -654,20 +661,20 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 			(populationAvailable.scientists < populationRequired.scientists))
 		{
 			structure->disable(DisabledReason::Population);
-			continue;
+			return;
 		}
 
 		if (structure->energyRequirement() > totalEnergyAvailable())
 		{
 			structure->disable(DisabledReason::Energy);
-			continue;
+			return;
 		}
 
 		// Check that enough resources are available for input.
 		if (!structure->isIdle() && !(resources >= structure->resourcesIn()))
 		{
 			structure->disable(DisabledReason::RefinedResources);
-			continue;
+			return;
 		}
 
 		structure->enable();
@@ -683,5 +690,4 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 
 			structure->think();
 		}
-	}
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -607,87 +607,87 @@ void StructureManager::updateStructures(const StorableResources& resources, Popu
 
 void StructureManager::updateStructure(const StorableResources& resources, PopulationPool& population, Structure* structure)
 {
-		structure->processTurn();
+	structure->processTurn();
 
-		if (structure->ages() && (structure->age() >= structure->maxAge() - 10))
-		{
-			mAgingStructures.push_back(structure);
-		}
+	if (structure->ages() && (structure->age() >= structure->maxAge() - 10))
+	{
+		mAgingStructures.push_back(structure);
+	}
 
-		if (structure->age() == structure->turnsToBuild())
-		{
-			mNewlyBuiltStructures.push_back(structure);
-		}
+	if (structure->age() == structure->turnsToBuild())
+	{
+		mNewlyBuiltStructures.push_back(structure);
+	}
 
-		if (structure->hasCrime() && !structure->underConstruction())
-		{
-			mStructuresWithCrime.push_back(structure);
-		}
+	if (structure->hasCrime() && !structure->underConstruction())
+	{
+		mStructuresWithCrime.push_back(structure);
+	}
 
-		// State Check
-		// ASSUMPTION:	Construction sites are considered self sufficient until they are
-		//				completed and connected to the rest of the colony.
-		if (structure->underConstruction() || structure->destroyed())
-		{
-			return;
-		}
+	// State Check
+	// ASSUMPTION:	Construction sites are considered self sufficient until they are
+	//				completed and connected to the rest of the colony.
+	if (structure->underConstruction() || structure->destroyed())
+	{
+		return;
+	}
 
-		if (structure->disabled() && structure->disabledReason() == DisabledReason::StructuralIntegrity)
-		{
-			return;
-		}
+	if (structure->disabled() && structure->disabledReason() == DisabledReason::StructuralIntegrity)
+	{
+		return;
+	}
 
-		// Connection Check
-		if (!structure->connected() && !structure->selfSustained())
-		{
-			structure->disable(DisabledReason::Disconnected);
-			return;
-		}
+	// Connection Check
+	if (!structure->connected() && !structure->selfSustained())
+	{
+		structure->disable(DisabledReason::Disconnected);
+		return;
+	}
 
-		// CHAP Check
-		if (structure->requiresCHAP() && !CHAPAvailable())
-		{
-			structure->disable(DisabledReason::Chap);
-			return;
-		}
+	// CHAP Check
+	if (structure->requiresCHAP() && !CHAPAvailable())
+	{
+		structure->disable(DisabledReason::Chap);
+		return;
+	}
 
-		// Population Check
-		const auto& populationRequired = structure->populationRequirements();
-		auto& populationAvailable = structure->populationAvailable();
+	// Population Check
+	const auto& populationRequired = structure->populationRequirements();
+	auto& populationAvailable = structure->populationAvailable();
 
-		populationAvailable = fillPopulationRequirements(population, populationRequired);
+	populationAvailable = fillPopulationRequirements(population, populationRequired);
 
-		if ((populationAvailable.workers < populationRequired.workers) ||
-			(populationAvailable.scientists < populationRequired.scientists))
-		{
-			structure->disable(DisabledReason::Population);
-			return;
-		}
+	if ((populationAvailable.workers < populationRequired.workers) ||
+		(populationAvailable.scientists < populationRequired.scientists))
+	{
+		structure->disable(DisabledReason::Population);
+		return;
+	}
 
-		if (structure->energyRequirement() > totalEnergyAvailable())
-		{
-			structure->disable(DisabledReason::Energy);
-			return;
-		}
+	if (structure->energyRequirement() > totalEnergyAvailable())
+	{
+		structure->disable(DisabledReason::Energy);
+		return;
+	}
 
-		// Check that enough resources are available for input.
-		if (!structure->isIdle() && !(resources >= structure->resourcesIn()))
-		{
-			structure->disable(DisabledReason::RefinedResources);
-			return;
-		}
+	// Check that enough resources are available for input.
+	if (!structure->isIdle() && !(resources >= structure->resourcesIn()))
+	{
+		structure->disable(DisabledReason::RefinedResources);
+		return;
+	}
 
-		structure->enable();
+	structure->enable();
 
-		if (structure->operational())
-		{
-			population.usePopulation(populationRequired);
+	if (structure->operational())
+	{
+		population.usePopulation(populationRequired);
 
-			auto consumed = structure->resourcesIn();
-			removeRefinedResources(consumed);
+		auto consumed = structure->resourcesIn();
+		removeRefinedResources(consumed);
 
-			mTotalEnergyUsed += structure->energyRequirement();
+		mTotalEnergyUsed += structure->energyRequirement();
 
-			structure->think();
-		}
+		structure->think();
+	}
 }

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -135,7 +135,7 @@ protected:
 	void disconnectAll();
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
-	void updateStructure(const StorableResources&, PopulationPool&, Structure*);
+	void updateStructure(const StorableResources&, PopulationPool&, Structure&);
 
 private:
 	std::vector<Structure*> mDeployedStructures;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -135,6 +135,7 @@ protected:
 	void disconnectAll();
 
 	void updateStructures(const StorableResources&, PopulationPool&, StructureList&);
+	void updateStructure(const StorableResources&, PopulationPool&, Structure*);
 
 private:
 	std::vector<Structure*> mDeployedStructures;


### PR DESCRIPTION
Split processing of an individual `Structure` from the structures collection.

The `Structure` processing function could potentially grow to include more types of processing. That could allow for a reduction in the number of subclasses of `Structure`.

Related:
- Issue #1804
