### PR TITLE
Remove `mStructureLists` from `StructureManager`

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -71,17 +71,6 @@ const std::map<StructureClass, std::string> StructureClassNames =
 };
 
 
-std::vector<StructureClass> allStructureClasses()
-{
-	std::vector<StructureClass> result;
-	for (const auto& entry : StructureClassNames)
-	{
-		result.push_back(entry.first);
-	}
-	return result;
-}
-
-
 Structure::Structure(StructureID id, Tile& tile) :
 	Structure{id, tile, constants::StructureStateConstruction}
 {

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -197,5 +197,3 @@ protected:
 
 
 using StructureList = std::vector<Structure*>;
-
-std::vector<StructureClass> allStructureClasses();

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -32,17 +32,6 @@
 
 namespace
 {
-	auto populateKeys()
-	{
-		std::map<StructureClass, StructureList> result;
-		for (const auto structureClass : allStructureClasses())
-		{
-			result[structureClass]; // Generate blank array value for given key
-		}
-		return result;
-	}
-
-
 	/**
 	 * Fills population requirements fields in a Structure.
 	 */
@@ -145,8 +134,7 @@ namespace
 }
 
 
-StructureManager::StructureManager() :
-	mStructureLists{populateKeys()}
+StructureManager::StructureManager()
 {
 }
 
@@ -172,8 +160,6 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
 	}
 
 	mDeployedStructures.push_back(&structure);
-
-	mStructureLists[structure.structureClass()].push_back(&structure);
 	tile.mapObject(&structure);
 }
 
@@ -186,21 +172,15 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
  */
 void StructureManager::removeStructure(Structure& structure)
 {
-	StructureList& structures = mStructureLists[structure.structureClass()];
-
-	const auto it = std::find(structures.begin(), structures.end(), &structure);
-	const auto isFoundStructureTable = it != structures.end();
-
 	const auto tileTableIt = std::find(mDeployedStructures.begin(), mDeployedStructures.end(), &structure);
 	const auto isFoundTileTable = tileTableIt != mDeployedStructures.end();
 
-	if (!isFoundStructureTable || !isFoundTileTable)
+	if (!isFoundTileTable)
 	{
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}
 
 	structure.tile().removeMapObject();
-	structures.erase(it);
 	mDeployedStructures.erase(tileTableIt);
 	delete &structure;
 }
@@ -215,7 +195,6 @@ void StructureManager::removeAllStructures()
 	}
 
 	mDeployedStructures.clear();
-	mStructureLists = populateKeys();
 }
 
 

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -173,9 +173,7 @@ void StructureManager::addStructure(Structure& structure, Tile& tile)
 void StructureManager::removeStructure(Structure& structure)
 {
 	const auto tileTableIt = std::find(mDeployedStructures.begin(), mDeployedStructures.end(), &structure);
-	const auto isFoundTileTable = tileTableIt != mDeployedStructures.end();
-
-	if (!isFoundTileTable)
+	if (tileTableIt == mDeployedStructures.end())
 	{
 		throw std::runtime_error("StructureManager::removeStructure(): Attempting to remove a Structure that is not managed by the StructureManager.");
 	}

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -124,7 +124,6 @@ protected:
 
 private:
 	std::vector<Structure*> mDeployedStructures;
-	std::map<StructureClass, StructureList> mStructureLists;
 
 	int mTotalEnergyOutput = 0; /**< Total energy output of all energy producers in the structure list. */
 	int mTotalEnergyUsed = 0;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -2,7 +2,6 @@
 
 #include "MapObjects/StructureClass.h"
 
-#include <map>
 #include <vector>
 
 


### PR DESCRIPTION
Remove the now unused `mStructureLists` collection from `StructureManager`.

Related:
- PR #2056
- PR #2054
- PR #2053
- PR #2052
- PR #2051
- Issue #1723
- Issue #1804
- Issue #1647
