### PR TITLE
Use `apt-get` instead of `apt` in scripted workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-    - run: sudo apt update && sudo apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libgtest-dev libgmock-dev
+    - run: sudo apt-get update && sudo apt-get --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libgtest-dev libgmock-dev
 
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
Fix warning:
> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

----

Noticed this while fixing other warnings noticed in the Linux Arm build logs.

Related:
- Issue #2233
- Issue #2235
- Issue #1860
