### PR TITLE
Add `OreHaulRoutes` class

### DIFF
--- a/appOPHD/Constants/Numbers.h
+++ b/appOPHD/Constants/Numbers.h
@@ -6,15 +6,6 @@
  */
 namespace constants
 {
-	/**<
-	 * The number of times a truck can traverse the shortest possible path
-	 * between a mine and a smelter (adjacent to one another). A truck can move 1
-	 * unit of ore per trip. The shortest path cost is 0.50f. This number
-	 * represents 100 round trips between the mine/smelter for effectively 100
-	 * units of ore transported per turn.
-	 */
-	inline constexpr float ShortestPathTraversalCount{100.0f};
-
 	inline constexpr int ColonyShipOrbitTime{24};
 
 	inline constexpr int RoadIntegrityChange{80};

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -115,12 +115,7 @@ void OreHaulRoutes::transportOreFromMines()
 
 			if (!smelter.operational()) { break; }
 
-			/* clamp route cost to minimum of 1.0f for next computation to avoid
-			   unintended multiplication. */
-			const float routeCost = std::clamp(routeIt->second.cost, 1.0f, FLT_MAX);
-
-			/* intentional truncation of fractional component*/
-			const int totalOreMovement = static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
+			const int totalOreMovement = getOreHaulCapacity(mineFacility);
 			const int oreMovementPart = totalOreMovement / 4;
 			const int oreMovementRemainder = totalOreMovement % 4;
 			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart + oreMovementRemainder};

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -21,12 +21,7 @@ namespace
 	 */
 	inline constexpr float ShortestPathTraversalCount{100.0f};
 
-
-	auto& getRouteTable()
-	{
-		static std::map<const MineFacility*, Route> routeTable;
-		return routeTable;
-	}
+	std::map<const MineFacility*, Route> routeTable;
 }
 
 
