### PR TITLE
Update tubes on structure placement

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -759,16 +759,11 @@ void MapViewState::changeViewDepth(int depth)
 }
 
 
-void MapViewState::insertTube(Tile& tile)
+void MapViewState::updateSurroundingTubeConnectorDir(const MapCoordinate& updatedLocation)
 {
-	const auto& newTubeLocation = tile.xyz();
-	const auto connectorDir = tubeConnectorDir(*mTileMap, newTubeLocation);
-	mStructureManager.addStructure(*new Tube(tile, connectorDir), tile);
-
-	// Update connectorDir of surrounding tubes
 	for (const auto& offset : DirectionClockwise4)
 	{
-		const auto adjacentTileLocation = newTubeLocation.translate(offset);
+		const auto adjacentTileLocation = updatedLocation.translate(offset);
 		const auto& adjacentTile = mTileMap->getTile(adjacentTileLocation);
 		if (adjacentTile.hasStructure())
 		{
@@ -780,6 +775,16 @@ void MapViewState::insertTube(Tile& tile)
 			}
 		}
 	}
+}
+
+
+void MapViewState::insertTube(Tile& tile)
+{
+	const auto& newTubeLocation = tile.xyz();
+	const auto connectorDir = tubeConnectorDir(*mTileMap, newTubeLocation);
+	mStructureManager.addStructure(*new Tube(tile, connectorDir), tile);
+
+	updateSurroundingTubeConnectorDir(newTubeLocation);
 }
 
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -904,6 +904,7 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 		}
 
 		auto& structure = mStructureManager.create(structureID, tile);
+		updateSurroundingTubeConnectorDir(tile.xyz());
 
 		if (structure.isFactory())
 		{

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -147,8 +147,9 @@ private:
 	void onDeployColonistLander();
 	void onDeploySeedLander(NAS2D::Point<int> point);
 	void insertSeedLander(NAS2D::Point<int> point);
-	void insertTube(Tile& tile);
 
+	void updateSurroundingTubeConnectorDir(const MapCoordinate& updatedLocation);
+	void insertTube(Tile& tile);
 	void placeTubes(Tile& tile);
 	void placeStructure(Tile& tile, StructureID structureID);
 	void placeRobot(Tile& tile, RobotTypeIndex robotTypeIndex);

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -55,22 +55,6 @@ bool isPointInRangeSameZ(MapCoordinate point1, MapCoordinate point2, int distanc
 
 
 /**
- * Checks to see if the given tile offers a proper connection for a Structure.
- */
-bool checkStructurePlacement(Tile& tile, Direction dir)
-{
-	Structure* structure = tile.structure();
-	if (tile.oreDeposit() || !tile.isBulldozed() || !tile.excavated() || !tile.hasStructure() || !structure->connected() || !structure->isConnector())
-	{
-		return false;
-	}
-
-	// Rely on symmetry of connector direction for back connection
-	return hasConnectorDirection(structure->connectorDirection(), dir);
-}
-
-
-/**
  * Checks to see if a tile is a valid tile to place a tube onto.
  */
 bool validTubeConnection(TileMap& tilemap, MapCoordinate position)
@@ -87,7 +71,9 @@ bool validTubeConnection(TileMap& tilemap, MapCoordinate position)
 bool validStructurePlacement(TileMap& tilemap, MapCoordinate position)
 {
 	return std::any_of(AllDirections4.begin(), AllDirections4.end(), [&](Direction direction){
-		return checkStructurePlacement(tilemap.getTile(position.translate(direction)), direction);
+		const auto& tile = tilemap.getTile(position.translate(direction));
+		const auto* structure = tile.structure();
+		return tile.hasStructure() && structure->isConnector() && structure->connected();
 	});
 }
 

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -26,7 +26,6 @@ enum class Direction;
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);
 bool isPointInRangeSameZ(MapCoordinate point1, MapCoordinate point2, int distance);
 
-bool checkStructurePlacement(Tile& tile, Direction dir);
 bool validTubeConnection(TileMap& tilemap, MapCoordinate position);
 bool validStructurePlacement(TileMap& tilemap, MapCoordinate position);
 bool validLanderSite(Tile& t);


### PR DESCRIPTION
Bug fix for previous PR, since we also need to update `Tube` connections during `Structure` placement.

Without this change, it was impossible to place a `Structure` next to a `Tube` that didn't already have a `ConnectorDir` pointing towards the `Structure`. This relaxes the `Structure` placement checks, and then updates the surrounding `Tube` tiles to connect towards the new `Structure`.

Related:
- Issue #1740
- PR #2106
