### PR TITLE
Add `Structure::isCommand()` and improve efficiency

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -341,6 +341,7 @@ bool Structure::repairable() const
 
 bool Structure::providesCHAP() const { return mStructureClass == StructureClass::LifeSupport; }
 
+bool Structure::isCommand() const { return mStructureClass == StructureClass::Command; }
 bool Structure::isFactory() const { return mStructureClass == StructureClass::Factory; }
 bool Structure::isWarehouse() const { return mStructureClass == StructureClass::Warehouse; }
 bool Structure::isRobotCommand() const { return mStructureClass == StructureClass::RobotCommand; }

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -339,8 +339,7 @@ bool Structure::repairable() const
 	return mStructureType.isRepairable && (mStructureState != StructureState::Destroyed);
 }
 
-bool Structure::providesCHAP() const { return mStructureClass == StructureClass::LifeSupport; }
-
+bool Structure::isChap() const { return mStructureClass == StructureClass::LifeSupport; }
 bool Structure::isCommand() const { return mStructureClass == StructureClass::Command; }
 bool Structure::isFactory() const { return mStructureClass == StructureClass::Factory; }
 bool Structure::isWarehouse() const { return mStructureClass == StructureClass::Warehouse; }

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -114,6 +114,7 @@ public:
 	bool repairable() const;
 
 	// CONVENIENCE FUCNTIONS
+	bool isCommand() const;
 	bool isFactory() const;
 	bool isWarehouse() const;
 	bool isRobotCommand() const;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -109,11 +109,11 @@ public:
 
 	// FLAGS
 	bool requiresCHAP() const;
-	bool providesCHAP() const;
 	bool selfSustained() const;
 	bool repairable() const;
 
 	// CONVENIENCE FUCNTIONS
+	bool isChap() const;
 	bool isCommand() const;
 	bool isFactory() const;
 	bool isWarehouse() const;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -988,7 +988,7 @@ void MapViewState::placeRobodozer(Tile& tile)
 		Structure* structure = tile.structure();
 
 		if (structure->isMineFacility()) { return; }
-		if (structure->structureClass() == StructureClass::Command)
+		if (structure->isCommand())
 		{
 			doAlertMessage(constants::AlertInvalidRobotPlacement, constants::AlertCannotBulldozeCc);
 			return;

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -289,6 +289,20 @@ StructureList StructureManager::structuresWithCrime() const
 }
 
 
+StructureList StructureManager::commandCenters() const
+{
+	StructureList structures;
+	for (auto* structure : mDeployedStructures)
+	{
+		if (structure->isCommand())
+		{
+			structures.push_back(structure);
+		}
+	}
+	return structures;
+}
+
+
 StructureList StructureManager::activeCommandCenters() const
 {
 	StructureList structures;

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -333,7 +333,14 @@ StructureList StructureManager::activePoliceStations() const
 
 bool StructureManager::hasCommandCenter() const
 {
-	return !commandCenters().empty();
+	for (auto* structure : mDeployedStructures)
+	{
+		if (structure->isCommand())
+		{
+			return true;
+		}
+	}
+	return false;
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -294,7 +294,7 @@ StructureList StructureManager::activePoliceStations() const
 	StructureList policeStations;
 	for (auto* structure : mDeployedStructures)
 	{
-		if (structure->operational() && structure->isPolice())
+		if (structure->isPolice() && structure->operational())
 		{
 			policeStations.push_back(structure);
 		}

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -333,7 +333,7 @@ StructureList StructureManager::activePoliceStations() const
 
 bool StructureManager::hasCommandCenter() const
 {
-	return !getStructures<CommandCenter>().empty();
+	return !commandCenters().empty();
 }
 
 
@@ -362,8 +362,7 @@ std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions()
 bool StructureManager::isInCcRange(NAS2D::Point<int> position) const
 {
 	const auto range = StructureCatalog::getType(StructureID::CommandCenter).commRange;
-	const auto& ccList = getStructures<CommandCenter>();
-	for (const auto* commandCenter : ccList)
+	for (const auto* commandCenter : commandCenters())
 	{
 		const auto location = commandCenter->xyz().xy;
 		if (isPointInRange(position, location, range))

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -289,6 +289,20 @@ StructureList StructureManager::structuresWithCrime() const
 }
 
 
+StructureList StructureManager::activeCommandCenters() const
+{
+	StructureList structures;
+	for (auto* structure : mDeployedStructures)
+	{
+		if (structure->isCommand() && structure->operational())
+		{
+			structures.push_back(structure);
+		}
+	}
+	return structures;
+}
+
+
 StructureList StructureManager::activePoliceStations() const
 {
 	StructureList structures;

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -337,12 +337,9 @@ CommandCenter& StructureManager::firstCc() const
 std::vector<MapCoordinate> StructureManager::operationalCommandCenterPositions() const
 {
 	std::vector<MapCoordinate> positions;
-	for (const auto* commandCenter : getStructures<CommandCenter>())
+	for (const auto* commandCenter : activeCommandCenters())
 	{
-		if (commandCenter->operational())
-		{
-			positions.push_back(commandCenter->xyz());
-		}
+		positions.push_back(commandCenter->xyz());
 	}
 	return positions;
 }

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -291,15 +291,15 @@ StructureList StructureManager::structuresWithCrime() const
 
 StructureList StructureManager::activePoliceStations() const
 {
-	StructureList policeStations;
+	StructureList structures;
 	for (auto* structure : mDeployedStructures)
 	{
 		if (structure->isPolice() && structure->operational())
 		{
-			policeStations.push_back(structure);
+			structures.push_back(structure);
 		}
 	}
-	return policeStations;
+	return structures;
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -339,12 +339,15 @@ bool StructureManager::hasCommandCenter() const
 
 CommandCenter& StructureManager::firstCc() const
 {
-	const auto& ccList = getStructures<CommandCenter>();
-	if (ccList.empty())
+	for (auto* structure : mDeployedStructures)
 	{
-		throw std::runtime_error("firstCc() called with no active CommandCenter");
+		auto* commandCenter = dynamic_cast<CommandCenter*>(structure);
+		if (commandCenter)
+		{
+			return *commandCenter;
+		}
 	}
-	return *ccList.at(0);
+	throw std::runtime_error("firstCc() called with no active CommandCenter");
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -502,7 +502,7 @@ bool StructureManager::CHAPAvailable() const
 {
 	for (const auto* structure : mDeployedStructures)
 	{
-		if (structure->providesCHAP() && structure->operational()) { return true; }
+		if (structure->isChap() && structure->operational()) { return true; }
 	}
 	return false;
 }

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -76,6 +76,7 @@ public:
 	StructureList newlyBuiltStructures() const;
 	StructureList structuresWithCrime() const;
 
+	StructureList commandCenters() const;
 	StructureList activeCommandCenters() const;
 	StructureList activePoliceStations() const;
 

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -76,6 +76,7 @@ public:
 	StructureList newlyBuiltStructures() const;
 	StructureList structuresWithCrime() const;
 
+	StructureList activeCommandCenters() const;
 	StructureList activePoliceStations() const;
 
 	bool hasCommandCenter() const;


### PR DESCRIPTION
Add `Structure::isCommand()` and improve efficiency of a number of `CommandCenter` related methods of `StructureManager`.

Rename `Structure` method `providesCHAP` to `isChap` for consistency.

Related:
- PR #2054
- PR #2053
- PR #2052
- Issue #1804
- Issue #1647 
