### PR TITLE
Refactor `ReportsState` to remove `MOUSE_COORDS` global

### DIFF
--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -28,7 +28,6 @@
 
 class Structure;
 
-extern NAS2D::Point<int> MOUSE_COORDS;
 
 namespace
 {
@@ -80,6 +79,16 @@ namespace
 			return mIsSelected;
 		}
 
+		void highlighted(bool isHighlighted)
+		{
+			mIsHighlighted = isHighlighted;
+		}
+
+		bool highlighted() const
+		{
+			return mIsHighlighted;
+		}
+
 	public:
 		Report* report = nullptr;
 		std::string name;
@@ -91,6 +100,7 @@ namespace
 
 	private:
 		bool mIsSelected = false;
+		bool mIsHighlighted = false;
 	};
 
 
@@ -144,7 +154,7 @@ namespace
 
 	void drawPanel(NAS2D::Renderer& renderer, Panel& panel, const NAS2D::Font& font)
 	{
-		if (panel.tabArea.contains(MOUSE_COORDS))
+		if (panel.highlighted())
 		{
 			renderer.drawBoxFilled(panel.tabArea, constants::HighlightColor);
 		}
@@ -178,6 +188,7 @@ ReportsState::ReportsState(const StructureManager& structureManager, TakeMeThere
 	eventHandler.windowResized().connect({this, &ReportsState::onWindowResized});
 	eventHandler.keyDown().connect({this, &ReportsState::onKeyDown});
 	eventHandler.mouseButtonDown().connect({this, &ReportsState::onMouseDown});
+	eventHandler.mouseMotion().connect({this, &ReportsState::onMouseMove});
 }
 
 
@@ -187,6 +198,7 @@ ReportsState::~ReportsState()
 	eventHandler.windowResized().disconnect({this, &ReportsState::onWindowResized});
 	eventHandler.keyDown().disconnect({this, &ReportsState::onKeyDown});
 	eventHandler.mouseButtonDown().disconnect({this, &ReportsState::onMouseDown});
+	eventHandler.mouseMotion().disconnect({this, &ReportsState::onMouseMove});
 
 	for (Panel& panel : panels)
 	{
@@ -310,6 +322,15 @@ void ReportsState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> posi
 	if (panels[ExitPanelIndex].selected())
 	{
 		onExit();
+	}
+}
+
+
+void ReportsState::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
+	for (auto& panel : panels)
+	{
+		panel.highlighted(panel.tabArea.contains(position));
 	}
 }
 

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -20,6 +20,8 @@
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
+#include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <array>
 

--- a/appOPHD/States/ReportsState.cpp
+++ b/appOPHD/States/ReportsState.cpp
@@ -295,7 +295,7 @@ void ReportsState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> posi
 	{
 		for (Panel& panel : panels)
 		{
-			bool selected = panel.tabArea.contains(MOUSE_COORDS);
+			bool selected = panel.tabArea.contains(position);
 			panel.selected(selected);
 
 			if (panel.report)

--- a/appOPHD/States/ReportsState.h
+++ b/appOPHD/States/ReportsState.h
@@ -57,6 +57,7 @@ protected:
 	void onTakeMeThere(const Structure* structure);
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onExit();
 
 	void deselectAllPanels();

--- a/appOPHD/States/ReportsState.h
+++ b/appOPHD/States/ReportsState.h
@@ -3,8 +3,6 @@
 #include "Wrapper.h"
 
 #include <NAS2D/Signal/Delegate.h>
-#include <NAS2D/Math/Point.h>
-#include <NAS2D/Math/Vector.h>
 
 #include <cstdint>
 
@@ -22,6 +20,9 @@ namespace NAS2D
 	enum class MouseButton;
 
 	class Font;
+
+	template <typename BaseType> struct Point;
+	template <typename BaseType> struct Vector;
 }
 
 

--- a/appOPHD/States/ReportsState.h
+++ b/appOPHD/States/ReportsState.h
@@ -4,6 +4,7 @@
 
 #include <NAS2D/Signal/Delegate.h>
 #include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 
 #include <cstdint>
 


### PR DESCRIPTION
Add method `ReportsState::onMouseMove` so the use of global `MOUSE_COORDS` can be removed.

This can help remove the Clang warning `-Wmissing-variable-declarations`.

Related:
- Issue #307
- PR #2141
- PR #2140
