### PR TITLE
Add `IntegrityLevel` enum

### DIFF
--- a/appOPHD/Constants/Numbers.h
+++ b/appOPHD/Constants/Numbers.h
@@ -6,5 +6,4 @@
  */
 namespace constants
 {
-	inline constexpr int RoadIntegrityChange{80};
 }

--- a/appOPHD/Constants/Numbers.h
+++ b/appOPHD/Constants/Numbers.h
@@ -1,9 +1,0 @@
-#pragma once
-
-
-/**
- * Numeric constants
- */
-namespace constants
-{
-}

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -5,7 +5,6 @@
 #include "TileMap.h"
 #include "../MapObjects/Structure.h"
 #include "../MicroPather/micropather.h"
-#include "../Constants/Numbers.h"
 
 #include <libOPHD/EnumIntegrityLevel.h>
 #include <libOPHD/EnumTerrainType.h>

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -63,18 +63,9 @@ namespace
 		{
 			Structure& road = *tile.structure();
 
-			if (road.integrityLevel() < IntegrityLevel::Worn)
-			{
-				return RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 1.0f;
-			}
-			else if (road.integrityLevel() < IntegrityLevel::Good)
-			{
-				return 0.75f;
-			}
-			else
-			{
-				return 0.5f;
-			}
+			if (road.integrityLevel() >= IntegrityLevel::Good) { return 0.5f; }
+			else if (road.integrityLevel() >= IntegrityLevel::Worn) { return 0.75f; }
+			else { return RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 1.0f; }
 		}
 
 		if (tile.hasMapObject() && (!tile.hasStructure() || (!tile.structure()->isMineFacility() && !tile.structure()->isSmelter())))

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -59,11 +59,6 @@ namespace
 
 	float tileMovementCost(const Tile& tile)
 	{
-		if (tile.index() == TerrainType::Impassable)
-		{
-			return FLT_MAX;
-		}
-
 		if (tile.hasStructure() && tile.structure()->isRoad())
 		{
 			Structure& road = *tile.structure();
@@ -83,6 +78,11 @@ namespace
 		}
 
 		if (tile.hasMapObject() && (!tile.hasStructure() || (!tile.structure()->isMineFacility() && !tile.structure()->isSmelter())))
+		{
+			return FLT_MAX;
+		}
+
+		if (tile.index() == TerrainType::Impassable)
 		{
 			return FLT_MAX;
 		}

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -7,6 +7,7 @@
 #include "../MicroPather/micropather.h"
 #include "../Constants/Numbers.h"
 
+#include <libOPHD/EnumIntegrityLevel.h>
 #include <libOPHD/EnumTerrainType.h>
 #include <libOPHD/DirectionOffset.h>
 
@@ -63,11 +64,11 @@ namespace
 		{
 			Structure& road = *tile.structure();
 
-			if (road.integrity() < 35)
+			if (road.integrityLevel() < IntegrityLevel::Worn)
 			{
 				return RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 1.0f;
 			}
-			else if (road.integrity() < constants::RoadIntegrityChange)
+			else if (road.integrityLevel() < IntegrityLevel::Good)
 			{
 				return 0.75f;
 			}

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -63,7 +63,7 @@ namespace
 		{
 			Structure& road = *tile.structure();
 
-			if (!road.operational())
+			if (road.integrity() < 35)
 			{
 				return RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 1.0f;
 			}

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -390,7 +390,7 @@ void Structure::updateIntegrityDecay()
 			destroy();
 		}
 	}
-	else if (level <= IntegrityLevel::Destroyed)
+	else if (level <= IntegrityLevel::Destroyed && !destroyed())
 	{
 		destroy();
 	}

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -11,6 +11,7 @@
 #include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/EnumIdleReason.h>
+#include <libOPHD/EnumIntegrityLevel.h>
 #include <libOPHD/MapObjects/StructureType.h>
 #include <libOPHD/RandomNumberGenerator.h>
 #include <libOPHD/MeanSolarDistance.h>
@@ -22,6 +23,24 @@
 
 namespace
 {
+	struct IntegrityTransition
+	{
+		int value;
+		IntegrityLevel integrityLevel;
+	};
+
+
+	constexpr std::array<IntegrityTransition, 6> IntegrityTransitions =
+	{{
+		{100, IntegrityLevel::Mint},
+		{80, IntegrityLevel::Good},
+		{35, IntegrityLevel::Worn},
+		{20, IntegrityLevel::Decayed},
+		{1, IntegrityLevel::Unstable},
+		{0, IntegrityLevel::Destroyed},
+	}};
+
+
 	const std::map<StructureState, std::string> StructureStateDescriptions =
 	{
 		{StructureState::UnderConstruction, "Under Construction"},
@@ -30,6 +49,16 @@ namespace
 		{StructureState::Disabled, "Disabled"},
 		{StructureState::Destroyed, "Destroyed"},
 	};
+
+
+	IntegrityLevel integrityLevel(int integrity)
+	{
+		for (const auto& integrityTransition : IntegrityTransitions)
+		{
+			if (integrity >= integrityTransition.value) { return integrityTransition.integrityLevel; }
+		}
+		throw std::runtime_error("Bad integrity value: " + std::to_string(integrity));
+	}
 }
 
 
@@ -442,6 +471,12 @@ void Structure::increaseCrimeRate(int deltaCrimeRate)
 void Structure::integrity(int integrity)
 {
 	mIntegrity = integrity;
+}
+
+
+IntegrityLevel Structure::integrityLevel() const
+{
+	return ::integrityLevel(mIntegrity);
 }
 
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -378,18 +378,19 @@ void Structure::updateIntegrityDecay()
 
 	mIntegrity = std::clamp(mIntegrity - integrityDecayRate(), 0, mIntegrity);
 
-	if (mIntegrity < 35 && !disabled())
+	const auto level = integrityLevel();
+	if (level < IntegrityLevel::Worn && !disabled())
 	{
 		disable(DisabledReason::StructuralIntegrity);
 	}
-	else if (mIntegrity < 20 && !destroyed())
+	else if (level < IntegrityLevel::Decayed && !destroyed())
 	{
 		if (randomNumber.generate(0, 100) < 10)
 		{
 			destroy();
 		}
 	}
-	else if (mIntegrity <= 0)
+	else if (level <= IntegrityLevel::Destroyed)
 	{
 		mIntegrity = 0;
 		destroy();

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -23,24 +23,6 @@
 
 namespace
 {
-	struct IntegrityTransition
-	{
-		int value;
-		IntegrityLevel integrityLevel;
-	};
-
-
-	constexpr std::array<IntegrityTransition, 6> IntegrityTransitions =
-	{{
-		{100, IntegrityLevel::Mint},
-		{80, IntegrityLevel::Good},
-		{35, IntegrityLevel::Worn},
-		{20, IntegrityLevel::Decayed},
-		{1, IntegrityLevel::Unstable},
-		{0, IntegrityLevel::Destroyed},
-	}};
-
-
 	const std::map<StructureState, std::string> StructureStateDescriptions =
 	{
 		{StructureState::UnderConstruction, "Under Construction"},
@@ -49,16 +31,6 @@ namespace
 		{StructureState::Disabled, "Disabled"},
 		{StructureState::Destroyed, "Destroyed"},
 	};
-
-
-	IntegrityLevel integrityLevel(int integrity)
-	{
-		for (const auto& integrityTransition : IntegrityTransitions)
-		{
-			if (integrity >= integrityTransition.value) { return integrityTransition.integrityLevel; }
-		}
-		throw std::runtime_error("Bad integrity value: " + std::to_string(integrity));
-	}
 }
 
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -20,14 +20,17 @@
 #include <algorithm>
 
 
-const std::map<StructureState, std::string> StructureStateDescriptions =
+namespace
 {
-	{StructureState::UnderConstruction, "Under Construction"},
-	{StructureState::Operational, "Operational"},
-	{StructureState::Idle, "Idle"},
-	{StructureState::Disabled, "Disabled"},
-	{StructureState::Destroyed, "Destroyed"},
-};
+	const std::map<StructureState, std::string> StructureStateDescriptions =
+	{
+		{StructureState::UnderConstruction, "Under Construction"},
+		{StructureState::Operational, "Operational"},
+		{StructureState::Idle, "Idle"},
+		{StructureState::Disabled, "Disabled"},
+		{StructureState::Destroyed, "Destroyed"},
+	};
+}
 
 
 Structure::Structure(StructureID id, Tile& tile) :

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -392,7 +392,6 @@ void Structure::updateIntegrityDecay()
 	}
 	else if (level <= IntegrityLevel::Destroyed)
 	{
-		mIntegrity = 0;
 		destroy();
 	}
 }
