### PR TITLE
Refactor map event handling

### DIFF
--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -258,7 +258,6 @@ MapViewState::~MapViewState()
 	setCursor(PointerType::Normal);
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.activate().disconnect({this, &MapViewState::onActivate});
 	eventHandler.keyDown().disconnect({this, &MapViewState::onKeyDown});
 	eventHandler.mouseButtonDown().disconnect({this, &MapViewState::onMouseDown});
 	eventHandler.mouseDoubleClick().disconnect({this, &MapViewState::onMouseDoubleClick});
@@ -300,7 +299,6 @@ void MapViewState::initialize()
 
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 
-	eventHandler.activate().connect({this, &MapViewState::onActivate});
 	eventHandler.keyDown().connect({this, &MapViewState::onKeyDown});
 	eventHandler.mouseButtonDown().connect({this, &MapViewState::onMouseDown});
 	eventHandler.mouseDoubleClick().connect({this, &MapViewState::onMouseDoubleClick});
@@ -384,15 +382,6 @@ void MapViewState::updatePlayerResources()
 		resources += structure->storage();
 	}
 	mResourcesCount = resources;
-}
-
-
-/**
- * Window activation handler.
- */
-void MapViewState::onActivate(bool /*newActiveValue*/)
-{
-	mMiniMap->onActivate();
 }
 
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -261,7 +261,6 @@ MapViewState::~MapViewState()
 	eventHandler.activate().disconnect({this, &MapViewState::onActivate});
 	eventHandler.keyDown().disconnect({this, &MapViewState::onKeyDown});
 	eventHandler.mouseButtonDown().disconnect({this, &MapViewState::onMouseDown});
-	eventHandler.mouseButtonUp().disconnect({this, &MapViewState::onMouseUp});
 	eventHandler.mouseDoubleClick().disconnect({this, &MapViewState::onMouseDoubleClick});
 	eventHandler.windowResized().disconnect({this, &MapViewState::onWindowResized});
 
@@ -304,7 +303,6 @@ void MapViewState::initialize()
 	eventHandler.activate().connect({this, &MapViewState::onActivate});
 	eventHandler.keyDown().connect({this, &MapViewState::onKeyDown});
 	eventHandler.mouseButtonDown().connect({this, &MapViewState::onMouseDown});
-	eventHandler.mouseButtonUp().connect({this, &MapViewState::onMouseUp});
 	eventHandler.mouseDoubleClick().connect({this, &MapViewState::onMouseDoubleClick});
 }
 
@@ -564,9 +562,6 @@ void MapViewState::onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> posi
 			onChangeDepth(oldDepth, mMapView->currentDepth());
 		}
 
-		// MiniMap Check
-		mMiniMap->onMouseDown(button, position);
-
 		// Click was within the bounds of the TileMap.
 		if (mDetailMap->isMouseOverTile())
 		{
@@ -592,15 +587,6 @@ void MapViewState::onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<in
 		{
 			mReportsState.showReport(*tile.structure());
 		}
-	}
-}
-
-
-void MapViewState::onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position)
-{
-	if (button == NAS2D::MouseButton::Left)
-	{
-		mMiniMap->onMouseUp(button, position);
 	}
 }
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -360,11 +360,6 @@ NAS2D::State* MapViewState::update()
 
 	renderer.drawImageStretched(mBackground, windowClientRect);
 
-	if (!modalUiElementDisplayed())
-	{
-		mDetailMap->onMouseMove(MOUSE_COORDS);
-	}
-
 	mDetailMap->update();
 	mDetailMap->draw(renderer);
 

--- a/appOPHD/States/MapViewState.cpp
+++ b/appOPHD/States/MapViewState.cpp
@@ -263,7 +263,6 @@ MapViewState::~MapViewState()
 	eventHandler.mouseButtonDown().disconnect({this, &MapViewState::onMouseDown});
 	eventHandler.mouseButtonUp().disconnect({this, &MapViewState::onMouseUp});
 	eventHandler.mouseDoubleClick().disconnect({this, &MapViewState::onMouseDoubleClick});
-	eventHandler.mouseMotion().disconnect({this, &MapViewState::onMouseMove});
 	eventHandler.windowResized().disconnect({this, &MapViewState::onWindowResized});
 
 	mOreHaulRoutes->clear();
