### PR TITLE
Update and simplify ore haul capacity

### DIFF
--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -58,7 +58,7 @@ int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
 	if (!hasRoute(mineFacility)) { return 0; }
 	const auto routeCost = getRouteCost(mineFacility);
-	return ShortestPathTraversalCount / routeCost * mineFacility.assignedTrucks();
+	return ShortestPathTraversalCount * mineFacility.assignedTrucks() / routeCost;
 }
 
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -19,7 +19,7 @@ namespace
 	 * represents 100 round trips between the mine/smelter for effectively 100
 	 * units of ore transported per turn.
 	 */
-	inline constexpr int ShortestPathTraversalCount{400};
+	inline constexpr int ShortestPathTraversalCount{100};
 
 	std::map<const MineFacility*, Route> routeTable;
 }
@@ -105,8 +105,7 @@ void OreHaulRoutes::transportOreFromMines()
 
 			if (!smelter.operational()) { break; }
 
-			const int totalOreMovement = getOreHaulCapacity(mineFacility);
-			const int oreMovementPart = totalOreMovement / 4;
+			const int oreMovementPart = getOreHaulCapacity(mineFacility);
 			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart};
 
 			auto& mineStorage = mineFacility.storage();

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -107,8 +107,7 @@ void OreHaulRoutes::transportOreFromMines()
 
 			const int totalOreMovement = getOreHaulCapacity(mineFacility);
 			const int oreMovementPart = totalOreMovement / 4;
-			const int oreMovementRemainder = totalOreMovement % 4;
-			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart + oreMovementRemainder};
+			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart};
 
 			auto& mineStorage = mineFacility.storage();
 			auto& smelterStored = smelter.production();

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -105,8 +105,8 @@ void OreHaulRoutes::transportOreFromMines()
 
 			if (!smelter.operational()) { break; }
 
-			const int oreMovementPart = getOreHaulCapacity(mineFacility);
-			const auto movementCap = StorableResources{oreMovementPart, oreMovementPart, oreMovementPart, oreMovementPart};
+			const int oreHaulCapacity = getOreHaulCapacity(mineFacility);
+			const auto movementCap = StorableResources{oreHaulCapacity, oreHaulCapacity, oreHaulCapacity, oreHaulCapacity};
 
 			auto& mineStorage = mineFacility.storage();
 			auto& smelterStored = smelter.production();

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -406,7 +406,6 @@ void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::P
 
 	const auto oreMovementTotal = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
 	const auto oreMovementComponent = oreMovementTotal / 4;
-	const auto oreMovementRemainder = oreMovementComponent + (oreMovementTotal % 4);
 
 	auto resourceOffset = lineOffset + NAS2D::Vector{0, 1 + constants::Margin + 2};
 	const auto progressBarSize = NAS2D::Vector{renderer.size().x - origin.x - 10, std::max(25, fontBold.height() + constants::MarginTight * 2)};
@@ -416,8 +415,7 @@ void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::P
 		renderer.drawSubImage(uiIcons, resourcePosition, ResourceImageRectsOre[i]);
 		const auto resourceNameOffset = NAS2D::Vector{ResourceImageRectsOre[i].size.x + constants::MarginTight + 2, 0};
 		renderer.drawText(fontBold, "Mine " + ResourceNamesOre[i], resourcePosition + resourceNameOffset, constants::PrimaryTextColor);
-		const auto oreMovement = (i != 3) ? oreMovementComponent : oreMovementRemainder;
-		drawLabelRightJustify(resourcePosition, panelWidth, font, std::to_string(oreMovement), constants::PrimaryTextColor);
+		drawLabelRightJustify(resourcePosition, panelWidth, font, std::to_string(oreMovementComponent), constants::PrimaryTextColor);
 
 		const auto resourceNameHeight = std::max(ResourceImageRectsOre[i].size.y, fontBold.height());
 		const auto progressBarPosition = resourcePosition + NAS2D::Vector{0, resourceNameHeight + constants::MarginTight + 2};

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -380,12 +380,12 @@ void MineReport::drawStatusPane(NAS2D::Renderer& renderer, const NAS2D::Point<in
 		constants::PrimaryTextColor
 	);
 
-	const auto oreMovementTotal = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
+	const auto oreHaulCapacity = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
 	drawLabelAndValueRightJustify(
 		routeValueOrigin + valueSpacing * 2,
 		labelWidth,
 		"Total Haul Capacity",
-		std::to_string(oreMovementTotal),
+		std::to_string(oreHaulCapacity * 4),
 		constants::PrimaryTextColor
 	);
 }
@@ -404,7 +404,7 @@ void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::P
 	const auto oreAvailable = oreDeposit.availableResources();
 	const auto oreTotalYield = oreDeposit.totalYield();
 
-	const auto oreMovementComponent = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
+	const auto oreHaulCapacity = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
 
 	auto resourceOffset = lineOffset + NAS2D::Vector{0, 1 + constants::Margin + 2};
 	const auto progressBarSize = NAS2D::Vector{renderer.size().x - origin.x - 10, std::max(25, fontBold.height() + constants::MarginTight * 2)};
@@ -414,7 +414,7 @@ void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::P
 		renderer.drawSubImage(uiIcons, resourcePosition, ResourceImageRectsOre[i]);
 		const auto resourceNameOffset = NAS2D::Vector{ResourceImageRectsOre[i].size.x + constants::MarginTight + 2, 0};
 		renderer.drawText(fontBold, "Mine " + ResourceNamesOre[i], resourcePosition + resourceNameOffset, constants::PrimaryTextColor);
-		drawLabelRightJustify(resourcePosition, panelWidth, font, std::to_string(oreMovementComponent), constants::PrimaryTextColor);
+		drawLabelRightJustify(resourcePosition, panelWidth, font, std::to_string(oreHaulCapacity), constants::PrimaryTextColor);
 
 		const auto resourceNameHeight = std::max(ResourceImageRectsOre[i].size.y, fontBold.height());
 		const auto progressBarPosition = resourcePosition + NAS2D::Vector{0, resourceNameHeight + constants::MarginTight + 2};

--- a/appOPHD/UI/Reports/MineReport.cpp
+++ b/appOPHD/UI/Reports/MineReport.cpp
@@ -404,8 +404,7 @@ void MineReport::drawOreProductionPane(NAS2D::Renderer& renderer, const NAS2D::P
 	const auto oreAvailable = oreDeposit.availableResources();
 	const auto oreTotalYield = oreDeposit.totalYield();
 
-	const auto oreMovementTotal = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
-	const auto oreMovementComponent = oreMovementTotal / 4;
+	const auto oreMovementComponent = mOreHaulRoutes->getOreHaulCapacity(*mSelectedFacility);
 
 	auto resourceOffset = lineOffset + NAS2D::Vector{0, 1 + constants::Margin + 2};
 	const auto progressBarSize = NAS2D::Vector{renderer.size().x - origin.x - 10, std::max(25, fontBold.height() + constants::MarginTight * 2)};


### PR DESCRIPTION
Redefine `getOreHaulCapacity` to be per ore type, rather than the sum for all types. This avoids division, and having to assign remainder capacity to an arbitrary ore type. Also updates haul capacity to multiple by the number of trucks before dividing by route cost, so any fractional components can be made use of there by assigning additional trucks such that the fractional components add up to a full unit of ore.

Related:
- Issue #1846
- PR #2100
