### PR TITLE
Update `drawLine` to fix offset problem

### DIFF
--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -335,7 +335,7 @@ void MapViewState::drawUI()
 	// Bottom UI
 	renderer.drawBoxFilled(mBottomUiRect.inset(1), NAS2D::Color{39, 39, 39});
 	renderer.drawBox(mBottomUiRect, NAS2D::Color{21, 21, 21});
-	renderer.drawLine(NAS2D::Point{mBottomUiRect.position.x + 2, mBottomUiRect.position.y}, NAS2D::Point{mBottomUiRect.position.x + mBottomUiRect.size.x - 2, mBottomUiRect.position.y}, NAS2D::Color{56, 56, 56});
+	renderer.drawLine(NAS2D::Point{mBottomUiRect.position.x + 1, mBottomUiRect.position.y}, NAS2D::Point{mBottomUiRect.position.x + mBottomUiRect.size.x - 1, mBottomUiRect.position.y}, NAS2D::Color{56, 56, 56});
 
 	mMiniMap->draw(renderer);
 	mNavControl->draw(renderer);

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -333,7 +333,7 @@ void MapViewState::drawUI()
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	// Bottom UI
-	renderer.drawBoxFilled(mBottomUiRect, NAS2D::Color{39, 39, 39});
+	renderer.drawBoxFilled(mBottomUiRect.inset(1), NAS2D::Color{39, 39, 39});
 	renderer.drawBox(mBottomUiRect, NAS2D::Color{21, 21, 21});
 	renderer.drawLine(NAS2D::Point{mBottomUiRect.position.x + 1, mBottomUiRect.position.y}, NAS2D::Point{mBottomUiRect.position.x + mBottomUiRect.size.x - 2, mBottomUiRect.position.y}, NAS2D::Color{56, 56, 56});
 

--- a/appOPHD/States/MapViewStateUi.cpp
+++ b/appOPHD/States/MapViewStateUi.cpp
@@ -335,7 +335,7 @@ void MapViewState::drawUI()
 	// Bottom UI
 	renderer.drawBoxFilled(mBottomUiRect.inset(1), NAS2D::Color{39, 39, 39});
 	renderer.drawBox(mBottomUiRect, NAS2D::Color{21, 21, 21});
-	renderer.drawLine(NAS2D::Point{mBottomUiRect.position.x + 1, mBottomUiRect.position.y}, NAS2D::Point{mBottomUiRect.position.x + mBottomUiRect.size.x - 2, mBottomUiRect.position.y}, NAS2D::Color{56, 56, 56});
+	renderer.drawLine(NAS2D::Point{mBottomUiRect.position.x + 2, mBottomUiRect.position.y}, NAS2D::Point{mBottomUiRect.position.x + mBottomUiRect.size.x - 2, mBottomUiRect.position.y}, NAS2D::Color{56, 56, 56});
 
 	mMiniMap->draw(renderer);
 	mNavControl->draw(renderer);

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -144,7 +144,7 @@ void ResourceInfoBar::update()
  */
 void ResourceInfoBar::draw(NAS2D::Renderer& renderer) const
 {
-	renderer.drawBoxFilled(mRect, NAS2D::Color{39, 39, 39});
+	renderer.drawBoxFilled(mRect.inset(1), NAS2D::Color{39, 39, 39});
 	renderer.drawBox(mRect, NAS2D::Color{21, 21, 21});
 	renderer.drawLine(NAS2D::Point{1, 0}, NAS2D::Point{renderer.size().x - 1, 0}, NAS2D::Color{56, 56, 56});
 

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -146,7 +146,7 @@ void ResourceInfoBar::draw(NAS2D::Renderer& renderer) const
 {
 	renderer.drawBoxFilled(mRect, NAS2D::Color{39, 39, 39});
 	renderer.drawBox(mRect, NAS2D::Color{21, 21, 21});
-	renderer.drawLine(NAS2D::Point{1, 0}, NAS2D::Point{renderer.size().x - 2, 0}, NAS2D::Color{56, 56, 56});
+	renderer.drawLine(NAS2D::Point{1, 0}, NAS2D::Point{renderer.size().x - 1, 0}, NAS2D::Color{56, 56, 56});
 
 	// Resources
 	int x = constants::MarginTight + 12;


### PR DESCRIPTION
Update NAS2D submodule to fix an offset problem with `drawLine`, and adjust a few `drawLine` calls for border highlights.

Related:
- Issue #1754
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3293414232
- PR https://github.com/lairworks/nas2d-core/pull/1326
- PR #2138
