### PR TITLE
Add method overload `StructureManager::getStructures`

### DIFF
--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -68,6 +68,20 @@ public:
 		return output;
 	}
 
+	template <typename Predicate>
+	std::vector<Structure*> getStructures(Predicate predicate) const
+	{
+		std::vector<Structure*> output;
+		for (auto* structure : mDeployedStructures)
+		{
+			if (predicate(*structure))
+			{
+				output.push_back(structure);
+			}
+		}
+		return output;
+	}
+
 	StructureList structureList(StructureClass structureClass) const;
 	StructureList structureList(StructureID structureId) const;
 	const StructureList& allStructures() const;


### PR DESCRIPTION
Add method overload `StructureManager::getStructures` taking a predicate to select which structures to return.

There are already a number of specialized methods that are near duplicates of each other, used to select certain types of structures, where only the boolean test of what to include changes. By adding a generic method overload taking a predicate, we can extract just the predicate test and reduce repetition.

Related:
- Issue #1804
- PR #2076
- PR #2075
