### PR TITLE
Auto set `Tube` `ConnectorDir` based on surrounding tiles

### DIFF
--- a/appOPHD/Map/Connections.cpp
+++ b/appOPHD/Map/Connections.cpp
@@ -49,11 +49,24 @@ namespace
 	}
 
 
+	std::size_t tubeConnectionBinaryEncodedIndex(const TileMap& tileMap, const MapCoordinate& mapCoordinate)
+	{
+		const auto isAdjacent = [](const Tile& tile) { return tile.hasStructure(); };
+		return connectionBinaryEncodedIndex(tileMap, mapCoordinate, isAdjacent);
+	}
+
+
 	std::size_t roadConnectionBinaryEncodedIndex(const TileMap& tileMap, const MapCoordinate& mapCoordinate)
 	{
 		const auto isRoadAdjacent = [](const Tile& tile) { return tile.hasStructure() && tile.structure()->isRoad(); };
 		return connectionBinaryEncodedIndex(tileMap, mapCoordinate, isRoadAdjacent);
 	}
+}
+
+
+ConnectorDir tubeConnectorDir(const TileMap& tileMap, const MapCoordinate& mapCoordinate)
+{
+	return binaryEncodedIndexToConnectorDir.at(tubeConnectionBinaryEncodedIndex(tileMap, mapCoordinate));
 }
 
 

--- a/appOPHD/Map/Connections.h
+++ b/appOPHD/Map/Connections.h
@@ -6,4 +6,5 @@ struct MapCoordinate;
 class TileMap;
 
 
+ConnectorDir tubeConnectorDir(const TileMap& tileMap, const MapCoordinate& mapCoordinate);
 ConnectorDir roadConnectorDir(const TileMap& tileMap, const MapCoordinate& mapCoordinate);

--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -12,6 +12,7 @@
 #include <libOPHD/EnumDisabledReason.h>
 #include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/EnumIntegrityLevel.h>
+#include <libOPHD/EnumStructureID.h>
 #include <libOPHD/MapObjects/StructureType.h>
 #include <libOPHD/RandomNumberGenerator.h>
 #include <libOPHD/MeanSolarDistance.h>
@@ -336,6 +337,7 @@ bool Structure::isLander() const { return mStructureClass == StructureClass::Lan
 bool Structure::isPark() const { return mStructureClass == StructureClass::Park; }
 bool Structure::isMaintenance() const { return mStructureClass == StructureClass::Maintenance; }
 bool Structure::isConnector() const { return mStructureClass == StructureClass::Tube; }
+bool Structure::isTube() const { return mStructureId == StructureID::Tube; }
 bool Structure::isRoad() const { return mStructureClass == StructureClass::Road; }
 
 

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -139,6 +139,7 @@ public:
 	bool isPark() const;
 	bool isMaintenance() const;
 	bool isConnector() const;
+	bool isTube() const;
 	bool isRoad() const;
 
 	void age(int newAge) { mAge = newAge; }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -783,7 +783,7 @@ void MapViewState::placeTubes(Tile& tile, ConnectorDir connectorDirection)
 
 	if (tile.mapObject() || tile.oreDeposit() || !tile.excavated()) { return; }
 
-	if (validTubeConnection(*mTileMap, tile.xyz(), connectorDirection))
+	if (validTubeConnection(*mTileMap, tile.xyz()))
 	{
 		insertTube(tile, connectorDirection);
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -14,6 +14,7 @@
 #include "../StructureCatalog.h"
 #include "../StructureManager.h"
 
+#include "../Map/Connections.h"
 #include "../Map/OreHaulRoutes.h"
 #include "../Map/Route.h"
 #include "../Map/RouteFinder.h"
@@ -707,12 +708,7 @@ void MapViewState::onClickMap()
 	}
 	else if (mMapObjectPicker.isInsertingTube())
 	{
-		/** FIXME: This is a kludge that only works because all of the tube structures are listed alphabetically.
-		* Should instead take advantage of the updated meta data in the IconGridItem.
-		*/
-		auto connectorDirection = static_cast<ConnectorDir>(mConnections.selectedIndex() + 1);
-
-		placeTubes(tile, connectorDirection);
+		placeTubes(tile);
 	}
 }
 
