### PR TITLE
Refactor `Tube` and `Road` connections

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -21,6 +21,7 @@ enum class StructureState;
 struct StructureType;
 struct MapCoordinate;
 class Tile;
+class TileMap;
 class StringTable;
 
 
@@ -143,7 +144,7 @@ public:
 	bool isRoad() const;
 
 	void age(int newAge) { mAge = newAge; }
-	virtual void connectorDirection(ConnectorDir) {}
+	virtual void updateConnections(const TileMap& /*tileMap*/) {}
 
 	void forcedStateChange(StructureState, DisabledReason, IdleReason);
 

--- a/appOPHD/MapObjects/Structures/Road.cpp
+++ b/appOPHD/MapObjects/Structures/Road.cpp
@@ -31,8 +31,5 @@ namespace
 
 void Road::updateConnections(const TileMap& tileMap)
 {
-	if (operational())
-	{
-		mSprite.play(roadAnimationName(*this, tileMap));
-	}
+	mSprite.play(roadAnimationName(*this, tileMap));
 }

--- a/appOPHD/MapObjects/Structures/Road.cpp
+++ b/appOPHD/MapObjects/Structures/Road.cpp
@@ -18,10 +18,8 @@ namespace
 	};
 
 
-	std::string roadAnimationName(const Road& road, const TileMap& tileMap)
+	std::string roadAnimationName(ConnectorDir connectorDir, IntegrityLevel integrityLevel)
 	{
-		const auto connectorDir = roadConnectorDir(tileMap, road.xyz());
-		const auto integrityLevel = road.integrityLevel();
 		const std::string tag = (integrityLevel == IntegrityLevel::Destroyed) ? "-destroyed" :
 			(integrityLevel < IntegrityLevel::Good) ? "-decayed" : "";
 		return ConnectorDirStringTable.at(connectorDir) + tag;
@@ -31,5 +29,7 @@ namespace
 
 void Road::updateConnections(const TileMap& tileMap)
 {
-	mSprite.play(roadAnimationName(*this, tileMap));
+	const auto connectorDir = roadConnectorDir(tileMap, xyz());
+	const auto integrityLevel = this->integrityLevel();
+	mSprite.play(roadAnimationName(connectorDir, integrityLevel));
 }

--- a/appOPHD/MapObjects/Structures/Road.h
+++ b/appOPHD/MapObjects/Structures/Road.h
@@ -17,5 +17,5 @@ public:
 	}
 
 
-	void updateConnections(const TileMap& tileMap);
+	void updateConnections(const TileMap& tileMap) override;
 };

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -2,6 +2,7 @@
 
 #include "../StructureState.h"
 #include "../../Constants/Strings.h"
+#include "../../Map/Connections.h"
 
 #include <libOPHD/EnumStructureID.h>
 #include <libOPHD/EnumConnectorDir.h>
@@ -30,6 +31,13 @@ Tube::Tube(Tile& tile) :
 	}
 {
 	mStructureState = StructureState::Operational;
+}
+
+
+void Tube::updateConnections(const TileMap& tileMap)
+{
+	const auto connectorDir = tubeConnectorDir(tileMap, xyz());
+	mSprite.play(getAnimationName(connectorDir));
 }
 
 

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -21,17 +21,12 @@ namespace
 	}
 }
 
+
 Tube::Tube(Tile& tile) :
-	Tube{tile, ConnectorDir::Intersection}
-{
-}
-
-
-Tube::Tube(Tile& tile, ConnectorDir dir) :
 	Structure{
 		StructureID::Tube,
 		tile,
-		getAnimationName(dir),
+		getAnimationName(ConnectorDir::Intersection),
 	}
 {
 	mStructureState = StructureState::Operational;

--- a/appOPHD/MapObjects/Structures/Tube.cpp
+++ b/appOPHD/MapObjects/Structures/Tube.cpp
@@ -39,9 +39,3 @@ void Tube::updateConnections(const TileMap& tileMap)
 	const auto connectorDir = tubeConnectorDir(tileMap, xyz());
 	mSprite.play(getAnimationName(connectorDir));
 }
-
-
-void Tube::connectorDirection(ConnectorDir dir)
-{
-	mSprite.play(getAnimationName(dir));
-}

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -7,7 +7,6 @@ class Tube : public Structure
 {
 public:
 	Tube(Tile& tile);
-	Tube(Tile& tile, ConnectorDir dir);
 
 	void connectorDirection(ConnectorDir dir) override;
 };

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -3,10 +3,14 @@
 #include "../Structure.h"
 
 
+class TileMap;
+
+
 class Tube : public Structure
 {
 public:
 	Tube(Tile& tile);
 
+	void updateConnections(const TileMap& tileMap);
 	void connectorDirection(ConnectorDir dir) override;
 };

--- a/appOPHD/MapObjects/Structures/Tube.h
+++ b/appOPHD/MapObjects/Structures/Tube.h
@@ -11,6 +11,5 @@ class Tube : public Structure
 public:
 	Tube(Tile& tile);
 
-	void updateConnections(const TileMap& tileMap);
-	void connectorDirection(ConnectorDir dir) override;
+	void updateConnections(const TileMap& tileMap) override;
 };

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -14,7 +14,6 @@
 #include "../StructureCatalog.h"
 #include "../StructureManager.h"
 
-#include "../Map/Connections.h"
 #include "../Map/OreHaulRoutes.h"
 #include "../Map/Route.h"
 #include "../Map/RouteFinder.h"
@@ -763,7 +762,7 @@ void MapViewState::updateAllTubeConnectorDir()
 	const auto& tubes = mStructureManager.structureList(StructureID::Tube);
 	for (auto* tube : tubes)
 	{
-		tube->connectorDirection(tubeConnectorDir(*mTileMap, tube->xyz()));
+		tube->updateConnections(*mTileMap);
 	}
 }
 
@@ -779,8 +778,7 @@ void MapViewState::updateSurroundingTubeConnectorDir(const MapCoordinate& update
 			auto& structure = *adjacentTile.structure();
 			if (structure.isTube())
 			{
-				const auto newConnectorDir = tubeConnectorDir(*mTileMap, adjacentTileLocation);
-				structure.connectorDirection(newConnectorDir);
+				structure.updateConnections(*mTileMap);
 			}
 		}
 	}
@@ -790,9 +788,8 @@ void MapViewState::updateSurroundingTubeConnectorDir(const MapCoordinate& update
 void MapViewState::insertTube(Tile& tile)
 {
 	const auto& newTubeLocation = tile.xyz();
-	const auto connectorDir = tubeConnectorDir(*mTileMap, newTubeLocation);
 	auto& tube = mStructureManager.create(StructureID::Tube, tile);
-	tube.connectorDirection(connectorDir);
+	tube.updateConnections(*mTileMap);
 
 	updateSurroundingTubeConnectorDir(newTubeLocation);
 }

--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -7,7 +7,6 @@
 #include "ColonyShip.h"
 
 
-#include "../Map/Connections.h"
 #include "../Map/OreHaulRoutes.h"
 #include "../Map/Route.h"
 #include "../Map/RouteFinder.h"


### PR DESCRIPTION
Make the interface to set `Tube` and `Road` connector directions that same. Reduce visibility of `Connections.h`.

Related:
- Issue #1804
