### PR TITLE
Update `DetailMap` draw area to avoid clipping

### DIFF
--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -180,7 +180,10 @@ void MapViewState::setupUiPositions(NAS2D::Vector<int> size)
 		{mBtnTurns.position().x - constants::Margin - constants::MarginTight, mBottomUiRect.size.y - constants::Margin * 2}
 	});
 
-	mDetailMap->size({size.x, size.y - mBottomUiRect.size.y});
+	mDetailMap->area({
+		mResourceInfoBar.area().crossYPoint(),
+		{size.x, size.y - mResourceInfoBar.size().y - mBottomUiRect.size.y}
+	});
 
 	// Allow for centering with rounding to integer values
 	const auto rendererCenter = NAS2D::Utility<NAS2D::Renderer>::get().center().to<int>();

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -77,7 +77,7 @@ DetailMap::DetailMap(MapView& mapView, TileMap& tileMap, const std::string& tile
 
 void DetailMap::onResize()
 {
-	const auto size = this->size();
+	const auto size = this->size() - NAS2D::Vector{0, TileDrawOffset.y};
 
 	// Set up map draw position
 	const auto sizeInTiles = size.skewInverseBy(TileSize);


### PR DESCRIPTION
Update `DetailMap` draw area to avoid clipping, by accounting for the `ResourceInfoBar` height, and the tall object overhang amount for mountains and such within a `Tile`.

There might still be a pixel or so of clipping at the bottom, though that might related to the bottom UI being drawn over the last pixel of the `DetailMap`.

Related:
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3293414232
- Issue #1754
- PR #2137