@@ -763,18 +759,31 @@ void MapViewState::changeViewDepth(int depth)
 }
 
 
-void MapViewState::insertTube(Tile& tile, ConnectorDir dir)
+void MapViewState::insertTube(Tile& tile)
 {
-	if (dir == ConnectorDir::Vertical)
-	{
-		throw std::runtime_error("MapViewState::insertTube() called with invalid ConnectorDir parameter.");
-	}
+	const auto& newTubeLocation = tile.xyz();
+	const auto connectorDir = tubeConnectorDir(*mTileMap, newTubeLocation);
+	mStructureManager.addStructure(*new Tube(tile, connectorDir), tile);
 
-	mStructureManager.addStructure(*new Tube(tile, dir), tile);
+	// Update connectorDir of surrounding tubes
+	for (const auto& offset : DirectionClockwise4)
+	{
+		const auto adjacentTileLocation = newTubeLocation.translate(offset);
+		const auto& adjacentTile = mTileMap->getTile(adjacentTileLocation);
+		if (adjacentTile.hasStructure())
+		{
+			auto& structure = *adjacentTile.structure();
+			if (structure.isTube())
+			{
+				const auto newConnectorDir = tubeConnectorDir(*mTileMap, adjacentTileLocation);
+				structure.connectorDirection(newConnectorDir);
+			}
+		}
+	}
 }
 
 