@@ -407,6 +406,7 @@ void Structure::destroy()
 {
 	mSprite.play(constants::StructureStateDestroyed);
 	mStructureState = StructureState::Destroyed;
+	mIntegrity = 0;
 }
 
 

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -376,7 +376,7 @@ void Structure::updateIntegrityDecay()
 	// structures being built don't decay
 	if (state() == StructureState::UnderConstruction) { return; }
 
-	mIntegrity = std::clamp(mIntegrity - integrityDecayRate(), 0, mIntegrity);
+	mIntegrity = std::clamp(mIntegrity - integrityDecayRate(), 0, 100);
 
 	const auto level = integrityLevel();
 	if (level < IntegrityLevel::Worn && !disabled())

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -373,7 +373,7 @@ void Structure::incrementAge()
 
 void Structure::updateIntegrityDecay()
 {
-	// structures being built don't decay
+	// Structures being built don't decay
 	if (state() == StructureState::UnderConstruction) { return; }
 
 	mIntegrity = std::clamp(mIntegrity - integrityDecayRate(), 0, 100);

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -378,11 +378,11 @@ void Structure::updateIntegrityDecay()
 
 	mIntegrity = std::clamp(mIntegrity - integrityDecayRate(), 0, mIntegrity);
 
-	if (mIntegrity <= 35 && !disabled())
+	if (mIntegrity < 35 && !disabled())
 	{
 		disable(DisabledReason::StructuralIntegrity);
 	}
-	else if (mIntegrity <= 20 && !destroyed())
+	else if (mIntegrity < 20 && !destroyed())
 	{
 		if (randomNumber.generate(0, 100) < 10)
 		{

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -15,6 +15,7 @@ enum class StructureID;
 enum class ConnectorDir;
 enum class DisabledReason;
 enum class IdleReason;
+enum class IntegrityLevel;
 enum class StructureClass;
 enum class StructureState;
 struct StructureType;
@@ -113,6 +114,7 @@ public:
 	int integrity() const { return mIntegrity; }
 	void integrity(int integrity);
 	int integrityDecayRate() const;
+	IntegrityLevel integrityLevel() const;
 
 	// FLAGS
 	bool requiresCHAP() const;

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -2,6 +2,7 @@
 
 #include "../../States/MapViewStateHelper.h"
 
+#include <libOPHD/EnumIntegrityLevel.h>
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/StorableResources.h>
@@ -159,7 +160,7 @@ void MaintenanceFacility::repairStructure(Structure* structure)
 	{
 		--mMaterialsLevel;
 		++mAssignedPersonnel;
-		if (structure->integrity() >= 35) // \fixme magic number
+		if (structure->integrityLevel() >= IntegrityLevel::Worn)
 		{
 			structure->integrity(100);
 			structure->enable();

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.cpp
@@ -159,7 +159,7 @@ void MaintenanceFacility::repairStructure(Structure* structure)
 	{
 		--mMaterialsLevel;
 		++mAssignedPersonnel;
-		if (structure->integrity() > 35) // \fixme magic number
+		if (structure->integrity() >= 35) // \fixme magic number
 		{
 			structure->integrity(100);
 			structure->enable();

--- a/appOPHD/MapObjects/Structures/Road.cpp
+++ b/appOPHD/MapObjects/Structures/Road.cpp
@@ -1,9 +1,9 @@
 #include "Road.h"
 
-#include "../../Constants/Numbers.h"
 #include "../../Map/Connections.h"
 
 #include <libOPHD/EnumConnectorDir.h>
+#include <libOPHD/EnumIntegrityLevel.h>
 
 #include <string>
 
@@ -21,9 +21,9 @@ namespace
 	std::string roadAnimationName(const Road& road, const TileMap& tileMap)
 	{
 		const auto connectorDir = roadConnectorDir(tileMap, road.xyz());
-		const auto integrity = road.integrity();
-		const std::string tag = (integrity == 0) ? "-destroyed" :
-			(integrity < constants::RoadIntegrityChange) ? "-decayed" : "";
+		const auto integrityLevel = road.integrityLevel();
+		const std::string tag = (integrityLevel == IntegrityLevel::Destroyed) ? "-destroyed" :
+			(integrityLevel < IntegrityLevel::Good) ? "-decayed" : "";
 		return ConnectorDirStringTable.at(connectorDir) + tag;
 	}
 }

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -288,7 +288,6 @@
   <ItemGroup>
     <ClInclude Include="Cache.h" />
     <ClInclude Include="CacheMusic.h" />
-    <ClInclude Include="Constants\Numbers.h" />
     <ClInclude Include="Constants\Strings.h" />
     <ClInclude Include="Constants\UiConstants.h" />
     <ClInclude Include="GraphWalker.h" />

--- a/appOPHD/appOPHD.vcxproj.filters
+++ b/appOPHD/appOPHD.vcxproj.filters
@@ -383,9 +383,6 @@
     <ClInclude Include="CacheMusic.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Constants\Numbers.h">
-      <Filter>Header Files\Constants</Filter>
-    </ClInclude>
     <ClInclude Include="Constants\Strings.h">
       <Filter>Header Files\Constants</Filter>
     </ClInclude>

--- a/libOPHD/EnumIntegrityLevel.cpp
+++ b/libOPHD/EnumIntegrityLevel.cpp
@@ -1,0 +1,36 @@
+#include "EnumIntegrityLevel.h"
+
+#include <array>
+#include <string>
+#include <stdexcept>
+
+
+namespace
+{
+	struct IntegrityTransition
+	{
+		int value;
+		IntegrityLevel integrityLevel;
+	};
+
+
+	constexpr std::array<IntegrityTransition, 6> IntegrityTransitions =
+	{{
+		{100, IntegrityLevel::Mint},
+		{80, IntegrityLevel::Good},
+		{35, IntegrityLevel::Worn},
+		{20, IntegrityLevel::Decayed},
+		{1, IntegrityLevel::Unstable},
+		{0, IntegrityLevel::Destroyed},
+	}};
+}
+
+
+IntegrityLevel integrityLevel(int integrity)
+{
+	for (const auto& integrityTransition : IntegrityTransitions)
+	{
+		if (integrity >= integrityTransition.value) { return integrityTransition.integrityLevel; }
+	}
+	throw std::runtime_error("Bad integrity value: " + std::to_string(integrity));
+}

--- a/libOPHD/EnumIntegrityLevel.h
+++ b/libOPHD/EnumIntegrityLevel.h
@@ -1,0 +1,12 @@
+#pragma once
+
+
+enum class IntegrityLevel
+{
+	Mint,
+	Good,
+	Worn,
+	Decayed,
+	Unstable,
+	Destroyed,
+};

--- a/libOPHD/EnumIntegrityLevel.h
+++ b/libOPHD/EnumIntegrityLevel.h
@@ -3,10 +3,10 @@
 
 enum class IntegrityLevel
 {
-	Mint,
-	Good,
-	Worn,
-	Decayed,
-	Unstable,
 	Destroyed,
+	Unstable,
+	Decayed,
+	Worn,
+	Good,
+	Mint,
 };

--- a/libOPHD/EnumIntegrityLevel.h
+++ b/libOPHD/EnumIntegrityLevel.h
@@ -10,3 +10,6 @@ enum class IntegrityLevel
 	Good,
 	Mint,
 };
+
+
+IntegrityLevel integrityLevel(int integrity);

--- a/libOPHD/libOPHD.vcxproj
+++ b/libOPHD/libOPHD.vcxproj
@@ -185,6 +185,7 @@
     <ClInclude Include="EnumDirection.h" />
     <ClInclude Include="EnumDisabledReason.h" />
     <ClInclude Include="EnumIdleReason.h" />
+    <ClInclude Include="EnumIntegrityLevel.h" />
     <ClInclude Include="EnumOreDepositYield.h" />
     <ClInclude Include="EnumMoraleIndex.h" />
     <ClInclude Include="EnumProductType.h" />

--- a/libOPHD/libOPHD.vcxproj
+++ b/libOPHD/libOPHD.vcxproj
@@ -163,6 +163,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="DirectionOffset.cpp" />
+    <ClCompile Include="EnumIntegrityLevel.cpp" />
     <ClCompile Include="MeanSolarDistance.cpp" />
     <ClCompile Include="PlanetAttributes.cpp" />
     <ClCompile Include="ProductCatalog.cpp" />

--- a/libOPHD/libOPHD.vcxproj.filters
+++ b/libOPHD/libOPHD.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="DirectionOffset.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="EnumIntegrityLevel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="MeanSolarDistance.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/libOPHD/libOPHD.vcxproj.filters
+++ b/libOPHD/libOPHD.vcxproj.filters
@@ -98,6 +98,9 @@
     <ClInclude Include="EnumIdleReason.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EnumIntegrityLevel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="EnumOreDepositYield.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Add `IntegrityLevel` enum and use it to isolate integrity cutoff values and ensure consistent boundaries.

This removes the last remaining constant (`RoadIntegrityChange`) from `Numbers.h`.

Related:
- Issue #1740
- Issue #1846
- PR #2098
- PR #2097
- PR #2095
- PR #2094
