### PR TITLE
Update NAS2D - Distinct path types

### DIFF
--- a/appOPHD/States/GameState.cpp
+++ b/appOPHD/States/GameState.cpp
@@ -173,7 +173,7 @@ void GameState::onLoadGame(const std::string& saveGameName)
 	auto saveGamePath = constants::SaveGamePath + saveGameName + ".xml";
 	try
 	{
-		if (!filesystem.exists(saveGamePath)) { throw std::runtime_error("Save game file does not exist: " + saveGamePath); }
+		if (!filesystem.exists(NAS2D::VirtualPath{saveGamePath})) { throw std::runtime_error("Save game file does not exist: " + saveGamePath); }
 	}
 	catch (const std::exception& e)
 	{
@@ -196,7 +196,7 @@ void GameState::onSaveGame(const std::string& saveGameName)
 	NAS2D::Xml::XmlMemoryBuffer buff;
 	savedGameFile.savedGameDocument().accept(&buff);
 
-	NAS2D::Utility<NAS2D::Filesystem>::get().writeFile(saveGamePath, buff.buffer());
+	NAS2D::Utility<NAS2D::Filesystem>::get().writeFile(NAS2D::VirtualPath{saveGamePath}, buff.buffer());
 }
 
 

--- a/appOPHD/UI/FileIo.cpp
+++ b/appOPHD/UI/FileIo.cpp
@@ -92,13 +92,13 @@ void FileIo::scanDirectory(const std::string& directory)
 	mScanPath = (NAS2D::Utility<NAS2D::Filesystem>::get().prefPath() / directory).string();
 
 	const auto& filesystem = NAS2D::Utility<NAS2D::Filesystem>::get();
-	auto dirList = filesystem.directoryList(directory);
+	auto dirList = filesystem.directoryList(NAS2D::VirtualPath{directory});
 	std::sort(dirList.begin(), dirList.end());
 
 	mListBox.clear();
 	for (auto& dir : dirList)
 	{
-		if (!filesystem.isDirectory(directory + dir.string()))
+		if (!filesystem.isDirectory(NAS2D::VirtualPath{directory + dir.string()}))
 		{
 			mListBox.add(dir.stem().string());
 		}
@@ -208,7 +208,7 @@ void FileIo::onFileDelete()
 	{
 		if(doYesNoMessage(constants::WindowFileIoTitleDelete, "Are you sure you want to delete " + mFileName.text() + "?"))
 		{
-			NAS2D::Utility<NAS2D::Filesystem>::get().del(filename);
+			NAS2D::Utility<NAS2D::Filesystem>::get().del(NAS2D::VirtualPath{filename});
 		}
 	}
 	catch(const std::exception& e)

--- a/appOPHD/main.cpp
+++ b/appOPHD/main.cpp
@@ -69,11 +69,11 @@ int main(int argc, char *argv[])
 	try
 	{
 		auto& filesystem = NAS2D::Utility<NAS2D::Filesystem>::init<NAS2D::Filesystem>("OutpostHD", "LairWorks");
-		filesystem.mountSoftFail("data");
-		filesystem.mount(filesystem.findInParents("data", filesystem.basePath()));
+		filesystem.mountSoftFail(NAS2D::RealPath{"data"});
+		filesystem.mount(filesystem.findInParents(NAS2D::RealPath{"data"}, filesystem.basePath()));
 		filesystem.mountReadWrite(filesystem.prefPath());
 
-		filesystem.makeDirectory(constants::SaveGamePath);
+		filesystem.makeDirectory(NAS2D::VirtualPath{constants::SaveGamePath});
 
 		NAS2D::Configuration& cf = NAS2D::Utility<NAS2D::Configuration>::init(
 			std::map<std::string, NAS2D::Dictionary>{
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
 		if (argc > 1)
 		{
 			std::string filename = constants::SaveGamePath + argv[1] + ".xml";
-			if (!filesystem.exists(filename))
+			if (!filesystem.exists(NAS2D::VirtualPath{filename}))
 			{
 				std::cout << "Savegame specified on command line: " << argv[1] << " could not be found." << std::endl;
 				stateManager.setState(new MainMenuState());

--- a/libOPHD/XmlSerializer.cpp
+++ b/libOPHD/XmlSerializer.cpp
@@ -8,7 +8,7 @@
 NAS2D::Xml::XmlDocument openXmlFile(std::string filename, std::string rootElementName)
 {
 	NAS2D::Xml::XmlDocument xmlDocument;
-	xmlDocument.parse(NAS2D::Utility<NAS2D::Filesystem>::get().readFile(filename).c_str());
+	xmlDocument.parse(NAS2D::Utility<NAS2D::Filesystem>::get().readFile(NAS2D::VirtualPath{filename}).c_str());
 
 	if (xmlDocument.error())
 	{


### PR DESCRIPTION
Update NAS2D submodule for distinct path types `RealPath` and `VirtualPath`

Previously both path types were an alias to the same underlying type `FilesystemPath`, which made them interchangeable. Now they are `struct` definitions producing distinct types, so it would now be an error to interchange these types. As the type checking is now more strict, we need to be more explicit about which path type we are constructing.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1349