@@ -307,7 +306,6 @@ void MapViewState::initialize()
 	eventHandler.mouseButtonDown().connect({this, &MapViewState::onMouseDown});
 	eventHandler.mouseButtonUp().connect({this, &MapViewState::onMouseUp});
 	eventHandler.mouseDoubleClick().connect({this, &MapViewState::onMouseDoubleClick});
-	eventHandler.mouseMotion().connect({this, &MapViewState::onMouseMove});
 }
 
 
@@ -604,13 +602,6 @@ void MapViewState::onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> positi
 	{
 		mMiniMap->onMouseUp(button, position);
 	}
-}
-
-
-void MapViewState::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative)
-{
-	if (!active()) { return; }
-	mMiniMap->onMouseMove(position, relative);
 }
 
 

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -115,7 +115,6 @@ private:
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<int> position);
-	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void onInspect(const MapCoordinate& tilePosition, bool inspectModifier);

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -116,7 +116,6 @@ private:
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
-	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 	void onWindowResized(NAS2D::Vector<int> newSize);
 
 	void onInspect(const MapCoordinate& tilePosition, bool inspectModifier);

--- a/appOPHD/States/MapViewState.h
+++ b/appOPHD/States/MapViewState.h
@@ -111,7 +111,6 @@ private:
 	void onActivate() override;
 
 	// EVENT HANDLERS
-	void onActivate(bool newActiveValue);
 	void onKeyDown(NAS2D::KeyCode key, NAS2D::KeyModifier mod, bool repeat);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDoubleClick(NAS2D::MouseButton button, NAS2D::Point<int> position);

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -6,10 +6,10 @@
 
 #include <libOPHD/MapObjects/MapObject.h>
 
-#include <NAS2D/Renderer/Color.h>
-#include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Utility.h>
 #include <NAS2D/EventHandler.h>
+#include <NAS2D/Renderer/Color.h>
+#include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Math/PointInRectangleRange.h>
 
 #include <map>

--- a/appOPHD/UI/DetailMap.cpp
+++ b/appOPHD/UI/DetailMap.cpp
@@ -9,6 +9,7 @@
 #include <NAS2D/Renderer/Color.h>
 #include <NAS2D/Renderer/Renderer.h>
 #include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/PointInRectangleRange.h>
 
 #include <map>
@@ -72,6 +73,16 @@ DetailMap::DetailMap(MapView& mapView, TileMap& tileMap, const std::string& tile
 	mMineBeacon{"structures/mine_beacon.png"}
 {
 	size(NAS2D::Utility<NAS2D::Renderer>::get().size());
+
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().connect({this, &DetailMap::onMouseMove});
+}
+
+
+DetailMap::~DetailMap()
+{
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().disconnect({this, &DetailMap::onMouseMove});
 }
 
 
@@ -179,7 +190,7 @@ void DetailMap::drawGrid(NAS2D::Renderer& renderer) const
 }
 
 
-void DetailMap::onMouseMove(NAS2D::Point<int> position)
+void DetailMap::onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> /*relative*/)
 {
 	const auto pixelOffset = position - mOriginPixelPosition;
 	const auto tileOffset = NAS2D::Vector{pixelOffset.x * TileSize.y + pixelOffset.y * TileSize.x, pixelOffset.y * TileSize.x - pixelOffset.x * TileSize.y} / (TileSize.x * TileSize.y);

--- a/appOPHD/UI/DetailMap.h
+++ b/appOPHD/UI/DetailMap.h
@@ -15,19 +15,19 @@ class DetailMap : public Control
 {
 public:
 	DetailMap(MapView& mapView, TileMap& tileMap, const std::string& tilesetPath);
+	~DetailMap() override;
 
 	bool isMouseOverTile() const;
 
 	MapCoordinate mouseTilePosition() const;
 	Tile& mouseTile();
 
-	void onMouseMove(NAS2D::Point<int> position);
-
 	void update() override;
 	void draw(NAS2D::Renderer& renderer) const override;
 
 protected:
 	void onResize() override;
+	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);
 
 	void drawGrid(NAS2D::Renderer& renderer) const;
 

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -41,6 +41,7 @@ MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& str
 	mUiIcons{getImage("ui/icons.png")}
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.activate().connect({this, &MiniMap::onActivate});
 	eventHandler.mouseMotion().connect({this, &MiniMap::onMouseMove});
 	eventHandler.mouseButtonDown().connect({this, &MiniMap::onMouseDown});
 	eventHandler.mouseButtonUp().connect({this, &MiniMap::onMouseUp});
@@ -50,6 +51,7 @@ MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& str
 MiniMap::~MiniMap()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.activate().disconnect({this, &MiniMap::onActivate});
 	eventHandler.mouseMotion().disconnect({this, &MiniMap::onMouseMove});
 	eventHandler.mouseButtonDown().disconnect({this, &MiniMap::onMouseDown});
 	eventHandler.mouseButtonUp().disconnect({this, &MiniMap::onMouseUp});
@@ -131,7 +133,7 @@ void MiniMap::draw(NAS2D::Renderer& renderer) const
 }
 
 
