### PR TITLE
Add explicit checkout step for NAS2D submodule to Arm build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,9 @@ jobs:
 
     - uses: actions/checkout@v6
 
+    - name: Checkout NAS2D
+      run: git submodule update --init nas2d-core/
+
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" ophd
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibOPHD


### PR DESCRIPTION
The build needs both the OPHD repository and the NAS2D repository. The `makefile` can compensate by automatically doing a checkout of submodules as part of the build. Though the automatic checkout includes both the NAS2D submodule and the OPHD-assets submodule. The assets are not needed for a regular build, so would be a waste of time and bandwidth to download. Plus, doing the checkout of the NAS2D submodule as part of the build means the time needed for that download gets included as part of the build, rather than tracked separately.

Related:
- Issue #2233

Closes #2233
