### PR TITLE
Refactor `TextArea` word wrap

### DIFF
--- a/demoLibControls/MainWindow.cpp
+++ b/demoLibControls/MainWindow.cpp
@@ -81,6 +81,7 @@ MainWindow::MainWindow() :
 	textFieldBorderAlways.text("Border Always");
 	textFieldBorderAlways.border(TextField::BorderVisibility::Always);
 
+	textArea.highlight(true);
 	textArea.size({100, 100});
 	textArea.text("This is some\nTextArea\ntext.");
 

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -18,6 +18,17 @@ namespace
 		}
 		return maxLength;
 	}
+
+
+	std::size_t countLeadingSpaces(std::string_view lineChunk)
+	{
+		std::size_t count = 0;
+		while (count < lineChunk.size() && lineChunk[count] == ' ')
+		{
+			++count;
+		}
+		return count;
+	}
 }
 
 
@@ -86,6 +97,8 @@ void TextArea::onLayoutText()
 			const auto softLine = lineChunk.substr(0, splitLength);
 			mFormattedList.push_back(std::string{softLine});
 			lineChunk = lineChunk.substr(splitLength);
+			const auto spaceCount = countLeadingSpaces(lineChunk);
+			lineChunk = lineChunk.substr(spaceCount);
 		}
 	}
 }

--- a/libControls/TextArea.cpp
+++ b/libControls/TextArea.cpp
@@ -73,8 +73,6 @@ void TextArea::onLayoutText()
 {
 	mFormattedList.clear();
 
-	if (mRect.size.x < 10 || mText.empty()) { return; }
-
 	const auto hardLines = NAS2D::split(mText, '\n');
 	for (const auto& line : hardLines)
 	{
@@ -83,7 +81,8 @@ void TextArea::onLayoutText()
 		{
 			const auto maxFitLineCharacters = mFont.widthBoundedSubstringLength(lineChunk, mRect.size.x);
 			const auto lastWordBreak = findLastWordBreak(lineChunk, maxFitLineCharacters);
-			const auto splitLength = lastWordBreak > 0 ? lastWordBreak : maxFitLineCharacters;
+			const auto splitOrSliceLength = lastWordBreak > 0 ? lastWordBreak : maxFitLineCharacters;
+			const auto splitLength = splitOrSliceLength > 0 ? splitOrSliceLength : 1;
 			const auto softLine = lineChunk.substr(0, splitLength);
 			mFormattedList.push_back(std::string{softLine});
 			lineChunk = lineChunk.substr(splitLength);


### PR DESCRIPTION
Refactor the `TextArea` word wrap code so it accounts for hard line breaks as well as soft line breaks at spaces, and will slice when a single token is too long for one line rather than get caught in an infinite loop.

----

This seems to improve layout in the `demoLibControls` project. No obvious layout changes in the game.

Note: There are hard line breaks around "TextArea". The original code breaks "some" to a new line, while the updated code doesn't. This is caused by line breaks (`\n`) not being counted as spaces (` `), so the original layout was grouping "some TextArea" as a single token, which was too long for that line. Meanwhile the display code did account for hard line breaks.

Original:
<img width="106" height="106" alt="image" src="https://github.com/user-attachments/assets/341e63d4-5260-4e07-a423-656431286ae4" />

Updated:
<img width="106" height="106" alt="image" src="https://github.com/user-attachments/assets/76639b47-f422-4a9e-8b40-873d44d6a819" />

----

Related:
- Issue #1902
