### PR TITLE
Inline `selfSustained` check

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -88,15 +88,6 @@ namespace
 	};
 
 
-	/**
-	* Determines if the structure is able to operate without a tube connection.
-	*/
-	bool selfSustained(StructureID id)
-	{
-		return StructureCatalog::getType(id).isSelfSustained;
-	}
-
-
 	NAS2D::Point<int> clampPointToRect(NAS2D::Point<int> point, const NAS2D::Rectangle<int>& rect)
 	{
 		const auto endPoint = rect.endPoint();
@@ -837,7 +828,7 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 {
 	if (structureID == StructureID::None) { throw std::runtime_error("MapViewState::placeStructure() called but structureID == STRUCTURE_NONE"); }
 
-	const auto isSelfSustained = selfSustained(structureID);
+	const auto isSelfSustained = StructureCatalog::getType(structureID).isSelfSustained;
 	if (!isSelfSustained && !mStructureManager.isInCcRange(tile.xy()))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOutOfRange);

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -837,7 +837,8 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 {
 	if (structureID == StructureID::None) { throw std::runtime_error("MapViewState::placeStructure() called but structureID == STRUCTURE_NONE"); }
 
-	if (!selfSustained(structureID) && !mStructureManager.isInCcRange(tile.xy()))
+	const auto isSelfSustained = selfSustained(structureID);
+	if (!isSelfSustained && !mStructureManager.isInCcRange(tile.xy()))
 	{
 		doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureOutOfRange);
 		return;
@@ -909,7 +910,7 @@ void MapViewState::placeStructure(Tile& tile, StructureID structureID)
 	}
 	else
 	{
-		if (!validStructurePlacement(*mTileMap, tile.xyz()) && !selfSustained(structureID))
+		if (!validStructurePlacement(*mTileMap, tile.xyz()) && !isSelfSustained)
 		{
 			doAlertMessage(constants::AlertInvalidStructureAction, constants::AlertStructureNoTube);
 			return;

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -46,6 +46,7 @@
 #include <libOPHD/ProductCatalog.h>
 #include <libOPHD/Population/MoraleChangeEntry.h>
 #include <libOPHD/MapObjects/OreDeposit.h>
+#include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/StringFrom.h>
 #include <NAS2D/Utility.h>
@@ -85,6 +86,15 @@ namespace
 		{RobotTypeIndex::Dozer, RobotMeta{constants::Robodozer, constants::RobodozerSheetId}},
 		{RobotTypeIndex::Miner, RobotMeta{constants::Robominer, constants::RobominerSheetId}}
 	};
+
+
+	/**
+	* Determines if the structure is able to operate without a tube connection.
+	*/
+	bool selfSustained(StructureID id)
+	{
+		return StructureCatalog::getType(id).isSelfSustained;
+	}
 
 
 	NAS2D::Point<int> clampPointToRect(NAS2D::Point<int> point, const NAS2D::Rectangle<int>& rect)

--- a/appOPHD/States/MapViewStateHelper.cpp
+++ b/appOPHD/States/MapViewStateHelper.cpp
@@ -26,7 +26,6 @@
 #include <libOPHD/DirectionOffset.h>
 #include <libOPHD/EnumDirection.h>
 #include <libOPHD/EnumStructureID.h>
-#include <libOPHD/MapObjects/StructureType.h>
 
 #include <NAS2D/Utility.h>
 
@@ -147,15 +146,6 @@ bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position)
 bool structureIsLander(StructureID id)
 {
 	return id == StructureID::SeedLander || id == StructureID::ColonistLander || id == StructureID::CargoLander;
-}
-
-
-/**
- * Determines if the structure is able to operate without a tube connection.
- */
-bool selfSustained(StructureID id)
-{
-	return StructureCatalog::getType(id).isSelfSustained;
 }
 
 

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -20,7 +20,6 @@ class TileMap;
 class Warehouse;
 struct StorableResources;
 enum class StructureID;
-enum class Direction;
 
 
 bool isPointInRange(NAS2D::Point<int> point1, NAS2D::Point<int> point2, int distance);

--- a/appOPHD/States/MapViewStateHelper.h
+++ b/appOPHD/States/MapViewStateHelper.h
@@ -31,7 +31,6 @@ bool validStructurePlacement(TileMap& tilemap, MapCoordinate position);
 bool validLanderSite(Tile& t);
 bool landingSiteSuitable(TileMap& tilemap, NAS2D::Point<int> position);
 bool structureIsLander(StructureID id);
-bool selfSustained(StructureID id);
 
 Warehouse* getAvailableWarehouse(ProductType type, std::size_t count);
 


### PR DESCRIPTION
This converts a use of `StructureCatalog` in a free function to one in a member function of `MapViewState`. If we convert `StructureCatalog` to a regular class, then we'll likely need an instance field for it, and a way to access that instance field. This is easier when the access is from `MapViewState`, which such an instance field is likely to be accessible.

Related:
- Issue #1336
