### PR TITLE
Fix bad use of `std::clamp` in `ScrollBar::onThumbResize()`

### DIFF
--- a/libControls/ScrollBar.cpp
+++ b/libControls/ScrollBar.cpp
@@ -259,13 +259,13 @@ void ScrollBar::onThumbResize()
 	if (mScrollBarType == ScrollBarType::Vertical)
 	{
 		const auto naturalThumbLength = mTrackRect.size.y * mLargeDelta / (mMax + mLargeDelta);
-		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().y, mTrackRect.size.y);
+		const auto thumbLength = std::max(naturalThumbLength, mSkins.skinThumb.minSize().y);
 		mThumbRect.size = {mTrackRect.size.x, thumbLength};
 	}
 	else
 	{
 		const auto naturalThumbLength = mTrackRect.size.x * mLargeDelta / (mMax + mLargeDelta);
-		const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().x, mTrackRect.size.x);
+		const auto thumbLength = std::max(naturalThumbLength, mSkins.skinThumb.minSize().x);
 		mThumbRect.size = {thumbLength, mTrackRect.size.y};
 	}
 }


### PR DESCRIPTION
We don't actually need `std::clamp` since the value can never exceed the given max. By using `std::max` we can avoid the undefined behavior in `std::clamp`. The max bound isn't needed since `naturalThumbLength` can never exceed the max bound. When computing it, the max value is scaled according to `mLargeDelta` and `mMax`, and the scale expression is guaranteed to be `<= 1`, since `mLargeDelta <= (mMax + mLargeDelta)`, which we know because each of those values are clamped, with `mMax >= 0` and `mLargeDelta >= 1`.

Sample original code:
```cpp
const auto naturalThumbLength = mTrackRect.size.y * mLargeDelta / (mMax + mLargeDelta);
const auto thumbLength = std::clamp(naturalThumbLength, mSkins.skinThumb.minSize().y, mTrackRect.size.y);
```

----

Related:
- Issue #2082
- PR #1961
