### PR TITLE
Less punishing ore haul falloff

### DIFF
--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -19,7 +19,8 @@ namespace
 	 * represents 100 round trips between the mine/smelter for effectively 100
 	 * units of ore transported per turn.
 	 */
-	constexpr int ShortestPathTraversalCount{100};
+	constexpr int ShortestPathTraversalCount{1000};
+	constexpr int LoadUnloadTime{36};
 
 	std::map<const MineFacility*, Route> routeTable;
 }
@@ -57,7 +58,7 @@ int OreHaulRoutes::getRouteCost(const MineFacility& mineFacility) const
 int OreHaulRoutes::getOreHaulCapacity(const MineFacility& mineFacility) const
 {
 	if (!hasRoute(mineFacility)) { return 0; }
-	const auto routeCost = getRouteCost(mineFacility);
+	const auto routeCost = LoadUnloadTime + getRouteCost(mineFacility);
 	return ShortestPathTraversalCount * mineFacility.assignedTrucks() / routeCost;
 }
 

--- a/appOPHD/Map/OreHaulRoutes.cpp
+++ b/appOPHD/Map/OreHaulRoutes.cpp
@@ -19,7 +19,7 @@ namespace
 	 * represents 100 round trips between the mine/smelter for effectively 100
 	 * units of ore transported per turn.
 	 */
-	inline constexpr int ShortestPathTraversalCount{100};
+	constexpr int ShortestPathTraversalCount{100};
 
 	std::map<const MineFacility*, Route> routeTable;
 }


### PR DESCRIPTION
Add a `LoadUnloadTime` constant to the ore haul capacity calculation, and adjust `ShortestPathTraversalCount` to balance and keep the same ore haul capacity for the shortest paths. The `LoadUnloadTime` will ensure the ore haul capacity falls off more slowly from there.

Based on the last updated graph in the associated Issue.

Related:
- Issue #1846
- Comment https://github.com/OutpostUniverse/OPHD/issues/1846#issuecomment-3244750436
