### PR TITLE
Update NAS2D submodule for `Delegate` simplifications

### DIFF
--- a/appOPHD/States/CrimeExecution.cpp
+++ b/appOPHD/States/CrimeExecution.cpp
@@ -69,7 +69,7 @@ CrimeExecution::CrimeExecution(const Difficulty& difficulty, CrimeEventDelegate 
 	mDifficulty{difficulty},
 	mCrimeEventHandler{crimeEventHandler}
 {
-	if (mCrimeEventHandler.empty())
+	if (!mCrimeEventHandler)
 	{
 		throw std::runtime_error("CrimeExecution needs a non-empty crimeEventHandler");
 	}

--- a/appOPHD/UI/DiggerDirection.cpp
+++ b/appOPHD/UI/DiggerDirection.cpp
@@ -34,7 +34,7 @@ DiggerDirection::DiggerDirection(DirectionSelectedDelegate directionSelectedHand
 
 	add(btnCancel, {5, 140});
 
-	if (directionSelectedHandler.empty())
+	if (!directionSelectedHandler)
 	{
 		throw std::runtime_error("DiggerDirection needs a non-empty directionSelectedHandler");
 	}


### PR DESCRIPTION
Use `Delegate::operator!` to simplify checks

The `Delegate::empty()` method will be removed as unnecessary duplicate functionality.

Related:
- https://github.com/lairworks/nas2d-core/pull/1432
- https://github.com/lairworks/nas2d-core/issues/1423
