### PR TITLE
Use a smaller random range so comment isn't necessary

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -380,8 +380,7 @@ void Structure::updateIntegrityDecay()
 	}
 	else if (mIntegrity <= 20 && !destroyed())
 	{
-		/* range is 0 - 1000, 0 - 100 for 10% chance */
-		if (randomNumber.generate(0, 1000) < 100)
+		if (randomNumber.generate(0, 100) < 10)
 		{
 			destroy();
 		}


### PR DESCRIPTION
Noticed this while looking at `RoadIntegrityChange`, which is the one constant left in `Numbers.h`.

Related:
- Issue #1846
- Issue #1804
- PR #2094
