### PR TITLE
Refactor `Tube` creation

### DIFF
--- a/appOPHD/MapObjects/Structure.cpp
+++ b/appOPHD/MapObjects/Structure.cpp
@@ -424,6 +424,9 @@ void Structure::destroy()
  */
 void Structure::forcedStateChange(StructureState structureState, DisabledReason disabledReason, IdleReason idleReason)
 {
+	// No state changes for Tube or AirShaft
+	if (isConnector()) { return; }
+
 	if (age() >= turnsToBuild())
 	{
 		mSprite.play(constants::StructureStateOperational);

--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -145,7 +145,7 @@ public:
 	void age(int newAge) { mAge = newAge; }
 	virtual void connectorDirection(ConnectorDir dir) { mConnectorDirection = dir; }
 
-	virtual void forcedStateChange(StructureState, DisabledReason, IdleReason);
+	void forcedStateChange(StructureState, DisabledReason, IdleReason);
 
 	void rebuild();
 

--- a/appOPHD/MapObjects/Structures/AirShaft.cpp
+++ b/appOPHD/MapObjects/Structures/AirShaft.cpp
@@ -17,8 +17,3 @@ AirShaft::AirShaft(Tile& tile) :
 	connectorDirection(ConnectorDir::Vertical);
 	mStructureState = StructureState::Operational;
 }
-
-
-void AirShaft::forcedStateChange(StructureState, DisabledReason, IdleReason)
-{
-}

--- a/appOPHD/MapObjects/Structures/AirShaft.h
+++ b/appOPHD/MapObjects/Structures/AirShaft.h
@@ -7,6 +7,4 @@ class AirShaft : public Structure
 {
 public:
 	AirShaft(Tile& tile);
-
-	void forcedStateChange(StructureState, DisabledReason, IdleReason) override;
 };

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -33,7 +33,6 @@
 #include "../MapObjects/Structures/MineFacility.h"
 #include "../MapObjects/Structures/SeedLander.h"
 #include "../MapObjects/Structures/StorageTanks.h"
-#include "../MapObjects/Structures/Tube.h"
 #include "../MapObjects/Structures/Warehouse.h"
 
 #include "../UI/MessageBox.h"
@@ -792,7 +791,8 @@ void MapViewState::insertTube(Tile& tile)
 {
 	const auto& newTubeLocation = tile.xyz();
 	const auto connectorDir = tubeConnectorDir(*mTileMap, newTubeLocation);
-	mStructureManager.addStructure(*new Tube(tile, connectorDir), tile);
+	auto& tube = mStructureManager.create(StructureID::Tube, tile);
+	tube.connectorDirection(connectorDir);
 
 	updateSurroundingTubeConnectorDir(newTubeLocation);
 }

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -759,6 +759,16 @@ void MapViewState::changeViewDepth(int depth)
 }
 
 
+void MapViewState::updateAllTubeConnectorDir()
+{
+	const auto& tubes = mStructureManager.structureList(StructureID::Tube);
+	for (auto* tube : tubes)
+	{
+		tube->connectorDirection(tubeConnectorDir(*mTileMap, tube->xyz()));
+	}
+}
+
+
 void MapViewState::updateSurroundingTubeConnectorDir(const MapCoordinate& updatedLocation)
 {
 	for (const auto& offset : DirectionClockwise4)

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -148,6 +148,7 @@ private:
 	void onDeploySeedLander(NAS2D::Point<int> point);
 	void insertSeedLander(NAS2D::Point<int> point);
 
+	void updateAllTubeConnectorDir();
 	void updateSurroundingTubeConnectorDir(const MapCoordinate& updatedLocation);
 	void insertTube(Tile& tile);
 	void placeTubes(Tile& tile);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -13,7 +13,6 @@
 #include "../OpenSaveGame.h"
 #include "../Constants/Strings.h"
 #include "../IOHelper.h"
-#include "../StructureCatalog.h"
 #include "../StructureManager.h"
 #include "../Map/OreHaulRoutes.h"
 #include "../Map/Route.h"
@@ -413,8 +412,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			continue; // FIXME: ugly
 		}
 
-		auto& structure = *StructureCatalog::create(structureId, tile);
-		mStructureManager.addStructure(structure, tile);
+		auto& structure = mStructureManager.create(structureId, tile);
 
 		structure.age(age);
 		structure.forcedStateChange(state, disabledReason, idleReason);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -408,8 +408,6 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 
 		auto& structure = mStructureManager.create(structureId, tile);
 
-		if (structureId == StructureID::Tube) { continue; } // FIXME: ugly
-
 		structure.age(age);
 		structure.forcedStateChange(state, disabledReason, idleReason);
 		if (forcedIdle) { structure.forceIdle(forcedIdle); }

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -406,13 +406,9 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 		tile.bulldoze();
 		tile.excavate();
 
-		if (structureId == StructureID::Tube)
-		{
-			insertTube(mTileMap->getTile(mapCoordinate));
-			continue; // FIXME: ugly
-		}
-
 		auto& structure = mStructureManager.create(structureId, tile);
+
+		if (structureId == StructureID::Tube) { continue; } // FIXME: ugly
 
 		structure.age(age);
 		structure.forcedStateChange(state, disabledReason, idleReason);

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -414,6 +414,7 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 		}
 
 		auto& structure = *StructureCatalog::create(structureId, tile);
+		mStructureManager.addStructure(structure, tile);
 
 		structure.age(age);
 		structure.forcedStateChange(state, disabledReason, idleReason);
@@ -505,8 +506,6 @@ void MapViewState::readStructures(NAS2D::Xml::XmlElement* element)
 			factory.resourcePool(&mResourcesCount);
 			factory.productionCompleteHandler({this, &MapViewState::onFactoryProductionComplete});
 		}
-
-		mStructureManager.addStructure(structure, tile);
 	}
 }
 

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -276,6 +276,7 @@ void MapViewState::load(NAS2D::Xml::XmlDocument* xmlDocument)
 
 	readRobots(root->firstChildElement("robots"));
 	readStructures(root->firstChildElement("structures"));
+	updateAllTubeConnectorDir();
 
 	mResearchTracker = readResearch(root->firstChildElement("research"));
 


### PR DESCRIPTION
Refactor `Tube` creation to rely more on `StructureManager::create`.

Reduce uses of `Structure` subclasses. Remove some uses of `new`.

Related:
- Issue #1740
- Issue #1804
- Issue #480
- PR #2106
- PR #2107
