### PR TITLE
Add explicit includes for `Xml` classes

### DIFF
--- a/appOPHD/IOHelper.cpp
+++ b/appOPHD/IOHelper.cpp
@@ -5,6 +5,7 @@
 #include <libOPHD/StorableResources.h>
 
 #include <NAS2D/ParserHelper.h>
+#include <NAS2D/Xml/XmlElement.h>
 
 
 StorableResources readResourcesOptional(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName, const StorableResources& defaultValue)

--- a/appOPHD/States/MapViewStateIO.cpp
+++ b/appOPHD/States/MapViewStateIO.cpp
@@ -44,6 +44,7 @@
 #include <NAS2D/StringUtils.h>
 #include <NAS2D/Xml/XmlDocument.h>
 #include <NAS2D/Xml/XmlMemoryBuffer.h>
+#include <NAS2D/Xml/XmlElement.h>
 #include <NAS2D/Dictionary.h>
 #include <NAS2D/ParserHelper.h>
 #include <NAS2D/ContainerUtils.h>

--- a/appOPHD/StructureCatalog.cpp
+++ b/appOPHD/StructureCatalog.cpp
@@ -10,6 +10,8 @@
 
 #include <NAS2D/Filesystem.h>
 #include <NAS2D/ParserHelper.h>
+#include <NAS2D/Xml/XmlDocument.h>
+#include <NAS2D/Xml/XmlElement.h>
 
 #include <array>
 #include <vector>

--- a/appOPHD/StructureManager.cpp
+++ b/appOPHD/StructureManager.cpp
@@ -22,6 +22,7 @@
 #include <libOPHD/Population/PopulationPool.h>
 
 #include <NAS2D/ParserHelper.h>
+#include <NAS2D/Xml/XmlElement.h>
 
 #include <algorithm>
 #include <stdexcept>

--- a/libOPHD/ProductCatalog.cpp
+++ b/libOPHD/ProductCatalog.cpp
@@ -3,6 +3,8 @@
 #include "XmlSerializer.h"
 
 #include <NAS2D/ParserHelper.h>
+#include <NAS2D/Xml/XmlDocument.h>
+#include <NAS2D/Xml/XmlElement.h>
 
 #include <map>
 #include <stdexcept>


### PR DESCRIPTION
These were brought in transitively through `ParserHelper.h`, which may be modified to use forward declares.

Related:
- Issue #1573
