### PR TITLE
Scale `Route` cost and use `int`

### DIFF
--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -57,7 +57,8 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 
 int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
-	const auto routeCost = hasRoute(mineFacility) ? getRouteCost(mineFacility) : FLT_MAX;
+	if (!hasRoute(mineFacility)) { return 0; }
+	const auto routeCost = getRouteCost(mineFacility);
 	return static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
 }
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -41,17 +41,17 @@ bool OreHaulRoutes::hasRoute(const MineFacility& mineFacility) const
 
 const Route& OreHaulRoutes::getRoute(const MineFacility& mineFacility) const
 {
+	if (!hasRoute(mineFacility))
+	{
+		throw std::runtime_error("Called getRoute when no valid route");
+	}
 	return routeTable.at(&mineFacility);
 }
 
 
 float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 {
-	if (!hasRoute(mineFacility))
-	{
-		throw std::runtime_error("Called getRouteCost without a route");
-	}
-	const auto& route = routeTable.at(&mineFacility);
+	const auto& route = getRoute(mineFacility);
 	return route.cost;
 }
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -51,8 +51,7 @@ const Route& OreHaulRoutes::getRoute(const MineFacility& mineFacility) const
 
 float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 {
-	const auto& route = getRoute(mineFacility);
-	return route.cost;
+	return getRoute(mineFacility).cost;
 }
 
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -57,7 +57,7 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 
 int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
-	const float routeCost = getRouteCost(mineFacility);
+	const auto routeCost = getRouteCost(mineFacility);
 	return static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
 }
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -57,7 +57,7 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 
 int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
-	const auto routeCost = getRouteCost(mineFacility);
+	const auto routeCost = hasRoute(mineFacility) ? getRouteCost(mineFacility) : FLT_MAX;
 	return static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
 }
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -19,7 +19,7 @@ namespace
 	 * represents 100 round trips between the mine/smelter for effectively 100
 	 * units of ore transported per turn.
 	 */
-	inline constexpr float ShortestPathTraversalCount{100.0f};
+	inline constexpr float ShortestPathTraversalCount{400.0f};
 
 	std::map<const MineFacility*, Route> routeTable;
 }
@@ -51,7 +51,7 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 		return FLT_MAX;
 	}
 	const auto& route = routeTable.at(&mineFacility);
-	return std::clamp(route.cost, 1.0f, FLT_MAX);
+	return std::clamp(route.cost, 4.0f, FLT_MAX);
 }
 
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -8,6 +8,7 @@
 #include <cfloat>
 #include <map>
 #include <algorithm>
+#include <stdexcept>
 
 
 namespace
@@ -48,7 +49,7 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 {
 	if (!hasRoute(mineFacility))
 	{
-		return FLT_MAX;
+		throw std::runtime_error("Called getRouteCost without a route");
 	}
 	const auto& route = routeTable.at(&mineFacility);
 	return route.cost;

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -51,7 +51,7 @@ float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 		return FLT_MAX;
 	}
 	const auto& route = routeTable.at(&mineFacility);
-	return std::clamp(route.cost, 4.0f, FLT_MAX);
+	return route.cost;
 }
 
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -46,7 +46,7 @@ const Route& OreHaulRoutes::getRoute(const MineFacility& mineFacility) const
 
 float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 {
-	if (routeTable.find(&mineFacility) == routeTable.end())
+	if (!hasRoute(mineFacility))
 	{
 		return FLT_MAX;
 	}

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -20,7 +20,7 @@ namespace
 	 * represents 100 round trips between the mine/smelter for effectively 100
 	 * units of ore transported per turn.
 	 */
-	inline constexpr float ShortestPathTraversalCount{400.0f};
+	inline constexpr int ShortestPathTraversalCount{400};
 
 	std::map<const MineFacility*, Route> routeTable;
 }
@@ -49,7 +49,7 @@ const Route& OreHaulRoutes::getRoute(const MineFacility& mineFacility) const
 }
 
 
-float OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
+int OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 {
 	return getRoute(mineFacility).cost;
 }
@@ -59,7 +59,7 @@ int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
 	if (!hasRoute(mineFacility)) { return 0; }
 	const auto routeCost = getRouteCost(mineFacility);
