### PR TITLE
Update tube graphics on `ConnectorDir` change

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -142,7 +142,7 @@ public:
 	bool isRoad() const;
 
 	void age(int newAge) { mAge = newAge; }
-	void connectorDirection(ConnectorDir dir) { mConnectorDirection = dir; }
+	virtual void connectorDirection(ConnectorDir dir) { mConnectorDirection = dir; }
 
 	virtual void forcedStateChange(StructureState, DisabledReason, IdleReason);
 

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -34,7 +34,7 @@ Tube::Tube(Tile& tile, ConnectorDir dir) :
 		getAnimationName(dir),
 	}
 {
-	connectorDirection(dir);
+	Structure::connectorDirection(dir);
 	mStructureState = StructureState::Operational;
 }
 

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -27,6 +27,13 @@ Tube::Tube(Tile& tile, ConnectorDir dir) :
 }
 
 
+void Tube::connectorDirection(ConnectorDir dir)
+{
+	Structure::connectorDirection(dir);
+	mSprite.play(getAnimationName(dir));
+}
+
+
 const std::string& Tube::getAnimationName(ConnectorDir dir)
 {
 	return

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -9,6 +9,18 @@
 #include <stdexcept>
 
 
+namespace
+{
+	const std::string& getAnimationName(ConnectorDir dir)
+	{
+		return
+			(dir == ConnectorDir::Intersection) ? constants::TubeIntersection :
+			(dir == ConnectorDir::EastWest) ? constants::TubeRight :
+			(dir == ConnectorDir::NorthSouth) ? constants::TubeLeft :
+			throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter.");
+	}
+}
+
 Tube::Tube(Tile& tile) :
 	Tube{tile, ConnectorDir::Intersection}
 {
@@ -31,14 +43,4 @@ void Tube::connectorDirection(ConnectorDir dir)
 {
 	Structure::connectorDirection(dir);
 	mSprite.play(getAnimationName(dir));
-}
-
-
-const std::string& Tube::getAnimationName(ConnectorDir dir)
-{
-	return
-		(dir == ConnectorDir::Intersection) ? constants::TubeIntersection :
-		(dir == ConnectorDir::EastWest) ? constants::TubeRight :
-		(dir == ConnectorDir::NorthSouth) ? constants::TubeLeft :
-		throw std::runtime_error("Tried to create a Tube structure with invalid connector direction parameter.");
 }

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -9,6 +9,8 @@ public:
 	Tube(Tile& tile);
 	Tube(Tile& tile, ConnectorDir dir);
 
+	void connectorDirection(ConnectorDir dir) override;
+
 private:
 	static const std::string& getAnimationName(ConnectorDir dir);
 };

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -10,7 +10,4 @@ public:
 	Tube(Tile& tile, ConnectorDir dir);
 
 	void connectorDirection(ConnectorDir dir) override;
-
-private:
-	static const std::string& getAnimationName(ConnectorDir dir);
 };


### PR DESCRIPTION
When `connectorDirection` is called to set the direction on a `Tube`, the associated graphics should also be updated.

Related:
- Issue #1740
