### PR TITLE
Two column `StructureInspector`

### DIFF
--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -61,24 +61,24 @@ namespace
 
 	StringTable buildGenericStructureAttributesStringTable(const Structure& structure)
 	{
-		StringTable stringTable{4, 6};
+		StringTable stringTable{4, 9};
 
 		stringTable[{0, 0}].text = "Type:";
 		stringTable[{1, 0}].text = structure.classDescription();
 
 		if (structure.underConstruction())
 		{
-			stringTable[{2, 0}].text = "Turns Remaining:";
-			stringTable[{3, 0}].text = std::to_string(structure.turnsToBuild() - structure.age());
+			stringTable[{0, 3}].text = "Turns Remaining:";
+			stringTable[{1, 3}].text = std::to_string(structure.turnsToBuild() - structure.age());
 		}
 		else
 		{
-			stringTable[{2, 0}].text = "Age:";
-			stringTable[{3, 0}].text = formatAge(structure);
+			stringTable[{0, 3}].text = "Age:";
+			stringTable[{1, 3}].text = formatAge(structure);
 		}
 
-		stringTable[{0, 1}].text = "Power Required:";
-		stringTable[{1, 1}].text = std::to_string(structure.energyRequirement());
+		stringTable[{0, 4}].text = "Power Required:";
+		stringTable[{1, 4}].text = std::to_string(structure.energyRequirement());
 
 		stringTable[{2, 1}].text = "State:";
 		stringTable[{3, 1}].text = structure.stateDescription(structure.state());
@@ -87,8 +87,8 @@ namespace
 
 		if (!structure.underConstruction() && !structure.destroyed())
 		{
-			stringTable[{0, 2}].text = "Integrity:";
-			stringTable[{1, 2}].text = std::to_string(structure.integrity());
+			stringTable[{0, 5}].text = "Integrity:";
+			stringTable[{1, 5}].text = std::to_string(structure.integrity());
 		}
 
 		const auto& populationAvailable = structure.populationAvailable();
@@ -96,22 +96,22 @@ namespace
 
 		if (populationRequirements.workers > 0)
 		{
-			stringTable[{0, 3}].text = "Workers:";
-			stringTable[{1, 3}].text = std::to_string(populationAvailable.workers) + " / " + std::to_string(populationRequirements.workers);
-			stringTable[{1, 3}].textColor = populationAvailable.workers >= populationRequirements.workers ? NAS2D::Color::White : NAS2D::Color::Red;
+			stringTable[{0, 6}].text = "Workers:";
+			stringTable[{1, 6}].text = std::to_string(populationAvailable.workers) + " / " + std::to_string(populationRequirements.workers);
+			stringTable[{1, 6}].textColor = populationAvailable.workers >= populationRequirements.workers ? NAS2D::Color::White : NAS2D::Color::Red;
 		}
 
 		if (populationRequirements.scientists > 0)
 		{
-			stringTable[{0, 4}].text = "Scientists:";
-			stringTable[{1, 4}].text = std::to_string(populationAvailable.scientists) + " / " + std::to_string(populationRequirements.scientists);
-			stringTable[{1, 4}].textColor = populationAvailable.scientists >= populationRequirements.scientists ? NAS2D::Color::White : NAS2D::Color::Red;
+			stringTable[{0, 7}].text = "Scientists:";
+			stringTable[{1, 7}].text = std::to_string(populationAvailable.scientists) + " / " + std::to_string(populationRequirements.scientists);
+			stringTable[{1, 7}].textColor = populationAvailable.scientists >= populationRequirements.scientists ? NAS2D::Color::White : NAS2D::Color::Red;
 		}
 
 		if (structure.hasCrime())
 		{
-			stringTable[{0, 5}].text = "Crime Rate:";
-			stringTable[{1, 5}].text = std::to_string(structure.crimeRate()) + "%";
+			stringTable[{0, 8}].text = "Crime Rate:";
+			stringTable[{1, 8}].text = std::to_string(structure.crimeRate()) + "%";
 		}
 
 		return stringTable;

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -82,14 +82,14 @@ namespace
 			stringTable[{1, 3}].text = formatAge(structure);
 		}
 
-		stringTable[{0, 4}].text = "Power Required:";
-		stringTable[{1, 4}].text = std::to_string(structure.energyRequirement());
-
 		if (!structure.underConstruction() && !structure.destroyed())
 		{
-			stringTable[{0, 5}].text = "Integrity:";
-			stringTable[{1, 5}].text = std::to_string(structure.integrity());
+			stringTable[{0, 4}].text = "Integrity:";
+			stringTable[{1, 4}].text = std::to_string(structure.integrity());
 		}
+
+		stringTable[{0, 5}].text = "Power Required:";
+		stringTable[{1, 5}].text = std::to_string(structure.energyRequirement());
 
 		const auto& populationAvailable = structure.populationAvailable();
 		const auto& populationRequirements = structure.populationRequirements();

--- a/appOPHD/UI/StructureInspector.cpp
+++ b/appOPHD/UI/StructureInspector.cpp
@@ -61,10 +61,15 @@ namespace
 
 	StringTable buildGenericStructureAttributesStringTable(const Structure& structure)
 	{
-		StringTable stringTable{4, 9};
+		StringTable stringTable{2, 9};
 
 		stringTable[{0, 0}].text = "Type:";
 		stringTable[{1, 0}].text = structure.classDescription();
+
+		stringTable[{0, 1}].text = "State:";
+		stringTable[{1, 1}].text = structure.stateDescription(structure.state());
+
+		stringTable[{1, 2}].text = getDisabledReason(structure);
 
 		if (structure.underConstruction())
 		{
@@ -79,11 +84,6 @@ namespace
 
 		stringTable[{0, 4}].text = "Power Required:";
 		stringTable[{1, 4}].text = std::to_string(structure.energyRequirement());
-
-		stringTable[{2, 1}].text = "State:";
-		stringTable[{3, 1}].text = structure.stateDescription(structure.state());
-
-		stringTable[{3, 2}].text = getDisabledReason(structure);
 
 		if (!structure.underConstruction() && !structure.destroyed())
 		{
@@ -183,7 +183,6 @@ StringTable StructureInspector::buildGenericStringTable() const
 	auto stringTable = buildGenericStructureAttributesStringTable(*mStructure);
 	stringTable.position(mRect.position + NAS2D::Vector{constants::Margin, sWindowTitleBarHeight + constants::Margin});
 	stringTable.setVerticalPadding(5);
-	stringTable.setColumnFont(2, stringTable.GetDefaultTitleFont());
 	stringTable.computeRelativeCellPositions();
 	return stringTable;
 }


### PR DESCRIPTION
Change `StructureInspector` layout from `4` columns to `2`columns.

Swap order of `integrity` and `energyRequirement` fields.

----

Original:
<img width="373" height="264" alt="image" src="https://github.com/user-attachments/assets/cd599cc0-c5d5-4818-ad94-5ad64541a42d" />

Update:
<img width="366" height="320" alt="image" src="https://github.com/user-attachments/assets/c523ad61-88bf-4758-b641-7f571e927dad" />

----

Related:
- Issue #1986
