### PR TITLE
Disable the Help button in main menu

### DIFF
--- a/appOPHD/States/MainMenuState.cpp
+++ b/appOPHD/States/MainMenuState.cpp
@@ -28,7 +28,9 @@ MainMenuState::MainMenuState() :
 	mReturnState{this},
 	mFade{{this, &MainMenuState::onFadeComplete}},
 	mFileIoDialog{{this, &MainMenuState::onLoadGame}}
-{}
+{
+	buttons[2].enabled(false);
+}
 
 
 MainMenuState::~MainMenuState()
@@ -117,6 +119,8 @@ void MainMenuState::enableButtons()
 	{
 		button.enabled(true);
 	}
+
+	buttons[2].enabled(false);
 }
 
 


### PR DESCRIPTION
Disables the 'Help' button for now since it doesn't really work well on Windows and I want to build a UI to handle this in came, kind of like the Civilopedia in the Civilization series of games.