### PR TITLE
Remove unnecessary value `CommandCenterPopulationCapacity`

### DIFF
--- a/appOPHD/Constants/Numbers.h
+++ b/appOPHD/Constants/Numbers.h
@@ -30,8 +30,6 @@ namespace constants
 
 	inline constexpr int DiggerTaskTime{5};
 
-	inline constexpr int CommandCenterPopulationCapacity{10};
-
 	inline constexpr int RobotCommandCapacity{10};
 
 	inline constexpr int RoadIntegrityChange{80};

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -417,10 +417,6 @@ void MapViewState::checkWarehouseCapacity()
 void MapViewState::updateResidentialCapacity()
 {
 	mResidentialCapacity = mStructureManager.totalResidentialCapacity();
-
-	const auto& residences = mStructureManager.getStructures<Residence>();
-	if (residences.empty()) { mResidentialCapacity = constants::CommandCenterPopulationCapacity; }
-
 	mPopulationPanel.residentialCapacity(mResidentialCapacity);
 }
 


### PR DESCRIPTION
This value has no real impact on the game simulation, at least not for early game where it's intended. It only has impact on the display, in a way that implies it impacts the game simulation. It's misleading to adjust the residential capacity without it providing some sort of impact.

The only way this value could impact the game is the number of colonists die down to `1` .. `10` people, and there are no `Residence` structures. There is no impact for `0` colonists, for greater than `10` colonists, or when a `Residence` is built.

Related:
- Issue #1723
