### PR TITLE
Mark `StructureManager::addStructure` as `protected`

### DIFF
--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -143,11 +143,6 @@ Structure& StructureManager::create(StructureID structureId, Tile& tile)
 
 void StructureManager::addStructure(Structure& structure, Tile& tile)
 {
-	if (std::find(mDeployedStructures.begin(), mDeployedStructures.end(), &structure) != mDeployedStructures.end())
-	{
-		throw std::runtime_error("StructureManager::addStructure(): Attempting to add a Structure that is already managed!");
-	}
-
 	if (tile.hasMapObject())
 	{
 		tile.removeMapObject();

--- a/appOPHD/StructureManager.h
+++ b/appOPHD/StructureManager.h
@@ -48,7 +48,6 @@ public:
 
 	Structure& create(StructureID structureId, Tile& tile);
 
-	void addStructure(Structure& structure, Tile& tile);
 	void removeStructure(Structure& structure);
 	void removeAllStructures();
 
@@ -133,6 +132,8 @@ public:
 	NAS2D::Xml::XmlElement* serialize() const;
 
 protected:
+	void addStructure(Structure& structure, Tile& tile);
+
 	void disconnectAll();
 	void updateEnergyProduction();
 	void updateEnergyConsumed();


### PR DESCRIPTION
After the recent `Tube` creation refactor, there are no longer any external uses of `addStructure`, and we should keep it that way.

Client code should instead use `StructureManager::create` to both create a new `Structure` instance, and add it to the `Structure` collection.

Related:
- Issue #1740
- PR #2111
