### PR TITLE
Remove `HOMEBREW_NO_AUTO_UPDATE` setting for MacOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
     macos:
       xcode: "26.5"
     environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/


### PR DESCRIPTION
We seem to get a lot of MacOS build errors related to `brew` installing dependencies.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1482
