### PR TITLE
Remove `Structure::state` setter method

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -90,7 +90,7 @@ void Structure::disable(DisabledReason reason)
 {
 	mSprite.pause();
 	mSprite.color(NAS2D::Color{255, 0, 0, 185});
-	state(StructureState::Disabled);
+	mStructureState = StructureState::Disabled;
 	mDisabledReason = reason;
 	mIdleReason = IdleReason::None;
 	disabledStateSet();
@@ -116,7 +116,7 @@ void Structure::enable()
 
 	mSprite.resume();
 	mSprite.color(NAS2D::Color::White);
-	state(StructureState::Operational);
+	mStructureState = StructureState::Operational;
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = IdleReason::None;
 }
@@ -142,7 +142,7 @@ void Structure::idle(IdleReason reason)
 	mSprite.color(NAS2D::Color{255, 255, 255, 185});
 	mDisabledReason = DisabledReason::None;
 	mIdleReason = reason;
-	state(StructureState::Idle);
+	mStructureState = StructureState::Idle;
 }
 
 
@@ -323,7 +323,7 @@ void Structure::activate()
 void Structure::rebuild()
 {
 	mSprite.play(constants::StructureStateConstruction);
-	state(StructureState::UnderConstruction);
+	mStructureState = StructureState::UnderConstruction;
 
 	age(1);
 }
@@ -398,7 +398,7 @@ void Structure::updateIntegrityDecay()
 void Structure::destroy()
 {
 	mSprite.play(constants::StructureStateDestroyed);
-	state(StructureState::Destroyed);
+	mStructureState = StructureState::Destroyed;
 }
 
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -153,8 +153,6 @@ protected:
 
 	virtual void disabledStateSet() {}
 
-	void state(StructureState newState) { mStructureState = newState; }
-
 	int calculateMaxEnergyProduction() const;
 
 private:

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -16,8 +16,7 @@ AirShaft::AirShaft(Tile& tile) :
 	}
 {
 	connectorDirection(ConnectorDir::Vertical);
-
-	state(StructureState::Operational);
+	mStructureState = StructureState::Operational;
 }
 
 

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -24,7 +24,7 @@ Tube::Tube(Tile& tile, ConnectorDir dir) :
 	}
 {
 	connectorDirection(dir);
-	state(StructureState::Operational);
+	mStructureState = StructureState::Operational;
 }
 
 


### PR DESCRIPTION
Prefer direct writes to internal `mStructureState` field, and remove `protected` setter method `state`.

Related:
- Issue #1804
