### PR TITLE
Remove excess braces around `StorableResources` initializer

### DIFF
--- a/appOPHD/IOHelper.cpp
+++ b/appOPHD/IOHelper.cpp
@@ -42,12 +42,12 @@ StorableResources readResources(const NAS2D::Xml::XmlElement& element)
 	const auto requiredFields = std::vector<std::string>{constants::SaveGameResource0, constants::SaveGameResource1, constants::SaveGameResource2, constants::SaveGameResource3};
 	NAS2D::reportMissingOrUnexpected(dictionary.keys(), requiredFields, {});
 
-	return StorableResources{{
+	return StorableResources{
 		dictionary.get<int>(constants::SaveGameResource0),
 		dictionary.get<int>(constants::SaveGameResource1),
 		dictionary.get<int>(constants::SaveGameResource2),
 		dictionary.get<int>(constants::SaveGameResource3),
-	}};
+	};
 }
 
 


### PR DESCRIPTION
At some point we may want to convert the implementation from using `std::array` to individual `struct` fields. That could remove the `<array>` include for a lot of files. Keep in mind that `StorableResources` is currently the most included file.

Related:
- Issue #1573
