### PR TITLE
Refactor `ResourceInfoBar` to remove `MOUSE_COORDS` global

### DIFF
--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -222,11 +222,11 @@ void ResourceInfoBar::draw(NAS2D::Renderer& renderer) const
 }
 
 
-void ResourceInfoBar::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> /*position*/)
+void ResourceInfoBar::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position)
 {
 	if (button == NAS2D::MouseButton::Left)
 	{
-		if (resourcePanelPinRect.contains(MOUSE_COORDS)) { mPinResourcePanel = !mPinResourcePanel; }
-		if (populationPanelPinRect.contains(MOUSE_COORDS)) { mPinPopulationPanel = !mPinPopulationPanel; }
+		if (resourcePanelPinRect.contains(position)) { mPinResourcePanel = !mPinResourcePanel; }
+		if (populationPanelPinRect.contains(position)) { mPinPopulationPanel = !mPinPopulationPanel; }
 	}
 }

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -17,6 +17,7 @@
 #include <NAS2D/Utility.h>
 #include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Point.h>
+#include <NAS2D/Math/Vector.h>
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
@@ -25,9 +26,6 @@
 
 #include <cstdint>
 #include <algorithm>
-
-
-extern NAS2D::Point<int> MOUSE_COORDS;
 
 
 namespace
@@ -105,6 +103,7 @@ ResourceInfoBar::ResourceInfoBar(const StorableResources& resources, const Struc
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().connect({this, &ResourceInfoBar::onMouseDown});
+	eventHandler.mouseMotion().connect({this, &ResourceInfoBar::onMouseMove});
 }
 
 
@@ -112,18 +111,19 @@ ResourceInfoBar::~ResourceInfoBar()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseButtonDown().disconnect({this, &ResourceInfoBar::onMouseDown});
+	eventHandler.mouseMotion().disconnect({this, &ResourceInfoBar::onMouseMove});
 }
 
 
 bool ResourceInfoBar::isResourcePanelVisible() const
 {
-	return mPinResourcePanel || NAS2D::Rectangle<int>{{0, 1}, {270, 19}}.contains(MOUSE_COORDS);
+	return mPinResourcePanel || mHoverResourcePanel;
 }
 
 
 bool ResourceInfoBar::isPopulationPanelVisible() const
 {
-	return mPinPopulationPanel || NAS2D::Rectangle<int>{{675, 1}, {75, 19}}.contains(MOUSE_COORDS);
+	return mPinPopulationPanel || mHoverPopulationPanel;
 }
 
 void ResourceInfoBar::ignoreGlow(const bool ignore)
@@ -230,4 +230,11 @@ void ResourceInfoBar::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> p
 		if (resourcePanelPinRect.contains(position)) { mPinResourcePanel = !mPinResourcePanel; }
 		if (populationPanelPinRect.contains(position)) { mPinPopulationPanel = !mPinPopulationPanel; }
 	}
+}
+
+
+void ResourceInfoBar::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
+{
+	mHoverResourcePanel = NAS2D::Rectangle<int>{{0, 1}, {270, 19}}.contains(position);
+	mHoverPopulationPanel = NAS2D::Rectangle<int>{{675, 1}, {75, 19}}.contains(position);
 }

--- a/appOPHD/UI/ResourceInfoBar.cpp
+++ b/appOPHD/UI/ResourceInfoBar.cpp
@@ -21,6 +21,7 @@
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Resource/Font.h>
+#include <NAS2D/Resource/Image.h>
 
 #include <cstdint>
 #include <algorithm>

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -3,13 +3,12 @@
 #include <libControls/ControlContainer.h>
 #include <libControls/ToolTip.h>
 
-#include <NAS2D/Math/Point.h>
-#include <NAS2D/Resource/Image.h>
-
 
 namespace NAS2D
 {
 	enum class MouseButton;
+	class Image;
+	template <typename BaseType> struct Point;
 }
 
 struct StorableResources;

--- a/appOPHD/UI/ResourceInfoBar.h
+++ b/appOPHD/UI/ResourceInfoBar.h
@@ -9,6 +9,7 @@ namespace NAS2D
 	enum class MouseButton;
 	class Image;
 	template <typename BaseType> struct Point;
+	template <typename BaseType> struct Vector;
 }
 
 struct StorableResources;
@@ -33,6 +34,7 @@ public:
 
 protected:
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 private:
 	const StorableResources& mResourcesCount;
@@ -54,5 +56,7 @@ private:
 
 	bool mPinResourcePanel = false;
 	bool mPinPopulationPanel = false;
+	bool mHoverResourcePanel = false;
+	bool mHoverPopulationPanel = false;
 	bool mIgnoreGlow = false;
 };


### PR DESCRIPTION
Add method `ResourceInfoBar::onMouseMove` so the use of global `MOUSE_COORDS` can be removed.

This can help remove the Clang warning `-Wmissing-variable-declarations`.

Related:
- Issue #307
- PR #2143
- PR #2142
- PR #2141
- PR #2140
