### PR TITLE
Fix MacOS CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
     macos:
       xcode: "26.5"
     environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/


### PR DESCRIPTION
Ignore `brew install` exit code

The exit code may only indicate a warning, not a real problem. For example:
> Warning: The post-install step did not complete successfully
> You can try again using:
>   brew postinstall glib

----

Related:
- PR #2199
- PR https://github.com/lairworks/nas2d-core/pull/1499
