### PR TITLE
Inline and remove mouse pointer string constants

### DIFF
--- a/appOPHD/Constants/UiConstants.h
+++ b/appOPHD/Constants/UiConstants.h
@@ -4,8 +4,6 @@
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Renderer/Color.h>
 
-#include <string>
-
 
 namespace constants
 {
@@ -50,10 +48,4 @@ namespace constants
 	const NAS2D::Color PrimaryTextColorVariant{PrimaryColorVariant};
 
 	const NAS2D::Color WarningTextColor = NAS2D::Color::Red;
-
-	// =====================================
-	// = MOUSE POINTERS
-	// =====================================
-	const std::string MousePointerNormal = "ui/pointers/normal.png";
-	const std::string MousePointerPlaceTile = "ui/pointers/place_tile.png";
 }

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -26,6 +26,7 @@
 
 #include <SDL2/SDL.h>
 
+#include <string>
 #include <iostream>
 #include <fstream>
 
@@ -134,8 +135,8 @@ int main(int argc, char *argv[])
 		renderer.minimumSize(constants::MinimumWindowSize);
 		renderer.resizeable(true);
 
-		addCursor(PointerType::Normal, constants::MousePointerNormal, {0, 0});
-		addCursor(PointerType::PlaceTile, constants::MousePointerPlaceTile, {16, 16});
+		addCursor(PointerType::Normal, "ui/pointers/normal.png", {0, 0});
+		addCursor(PointerType::PlaceTile, "ui/pointers/place_tile.png", {16, 16});
 		setCursor(PointerType::Normal);
 
 		Control::setDefaultFont(getFont());


### PR DESCRIPTION
Inline and remove single use mouse pointer string constants. This removes the need to include `<string>` from the header file.

Related:
- Issue #1573
- PR #2131
- PR #2130
