### PR TITLE
Add `StructureManager` parameter to `Robot::processTurn`

### DIFF
--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -146,7 +146,7 @@ NAS2D::Dictionary Robot::getDataDict() const
 }
 
 
-void Robot::processTurn(TileMap& tileMap)
+void Robot::processTurn(TileMap& tileMap, StructureManager& /*structureManager*/)
 {
 	if (mSelfDestruct)
 	{

--- a/appOPHD/MapObjects/Robot.cpp
+++ b/appOPHD/MapObjects/Robot.cpp
@@ -146,7 +146,7 @@ NAS2D::Dictionary Robot::getDataDict() const
 }
 
 
-void Robot::processTurn(TileMap& tileMap, StructureManager& /*structureManager*/)
+void Robot::processTurn(TileMap& tileMap, StructureManager& structureManager)
 {
 	if (mSelfDestruct)
 	{
@@ -164,7 +164,7 @@ void Robot::processTurn(TileMap& tileMap, StructureManager& /*structureManager*/
 
 	if (mTurnsToCompleteTask == 0)
 	{
-		onTaskComplete(tileMap);
+		onTaskComplete(tileMap, structureManager);
 		if (mTaskCompleteHandler) { mTaskCompleteHandler(*this); }
 	}
 

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -67,7 +67,7 @@ public:
 	virtual NAS2D::Dictionary getDataDict() const;
 
 protected:
-	virtual void onTaskComplete(TileMap& tileMap) = 0;
+	virtual void onTaskComplete(TileMap& tileMap, StructureManager& structureManager) = 0;
 
 private:
 	const RobotType& mRobotType;

--- a/appOPHD/MapObjects/Robot.h
+++ b/appOPHD/MapObjects/Robot.h
@@ -16,6 +16,7 @@ struct RobotType;
 struct MapCoordinate;
 class Tile;
 class TileMap;
+class StructureManager;
 
 
 class Robot : public MapObject
@@ -35,7 +36,7 @@ public:
 	bool isDead() const;
 	virtual void die();
 
-	virtual void processTurn(TileMap& tileMap);
+	virtual void processTurn(TileMap& tileMap, StructureManager& structureManager);
 
 	virtual void startTask(Tile& tile);
 	void startTask(Tile& tile, int turns);

--- a/appOPHD/MapObjects/Robots/Robodigger.cpp
+++ b/appOPHD/MapObjects/Robots/Robodigger.cpp
@@ -34,6 +34,6 @@ NAS2D::Dictionary Robodigger::getDataDict() const
 }
 
 
-void Robodigger::onTaskComplete(TileMap& /*tileMap*/)
+void Robodigger::onTaskComplete(TileMap& /*tileMap*/, StructureManager& /*structureManager*/)
 {
 }

--- a/appOPHD/MapObjects/Robots/Robodigger.h
+++ b/appOPHD/MapObjects/Robots/Robodigger.h
@@ -17,7 +17,7 @@ public:
 	NAS2D::Dictionary getDataDict() const override;
 
 protected:
-	void onTaskComplete(TileMap& tileMap) override;
+	void onTaskComplete(TileMap& tileMap, StructureManager& structureManager) override;
 
 private:
 	Direction mDirection;

--- a/appOPHD/MapObjects/Robots/Robodozer.cpp
+++ b/appOPHD/MapObjects/Robots/Robodozer.cpp
@@ -26,6 +26,6 @@ void Robodozer::abortTask()
 }
 
 
-void Robodozer::onTaskComplete(TileMap& /*tileMap*/)
+void Robodozer::onTaskComplete(TileMap& /*tileMap*/, StructureManager& /*structureManager*/)
 {
 }

--- a/appOPHD/MapObjects/Robots/Robodozer.h
+++ b/appOPHD/MapObjects/Robots/Robodozer.h
@@ -14,7 +14,7 @@ public:
 	void abortTask() override;
 
 protected:
-	void onTaskComplete(TileMap& tileMap) override;
+	void onTaskComplete(TileMap& tileMap, StructureManager& structureManager) override;
 
 private:
 	std::size_t mTileIndex = 0;

--- a/appOPHD/MapObjects/Robots/Robominer.cpp
+++ b/appOPHD/MapObjects/Robots/Robominer.cpp
@@ -42,6 +42,6 @@ MineFacility& Robominer::buildMine(TileMap& tileMap, const MapCoordinate& positi
 }
 
 
-void Robominer::onTaskComplete(TileMap& /*tileMap*/)
+void Robominer::onTaskComplete(TileMap& /*tileMap*/, StructureManager& /*structureManager*/)
 {
 }

--- a/appOPHD/MapObjects/Robots/Robominer.h
+++ b/appOPHD/MapObjects/Robots/Robominer.h
@@ -16,5 +16,5 @@ public:
 	MineFacility& buildMine(TileMap& tileMap, const MapCoordinate& position);
 
 protected:
-	void onTaskComplete(TileMap& tileMap) override;
+	void onTaskComplete(TileMap& tileMap, StructureManager& structureManager) override;
 };

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -1268,7 +1268,7 @@ void MapViewState::updateRobots()
 		auto& robot = *robotPointer;
 		auto& tile = robot.tile();
 
-		robot.processTurn(*mTileMap);
+		robot.processTurn(*mTileMap, mStructureManager);
 
 		if (robot.isDead())
 		{


### PR DESCRIPTION
A number of `Robot` tasks involve the creation of `Structure` instances. This needs access to the `StructureManager` to complete. By adding `StructureManager` as a parameter to `processTurn`, it becomes possible for the `Robot` instance to complete the game state modification itself.

I'm still a little on the fence about moving the code into subclasses of `Robot`, or perhaps putting it in `Robot` itself. Moving the code may require adding a lot of `#include` lines to the files where it is moved, so we might want to keep the modification code together somewhere.

Additionally, it might be wise to allow for standard modification functions for `Tile` modification and `Structure` creation, and perhaps allow `Robot` tasks to be configured, maybe even through an external data file. For instance, task X might set `bulldozed` and `excavated` on the `Tile` at offset `{{0, 0}, 0}` (relative to the `Robot` location), and then create a structure with given `structureIndex` at offset `{{0, 0}, 0}`. Being able to compose operations from basic modifications operations might allow for a fairly generic `Robot` implementation.

Regardless of how this ends up being implemented, the modification operations will need access to `TileMap` and `StructureManager`.

----

Related:
- Issue #1647
- Issue #650
- Issue #1723
- Issue #1804