-void MiniMap::onActivate()
+void MiniMap::onActivate(bool /*newActiveValue*/)
 {
 	mLeftButtonDown = false;
 }

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -13,6 +13,8 @@
 #include <libOPHD/MapObjects/OreDeposit.h>
 
 #include <NAS2D/EnumMouseButton.h>
+#include <NAS2D/Utility.h>
+#include <NAS2D/EventHandler.h>
 #include <NAS2D/Math/Vector.h>
 #include <NAS2D/Math/Rectangle.h>
 #include <NAS2D/Renderer/Color.h>
@@ -37,7 +39,17 @@ MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& str
 	mBackgroundSatellite{mapName + MapDisplayExtension},
 	mBackgroundHeightMap{mapName + MapTerrainExtension},
 	mUiIcons{getImage("ui/icons.png")}
-{}
+{
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().connect({this, &MiniMap::onMouseMove});
+}
+
+
+MiniMap::~MiniMap()
+{
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().disconnect({this, &MiniMap::onMouseMove});
+}
 
 
 bool MiniMap::heightMapVisible() const

--- a/appOPHD/UI/MiniMap.cpp
+++ b/appOPHD/UI/MiniMap.cpp
@@ -42,6 +42,8 @@ MiniMap::MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& str
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseMotion().connect({this, &MiniMap::onMouseMove});
+	eventHandler.mouseButtonDown().connect({this, &MiniMap::onMouseDown});
+	eventHandler.mouseButtonUp().connect({this, &MiniMap::onMouseUp});
 }
 
 
@@ -49,6 +51,8 @@ MiniMap::~MiniMap()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
 	eventHandler.mouseMotion().disconnect({this, &MiniMap::onMouseMove});
+	eventHandler.mouseButtonDown().disconnect({this, &MiniMap::onMouseDown});
+	eventHandler.mouseButtonUp().disconnect({this, &MiniMap::onMouseUp});
 }
 
 
@@ -133,9 +137,12 @@ void MiniMap::onActivate()
 }
 
 
-void MiniMap::onMouseUp(NAS2D::MouseButton /*button*/, NAS2D::Point<int> /*position*/)
+void MiniMap::onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> /*position*/)
 {
-	mLeftButtonDown = false;
+	if (button == NAS2D::MouseButton::Left)
+	{
+		mLeftButtonDown = false;
+	}
 }
 
 

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -29,6 +29,7 @@ class MiniMap : public Control
 {
 public:
 	MiniMap(MapView& mapView, TileMap& tileMap, const StructureManager& structureManager, const std::vector<Robot*>& deployedRobots, const OreHaulRoutes& oreHaulRoutes, const std::string& mapName);
+	~MiniMap() override;
 
 	bool heightMapVisible() const;
 	void heightMapVisible(bool isVisible);

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -38,7 +38,7 @@ public:
 
 protected:
 	friend MapViewState;
-	void onActivate();
+	void onActivate(bool newActiveValue);
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> relative);

--- a/appOPHD/UI/MiniMap.h
+++ b/appOPHD/UI/MiniMap.h
@@ -37,7 +37,6 @@ public:
 	void draw(NAS2D::Renderer& renderer) const override;
 
 protected:
-	friend MapViewState;
 	void onActivate(bool newActiveValue);
 	void onMouseUp(NAS2D::MouseButton button, NAS2D::Point<int> position);
 	void onMouseDown(NAS2D::MouseButton button, NAS2D::Point<int> position);


### PR DESCRIPTION
Make `DetailMap` and `MiniMap` responsible for their own event listening, rather than require `MapViewState` to pass them events.

This makes the controls more standalone, and consistent with how other controls manage events.

Related:
- Issue #307
- PR #2144
- PR #2142
- PR #2141
- PR #2140
