### PR TITLE
Update GitHub actions for `Node.js` 20 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       run: git submodule update --init nas2d-core/
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.3.2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       VcpkgManifestInstall: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Checkout NAS2D
       run: git submodule update --init nas2d-core/
@@ -171,7 +171,7 @@ jobs:
     steps:
     - run: sudo apt update && sudo apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libgtest-dev libgmock-dev
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" ophd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         echo "cacheKeyPrefixOphd=${cacheKeyPrefixOphd}" >> $GITHUB_ENV
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cacheRestoreVcpkg
       with:
         path: vcpkg_installed
@@ -64,7 +64,7 @@ jobs:
         msbuild . /target:appOPHD:VcpkgInstallManifestDependencies
 
     - name: Save vcpkg dependency cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
       with:
         path: vcpkg_installed
@@ -92,7 +92,7 @@ jobs:
         find nas2d-core/ -type f -exec touch -d "${commitTime}" '{}' +
 
     - name: Restore NAS2D cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cacheRestoreNas2d
       if: steps.cacheRestoreVcpkg.outputs.cache-hit == 'true'
       with:
@@ -104,14 +104,14 @@ jobs:
         msbuild . /maxCpuCount /warnAsError /property:RunCodeAnalysis=true /target:NAS2D
 
     - name: Save build cache - NAS2D
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.cacheRestoreNas2d.outputs.cache-hit != 'true'
       with:
         path: nas2d-core/.build/
         key: ${{ env.cacheKeyNas2d }}
 
     - name: Restore incremental build cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cacheRestoreOphd
       if: steps.cacheRestoreNas2d.outputs.cache-hit == 'true' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
       with:
@@ -153,7 +153,7 @@ jobs:
         msbuild . /maxCpuCount /warnAsError /property:RunCodeAnalysis=true
 
     - name: Save incremental build cache - OPHD
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.cacheRestoreOphd.outputs.cache-hit != 'true'
       with:
         path: .build


### PR DESCRIPTION
This should address the warnings on the run summary page:
> Node.js 20 actions are deprecated.

----

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1446
- Issue https://github.com/lairworks/nas2d-core/issues/528