-	return static_cast<int>(ShortestPathTraversalCount / routeCost) * mineFacility.assignedTrucks();
+	return ShortestPathTraversalCount / routeCost * mineFacility.assignedTrucks();
 }
 
 

--- a/appOPHD/Map/OreHaulRoutes.h
+++ b/appOPHD/Map/OreHaulRoutes.h
@@ -19,7 +19,7 @@ public:
 
 	bool hasRoute(const MineFacility& mineFacility) const;
 	const Route& getRoute(const MineFacility& mineFacility) const;
-	float getRouteCost(const MineFacility& mineFacility) const;
+	int getRouteCost(const MineFacility& mineFacility) const;
 	int getOreHaulCapacity(const MineFacility& mineFacility) const;
 
 	void removeMine(const MineFacility& mineFacility);

--- a/appOPHD/Map/Route.h
+++ b/appOPHD/Map/Route.h
@@ -9,7 +9,7 @@ class Tile;
 struct Route
 {
 	std::vector<Tile*> path;
-	float cost = 0.0f;
+	int cost = 0;
 
 	bool isEmpty() const { return path.empty(); }
 };

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -31,10 +31,15 @@ namespace
 			auto& end = smelter->tile();
 
 			Route route;
+			float floatCost;
 			solver->Reset();
-			solver->Solve(&start, &end, reinterpret_cast<std::vector<void*>*>(&route.path), &route.cost);
+			solver->Solve(&start, &end, reinterpret_cast<std::vector<void*>*>(&route.path), &floatCost);
 
-			if (!route.isEmpty()) { routeList.push_back(route); }
+			if (!route.isEmpty())
+			{
+				route.cost = static_cast<int>(floatCost);
+				routeList.push_back(route);
+			}
 		}
 
 		return routeList;

--- a/appOPHD/Map/RouteFinder.cpp
+++ b/appOPHD/Map/RouteFinder.cpp
@@ -15,7 +15,7 @@
 
 namespace
 {
-	constexpr float RouteBaseCost{0.5f};
+	constexpr float RouteBaseCost{2.0f};
 
 
 	std::vector<Route> findRoutes(micropather::MicroPather* solver, const Structure* mineFacility, const std::vector<Structure*>& smelters)
@@ -63,9 +63,9 @@ namespace
 		{
 			Structure& road = *tile.structure();
 
-			if (road.integrityLevel() >= IntegrityLevel::Good) { return 0.5f; }
-			else if (road.integrityLevel() >= IntegrityLevel::Worn) { return 0.75f; }
-			else { return RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 1.0f; }
+			if (road.integrityLevel() >= IntegrityLevel::Good) { return 2.0f; }
+			else if (road.integrityLevel() >= IntegrityLevel::Worn) { return 3.0f; }
+			else { return RouteBaseCost * static_cast<float>(TerrainType::Difficult) + 4.0f; }
 		}
 
 		if (tile.hasMapObject() && (!tile.hasStructure() || (!tile.structure()->isMineFacility() && !tile.structure()->isSmelter())))
@@ -78,7 +78,7 @@ namespace
 			return FLT_MAX;
 		}
 
-		return RouteBaseCost * static_cast<float>(tile.index()) + 1.0f;
+		return RouteBaseCost * static_cast<float>(tile.index()) + 4.0f;
 	}
 }
 

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -35,12 +35,6 @@ namespace
 		const auto& surfaceLocation = structure.xyz().xy;
 		return structure.name() + " at " + NAS2D::stringFrom(surfaceLocation);
 	}
-
-	std::string formatRouteCost(float routeCost)
-	{
-		const auto routeCostString = std::to_string(routeCost);
-		return routeCostString.substr(0, routeCostString.find(".") + 3);
-	}
 }
 
 
@@ -382,7 +376,7 @@ void MineReport::drawStatusPane(NAS2D::Renderer& renderer, const NAS2D::Point<in
 		routeValueOrigin + valueSpacing,
 		labelWidth,
 		"Cost",
-		formatRouteCost(routeCost),
+		std::to_string(routeCost),
 		constants::PrimaryTextColor
 	);
 


### PR DESCRIPTION
Scale `Route` cost by a factor of `4` and convert from `float` to `int`.

Scale the corresponding ore haul constant as well to balance out the route cost change, so the same amount of ore is transported per turn.

Related:
- Issue #1846
- PR #2099
