### PR TITLE
Add automatic underground sprite support

### DIFF
--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -91,7 +91,6 @@ namespace constants
 	// =====================================
 	const std::string StructureStateConstruction = "construction";
 	const std::string StructureStateOperational = "operational";
-	const std::string StructureStateOperationalUg = "operational";
 	const std::string StructureStateDestroyed = "destroyed";
 
 

--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -81,13 +81,13 @@ namespace constants
 	// =====================================
 	// = TUBE STATES
 	// =====================================
-	const std::string AgTubeIntersection = "ag_intersection";
-	const std::string AgTubeRight = "ag_right";
-	const std::string AgTubeLeft = "ag_left";
+	const std::string AgTubeIntersection = "intersection";
+	const std::string AgTubeRight = "right";
+	const std::string AgTubeLeft = "left";
 
-	const std::string UgTubeIntersection = "ug_intersection";
-	const std::string UgTubeRight = "ug_right";
-	const std::string UgTubeLeft = "ug_left";
+	const std::string UgTubeIntersection = "intersection";
+	const std::string UgTubeRight = "right";
+	const std::string UgTubeLeft = "left";
 
 
 	// =====================================
@@ -95,7 +95,7 @@ namespace constants
 	// =====================================
 	const std::string StructureStateConstruction = "construction";
 	const std::string StructureStateOperational = "operational";
-	const std::string StructureStateOperationalUg = "operational-ug";
+	const std::string StructureStateOperationalUg = "operational";
 	const std::string StructureStateDestroyed = "destroyed";
 
 

--- a/appOPHD/Constants/Strings.h
+++ b/appOPHD/Constants/Strings.h
@@ -81,13 +81,9 @@ namespace constants
 	// =====================================
 	// = TUBE STATES
 	// =====================================
-	const std::string AgTubeIntersection = "intersection";
-	const std::string AgTubeRight = "right";
-	const std::string AgTubeLeft = "left";
-
-	const std::string UgTubeIntersection = "intersection";
-	const std::string UgTubeRight = "right";
-	const std::string UgTubeLeft = "left";
+	const std::string TubeIntersection = "intersection";
+	const std::string TubeRight = "right";
+	const std::string TubeLeft = "left";
 
 
 	// =====================================

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -31,6 +31,13 @@ namespace
 		{StructureState::Disabled, "Disabled"},
 		{StructureState::Destroyed, "Destroyed"},
 	};
+
+
+	const std::string& getSpritePath(StructureID id, bool isSurface)
+	{
+		const auto& structureType = StructureCatalog::getType(id);
+		return (isSurface || structureType.spritePathUnderground.empty()) ? structureType.spritePath : structureType.spritePathUnderground;
+	}
 }
 
 
@@ -41,7 +48,7 @@ Structure::Structure(StructureID id, Tile& tile) :
 
 
 Structure::Structure(StructureID id, Tile& tile, const std::string& initialAction) :
-	MapObject{StructureCatalog::getType(id).spritePath, initialAction},
+	MapObject{getSpritePath(id, tile.isSurface()), initialAction},
 	mStructureType{StructureCatalog::getType(id)},
 	mStructureId{id},
 	mStructureClass{structureIdToClass(id)},

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -1,7 +1,6 @@
 #include "AirShaft.h"
 
 #include "../StructureState.h"
-#include "../../Map/Tile.h"
 #include "../../Constants/Strings.h"
 
 #include <libOPHD/EnumStructureID.h>

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -12,7 +12,7 @@ AirShaft::AirShaft(Tile& tile) :
 	Structure{
 		StructureID::AirShaft,
 		tile,
-		tile.isSurface() ? constants::StructureStateOperational : constants::StructureStateOperationalUg,
+		constants::StructureStateOperational,
 	}
 {
 	connectorDirection(ConnectorDir::Vertical);

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -1,7 +1,6 @@
 #include "Tube.h"
 
 #include "../StructureState.h"
-#include "../../Map/Tile.h"
 #include "../../Constants/Strings.h"
 
 #include <libOPHD/EnumStructureID.h>

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -20,7 +20,7 @@ Tube::Tube(Tile& tile, ConnectorDir dir) :
 	Structure{
 		StructureID::Tube,
 		tile,
-		getAnimationName(dir, tile.isSurface()),
+		getAnimationName(dir),
 	}
 {
 	connectorDirection(dir);
@@ -28,14 +28,11 @@ Tube::Tube(Tile& tile, ConnectorDir dir) :
 }
 
 
-const std::string& Tube::getAnimationName(ConnectorDir dir, bool isSurface)
+const std::string& Tube::getAnimationName(ConnectorDir dir)
 {
 	return
-		(dir == ConnectorDir::Intersection) ?
-			(isSurface ? constants::TubeIntersection : constants::TubeIntersection) :
-		(dir == ConnectorDir::EastWest) ?
-			(isSurface ? constants::TubeRight : constants::TubeRight) :
-		(dir == ConnectorDir::NorthSouth) ?
-			(isSurface ? constants::TubeLeft : constants::TubeLeft) :
+		(dir == ConnectorDir::Intersection) ? constants::TubeIntersection :
+		(dir == ConnectorDir::EastWest) ? constants::TubeRight :
+		(dir == ConnectorDir::NorthSouth) ? constants::TubeLeft :
 		throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter.");
 }

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -32,10 +32,10 @@ const std::string& Tube::getAnimationName(ConnectorDir dir, bool isSurface)
 {
 	return
 		(dir == ConnectorDir::Intersection) ?
-			(isSurface ? constants::AgTubeIntersection : constants::UgTubeIntersection) :
+			(isSurface ? constants::TubeIntersection : constants::TubeIntersection) :
 		(dir == ConnectorDir::EastWest) ?
-			(isSurface ? constants::AgTubeRight : constants::UgTubeRight) :
+			(isSurface ? constants::TubeRight : constants::TubeRight) :
 		(dir == ConnectorDir::NorthSouth) ?
-			(isSurface ? constants::AgTubeLeft : constants::UgTubeLeft) :
+			(isSurface ? constants::TubeLeft : constants::TubeLeft) :
 		throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter.");
 }

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -10,5 +10,5 @@ public:
 	Tube(Tile& tile, ConnectorDir dir);
 
 private:
-	static const std::string& getAnimationName(ConnectorDir dir, bool underground);
+	static const std::string& getAnimationName(ConnectorDir dir);
 };

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -109,7 +109,7 @@ namespace
 		const auto& structuresElement = *document.firstChildElement("Structures");
 
 		const auto requiredFields = std::vector<std::string>{"Name", "ImagePath"};
