### PR TITLE
Move `#include` outside of unnamed namespace

### DIFF
--- a/appOPHD/ShellOpenPath.cpp
+++ b/appOPHD/ShellOpenPath.cpp
@@ -4,12 +4,15 @@
 #include <cstdlib>
 #include <tuple>
 
+#if defined(_WIN32)
+	#include <windows.h>
+	#include <shellapi.h>
+#endif
+
 
 namespace
 {
 	#if defined(_WIN32)
-		#include <windows.h>
-		#include <shellapi.h>
 	#elif defined(__APPLE__)
 		constexpr const std::string_view ShellOpenCommand{"open"};
 	#elif defined(__linux__) || defined(__FreeBSD__)


### PR DESCRIPTION
Names defined in the headers would be placed in the unnamed namespace rather than global scope.

----

On `ARM64` with MSVC the nested `#include` emits the errors:
> ```
> error C2664: 'unsigned int `anonymous-namespace'::_InterlockedIncrement(volatile unsigned int *)': cannot convert argument 1 from 'volatile long *' to 'volatile unsigned int *'
> error C2665: '`anonymous-namespace'::_InterlockedIncrement': no overloaded function could convert all the argument types
> ```

----

Added unnamed `namespace` in PR #1165, commit: 3a07a4295f7824080e60a97c78cec09515b67341

Added `#include` to existing `#if defined(_WIN32)` block in PR #1305, commit 7c5afafca04132c5462df71699f1ab41fb44ec13

----

Closes #2192

Related:
- Issue #2192
- Issue #1860
