### PR TITLE
Remove `routeObstructed` and refactor `findMineRoutes()`

### DIFF
--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -143,22 +143,6 @@ private:
 };
 
 
-bool routeObstructed(Route& route)
-{
-	for (auto tilePtr : route.path)
-	{
-		auto& tile = *tilePtr;
-
-		// \note	Tile being occupied by a robot is not an obstruction for the
-		//			purposes of routing/pathing.
-		if (tile.hasStructure() && !tile.structure()->isRoad()) { return true; }
-		if (tile.index() == TerrainType::Impassable) { return true; }
-	}
-
-	return false;
-}
-
-
 RouteFinder::RouteFinder(TileMap& tileMap) :
 	mTileMapGraph{std::make_unique<TileMapGraph>(tileMap)},
 	mPathSolver{std::make_unique<micropather::MicroPather>(mTileMapGraph.get(), 250, 6, false)}

--- a/appOPHD/Map/RouteFinder.h
+++ b/appOPHD/Map/RouteFinder.h
@@ -16,9 +16,6 @@ class TileMap;
 class TileMapGraph;
 
 
-bool routeObstructed(Route& route);
-
-
 class RouteFinder
 {
 public:

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -261,7 +261,7 @@ void MapViewState::findMineRoutes()
 		auto routeIt = routeTable.find(mineFacility);
 		bool findNewRoute = routeIt == routeTable.end();
 
-		if (!findNewRoute && routeObstructed(routeIt->second))
+		if (!findNewRoute)
 		{
 			routeTable.erase(mineFacility);
 			findNewRoute = true;

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -258,23 +258,13 @@ void MapViewState::findMineRoutes()
 	{
 		if (!mineFacility->operational() && !mineFacility->isIdle()) { continue; } // consider a different control path.
 
-		auto routeIt = routeTable.find(mineFacility);
-		bool findNewRoute = routeIt == routeTable.end();
+		routeTable.erase(mineFacility);
 
-		if (!findNewRoute)
-		{
-			routeTable.erase(mineFacility);
-			findNewRoute = true;
-		}
+		auto newRoute = mPathSolver->findLowestCostRoute(mineFacility, smelters);
 
-		if (findNewRoute)
-		{
-			auto newRoute = mPathSolver->findLowestCostRoute(mineFacility, smelters);
+		if (newRoute.isEmpty()) { continue; } // give up and move on to the next mine facility.
 
-			if (newRoute.isEmpty()) { continue; } // give up and move on to the next mine facility.
-
-			routeTable[mineFacility] = newRoute;
-		}
+		routeTable[mineFacility] = newRoute;
 	}
 }
 


### PR DESCRIPTION
Remove useless `routeObstructed` and refactor `findMineRoutes()`.

The `routeObstructed` didn't account for the `MineFacility` (or smelter) at the start (and end) of the route, and so it always returns `true` to indicate the route was obstructed. This caused routes to always be recalculated.

We do actually need to always recalculate all the routes each turn. It's the only way to find new lower cost routes that may be opened up by bulldozing or new roads.

Related:
- Issue #1846
