### PR TITLE
Compress `Structure` constructor switch case blocks

### DIFF
--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -226,9 +226,6 @@ Structure* StructureCatalog::create(StructureID structureId, Tile& tile)
 {
 	Structure* structure = nullptr;
 
-	// This seems like a naive approach... I usually see these implemented as the base
-	// object type has a static function that is used as an interface to instantiate
-	// derived types.
 	switch (structureId)
 	{
 		case StructureID::Agridome:


### PR DESCRIPTION
Group `switch` case blocks with identical bodies, and place all labels on a single code block.

Using the `structureId` parameter rather than a hard coded constant in the code block makes many of the code blocks identical. We can potentially remove the `switch` block if we can remove all subclasses of `Structure`, since then there would be a single code block to handle all cases.

Related:
- Issue #1804
