### PR TITLE
Refactor `Residence` capacities

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -250,6 +250,11 @@ int Structure::residentialCapacity() const
 	return mStructureType.residentialCapacity;
 }
 
+int Structure::bioWasteStorageCapacity() const
+{
+	return mStructureType.bioWasteCapacity;
+}
+
 int Structure::refinedOreStorageCapacity() const
 {
 	return mStructureType.oreStorageCapacity;

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -245,6 +245,11 @@ int Structure::foodStorageCapacity() const
 	return mStructureType.foodStorageCapacity;
 }
 
+int Structure::residentialCapacity() const
+{
+	return mStructureType.residentialCapacity;
+}
+
 int Structure::refinedOreStorageCapacity() const
 {
 	return mStructureType.oreStorageCapacity;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -95,6 +95,7 @@ public:
 	int energyProducedMax() const;
 	int foodProduced() const;
 	int foodStorageCapacity() const;
+	int residentialCapacity() const;
 	int refinedOreStorageCapacity() const;
 	int commRange() const;
 	int policeRange() const;

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -96,6 +96,7 @@ public:
 	int foodProduced() const;
 	int foodStorageCapacity() const;
 	int residentialCapacity() const;
+	int bioWasteStorageCapacity() const;
 	int refinedOreStorageCapacity() const;
 	int commRange() const;
 	int policeRange() const;

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -14,12 +14,10 @@ Residence::Residence(Tile& tile) :
 }
 
 
-int Residence::wasteCapacity() const { return mStructureType.bioWasteCapacity; }
-
-int Residence::wasteAccumulated() const { return std::min(mWasteAccumulated, mStructureType.bioWasteCapacity); }
+int Residence::wasteAccumulated() const { return std::min(mWasteAccumulated, bioWasteStorageCapacity()); }
 void Residence::wasteAccumulated(int amount) { mWasteAccumulated = amount; }
 
-int Residence::wasteOverflow() const { return std::max(mWasteAccumulated - mStructureType.bioWasteCapacity, 0); }
+int Residence::wasteOverflow() const { return std::max(mWasteAccumulated - bioWasteStorageCapacity(), 0); }
 
 
 int Residence::removeWaste(int amount)
@@ -50,7 +48,7 @@ StringTable Residence::createInspectorViewTable() const
 	stringTable[{1, 1}].text = std::to_string(assignedColonists());
 
 	stringTable[{0, 3}].text = "Waste Capacity:";
-	stringTable[{1, 3}].text = std::to_string(wasteCapacity());
+	stringTable[{1, 3}].text = std::to_string(bioWasteStorageCapacity());
 
 	stringTable[{0, 4}].text = "Waste Accumulated:";
 	stringTable[{1, 4}].text = std::to_string(wasteAccumulated());

--- a/appOPHD/MapObjects/Structures/Residence.cpp
+++ b/appOPHD/MapObjects/Structures/Residence.cpp
@@ -14,8 +14,6 @@ Residence::Residence(Tile& tile) :
 }
 
 
-int Residence::capacity() const { return mStructureType.residentialCapacity; }
-
 int Residence::wasteCapacity() const { return mStructureType.bioWasteCapacity; }
 
 int Residence::wasteAccumulated() const { return std::min(mWasteAccumulated, mStructureType.bioWasteCapacity); }
@@ -34,7 +32,7 @@ int Residence::removeWaste(int amount)
 
 void Residence::assignColonists(int amount)
 {
-	mAssignedColonists = std::clamp(amount, 0, capacity());
+	mAssignedColonists = std::clamp(amount, 0, residentialCapacity());
 }
 
 
@@ -46,7 +44,7 @@ StringTable Residence::createInspectorViewTable() const
 	StringTable stringTable(2, 6);
 
 	stringTable[{0, 0}].text = "Colonist Capacity:";
-	stringTable[{1, 0}].text = std::to_string(capacity());
+	stringTable[{1, 0}].text = std::to_string(residentialCapacity());
 
 	stringTable[{0, 1}].text = "Colonists Assigned:";
 	stringTable[{1, 1}].text = std::to_string(assignedColonists());

--- a/appOPHD/MapObjects/Structures/Residence.h
+++ b/appOPHD/MapObjects/Structures/Residence.h
@@ -8,7 +8,6 @@ class Residence : public Structure
 public:
 	Residence(Tile& tile);
 
-	int capacity() const;
 	int wasteCapacity() const;
 	int wasteAccumulated() const;
 	void wasteAccumulated(int amount);

--- a/appOPHD/MapObjects/Structures/Residence.h
+++ b/appOPHD/MapObjects/Structures/Residence.h
@@ -8,7 +8,6 @@ class Residence : public Structure
 public:
 	Residence(Tile& tile);
 
-	int wasteCapacity() const;
 	int wasteAccumulated() const;
 	void wasteAccumulated(int amount);
 	int wasteOverflow() const;

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -419,7 +419,7 @@ void MapViewState::updateResidentialCapacity()
 	const auto& residences = mStructureManager.getStructures<Residence>();
 	for (const auto* residence : residences)
 	{
-		if (residence->operational()) { mResidentialCapacity += residence->capacity(); }
+		if (residence->operational()) { mResidentialCapacity += residence->residentialCapacity(); }
 	}
 
 	if (residences.empty()) { mResidentialCapacity = constants::CommandCenterPopulationCapacity; }

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -415,13 +415,9 @@ void MapViewState::checkWarehouseCapacity()
 
 void MapViewState::updateResidentialCapacity()
 {
-	mResidentialCapacity = 0;
-	const auto& residences = mStructureManager.getStructures<Residence>();
-	for (const auto* residence : residences)
-	{
-		if (residence->operational()) { mResidentialCapacity += residence->residentialCapacity(); }
-	}
+	mResidentialCapacity = mStructureManager.totalResidentialCapacity();
 
+	const auto& residences = mStructureManager.getStructures<Residence>();
 	if (residences.empty()) { mResidentialCapacity = constants::CommandCenterPopulationCapacity; }
 
 	mPopulationPanel.residentialCapacity(mResidentialCapacity);

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -534,6 +534,19 @@ int StructureManager::totalFoodStorageCapacity() const
 }
 
 
+int StructureManager::totalResidentialCapacity() const
+{
+	int residentialCapacity = 0;
+
+	for (const auto* structure : mDeployedStructures)
+	{
+		if (structure->operational()) { residentialCapacity += structure->residentialCapacity(); }
+	}
+
+	return residentialCapacity;
+}
+
+
 int StructureManager::totalRobotCommandCapacity() const
 {
 	int totalRobotCommandCapacity = 0;

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -105,6 +105,7 @@ public:
 
 	int totalRefinedOreStorageCapacity() const;
 	int totalFoodStorageCapacity() const;
+	int totalResidentialCapacity() const;
 	int totalRobotCommandCapacity() const;
 
 	void assignColonistsToResidences(PopulationPool&);


### PR DESCRIPTION
Move `Residence` capacity methods to `Structure`.

Move `totalResidentialCapacity` calculation from `MapViewState` to `StructureManager`.

Related:
- Issue #1804
- Issue #1723
- PR #2066
- PR #2065
