### PR TITLE
Normalize use of `CAExcludePath` across all projects

### DIFF
--- a/demoLibControls/demoLibControls.vcxproj
+++ b/demoLibControls/demoLibControls.vcxproj
@@ -200,4 +200,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;MicroPather;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>

--- a/libControls/libControls.vcxproj
+++ b/libControls/libControls.vcxproj
@@ -207,4 +207,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;MicroPather;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>

--- a/libOPHD/libOPHD.vcxproj
+++ b/libOPHD/libOPHD.vcxproj
@@ -213,4 +213,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;MicroPather;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The `CAExcludePath` property is not initialized with a default value until `Microsoft.CodeAnalysis.Targets`, so any override needs to happen after the `Import` of `Microsoft.Cpp.targets`.

----

Related:
- Issue #2196
- PR https://github.com/lairworks/nas2d-core/pull/1495
