### PR TITLE
Update Vcpkg baseline to latest available on CI runners

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,5 +9,5 @@
     "sdl2-mixer",
     "gtest"
   ],
-  "builtin-baseline": "f3a67b0c4d7b0ee4feaf912ed1729ed1c4419826"
+  "builtin-baseline": "031f4afe03be385aee354f15be6e6b1fe57497c7"
 }


### PR DESCRIPTION
This will cause updated packages to be used. It also makes it a bit easier to test the code with newly available packages, that might not have been present in the old baseline.

If someone has an older install of `vcpkg`, they may need to update it to support the newer baseline.

Related:
- https://github.com/lairworks/nas2d-core/pull/1464

----

Update NAS2D submodule to latest for related change. See individual commit messages for updates and fixes that are included since the last submodule update.
