### PR TITLE
Rename `PopulationModel` class

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -193,9 +193,9 @@ MapViewState::MapViewState(GameState& gameState, NAS2D::Xml::XmlDocument& saveGa
 	},
 	mNotificationArea{{this, &MapViewState::onNotificationClicked}},
 	mNotificationWindow{{this, &MapViewState::onTakeMeThere}},
-	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
+	mPopulationPanel{mPopulationModel, mPopulationPool, mMorale},
 	mQuitHandler{quitHandler},
-	mResourceInfoBar{mResourcesCount, mStructureManager, mPopulation, mMorale, mFood},
+	mResourceInfoBar{mResourcesCount, mStructureManager, mPopulationModel, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool}
 {
 	NAS2D::Utility<NAS2D::EventHandler>::get().windowResized().connect({this, &MapViewState::onWindowResized});
@@ -238,10 +238,10 @@ MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetA
 	},
 	mNotificationArea{{this, &MapViewState::onNotificationClicked}},
 	mNotificationWindow{{this, &MapViewState::onTakeMeThere}},
-	mPopulationPanel{mPopulation, mPopulationPool, mMorale},
+	mPopulationPanel{mPopulationModel, mPopulationPool, mMorale},
 	mQuitHandler{quitHandler},
 	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth() + 1)},
-	mResourceInfoBar{mResourcesCount, mStructureManager, mPopulation, mMorale, mFood},
+	mResourceInfoBar{mResourcesCount, mStructureManager, mPopulationModel, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
 	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mStructureManager, mDeployedRobots, planetAttributes.mapImagePath)},
 	mDetailMap{std::make_unique<DetailMap>(*mMapView, *mTileMap, planetAttributes.tilesetPath)},
@@ -285,7 +285,7 @@ void MapViewState::initialize()
 
 	setCursor(PointerType::Normal);
 
-	mPopulationPool.population(&mPopulation);
+	mPopulationPool.population(&mPopulationModel);
 
 	if (mLoadingExisting)
 	{

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -287,7 +287,7 @@ private:
 	PopulationPool mPopulationPool;
 
 	std::vector<Robot*>& mDeployedRobots;
-	PopulationModel mPopulation;
+	PopulationModel mPopulationModel;
 
 	// ROUTING
 	std::unique_ptr<RouteFinder> mPathSolver;

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -33,7 +33,7 @@
 #include <libOPHD/Map/MapCoordinate.h>
 
 #include <libOPHD/Population/PopulationPool.h>
-#include <libOPHD/Population/Population.h>
+#include <libOPHD/Population/PopulationModel.h>
 #include <libOPHD/Population/Morale.h>
 
 #include <libOPHD/Technology/ResearchTracker.h>
@@ -287,7 +287,7 @@ private:
 	PopulationPool mPopulationPool;
 
 	std::vector<Robot*>& mDeployedRobots;
-	Population mPopulation;
+	PopulationModel mPopulation;
 
 	// ROUTING
 	std::unique_ptr<RouteFinder> mPathSolver;

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -97,7 +97,7 @@ void MapViewState::onDeployColonistLander()
 	if (mTurnNumberOfLanding > mTurnCount) {
 		mTurnNumberOfLanding = mTurnCount;
 	}
-	mPopulation.addPopulation({0, 10, 20, 20, 0});
+	mPopulationModel.addPopulation({0, 10, 20, 20, 0});
 }
 
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -176,7 +176,7 @@ void MapViewState::save(NAS2D::Xml::XmlDocument& saveGameDocument)
 	root->linkEndChild(writeResearch(mResearchTracker));
 	root->linkEndChild(NAS2D::dictionaryToAttributes("turns", {{{"count", mTurnCount}}}));
 
