### PR TITLE
Update `MineFacility` ore extraction

### DIFF
--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -39,6 +39,12 @@ void MineFacility::maxDepth(int depth)
 }
 
 
+bool MineFacility::isAtMaxStorageCapacity() const
+{
+	return storage() >= maxCapacity();
+}
+
+
 StorableResources MineFacility::maxCapacity() const
 {
 	const auto oreCapacity = rawOreStorageCapacity();
@@ -78,7 +84,7 @@ void MineFacility::think()
 
 	if (isIdle())
 	{
-		if (!(storage() >= maxCapacity()))
+		if (!isAtMaxStorageCapacity())
 		{
 			enable();
 		}
@@ -90,7 +96,7 @@ void MineFacility::think()
 		return;
 	}
 
-	if (storage() >= maxCapacity())
+	if (isAtMaxStorageCapacity())
 	{
 		idle(IdleReason::InternalStorageFull);
 		return;

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -78,7 +78,7 @@ void MineFacility::think()
 
 	if (isIdle())
 	{
-		if (storage() < maxCapacity())
+		if (!(storage() >= maxCapacity()))
 		{
 			enable();
 		}

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -54,7 +54,7 @@ StorableResources MineFacility::maxCapacity() const
 
 StorableResources MineFacility::maxTransferAmounts() const
 {
-	const auto remainingCapacity = maxCapacity() - production();
+	const auto remainingCapacity = maxCapacity() - storage();
 	auto maxTransfer = remainingCapacity.cap(BaseMineProductionRate);
 	return maxTransfer;
 }

--- a/appOPHD/MapObjects/Structures/MineFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MineFacility.cpp
@@ -54,8 +54,8 @@ StorableResources MineFacility::maxCapacity() const
 
 StorableResources MineFacility::maxTransferAmounts() const
 {
-	const auto remainingCapacity = maxCapacity() - storage();
-	auto maxTransfer = remainingCapacity.cap(BaseMineProductionRate);
+	const auto availableCapacity = maxCapacity() - storage();
+	auto maxTransfer = availableCapacity.cap(BaseMineProductionRate);
 	return maxTransfer;
 }
 

--- a/appOPHD/MapObjects/Structures/MineFacility.h
+++ b/appOPHD/MapObjects/Structures/MineFacility.h
@@ -39,6 +39,7 @@ public:
 protected:
 	friend class MapViewState;
 
+	bool isAtMaxStorageCapacity() const;
 	StorableResources maxCapacity() const;
 	StorableResources maxTransferAmounts() const;
 


### PR DESCRIPTION
Fix a couple of buggy behaviors for `MineFacility` regarding when it auto re-activates, and how it caps extracted raw ore to the raw ore storage capacity.

Related:
- Issue #1767
- Issue #1723
- PR #2090
- PR #2087
