### PR TITLE
Simplify `addRefinedResources`

### DIFF
--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -312,15 +312,9 @@ StorableResources addRefinedResources(StorableResources resourcesToAdd)
 	 * game before storage tanks are built. This ensure that the CC is in the storage
 	 * structure list and that it's always the first structure in the list.
 	 */
-
-	const auto& command = NAS2D::Utility<StructureManager>::get().getStructures<CommandCenter>();
-	const auto& storageTanks = NAS2D::Utility<StructureManager>::get().getStructures<StorageTanks>();
-
-	std::vector<Structure*> storage;
-	storage.insert(storage.end(), command.begin(), command.end());
-	storage.insert(storage.end(), storageTanks.begin(), storageTanks.end());
-
-	for (auto* structure : storage)
+	const auto structureIsOreStore = [](const Structure& structure) { return structure.isOreStore(); };
+	const auto& storageStructures = NAS2D::Utility<StructureManager>::get().getStructures(structureIsOreStore);
+	for (auto* structure : storageStructures)
 	{
 		if (resourcesToAdd.isEmpty()) { break; }
 


### PR DESCRIPTION
Use new `getStructures` overload to simplify building structure list in `addRefinedResources`.

Technically the comment above the code change may be slightly outdated, since storing in the Command Center first requires the structure list to be sorted such that Command Centers are first. This change relaxes that guarantee, since structures are now in their natural collection order, which is sorted once per turn to be in priority order. The priority order should place Command Centers first. However, there isn't a strong guarantee this method won't be called between modifying the structure list and sorting it in priority order. Thus there is a possibility a Command Center won't have priority for about the first turn it is built. Regardless, such a concern won't matter until we can build multiple Command Centers, and so there is a possibility of a Command Center being added later in the list. It also won't matter once we switch to global resources, which is likely to happen before we allow constructing multiple Command Centers.

----

Related:
- PR #2077
- Issue #1804
