### PR TITLE
Replace resource total counts

### DIFF
--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -192,7 +192,7 @@ void ResourceInfoBar::draw(NAS2D::Renderer& renderer) const
 	const auto energyAvailable = mStructureManager.totalEnergyAvailable();
 	const std::array storageCapacities
 	{
-		std::tuple{oreIconRect, maxOreComponent, refinedOreCapacity, refinedOreCapacity - maxOreComponent <= 100},
+		std::tuple{oreIconRect, maxOreComponent, refinedOreCapacity, false},
 		std::tuple{foodIconRect, mFood, mStructureManager.totalFoodStorageCapacity(), mFood <= 10},
 		std::tuple{powerIconRect, energyAvailable, mStructureManager.totalEnergyProduction(), energyAvailable <= 5}
 	};


### PR DESCRIPTION
There is no real meaning to total resources (sum of all resource components). The sum has no real implication on any game mechanic. Rather it's the individual components that matter. As such, we should display information that is focused on individual components. In particular, we need to know the max storage for any one component. It may also be useful to know at a glance which component/value is closest to that max. Hence this update changes the display to the largest component value, and the max of any component value.

Additionally, the pulse highlighting was removed for storage being full. We should warn for low resources, not an abundance of resources. Besides, we already have low resource pulse highlighting on each individual ore component.

----

Original:
<img width="375" height="24" alt="Image" src="https://github.com/user-attachments/assets/162e70ab-3c91-4088-a9fc-a90c52ef7e9c" />

Updated:
<img width="353" height="23" alt="image" src="https://github.com/user-attachments/assets/d97747df-1fdb-47e0-ab49-f90acea30a52" />

----

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3281016317
- Issue #695
