### PR TITLE
Remove `package` target from `makefile`

### DIFF
--- a/makefile
+++ b/makefile
@@ -316,21 +316,6 @@ clean-all:
 	-rm -f $(ophd_OUTPUT)
 
 
-## Package ##
-
-PACKAGEDIR := $(ROOTBUILDDIR)/package/
-VERSION = $(shell git describe --tags --dirty)
-CONFIG = $(TARGET_OS)-$(TARGET_PLATFORM)
-PACKAGE_NAME = $(PACKAGEDIR)ophd-$(VERSION)-$(CONFIG).tar.gz
-
-.PHONY: package
-package: $(PACKAGE_NAME)
-
-$(PACKAGE_NAME): $(ophd_OUTPUT)
-	@mkdir -p "$(PACKAGEDIR)"
-	tar -czf $(PACKAGE_NAME) $(ophd_OUTPUT)
-
-
 ## Dependencies ##
 
 .PHONY: install-dependencies


### PR DESCRIPTION
This target wasn't really used or needed, and wasn't particularly useful in it's current form. Removing it removes warnings messages during certain builds.

The problem with the rule is the `$(PACKAGE_NAME)` target forced recurive evaulation of variables, which evaluated the `VERSION` variable, which called the shell command `git describe --tags --dirty`, which produced the warning messages. There was no way to fix this so long as a variable name was used as a target in the current `makefile` and needed the `VERSION` variable to be evaluated.

Related:
- Issue #2235
- Issue #2233

Closes #2235
