### PR TITLE
Fix missing `<vector>` includes and update NAS2D submodule

### DIFF
--- a/appOPHD/MapObjects/Structure.h
+++ b/appOPHD/MapObjects/Structure.h
@@ -190,6 +190,3 @@ protected:
 	bool mConnected{false};
 	bool mForcedIdle{false}; /**< Indicates that the Structure was manually set to Idle by the user and should remain that way until the user says otherwise. */
 };
-
-
-using StructureList = std::vector<Structure*>;

--- a/appOPHD/MapObjects/Structures/Factory.h
+++ b/appOPHD/MapObjects/Structures/Factory.h
@@ -6,6 +6,8 @@
 
 #include <NAS2D/Signal/Delegate.h>
 
+#include <vector>
+
 
 struct ProductionCost;
 struct StorableResources;

--- a/appOPHD/MapObjects/Structures/MaintenanceFacility.h
+++ b/appOPHD/MapObjects/Structures/MaintenanceFacility.h
@@ -2,8 +2,12 @@
 
 #include "../Structure.h"
 
+#include <vector>
+
 
 struct StorableResources;
+
+using StructureList = std::vector<Structure*>;
 
 
 class MaintenanceFacility : public Structure


### PR DESCRIPTION
Fix missing `<vector>` includes and update NAS2D submodule to latest, which removed an unnecessary include for `<vector>` from the `Sprite` header.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1357
- PR https://github.com/lairworks/nas2d-core/pull/1358
- PR https://github.com/lairworks/nas2d-core/pull/1359
