### PR TITLE
Update MacOS build environment to xcode `26.2.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "16.4.0"
+      xcode: "26.2.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:


### PR DESCRIPTION
Latest available version that is not marked as a Release Candidate. There is a `26.3.0`, though it is marked as "RC".

https://circleci.com/docs/guides/execution-managed/using-macos/#supported-xcode-versions

Update NAS2D submodule for corresponding update to MacOS build environment. This is not needed, but helps to track related changes.

----

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1434
- Issue https://github.com/lairworks/nas2d-core/issues/1431