-void MapViewState::placeTubes(Tile& tile, ConnectorDir connectorDirection)
+void MapViewState::placeTubes(Tile& tile)
 {
 	if (!tile.isBulldozed()) {
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertTubeTerrain);
@@ -785,7 +794,7 @@ void MapViewState::placeTubes(Tile& tile, ConnectorDir connectorDirection)
 
 	if (validTubeConnection(*mTileMap, tile.xyz()))
 	{
-		insertTube(tile, connectorDirection);
+		insertTube(tile);
 
 		// FIXME: Naive approach -- will be slow with larger colonies.
 		updateConnectedness();

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -64,7 +64,6 @@ namespace NAS2D
 
 enum class Difficulty;
 enum class Direction;
-enum class ConnectorDir;
 enum class StructureID;
 enum class RobotTypeIndex;
 
@@ -148,9 +147,9 @@ private:
 	void onDeployColonistLander();
 	void onDeploySeedLander(NAS2D::Point<int> point);
 	void insertSeedLander(NAS2D::Point<int> point);
-	void insertTube(Tile& tile, ConnectorDir dir);
+	void insertTube(Tile& tile);
 
-	void placeTubes(Tile& tile, ConnectorDir connectorDirection);
+	void placeTubes(Tile& tile);
 	void placeStructure(Tile& tile, StructureID structureID);
 	void placeRobot(Tile& tile, RobotTypeIndex robotTypeIndex);
 

--- a/appOPHD/States/MapViewStateEvent.cpp
+++ b/appOPHD/States/MapViewStateEvent.cpp
@@ -20,7 +20,6 @@
 #include "../MapObjects/Structures/Warehouse.h"
 
 #include <libOPHD/DirectionOffset.h>
-#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/EnumIdleReason.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
 

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -55,28 +55,6 @@ bool isPointInRangeSameZ(MapCoordinate point1, MapCoordinate point2, int distanc
 
 
 /**
- * Checks to see if a given tube connection is valid.
- */
-bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir)
-{
-	if (tile.oreDeposit() || !tile.isBulldozed() || !tile.excavated() || !tile.hasStructure())
-	{
-		return false;
-	}
-
-	Structure* structure = tile.structure();
-	const auto connectorDirection = structure->connectorDirection();
-
-	// Only follow directions that are valid for source connector
-	if (!hasConnectorDirection(sourceConnectorDir, dir)) { return false; }
-
-	// Check if destination can receive a connection from the given direction
-	// (Relies on symmetry of connector directions)
-	return hasConnectorDirection(connectorDirection, dir);
-}
-
-
-/**
  * Checks to see if the given tile offers a proper connection for a Structure.
  */
 bool checkStructurePlacement(Tile& tile, Direction dir)
@@ -95,10 +73,10 @@ bool checkStructurePlacement(Tile& tile, Direction dir)
 /**
  * Checks to see if a tile is a valid tile to place a tube onto.
  */
-bool validTubeConnection(TileMap& tilemap, MapCoordinate position, ConnectorDir dir)
+bool validTubeConnection(TileMap& tilemap, MapCoordinate position)
 {
 	return std::any_of(AllDirections4.begin(), AllDirections4.end(), [&](Direction direction){
-		return checkTubeConnection(tilemap.getTile(position.translate(direction)), direction, dir);
+		return tilemap.getTile(position.translate(direction)).hasStructure();
 	});
 }
 

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -21,15 +21,13 @@ class Warehouse;
 struct StorableResources;
 enum class StructureID;
 enum class Direction;
-enum class ConnectorDir;
 
 
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);
 bool isPointInRangeSameZ(MapCoordinate point1, MapCoordinate point2, int distance);
 
-bool checkTubeConnection(Tile& tile, Direction dir, ConnectorDir sourceConnectorDir);
 bool checkStructurePlacement(Tile& tile, Direction dir);
-bool validTubeConnection(TileMap& tilemap, MapCoordinate position, ConnectorDir dir);
+bool validTubeConnection(TileMap& tilemap, MapCoordinate position);
 bool validStructurePlacement(TileMap& tilemap, MapCoordinate position);
 bool validLanderSite(Tile& t);
 bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -409,7 +409,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		if (structureId == StructureID::Tube)
 		{
-			insertTube(mTileMap->getTile(mapCoordinate), direction);
+			insertTube(mTileMap->getTile(mapCoordinate));
 			continue; // FIXME: ugly
 		}
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -388,7 +388,6 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 		const auto structureId = static_cast<StructureID>(dictionary.get<int>("type"));
 		const auto age = dictionary.get<int>("age");
 		const auto state = static_cast<StructureState>(dictionary.get<int>("state"));
-		const auto direction = static_cast<ConnectorDir>(dictionary.get<int>("direction"));
 		const auto forcedIdle = dictionary.get<bool>("forced_idle");
 		const auto disabledReason = static_cast<DisabledReason>(dictionary.get<int>("disabled_reason"));
 		const auto idleReason = static_cast<IdleReason>(dictionary.get<int>("idle_reason"));
@@ -418,7 +417,6 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 		structure.age(age);
 		structure.forcedStateChange(state, disabledReason, idleReason);
 		if (forcedIdle) { structure.forceIdle(forcedIdle); }
-		structure.connectorDirection(direction);
 		structure.integrity(integrity);
 		structure.production() = readResourcesOptional(*structureElement, "production");
 		structure.storage() = readResourcesOptional(*structureElement, "storage");

--- a/appOPHD/UI/MapObjectPicker.cpp
+++ b/appOPHD/UI/MapObjectPicker.cpp
@@ -7,7 +7,6 @@
 #include "../StructureCatalog.h"
 
 #include <libOPHD/EnumStructureID.h>
-#include <libOPHD/EnumConnectorDir.h>
 #include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/Utility.h>
@@ -78,15 +77,11 @@ namespace
 
 
 	const std::vector<IconGridItem> SurfaceTubes = {
-		{constants::TubeIntersection, 110, static_cast<int>(ConnectorDir::Intersection)},
-		{constants::TubeRight, 112, static_cast<int>(ConnectorDir::EastWest)},
-		{constants::TubeLeft, 111, static_cast<int>(ConnectorDir::NorthSouth)},
+		{constants::TubeIntersection, 110},
 	};
 
 	const std::vector<IconGridItem> UndergroundTubes = {
-		{constants::TubeIntersection, 113, static_cast<int>(ConnectorDir::Intersection)},
-		{constants::TubeRight, 115, static_cast<int>(ConnectorDir::EastWest)},
-		{constants::TubeLeft, 114, static_cast<int>(ConnectorDir::NorthSouth)},
+		{constants::TubeIntersection, 113},
 	};
 
 


### PR DESCRIPTION
Relax `Tube` placement rules to not check `ConnectorDir`, auto set `Tube` `ConnectorDir` based on surrounding tiles, and trim `Tube` selection menu to just the intersection icon.

Related:
- Issue #1740
- PR #2105
- PR #2104
- PR #2103
