### PR TITLE
Remove use of global `MOUSE_COORDS` in `ResearchReport`

### DIFF
--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -104,7 +104,8 @@ ResearchReport::ResearchReport(const StructureManager& structureManager, TakeMeT
 	lstResearchTopics{{this, &ResearchReport::handleTopicChanged}},
 	txtTopicDescription{getFontMedium(), constants::PrimaryTextColor}
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &ResearchReport::onMouseDown});
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseButtonDown().connect({this, &ResearchReport::onMouseDown});
 
 	add(lstResearchTopics, {});
 
@@ -114,7 +115,8 @@ ResearchReport::ResearchReport(const StructureManager& structureManager, TakeMeT
 
 ResearchReport::~ResearchReport()
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &ResearchReport::onMouseDown});
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseButtonDown().disconnect({this, &ResearchReport::onMouseDown});
 }
 
 

--- a/appOPHD/UI/Reports/ResearchReport.cpp
+++ b/appOPHD/UI/Reports/ResearchReport.cpp
@@ -17,15 +17,11 @@
 #include <NAS2D/EnumMouseButton.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <array>
 #include <vector>
 #include <algorithm>
-
-
-extern NAS2D::Point<int> MOUSE_COORDS;	// <-- Yuck, really need to find a better way to
-										// poll mouse position. Might make sense to add a
-										// method to NAS2D::EventHandler for that.
 
 
 namespace
@@ -106,6 +102,7 @@ ResearchReport::ResearchReport(const StructureManager& structureManager, TakeMeT
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &ResearchReport::onMouseDown});
+	eventHandler.mouseMotion().connect({this, &ResearchReport::onMouseMove});
 
 	add(lstResearchTopics, {});
 
@@ -117,6 +114,7 @@ ResearchReport::~ResearchReport()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect({this, &ResearchReport::onMouseDown});
+	eventHandler.mouseMotion().disconnect({this, &ResearchReport::onMouseMove});
 }
 
 
@@ -191,6 +189,20 @@ void ResearchReport::injectTechReferences(TechnologyCatalog& catalog, ResearchTr
 void ResearchReport::onResize()
 {
 	refresh();
+}
+
+
+void ResearchReport::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
+	for (const auto& panel : mCategoryPanels)
+	{
+		if (panel.rect.contains(position))
+		{
+			mMouseHighlightPanel = &panel;
+			return;
+		}
+	}
+	mMouseHighlightPanel = nullptr;
 }
 
 
@@ -393,7 +405,7 @@ void ResearchReport::drawCategories(NAS2D::Renderer& renderer) const
 		{
 			renderer.drawBoxFilled(panelRect, constants::PrimaryColorVariant);
 		}
-		else if (panel.rect.contains(MOUSE_COORDS))
+		else if (&panel == mMouseHighlightPanel)
 		{
 			renderer.drawBoxFilled(panelRect, constants::HighlightColor);
 		}

--- a/appOPHD/UI/Reports/ResearchReport.h
+++ b/appOPHD/UI/Reports/ResearchReport.h
@@ -17,6 +17,7 @@ namespace NAS2D
 {
 	class Font;
 	class Image;
+	template <typename BaseType> struct Vector;
 }
 
 class Structure;
@@ -45,7 +46,7 @@ public:
 
 private:
 	void onResize() override;
-
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void handleMouseDownInCategories(NAS2D::Point<int>& position);
 
@@ -111,6 +112,7 @@ private:
 	TechnologyCatalog* mTechCatalog{nullptr};
 	ResearchTracker* mResearchTracker{nullptr};
 
+	const CategoryPanel* mMouseHighlightPanel{nullptr};
 	CategoryPanel* mSelectedCategory{nullptr};
 	std::vector<CategoryPanel> mCategoryPanels;
 


### PR DESCRIPTION
Add method `ResearchReport::onMouseMove` so the use of global `MOUSE_COORDS` can be removed.

This can help remove the Clang warning `-Wmissing-variable-declarations`.

Related:
- Issue #307
- PR #2140
