### PR TITLE
Add `AnimationSet` cache

### DIFF
--- a/appOPHD/CacheImage.cpp
+++ b/appOPHD/CacheImage.cpp
@@ -1,12 +1,14 @@
 #include "CacheImage.h"
 
 #include <NAS2D/Resource/Image.h>
+#include <NAS2D/Resource/AnimationSet.h>
 #include <NAS2D/Resource/ResourceCache.h>
 
 
 namespace
 {
 	NAS2D::ResourceCache<NAS2D::Image, std::string> imageCache;
+	NAS2D::ResourceCache<NAS2D::AnimationSet, std::string> animationSetCache;
 }
 
 
@@ -19,4 +21,10 @@ NAS2D::ResourceCache<NAS2D::Image, std::string>& getImageCache()
 const NAS2D::Image& getImage(const std::string& imageName)
 {
 	return imageCache.load(imageName);
+}
+
+
+const NAS2D::AnimationSet& getAnimationSet(const std::string& filePath)
+{
+	return animationSetCache.load(filePath);
 }

--- a/appOPHD/CacheImage.h
+++ b/appOPHD/CacheImage.h
@@ -6,6 +6,7 @@
 namespace NAS2D
 {
 	class Image;
+	class AnimationSet;
 	template <typename Resource, typename... Params> class ResourceCache;
 }
 
@@ -13,3 +14,4 @@ namespace NAS2D
 NAS2D::ResourceCache<NAS2D::Image, std::string>& getImageCache();
 
 const NAS2D::Image& getImage(const std::string& imageName);
+const NAS2D::AnimationSet& getAnimationSet(const std::string& filePath);

--- a/appOPHD/MapObjects/MapObject.cpp
+++ b/appOPHD/MapObjects/MapObject.cpp
@@ -1,10 +1,12 @@
 #include "MapObject.h"
 
+#include "../CacheImage.h"
+
 #include <NAS2D/Math/Point.h>
 
 
 MapObject::MapObject(const std::string& spritePath, const std::string& initialAction) :
-	mSprite(spritePath, initialAction)
+	mSprite(getAnimationSet(spritePath), initialAction)
 {}
 
 


### PR DESCRIPTION
Add `AnimationSet` cache to allow code to create a `Sprite` instance using an `AnimationSet` cache under custom control, rather than relying on a cache in NAS2D. We should strive to avoid using object instances that live in NAS2D, as we don't control the lifetime of such objects. Ideally libraries should provide types and code rather than object instances.

With the `AnimationSet` cache update, we no longer use or need the `Sprite` constructor overload that takes a `filePath`. Instead we load data into an `AnimationSet` instance first, and then create a `Sprite` from the `AnimationSet`.

Update NAS2D for the removal of the `Sprite` constructor taking a `filePath`.

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/991
- PR https://github.com/lairworks/nas2d-core/pull/1336
- PR #2152