@@ -39,20 +34,18 @@ OreHaulRoutes::OreHaulRoutes(TileMap& tileMap, const StructureManager& structure
 
 bool OreHaulRoutes::hasRoute(const MineFacility& mineFacility) const
 {
-	const auto& routeTable = getRouteTable();
 	return routeTable.find(&mineFacility) != routeTable.end();
 }
 
 
 const Route& OreHaulRoutes::getRoute(const MineFacility& mineFacility) const
 {
-	return getRouteTable().at(&mineFacility);
+	return routeTable.at(&mineFacility);
 }
 
 
 float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 {
-	const auto& routeTable = getRouteTable();
 	if (routeTable.find(&mineFacility) == routeTable.end())
 	{
 		return FLT_MAX;
@@ -71,19 +64,18 @@ int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 
 void OreHaulRoutes::removeMine(const MineFacility& mineFacility)
 {
-	getRouteTable().erase(&mineFacility);
+	routeTable.erase(&mineFacility);
 }
 
 
 void OreHaulRoutes::clear()
 {
-	getRouteTable().clear();
+	routeTable.clear();
 }
 
 
 void OreHaulRoutes::updateRoutes()
 {
-	auto& routeTable = getRouteTable();
 	routeTable.clear();
 
 	const auto structureIsSmelter = [](const Structure& structure) { return structure.isSmelter(); };
@@ -102,7 +94,6 @@ void OreHaulRoutes::updateRoutes()
 
 void OreHaulRoutes::transportOreFromMines()
 {
-	const auto& routeTable = getRouteTable();
 	for (const auto* mineFacilityPtr : mStructureManager.getStructures<MineFacility>())
 	{
 		auto routeIt = routeTable.find(mineFacilityPtr);
@@ -136,7 +127,7 @@ void OreHaulRoutes::transportOreFromMines()
 std::vector<Tile*> OreHaulRoutes::getRouteOverlay() const
 {
 	std::vector<Tile*> routeTiles;
-	for (auto& [_, route] : getRouteTable())
+	for (auto& [_, route] : routeTable)
 	{
 		for (auto* tile : route.path)
 		{

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -5,8 +5,6 @@
 #include "../StructureManager.h"
 #include "../MapObjects/Structures/MineFacility.h"
 
-#include <NAS2D/Utility.h>
-
 #include <cfloat>
 #include <map>
 #include <algorithm>
@@ -26,7 +24,8 @@ namespace
 
 	auto& getRouteTable()
 	{
-		return NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
+		static std::map<const MineFacility*, Route> routeTable;
+		return routeTable;
 	}
 }
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -1,6 +1,5 @@
 #include "OreHaulRoutes.h"
 
-#include "../Constants/Numbers.h"
 #include "Route.h"
 #include "Tile.h"
 #include "../StructureManager.h"
@@ -15,6 +14,16 @@
 
 namespace
 {
+	/**<
+	 * The number of times a truck can traverse the shortest possible path
+	 * between a mine and a smelter (adjacent to one another). A truck can move 1
+	 * unit of ore per trip. The shortest path cost is 0.50f. This number
+	 * represents 100 round trips between the mine/smelter for effectively 100
+	 * units of ore transported per turn.
+	 */
+	inline constexpr float ShortestPathTraversalCount{100.0f};
+
+
 	auto& getRouteTable()
 	{
 		return NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
@@ -57,7 +66,7 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
 	const float routeCost = getRouteCost(mineFacility);
-	return static_cast<int>(constants::ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
+	return static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
 }
 
 
@@ -111,7 +120,7 @@ void OreHaulRoutes::transportOreFromMines()
 			const float routeCost = std::clamp(routeIt->second.cost, 1.0f, FLT_MAX);
 
 			/* intentional truncation of fractional component*/
-			const int totalOreMovement = static_cast<int>(constants::ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
+			const int totalOreMovement = static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
 			const int oreMovementPart = totalOreMovement / 4;
 			const int oreMovementRemainder = totalOreMovement % 4;
 			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart + oreMovementRemainder};

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -1,0 +1,144 @@
+#include "OreHaulRoutes.h"
+
+#include "../Constants/Numbers.h"
+#include "Route.h"
+#include "Tile.h"
+#include "../StructureManager.h"
+#include "../MapObjects/Structures/MineFacility.h"
+
+#include <NAS2D/Utility.h>
+
+#include <cfloat>
+#include <map>
+#include <algorithm>
+
+
+namespace
+{
+	auto& getRouteTable()
+	{
+		return NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
+	}
+}
+
+
+OreHaulRoutes::OreHaulRoutes(TileMap& tileMap, const StructureManager& structureManager) :
+	mRouteFinder{tileMap},
+	mStructureManager{structureManager}
+{
+}
+
+
+bool OreHaulRoutes::hasRoute(const MineFacility& mineFacility) const
+{
+	const auto& routeTable = getRouteTable();
+	return routeTable.find(&mineFacility) != routeTable.end();
+}
+
+
+const Route& OreHaulRoutes::getRoute(const MineFacility& mineFacility) const
+{
+	return getRouteTable().at(&mineFacility);
+}
+
+
+float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
+{
+	const auto& routeTable = getRouteTable();
+	if (routeTable.find(&mineFacility) == routeTable.end())
+	{
+		return FLT_MAX;
+	}
+	const auto& route = routeTable.at(&mineFacility);
+	return std::clamp(route.cost, 1.0f, FLT_MAX);
+}
+
+
+int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
+{
+	const float routeCost = getRouteCost(mineFacility);
+	return static_cast<int>(constants::ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
+}
+
+
+void OreHaulRoutes::removeMine(const MineFacility& mineFacility)
+{
+	getRouteTable().erase(&mineFacility);
+}
+
+
+void OreHaulRoutes::clear()
+{
+	getRouteTable().clear();
+}
+
+
+void OreHaulRoutes::updateRoutes()
+{
+	auto& routeTable = getRouteTable();
+	routeTable.clear();
+
+	const auto structureIsSmelter = [](const Structure& structure) { return structure.isSmelter(); };
+	const auto structureIsOperableMine = [](const Structure& structure) { return structure.isMineFacility() && structure.isOperable(); };
+	const auto& smelters = mStructureManager.getStructures(structureIsSmelter);
+	const auto& mines = mStructureManager.getStructures(structureIsOperableMine);
+	for (const auto* mineFacility : mines)
+	{
+		auto newRoute = mRouteFinder.findLowestCostRoute(mineFacility, smelters);
+		if (!newRoute.isEmpty()) {
+			routeTable[dynamic_cast<const MineFacility*>(mineFacility)] = newRoute;
+		}
+	}
+}
+
+
+void OreHaulRoutes::transportOreFromMines()
+{
+	const auto& routeTable = getRouteTable();
+	for (const auto* mineFacilityPtr : mStructureManager.getStructures<MineFacility>())
+	{
+		auto routeIt = routeTable.find(mineFacilityPtr);
+		if (routeIt != routeTable.end())
+		{
+			const auto& route = routeIt->second;
+			auto& smelter = *route.path.back()->structure();
+			auto& mineFacility = dynamic_cast<MineFacility&>(*route.path.front()->structure());
+
+			if (!smelter.operational()) { break; }
+
+			/* clamp route cost to minimum of 1.0f for next computation to avoid
+			   unintended multiplication. */
+			const float routeCost = std::clamp(routeIt->second.cost, 1.0f, FLT_MAX);
+
+			/* intentional truncation of fractional component*/
+			const int totalOreMovement = static_cast<int>(constants::ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
+			const int oreMovementPart = totalOreMovement / 4;
+			const int oreMovementRemainder = totalOreMovement % 4;
+			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart + oreMovementRemainder};
+
+			auto& mineStorage = mineFacility.storage();
+			auto& smelterStored = smelter.production();
+
+			const auto oreAvailable = smelterStored + mineStorage.cap(movementCap);
+			const auto newSmelterStored = oreAvailable.cap(smelter.rawOreStorageCapacity());
+			const auto movedOre = newSmelterStored - smelterStored;
+
+			mineStorage -= movedOre;
+			smelterStored = newSmelterStored;
+		}
+	}
+}
+
+
+std::vector<Tile*> OreHaulRoutes::getRouteOverlay() const
+{
+	std::vector<Tile*> routeTiles;
+	for (auto& [_, route] : getRouteTable())
+	{
+		for (auto* tile : route.path)
+		{
+			routeTiles.push_back(tile);
+		}
+	}
+	return routeTiles;
+}

--- a/appOPHD/Map/OreHaulRoutes.h
+++ b/appOPHD/Map/OreHaulRoutes.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RouteFinder.h"
+
+#include <vector>
+
+
+struct Route;
+class Tile;
+class TileMap;
+class MineFacility;
+class StructureManager;
+
+
+class OreHaulRoutes
+{
+public:
+	OreHaulRoutes(TileMap& tileMap, const StructureManager& structureManager);
+
+	bool hasRoute(const MineFacility& mineFacility) const;
+	const Route& getRoute(const MineFacility& mineFacility) const;
+	float getRouteCost(const MineFacility& mineFacility) const;
+	int getOreHaulCapacity(const MineFacility& mineFacility) const;
+
+	void removeMine(const MineFacility& mineFacility);
+	void clear();
+
+	void updateRoutes();
+	void transportOreFromMines();
+
+	std::vector<Tile*> getRouteOverlay() const;
+
+private:
+	RouteFinder mRouteFinder;
+	const StructureManager& mStructureManager;
+};

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -244,7 +244,7 @@ MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetA
 	mPoliceOverlays{static_cast<std::vector<Tile*>::size_type>(mTileMap->maxDepth() + 1)},
 	mResourceInfoBar{mResourcesCount, mStructureManager, mPopulationModel, mMorale, mFood},
 	mRobotDeploymentSummary{mRobotPool},
-	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mStructureManager, mDeployedRobots, planetAttributes.mapImagePath)},
+	mMiniMap{std::make_unique<MiniMap>(*mMapView, *mTileMap, mStructureManager, mDeployedRobots, *mOreHaulRoutes, planetAttributes.mapImagePath)},
 	mDetailMap{std::make_unique<DetailMap>(*mMapView, *mTileMap, planetAttributes.tilesetPath)},
 	mNavControl{std::make_unique<NavControl>(*mMapView)}
 {

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -214,6 +214,7 @@ MapViewState::MapViewState(GameState& gameState, const PlanetAttributes& planetA
 	mTurnNumberOfLanding{constants::ColonyShipOrbitTime},
 	mRobotPool{mStructureManager},
 	mDeployedRobots{mRobotPool.deployedRobots()},
+	mOreHaulRoutes{std::make_unique<OreHaulRoutes>(*mTileMap, mStructureManager)},
 	mReportsState{gameState.reportsState()},
 	mMapView{std::make_unique<MapView>(*mTileMap)},
 	mMapObjectPicker{mResourcesCount, {this, &MapViewState::onMapObjectSelectionChanged}},
@@ -308,8 +309,6 @@ void MapViewState::initialize()
 	eventHandler.mouseButtonUp().connect({this, &MapViewState::onMouseUp});
 	eventHandler.mouseDoubleClick().connect({this, &MapViewState::onMouseDoubleClick});
 	eventHandler.mouseMotion().connect({this, &MapViewState::onMouseMove});
-
-	mOreHaulRoutes = std::make_unique<OreHaulRoutes>(*mTileMap, mStructureManager);
 }
 
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -297,6 +297,7 @@ void MapViewState::initialize()
 
 	setupUiPositions(renderer.size());
 
+	mReportsState.injectOreHaulRoutes(*mOreHaulRoutes);
 	mReportsState.injectTechnology(mTechnologyReader, mResearchTracker);
 
 	mFade.fadeIn(constants::FadeSpeed);

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -72,7 +72,7 @@ class Structure;
 class StructureManager;
 class Tile;
 class TileMap;
-class RouteFinder;
+class OreHaulRoutes;
 class MapView;
 class DetailMap;
 class MiniMap;
@@ -199,8 +199,6 @@ private:
 	void updateRoads();
 	void updateRobots();
 
-	void findMineRoutes();
-	void transportOreFromMines();
 	void transportResourcesToStorage();
 
 	void checkAgingStructures();
@@ -290,7 +288,7 @@ private:
 	PopulationModel mPopulationModel;
 
 	// ROUTING
-	std::unique_ptr<RouteFinder> mPathSolver;
+	std::unique_ptr<OreHaulRoutes> mOreHaulRoutes;
 
 	bool mLoadingExisting = false;
 	NAS2D::Xml::XmlDocument* mExistingToLoad = nullptr; 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -267,14 +267,13 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 
 	mTileMap = std::make_unique<TileMap>(mPlanetAttributes.mapImagePath, mPlanetAttributes.maxDepth);
 	mTileMap->deserialize(root);
+	mOreHaulRoutes = std::make_unique<OreHaulRoutes>(*mTileMap, mStructureManager);
+	mOreHaulRoutes->clear();
 	mMapView = std::make_unique<MapView>(*mTileMap);
 	mMapView->deserialize(root);
 	mMiniMap = std::make_unique<MiniMap>(*mMapView, *mTileMap, mStructureManager, mDeployedRobots, mPlanetAttributes.mapImagePath);
 	mDetailMap = std::make_unique<DetailMap>(*mMapView, *mTileMap, mPlanetAttributes.tilesetPath);
 	mNavControl = std::make_unique<NavControl>(*mMapView);
-
-	mOreHaulRoutes = std::make_unique<OreHaulRoutes>(*mTileMap, mStructureManager);
-	mOreHaulRoutes->clear();
 
 	readRobots(root->firstChildElement("robots"));
 	readStructures(root->firstChildElement("structures"));

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -271,7 +271,7 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 	mOreHaulRoutes->clear();
 	mMapView = std::make_unique<MapView>(*mTileMap);
 	mMapView->deserialize(root);
-	mMiniMap = std::make_unique<MiniMap>(*mMapView, *mTileMap, mStructureManager, mDeployedRobots, mPlanetAttributes.mapImagePath);
+	mMiniMap = std::make_unique<MiniMap>(*mMapView, *mTileMap, mStructureManager, mDeployedRobots, *mOreHaulRoutes, mPlanetAttributes.mapImagePath);
 	mDetailMap = std::make_unique<DetailMap>(*mMapView, *mTileMap, mPlanetAttributes.tilesetPath);
 	mNavControl = std::make_unique<NavControl>(*mMapView);
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -16,6 +16,7 @@
 #include "../IOHelper.h"
 #include "../StructureCatalog.h"
 #include "../StructureManager.h"
+#include "../Map/OreHaulRoutes.h"
 #include "../Map/Route.h"
 #include "../Map/RouteFinder.h"
 #include "../Map/TileMap.h"
@@ -272,8 +273,8 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 	mDetailMap = std::make_unique<DetailMap>(*mMapView, *mTileMap, mPlanetAttributes.tilesetPath);
 	mNavControl = std::make_unique<NavControl>(*mMapView);
 
-	mPathSolver = std::make_unique<RouteFinder>(*mTileMap);
-	NAS2D::Utility<std::map<const MineFacility*, Route>>::get().clear();
+	mOreHaulRoutes = std::make_unique<OreHaulRoutes>(*mTileMap, mStructureManager);
+	mOreHaulRoutes->clear();
 
 	readRobots(root->firstChildElement("robots"));
 	readStructures(root->firstChildElement("structures"));
@@ -296,7 +297,7 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 	updateStructuresAvailability();
 
 	updateRoads();
-	findMineRoutes();
+	mOreHaulRoutes->updateRoutes();
 	updateFood();
 	updatePlayerResources();
 	updateResearch();

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -26,7 +26,6 @@
 #include "../Cache.h"
 #include "../MoraleString.h"
 #include "../StructureManager.h"
-#include "../Constants/Numbers.h"
 #include "../Constants/Strings.h"
 
 #include <libOPHD/DirectionOffset.h>

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -40,6 +40,7 @@ namespace
 	};
 
 	constexpr auto ResearchPanelIndex = static_cast<size_t>(NavigationPanel::Research);
+	constexpr auto MinePanelIndex = static_cast<size_t>(NavigationPanel::Mines);
 	constexpr auto ExitPanelIndex = static_cast<size_t>(NavigationPanel::Exit);
 
 
@@ -355,6 +356,13 @@ void ReportsState::showReport(Structure& structure)
 			}
 		}
 	}
+}
+
+
+void ReportsState::injectOreHaulRoutes(const OreHaulRoutes& oreHaulRoutes)
+{
+	auto* minePanel = panels[MinePanelIndex].report;
+	dynamic_cast<MineReport&>(*minePanel).injectOreHaulRoutes(oreHaulRoutes);
 }
 
 

--- a/appOPHD/States/ReportsState.h
+++ b/appOPHD/States/ReportsState.h
@@ -9,6 +9,7 @@
 
 
 class Structure;
+class OreHaulRoutes;
 class TechnologyCatalog;
 class ResearchTracker;
 
@@ -37,6 +38,7 @@ public:
 	void showReport();
 	void showReport(Structure& structure);
 
+	void injectOreHaulRoutes(const OreHaulRoutes& oreHaulRoutes);
 	void injectTechnology(TechnologyCatalog&, ResearchTracker&);
 
 	void clearLists();

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -8,7 +8,6 @@
 #include <libOPHD/StorableResources.h>
 #include <libOPHD/XmlSerializer.h>
 
-#include <NAS2D/Utility.h>
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/ParserHelper.h>
 

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -31,11 +31,12 @@ namespace
 }
 
 
-MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& structureManager, const std::vector<Robot*>& deployedRobots, const std::string& mapName) :
+MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& structureManager, const std::vector<Robot*>& deployedRobots, const OreHaulRoutes& oreHaulRoutes, const std::string& mapName) :
 	mMapView{mapView},
 	mTileMap{tileMap},
 	mStructureManager{structureManager},
 	mDeployedRobots{deployedRobots},
+	mOreHaulRoutes{oreHaulRoutes},
 	mIsHeightMapVisible{false},
 	mBackgroundSatellite{mapName + MapDisplayExtension},
 	mBackgroundHeightMap{mapName + MapTerrainExtension},

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -93,8 +93,6 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 		renderer.drawSubImage(mUiIcons, oreDeposit->location() + miniMapOffset - NAS2D::Vector{2, 2}, beaconImageRect);
 	}
 
-	// Temporary debug aid, will be slow with high numbers of mines
-	// especially with routes of longer lengths.
 	if (mIsOreHaulRoutesVisible)
 	{
 		for (auto* tile : mOreHaulRoutes.getRouteOverlay())

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -13,7 +13,6 @@
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <NAS2D/EnumMouseButton.h>
-#include <NAS2D/Utility.h>
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Renderer/Color.h>

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -1,6 +1,7 @@
 #include "MiniMap.h"
 
 #include "../Cache.h"
+#include "../Map/OreHaulRoutes.h"
 #include "../Map/Route.h"
 #include "../Map/Tile.h"
 #include "../Map/TileMap.h"
@@ -18,11 +19,6 @@
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
 
-#include <map>
-
-
-class MineFacility;
-
 
 namespace
 {
@@ -37,6 +33,7 @@ MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& str
 	mStructureManager{structureManager},
 	mDeployedRobots{deployedRobots},
 	mOreHaulRoutes{oreHaulRoutes},
+	mIsOreHaulRoutesVisible{true},
 	mIsHeightMapVisible{false},
 	mBackgroundSatellite{mapName + MapDisplayExtension},
 	mBackgroundHeightMap{mapName + MapTerrainExtension},
@@ -98,10 +95,9 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 
 	// Temporary debug aid, will be slow with high numbers of mines
 	// especially with routes of longer lengths.
-	const auto& routeTable = NAS2D::Utility<std::map<const MineFacility*, Route>>::get();
-	for (auto route : routeTable)
+	if (mIsOreHaulRoutesVisible)
 	{
-		for (auto tile : route.second.path)
+		for (auto* tile : mOreHaulRoutes.getRouteOverlay())
 		{
 			const auto tilePosition = tile->xy();
 			renderer.drawPoint(tilePosition + miniMapOffset, NAS2D::Color::Magenta);

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -49,6 +49,7 @@ private:
 	const StructureManager& mStructureManager;
 	const std::vector<Robot*>& mDeployedRobots;
 	const OreHaulRoutes& mOreHaulRoutes;
+	bool mIsOreHaulRoutesVisible;
 	bool mIsHeightMapVisible;
 	NAS2D::Image mBackgroundSatellite;
 	NAS2D::Image mBackgroundHeightMap;

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -19,6 +19,7 @@ namespace NAS2D
 class Tile;
 class TileMap;
 class StructureManager;
+class OreHaulRoutes;
 class MapView;
 class Robot;
 class MapViewState;
@@ -27,7 +28,7 @@ class MapViewState;
 class MiniMap : public Control
 {
 public:
-	MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& structureManager, const std::vector<Robot*>& deployedRobots, const std::string& mapName);
+	MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& structureManager, const std::vector<Robot*>& deployedRobots, const OreHaulRoutes& oreHaulRoutes, const std::string& mapName);
 
 	bool heightMapVisible() const;
 	void heightMapVisible(bool isVisible);
@@ -47,6 +48,7 @@ private:
 	TileMap& mTileMap;
 	const StructureManager& mStructureManager;
 	const std::vector<Robot*>& mDeployedRobots;
+	const OreHaulRoutes& mOreHaulRoutes;
 	bool mIsHeightMapVisible;
 	NAS2D::Image mBackgroundSatellite;
 	NAS2D::Image mBackgroundHeightMap;

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -3,7 +3,6 @@
 #include "../TextRender.h"
 #include "../ProgressBar.h"
 
-#include "../../Constants/Numbers.h"
 #include "../../Constants/Strings.h"
 #include "../../Constants/UiConstants.h"
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -163,6 +163,12 @@ void MineReport::refresh()
 }
 
 
+void MineReport::injectOreHaulRoutes(const OreHaulRoutes& oreHaulRoutes)
+{
+	mOreHaulRoutes = &oreHaulRoutes;
+}
+
+
 void MineReport::onResize()
 {
 	Control::onResize();

--- a/appOPHD/UI/Reports/MineReport.h
+++ b/appOPHD/UI/Reports/MineReport.h
@@ -18,6 +18,7 @@ namespace NAS2D
 
 class StructureManager;
 class MineFacility;
+class OreHaulRoutes;
 
 
 class MineReport : public Report
@@ -32,6 +33,8 @@ public:
 	void clearSelected() override;
 	void fillLists() override;
 	void refresh() override;
+
+	void injectOreHaulRoutes(const OreHaulRoutes& oreHaulRoutes);
 
 	void update() override;
 	void draw(NAS2D::Renderer& renderer) const override;
@@ -63,6 +66,7 @@ protected:
 
 private:
 	const StructureManager& mStructureManager;
+	const OreHaulRoutes* mOreHaulRoutes;
 
 	TakeMeThereDelegate mTakeMeThereHandler;
 	const NAS2D::Font& font;

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Map\Connections.cpp" />
     <ClCompile Include="Map\MapView.cpp" />
+    <ClCompile Include="Map\OreHaulRoutes.cpp" />
     <ClCompile Include="Map\RouteFinder.cpp" />
     <ClCompile Include="Map\Tile.cpp" />
     <ClCompile Include="Map\TileMap.cpp" />
@@ -294,6 +295,7 @@
     <ClInclude Include="IOHelper.h" />
     <ClInclude Include="Map\Connections.h" />
     <ClInclude Include="Map\MapView.h" />
+    <ClInclude Include="Map\OreHaulRoutes.h" />
     <ClInclude Include="Map\Route.h" />
     <ClInclude Include="Map\RouteFinder.h" />
     <ClInclude Include="Map\Tile.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="Map\MapView.cpp">
       <Filter>Source Files\Map</Filter>
     </ClCompile>
+    <ClCompile Include="Map\OreHaulRoutes.cpp">
+      <Filter>Source Files\Map</Filter>
+    </ClCompile>
     <ClCompile Include="Map\RouteFinder.cpp">
       <Filter>Source Files\Map</Filter>
     </ClCompile>
@@ -399,6 +402,9 @@
       <Filter>Header Files\Map</Filter>
     </ClInclude>
     <ClInclude Include="Map\MapView.h">
+      <Filter>Header Files\Map</Filter>
+    </ClInclude>
+    <ClInclude Include="Map\OreHaulRoutes.h">
       <Filter>Header Files\Map</Filter>
     </ClInclude>
     <ClInclude Include="Map\Route.h">


### PR DESCRIPTION
Add `OreHaulRoutes` class and use it to wrap and remove uses of `NAS2D::Utility<std::map<const MineFacility*, Route>>`.

This helps group ore haul route code together under a higher level interface. This moves a chunk of code out of `MapViewState`, which helps make `MapViewState` smaller.

This helps remove a few uses of `Utility`.

Related:
- Issue #1846
- Issue #1767
- Issue #650
- Issue #949
- Issue #1573
- PR #2092
- PR #2091
- PR #2090
- PR #2089
- PR #2087
