### PR TITLE
Use `msbuild` to run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,10 @@ jobs:
         key: ${{ env.cacheKeyOphd }}
 
     - name: Run libOPHD unit tests
-      run: .build/${{env.Configuration}}_${{env.Platform}}_testLibOPHD/testLibOPHD.exe
+      run: msbuild /target:testLibOPHD:Run
 
     - name: Run libControls unit tests
-      run: .build/${{env.Configuration}}_${{env.Platform}}_testLibControls/testLibControls.exe
+      run: msbuild /target:testLibControls:Run
 
   linux-arm:
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
We no longer need to worry about changes to `OutDir` or the target filename. Knowing just the project name is enough. We also don't need to worry about setting the `working-directory`.

This does adjust the logs slightly as there is now `msbuild` output wrapping the unit test runs.

Related:
- Issue #1860
  - https://github.com/OutpostUniverse/OPHD/issues/1860#issuecomment-4529074927
  - https://github.com/OutpostUniverse/OPHD/issues/1860#issuecomment-4529159076
- PR https://github.com/lairworks/nas2d-core/pull/1470