-		const auto optionalFields = std::vector<std::string>{"Description", "TurnsToBuild", "MaxAge", "RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "SolarEnergyProduced", "RawOreStorageCapacity", "OreStorageCapacity", "FoodProduced", "FoodStorageCapacity", "ResidentialCapacity", "BioWasteStorageCapacity", "BioWasteProcessingCapacity", "RobotCommandCapacity", "CommRange", "PoliceRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
+		const auto optionalFields = std::vector<std::string>{"Description", "ImagePathUnderground", "TurnsToBuild", "MaxAge", "RequiredWorkers", "RequiredScientists", "Priority", "EnergyRequired", "EnergyProduced", "SolarEnergyProduced", "RawOreStorageCapacity", "OreStorageCapacity", "FoodProduced", "FoodStorageCapacity", "ResidentialCapacity", "BioWasteStorageCapacity", "BioWasteProcessingCapacity", "RobotCommandCapacity", "CommRange", "PoliceRange", "IntegrityDecayRate", "PopulationRequirements", "ResourceRequirements", "IsSelfSustained", "IsRepairable", "IsChapRequired", "IsCrimeTarget"};
 
 		std::vector<StructureType> loadedStructureTypes;
 		for (const auto* structureElement = structuresElement.firstChildElement(); structureElement; structureElement = structureElement->nextSiblingElement())
@@ -121,6 +121,7 @@ namespace
 				dictionary.get("Name"),
 				dictionary.get("Description", std::string{}),
 				dictionary.get("ImagePath"),
+				dictionary.get("ImagePathUnderground", std::string{}),
 				readResourcesOptional(*structureElement, "BuildCost"),
 				readResourcesOptional(*structureElement, "OperationalCost"),
 				{

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -78,15 +78,15 @@ namespace
 
 
 	const std::vector<IconGridItem> SurfaceTubes = {
-		{constants::AgTubeIntersection, 110, static_cast<int>(ConnectorDir::Intersection)},
-		{constants::AgTubeRight, 112, static_cast<int>(ConnectorDir::EastWest)},
-		{constants::AgTubeLeft, 111, static_cast<int>(ConnectorDir::NorthSouth)},
+		{constants::TubeIntersection, 110, static_cast<int>(ConnectorDir::Intersection)},
+		{constants::TubeRight, 112, static_cast<int>(ConnectorDir::EastWest)},
+		{constants::TubeLeft, 111, static_cast<int>(ConnectorDir::NorthSouth)},
 	};
 
 	const std::vector<IconGridItem> UndergroundTubes = {
-		{constants::UgTubeIntersection, 113, static_cast<int>(ConnectorDir::Intersection)},
-		{constants::UgTubeRight, 115, static_cast<int>(ConnectorDir::EastWest)},
-		{constants::UgTubeLeft, 114, static_cast<int>(ConnectorDir::NorthSouth)},
+		{constants::TubeIntersection, 113, static_cast<int>(ConnectorDir::Intersection)},
+		{constants::TubeRight, 115, static_cast<int>(ConnectorDir::EastWest)},
+		{constants::TubeLeft, 114, static_cast<int>(ConnectorDir::NorthSouth)},
 	};
 
 

--- a/libOPHD/MapObjects/StructureType.h
+++ b/libOPHD/MapObjects/StructureType.h
@@ -11,6 +11,7 @@ struct StructureType
 	std::string name;
 	std::string description;
 	std::string spritePath;
+	std::string spritePathUnderground;
 
 	StorableResources buildCost{};
 	StorableResources operationalCost{};


### PR DESCRIPTION
Allow automatic selection of underground versions of `Sprite` files.

This allows animations names to be consistent between the two `Sprite` versions, so no code hacks are needed to choose the right animation based on above ground or under ground status. It also means we don't need to specify a new `StructureID` for two versions of the structure. All that's needed is an extra optional field for `ImagePathUnderground`

Related:
- Issue #1740
- PR #2103