-	const auto& population = mPopulation.getPopulations();
+	const auto& population = mPopulationModel.getPopulations();
 	root->linkEndChild(NAS2D::dictionaryToAttributes(
 		"population",
 		{{
@@ -536,7 +536,7 @@ void MapViewState::readPopulation(NAS2D::Xml::XmlElement* element)
 {
 	if (element)
 	{
-		mPopulation = {};
+		mPopulationModel = {};
 
 		const auto dictionary = NAS2D::attributesToDictionary(*element);
 
@@ -554,7 +554,7 @@ void MapViewState::readPopulation(NAS2D::Xml::XmlElement* element)
 
 		mPopulationPanel.crimeRate(meanCrimeRate);
 
-		mPopulation.addPopulation({children, students, workers, scientists, retired});
+		mPopulationModel.addPopulation({children, students, workers, scientists, retired});
 	}
 }
 

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -109,7 +109,7 @@ void MapViewState::updatePopulation()
 	const auto& commandCenters = mStructureManager.getStructures<CommandCenter>();
 	foodProducers.insert(foodProducers.end(), commandCenters.begin(), commandCenters.end());
 
-	int amountToConsume = mPopulation.update(mMorale.currentMorale(), mFood, residences, universities, nurseries, hospitals);
+	int amountToConsume = mPopulationModel.update(mMorale.currentMorale(), mFood, residences, universities, nurseries, hospitals);
 	consumeFood(foodProducers, amountToConsume);
 }
 
@@ -173,7 +173,7 @@ void MapViewState::updateMorale()
 {
 	// POSITIVE MORALE EFFECTS
 	// =========================================
-	const int birthCount = mPopulation.birthCount();
+	const int birthCount = mPopulationModel.birthCount();
 	const int parkCount = mStructureManager.operationalCount(StructureClass::Park);
 	const int recreationCount = mStructureManager.operationalCount(StructureClass::RecreationCenter);
 	const int foodProducingStructures = mStructureManager.operationalCount(StructureClass::FoodProduction);
@@ -181,10 +181,10 @@ void MapViewState::updateMorale()
 
 	// NEGATIVE MORALE EFFECTS
 	// =========================================
-	const int deathCount = mPopulation.deathCount();
+	const int deathCount = mPopulationModel.deathCount();
 	const int structuresDisabled = mStructureManager.disabledCount();
 	const int structuresDestroyed = mStructureManager.destroyedCount();
-	const int residentialOverCapacityHit = mPopulation.getPopulations().size() > mResidentialCapacity ? 2 : 0;
+	const int residentialOverCapacityHit = mPopulationModel.getPopulations().size() > mResidentialCapacity ? 2 : 0;
 	const int foodProductionHit = foodProducingStructures > 0 ? 0 : 5;
 
 	const auto& residences = mStructureManager.getStructures<Residence>();
@@ -225,8 +225,8 @@ void MapViewState::updateMorale()
 
 void MapViewState::notifyBirthsAndDeaths()
 {
-	const int birthCount = mPopulation.birthCount();
-	const int deathCount = mPopulation.deathCount();
+	const int birthCount = mPopulationModel.birthCount();
+	const int deathCount = mPopulationModel.deathCount();
 
 	// Push notifications
 	if (birthCount)
@@ -703,7 +703,7 @@ void MapViewState::nextTurn()
 	mMineOperationsWindow.updateTruckAvailability();
 
 	// Check for Game Over conditions
-	if (mPopulation.getPopulations().size() <= 0 && mColonyShip.colonistLanders() == 0)
+	if (mPopulationModel.getPopulations().size() <= 0 && mColonyShip.colonistLanders() == 0)
 	{
 		hideUi();
 		mGameOverDialog.show();

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -567,34 +567,34 @@ void MapViewState::onCheatCodeEntry(CheatMenu::CheatCode cheatCode)
 		}
 		break;
 		case CheatMenu::CheatCode::AddChildren:
-			mPopulation.addPopulation({10, 0, 0, 0, 0});
+			mPopulationModel.addPopulation({10, 0, 0, 0, 0});
 		break;
 		case CheatMenu::CheatCode::AddStudents:
-			mPopulation.addPopulation({0, 10, 0, 0, 0});
+			mPopulationModel.addPopulation({0, 10, 0, 0, 0});
 		break;
 		case CheatMenu::CheatCode::AddWorkers:
-			mPopulation.addPopulation({0, 0, 10, 0, 0});
+			mPopulationModel.addPopulation({0, 0, 10, 0, 0});
 		break;
 		case CheatMenu::CheatCode::AddScientists:
-			mPopulation.addPopulation({0, 0, 0, 10, 0});
+			mPopulationModel.addPopulation({0, 0, 0, 10, 0});
 		break;
 		case CheatMenu::CheatCode::AddRetired:
-			mPopulation.addPopulation({0, 0, 0, 0, 10});
+			mPopulationModel.addPopulation({0, 0, 0, 0, 10});
 		break;
 		case CheatMenu::CheatCode::RemoveChildren:
-			mPopulation.removePopulation({10, 0, 0, 0, 0});
+			mPopulationModel.removePopulation({10, 0, 0, 0, 0});
 		break;
 		case CheatMenu::CheatCode::RemoveStudents:
-			mPopulation.removePopulation({0, 10, 0, 0, 0});
+			mPopulationModel.removePopulation({0, 10, 0, 0, 0});
 		break;
 		case CheatMenu::CheatCode::RemoveWorkers:
-			mPopulation.removePopulation({0, 0, 10, 0, 0});
+			mPopulationModel.removePopulation({0, 0, 10, 0, 0});
 		break;
 		case CheatMenu::CheatCode::RemoveScientists:
-			mPopulation.removePopulation({0, 0, 0, 10, 0});
+			mPopulationModel.removePopulation({0, 0, 0, 10, 0});
 		break;
 		case CheatMenu::CheatCode::RemoveRetired:
-			mPopulation.removePopulation({0, 0, 0, 0, 10});
+			mPopulationModel.removePopulation({0, 0, 0, 0, 10});
 		break;
 		case CheatMenu::CheatCode::AddRobots:
 			mRobotPool.addRobot(RobotTypeIndex::Digger);

--- a/appOPHD/UI/PopulationPanel.cpp
+++ b/appOPHD/UI/PopulationPanel.cpp
@@ -8,7 +8,7 @@
 #include "../Constants/UiConstants.h"
 
 #include <libOPHD/EnumMoraleIndex.h>
-#include <libOPHD/Population/Population.h>
+#include <libOPHD/Population/PopulationModel.h>
 #include <libOPHD/Population/PopulationPool.h>
 #include <libOPHD/Population/Morale.h>
 #include <libOPHD/Population/MoraleChangeEntry.h>
@@ -44,7 +44,7 @@ namespace
 }
 
 
-PopulationPanel::PopulationPanel(const Population& pop, const PopulationPool& popPool, const Morale& morale) :
+PopulationPanel::PopulationPanel(const PopulationModel& pop, const PopulationPool& popPool, const Morale& morale) :
 	mFont{Control::getDefaultFont()},
 	mFontBold{Control::getDefaultFontBold()},
 	mIcons{imageCache.load("ui/icons.png")},

--- a/appOPHD/UI/PopulationPanel.cpp
+++ b/appOPHD/UI/PopulationPanel.cpp
@@ -49,7 +49,7 @@ PopulationPanel::PopulationPanel(const PopulationModel& pop, const PopulationPoo
 	mFontBold{Control::getDefaultFontBold()},
 	mIcons{imageCache.load("ui/icons.png")},
 	mSkin{loadRectangleSkin("ui/skin/window")},
-	mPopulation(pop),
+	mPopulationModel(pop),
 	mPopulationPool(popPool),
 	mMorale(morale)
 {
@@ -93,7 +93,7 @@ void PopulationPanel::draw(NAS2D::Renderer& renderer) const
 
 	// POPULATION Statistics
 	renderer.drawText(mFontBold, constants::PopulationBreakdown, position);
-	const auto& population = mPopulation.getPopulations();
+	const auto& population = mPopulationModel.getPopulations();
 	const std::array populationData
 	{
 		std::tuple{NAS2D::Rectangle<int>{{0, 96}, {IconSize, IconSize}}, population.child, std::string("Children")},

--- a/appOPHD/UI/PopulationPanel.h
+++ b/appOPHD/UI/PopulationPanel.h
@@ -8,7 +8,7 @@
 
 
 struct MoraleChangeEntry;
-class Population;
+class PopulationModel;
 class PopulationPool;
 class Morale;
 
@@ -21,7 +21,7 @@ namespace NAS2D
 class PopulationPanel : public Control
 {
 public:
-	PopulationPanel(const Population& pop, const PopulationPool& popPool, const Morale& morale);
+	PopulationPanel(const PopulationModel& pop, const PopulationPool& popPool, const Morale& morale);
 	~PopulationPanel() override;
 
 	void residentialCapacity(int val) { mResidentialCapacity = val; }
@@ -38,7 +38,7 @@ private:
 
 	std::vector<MoraleChangeEntry> mMoraleChangeReasons;
 
-	const Population& mPopulation;
+	const PopulationModel& mPopulation;
 	const PopulationPool& mPopulationPool;
 	const Morale& mMorale;
 

--- a/appOPHD/UI/PopulationPanel.h
+++ b/appOPHD/UI/PopulationPanel.h
@@ -38,7 +38,7 @@ private:
 
 	std::vector<MoraleChangeEntry> mMoraleChangeReasons;
 
-	const PopulationModel& mPopulation;
+	const PopulationModel& mPopulationModel;
 	const PopulationPool& mPopulationPool;
 	const Morale& mMorale;
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -72,7 +72,7 @@ ResourceInfoBar::ResourceInfoBar(const StorableResources& resources, const Struc
 	ControlContainer{{&mToolTip}},
 	mResourcesCount{resources},
 	mStructureManager{structureManager},
-	mPopulation{population},
+	mPopulationModel{population},
 	mMorale{morale},
 	mFood{food},
 	mUiIcons{imageCache.load("ui/icons.png")}
@@ -217,7 +217,7 @@ void ResourceInfoBar::draw(NAS2D::Renderer& renderer) const
 	const auto moraleLevel = (std::clamp(mMorale.currentMorale(), 1, 999) / 200);
 	const auto popMoraleImageRect = NAS2D::Rectangle<int>{{176 + moraleLevel * constants::ResourceIconSize, 0}, {constants::ResourceIconSize, constants::ResourceIconSize}};
 	drawIcon(position, popMoraleImageRect);
-	renderer.drawText(font, std::to_string(mPopulation.getPopulations().size()), position + textOffset, NAS2D::Color::White);
+	renderer.drawText(font, std::to_string(mPopulationModel.getPopulations().size()), position + textOffset, NAS2D::Color::White);
 }
 
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -10,7 +10,7 @@
 #include "../StructureManager.h"
 
 #include <libOPHD/StorableResources.h>
-#include <libOPHD/Population/Population.h>
+#include <libOPHD/Population/PopulationModel.h>
 #include <libOPHD/Population/Morale.h>
 
 #include <NAS2D/EnumMouseButton.h>
@@ -68,7 +68,7 @@ namespace
 }
 
 
-ResourceInfoBar::ResourceInfoBar(const StorableResources& resources, const StructureManager& structureManager, const Population& population, const Morale& morale, const int& food) :
+ResourceInfoBar::ResourceInfoBar(const StorableResources& resources, const StructureManager& structureManager, const PopulationModel& population, const Morale& morale, const int& food) :
 	ControlContainer{{&mToolTip}},
 	mResourcesCount{resources},
 	mStructureManager{structureManager},

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -38,7 +38,7 @@ protected:
 private:
 	const StorableResources& mResourcesCount;
 	const StructureManager& mStructureManager;
-	const PopulationModel& mPopulation;
+	const PopulationModel& mPopulationModel;
 	const Morale& mMorale;
 	const int& mFood;
 

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -14,14 +14,14 @@ namespace NAS2D
 
 struct StorableResources;
 class StructureManager;
-class Population;
+class PopulationModel;
 class Morale;
 
 
 class ResourceInfoBar : public ControlContainer
 {
 public:
-	ResourceInfoBar(const StorableResources& resources, const StructureManager& structureManager, const Population& population, const Morale& morale, const int& food);
+	ResourceInfoBar(const StorableResources& resources, const StructureManager& structureManager, const PopulationModel& population, const Morale& morale, const int& food);
 	~ResourceInfoBar() override;
 
 	bool isResourcePanelVisible() const;
@@ -38,7 +38,7 @@ protected:
 private:
 	const StorableResources& mResourcesCount;
 	const StructureManager& mStructureManager;
-	const Population& mPopulation;
+	const PopulationModel& mPopulation;
 	const Morale& mMorale;
 	const int& mFood;
 

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -1,4 +1,4 @@
-#include "Population.h"
+#include "PopulationModel.h"
 #include "Morale.h"
 
 #include "../RandomNumberGenerator.h"
@@ -35,24 +35,24 @@ namespace
 }
 
 
-const PopulationTable& Population::getPopulations() const
+const PopulationTable& PopulationModel::getPopulations() const
 {
 	return mPopulation;
 }
 
 
-void Population::addPopulation(const PopulationTable& population)
+void PopulationModel::addPopulation(const PopulationTable& population)
 {
 	mPopulation += population;
 }
 
-void Population::removePopulation(const PopulationTable& population)
+void PopulationModel::removePopulation(const PopulationTable& population)
 {
 	mPopulation -= population.cap(mPopulation);
 }
 
 
-void Population::spawnPopulation(int morale, int residences, int nurseries, int universities)
+void PopulationModel::spawnPopulation(int morale, int residences, int nurseries, int universities)
 {
 	const int growthChild = (residences > 0 || nurseries > 0) ?
 		mPopulation.scientist / 4 + mPopulation.worker / 2 : 0;
@@ -97,7 +97,7 @@ void Population::spawnPopulation(int morale, int residences, int nurseries, int 
 }
 
 
-PopulationTable Population::spawnRoles(const PopulationTable& growth, const PopulationTable& divisor)
+PopulationTable PopulationModel::spawnRoles(const PopulationTable& growth, const PopulationTable& divisor)
 {
 	mPopulationGrowth += growth;
 	const auto newRoles = mPopulationGrowth / divisor;
@@ -107,7 +107,7 @@ PopulationTable Population::spawnRoles(const PopulationTable& growth, const Popu
 }
 
 
-void Population::killRoles(const PopulationTable& divisor)
+void PopulationModel::killRoles(const PopulationTable& divisor)
 {
 	mPopulationDeath += mPopulation;
 
@@ -128,7 +128,7 @@ void Population::killRoles(const PopulationTable& divisor)
 }
 
 
-void Population::killPopulation(int morale, int nurseries, int hospitals)
+void PopulationModel::killPopulation(int morale, int nurseries, int hospitals)
 {
 	const auto mortalityRate = moraleModifierTable[moraleIndex(morale)].mortalityRate;
 
@@ -155,7 +155,7 @@ void Population::killPopulation(int morale, int nurseries, int hospitals)
  *
  * \return	Actual amount of food consumed.
  */
-int Population::consumeFood(int food)
+int PopulationModel::consumeFood(int food)
 {
 	const int PopulationPerFood = 10;
 	const int populationFed = food * PopulationPerFood;
@@ -181,7 +181,7 @@ int Population::consumeFood(int food)
 /**
  * \return	Actual amount of food consumed.
  */
-int Population::update(int morale, int food, int residences, int universities, int nurseries, int hospitals)
+int PopulationModel::update(int morale, int food, int residences, int universities, int nurseries, int hospitals)
 {
 	mBirthCount = 0;
 	mDeathCount = 0;

--- a/libOPHD/Population/PopulationModel.h
+++ b/libOPHD/Population/PopulationModel.h
@@ -3,7 +3,7 @@
 #include "PopulationTable.h"
 
 
-class Population
+class PopulationModel
 {
 public:
 	int birthCount() const { return mBirthCount; }

--- a/libOPHD/Population/PopulationPool.cpp
+++ b/libOPHD/Population/PopulationPool.cpp
@@ -16,19 +16,19 @@
  */
 void PopulationPool::population(PopulationModel* pop)
 {
-	mPopulation = pop;
+	mPopulationModel = pop;
 }
 
 
 int PopulationPool::availableWorkers() const
 {
-	return mPopulation->getPopulations().worker - workersEmployed();
+	return mPopulationModel->getPopulations().worker - workersEmployed();
 }
 
 
 int PopulationPool::availableScientists() const
 {
-	return mPopulation->getPopulations().scientist - scientistsEmployed();
+	return mPopulationModel->getPopulations().scientist - scientistsEmployed();
 }
 
 
@@ -36,7 +36,7 @@ bool PopulationPool::usePopulation(PopulationRequirements populationRequirements
 {
 	const auto [workersRequired, scientistsRequired] = populationRequirements;
 
-	const auto& population = mPopulation->getPopulations();
+	const auto& population = mPopulationModel->getPopulations();
 	const auto scientistsAvailable = population.scientist - (mScientistsAsWorkers + mScientistsUsed);
 	const auto workersAvailable = population.worker - mWorkersUsed;
 
@@ -103,5 +103,5 @@ int PopulationPool::populationEmployed() const
 
 int PopulationPool::size() const
 {
-	return mPopulation->getPopulations().size();
+	return mPopulationModel->getPopulations().size();
 }

--- a/libOPHD/Population/PopulationPool.cpp
+++ b/libOPHD/Population/PopulationPool.cpp
@@ -1,6 +1,6 @@
 #include "PopulationPool.h"
 
-#include "Population.h"
+#include "PopulationModel.h"
 #include "PopulationRequirements.h"
 
 #include <algorithm>
@@ -9,12 +9,12 @@
 
 
 /**
- * Sets a pointer to a Population object.
+ * Sets a pointer to a PopulationModel object.
  *
  * \note	PopulationPool expects a valid object and does no checking
  *			for invalid states.
  */
-void PopulationPool::population(Population* pop)
+void PopulationPool::population(PopulationModel* pop)
 {
 	mPopulation = pop;
 }

--- a/libOPHD/Population/PopulationPool.h
+++ b/libOPHD/Population/PopulationPool.h
@@ -29,5 +29,5 @@ private:
 	int mScientistsUsed{0};
 	int mWorkersUsed{0};
 
-	PopulationModel* mPopulation{nullptr};
+	PopulationModel* mPopulationModel{nullptr};
 };

--- a/libOPHD/Population/PopulationPool.h
+++ b/libOPHD/Population/PopulationPool.h
@@ -2,13 +2,13 @@
 
 
 struct PopulationRequirements;
-class Population;
+class PopulationModel;
 
 
 class PopulationPool
 {
 public:
-	void population(Population* pop);
+	void population(PopulationModel* pop);
 
 	int availableWorkers() const;
 	int availableScientists() const;
@@ -29,5 +29,5 @@ private:
 	int mScientistsUsed{0};
 	int mWorkersUsed{0};
 
-	Population* mPopulation{nullptr};
+	PopulationModel* mPopulation{nullptr};
 };

--- a/libOPHD/libOPHD.vcxproj
+++ b/libOPHD/libOPHD.vcxproj
@@ -172,7 +172,7 @@
     <ClCompile Include="MapObjects\MapObject.cpp" />
     <ClCompile Include="MapObjects\OreDeposit.cpp" />
     <ClCompile Include="Population\Morale.cpp" />
-    <ClCompile Include="Population\Population.cpp" />
+    <ClCompile Include="Population\PopulationModel.cpp" />
     <ClCompile Include="Population\PopulationPool.cpp" />
     <ClCompile Include="Population\PopulationTable.cpp" />
     <ClCompile Include="Technology\ResearchTracker.cpp" />
@@ -204,7 +204,7 @@
     <ClInclude Include="MapObjects\StructureType.h" />
     <ClInclude Include="Population\Morale.h" />
     <ClInclude Include="Population\MoraleChangeEntry.h" />
-    <ClInclude Include="Population\Population.h" />
+    <ClInclude Include="Population\PopulationModel.h" />
     <ClInclude Include="Population\PopulationPool.h" />
     <ClInclude Include="Population\PopulationRequirements.h" />
     <ClInclude Include="Population\PopulationTable.h" />

--- a/libOPHD/libOPHD.vcxproj.filters
+++ b/libOPHD/libOPHD.vcxproj.filters
@@ -63,7 +63,7 @@
     <ClCompile Include="Population\Morale.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Population\Population.cpp">
+    <ClCompile Include="Population\PopulationModel.cpp">
       <Filter>Source Files\Population</Filter>
     </ClCompile>
     <ClCompile Include="Population\PopulationPool.cpp">
@@ -155,7 +155,7 @@
     <ClInclude Include="Population\MoraleChangeEntry.h">
       <Filter>Header Files\Population</Filter>
     </ClInclude>
-    <ClInclude Include="Population\Population.h">
+    <ClInclude Include="Population\PopulationModel.h">
       <Filter>Header Files\Population</Filter>
     </ClInclude>
     <ClInclude Include="Population\PopulationPool.h">


### PR DESCRIPTION
I found the original name a bit misleading and easily confused with `PopulationTable`. Perhaps `PopulationTable` should be renamed to `Population`. Though a larger name is easier to search on, so I think I'll leave `PopulationTable` for now.

Related:
- Issue #1767
