### PR TITLE
Remove obsolete `ToolsVersion` on `Project` element

### DIFF
--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/appOPHD/appOPHD.vcxproj
+++ b/appOPHD/appOPHD.vcxproj
@@ -71,9 +71,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup>
-    <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
     <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
   </PropertyGroup>


### PR DESCRIPTION
Increase consistency between project files, since the setting is now obsolete, and only the `appOPHD` project had this value set.

Documentation:
https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-toolset-toolsversion?view=visualstudio
> The MSBuild ToolsVersion attribute on the Project element in Visual Studio and MSBuild project files is considered obsolete in Visual Studio 2019 and later; you can safely delete it.

----

Also remove the obsolete `_ProjectFileVersion` setting.

----

Related:
- Issue #2196
- PR https://github.com/lairworks/nas2d-core/pull/1492
