### PR TITLE
Prefer single flat collection in `StructureManager`

### DIFF
--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -225,7 +225,7 @@ const StructureList& StructureManager::structureList(StructureClass structureCla
 }
 
 
-StructureList StructureManager::allStructures() const
+const StructureList& StructureManager::allStructures() const
 {
 	return mDeployedStructures;
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -395,13 +395,7 @@ void StructureManager::disconnectAll()
  */
 int StructureManager::count() const
 {
-	int count = 0;
-	for (auto& pair : mStructureLists)
-	{
-		count += static_cast<int>(pair.second.size());
-	}
-
-	return count;
+	return static_cast<int>(mDeployedStructures.size());
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -235,7 +235,7 @@ StructureList StructureManager::agingStructures() const
 {
 	StructureList agingStructures{};
 
-	for (auto* structure : allStructures())
+	for (auto* structure : mDeployedStructures)
 	{
 		if (structure->ages() && (structure->age() >= structure->maxAge() - 10))
 		{
@@ -251,7 +251,7 @@ StructureList StructureManager::newlyBuiltStructures() const
 {
 	StructureList newlyBuiltStructures{};
 
-	for (auto* structure : allStructures())
+	for (auto* structure : mDeployedStructures)
 	{
 		if (structure->ages() && (structure->age() == structure->turnsToBuild()))
 		{
@@ -267,7 +267,7 @@ StructureList StructureManager::structuresWithCrime() const
 {
 	StructureList structuresWithCrime{};
 
-	for (auto* structure : allStructures())
+	for (auto* structure : mDeployedStructures)
 	{
 		if (structure->hasCrime() && !structure->underConstruction())
 		{
@@ -282,7 +282,7 @@ StructureList StructureManager::structuresWithCrime() const
 StructureList StructureManager::activePoliceStations() const
 {
 	StructureList policeStations;
-	for (auto* structure : allStructures())
+	for (auto* structure : mDeployedStructures)
 	{
 		if (structure->operational() && structure->isPolice())
 		{
@@ -342,8 +342,7 @@ bool StructureManager::isInCcRange(NAS2D::Point<int> position) const
 
 bool StructureManager::isInCommRange(NAS2D::Point<int> position) const
 {
-	const auto& structures = allStructures();
-	for (const auto* structure : structures)
+	for (const auto* structure : mDeployedStructures)
 	{
 		const auto commRange = structure->commRange();
 		if (commRange > 0 && isPointInRange(position, structure->xyz().xy, commRange))
@@ -457,7 +456,7 @@ void StructureManager::updateEnergyProduction()
 	mTotalEnergyOutput = 0;
 	mTotalEnergyUsed = 0;
 
-	for (auto* structure : allStructures())
+	for (auto* structure : mDeployedStructures)
 	{
 		mTotalEnergyOutput += structure->energyProduced();
 	}
@@ -486,7 +485,7 @@ int StructureManager::totalRefinedOreStorageCapacity() const
 {
 	int storageCapacity = 0;
 
-	for (const auto* structure : allStructures())
+	for (const auto* structure : mDeployedStructures)
 	{
 		if (structure->operational() || structure->isIdle())
 		{
@@ -502,7 +501,7 @@ int StructureManager::totalFoodStorageCapacity() const
 {
 	int storageCapacity = 0;
 
-	for (const auto* structure : allStructures())
+	for (const auto* structure : mDeployedStructures)
 	{
 		if (structure->operational() || structure->isIdle())
 		{
@@ -518,7 +517,7 @@ int StructureManager::totalRobotCommandCapacity() const
 {
 	int totalRobotCommandCapacity = 0;
 
-	for (const auto* structure : allStructures())
+	for (const auto* structure : mDeployedStructures)
 	{
 		if (structure->operational())
 		{

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -200,7 +200,7 @@ void StructureManager::removeStructure(Structure& structure)
 	}
 
 	structures.erase(it);
-	(*tileTableIt)->tile().removeMapObject();
+	structure.tile().removeMapObject();
 	mDeployedStructures.erase(tileTableIt);
 	delete &structure;
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -227,15 +227,7 @@ const StructureList& StructureManager::structureList(StructureClass structureCla
 
 StructureList StructureManager::allStructures() const
 {
-	StructureList structuresOut;
-
-	for (auto& classListPair : mStructureLists)
-	{
-		auto& structures = classListPair.second;
-		std::copy(structures.begin(), structures.end(), std::back_inserter(structuresOut));
-	}
-
-	return structuresOut;
+	return mDeployedStructures;
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -199,8 +199,8 @@ void StructureManager::removeStructure(Structure& structure)
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
 
-	structures.erase(it);
 	structure.tile().removeMapObject();
+	structures.erase(it);
 	mDeployedStructures.erase(tileTableIt);
 	delete &structure;
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -547,12 +547,15 @@ void StructureManager::assignScientistsToResearchFacilities(PopulationPool& popu
 	for (auto* laboratory : mStructureLists[StructureClass::Laboratory])
 	{
 		auto* lab = dynamic_cast<ResearchFacility*>(laboratory);
-		lab->assignScientists(0);
-		if (lab->operational())
+		if (lab)
 		{
-			lab->assignScientists(availableScientists);
-			availableScientists -= lab->assignedScientists();
-			population.usePopulation({0, lab->assignedScientists()});
+			lab->assignScientists(0);
+			if (lab->operational())
+			{
+				lab->assignScientists(availableScientists);
+				availableScientists -= lab->assignedScientists();
+				population.usePopulation({0, lab->assignedScientists()});
+			}
 		}
 	}
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -416,11 +416,13 @@ int StructureManager::getCountInState(StructureClass structureClass, StructureSt
 int StructureManager::disabledCount() const
 {
 	int count = 0;
-	for (auto& pair : mStructureLists)
+	for (const auto* structure : mDeployedStructures)
 	{
-		count += getCountInState(pair.first, StructureState::Disabled);
+		if (structure->state() == StructureState::Disabled)
+		{
+			++count;
+		}
 	}
-
 	return count;
 }
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -544,7 +544,7 @@ void StructureManager::assignColonistsToResidences(PopulationPool& population)
 void StructureManager::assignScientistsToResearchFacilities(PopulationPool& population)
 {
 	int availableScientists = population.availableScientists();
-	for (auto* laboratory : mStructureLists[StructureClass::Laboratory])
+	for (auto* laboratory : mDeployedStructures)
 	{
 		auto* lab = dynamic_cast<ResearchFacility*>(laboratory);
 		if (lab)

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -529,7 +529,7 @@ int StructureManager::totalRobotCommandCapacity() const
 void StructureManager::assignColonistsToResidences(PopulationPool& population)
 {
 	int populationCount = population.size();
-	for (auto* structure : mStructureLists[StructureClass::Residence])
+	for (auto* structure : mDeployedStructures)
 	{
 		Residence* residence = dynamic_cast<Residence*>(structure);
 		if (residence && residence->operational())

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -430,11 +430,13 @@ int StructureManager::disabledCount() const
 int StructureManager::destroyedCount() const
 {
 	int count = 0;
-	for (auto& pair : mStructureLists)
+	for (const auto* structure : mDeployedStructures)
 	{
-		count += getCountInState(pair.first, StructureState::Destroyed);
+		if (structure->state() == StructureState::Destroyed)
+		{
+			++count;
+		}
 	}
-
 	return count;
 }
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -468,14 +468,11 @@ void StructureManager::updateEnergyConsumed()
 {
 	mTotalEnergyUsed = 0;
 
-	for (auto& classListPair : mStructureLists)
+	for (const auto* structure : mDeployedStructures)
 	{
-		for (const auto* structure : classListPair.second)
+		if (structure->operational())
 		{
-			if (structure->operational())
-			{
-				mTotalEnergyUsed += structure->energyRequirement();
-			}
+			mTotalEnergyUsed += structure->energyRequirement();
 		}
 	}
 }

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -74,7 +74,7 @@ public:
 	}
 
 	const StructureList& structureList(StructureClass structureClass) const;
-	StructureList allStructures() const;
+	const StructureList& allStructures() const;
 
 	StructureList agingStructures() const;
 	StructureList newlyBuiltStructures() const;


### PR DESCRIPTION
Prefer single flat collection `mDeployedStructures` in `StructureManager` over the multi-level list divided up by `StructureClass`.

Both collections are always updated together, so should always contain the same elements. In a number of cases, `mDeployedStructures` is already used as the primary. This furthers that, by using `mDeployedStructures` in more places. This moves us towards being able to get rid of the multi-level list divided up by `StructureClass`. This will promote a more uniform way of handling `Structure` instances.

Related:
- Issue #1804
- Issue #1647
- PR #2052
- PR #2051
- PR #2044
