### PR TITLE
Remove useless `dynamic_cast`

### DIFF
--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -410,7 +410,7 @@ void MapViewState::transferFoodToCommandCenter()
 
 		while (foodProducerIterator != foodProducers.end())
 		{
-			auto foodProducer = dynamic_cast<FoodProduction*>(*foodProducerIterator);
+			auto* foodProducer = *foodProducerIterator;
 			const int foodMoved = std::clamp(foodToMove, 0, foodProducer->foodLevel());
 			foodProducer->foodLevel(foodProducer->foodLevel() - foodMoved);
 			commandCenter->foodLevel(commandCenter->foodLevel() + foodMoved);


### PR DESCRIPTION
Fix Clang warning `-Wuseless-cast`.

----

The initial version of the code needed a cast (`static_cast`) since the early version of `StrutcureManager::structureList` filtered by `enum StructureClass` and returned results in a `std::vector` of `Structure*`. Eventually the code was upgraded to use the newer templated `StructureManager::structures` (later renamed `getStructures`) which uses `dynamic_cast` to filter and returns a `std::vector` of the specific derived structure type. With this method there is no longer a need for the caller to cast. Right after that change, the `-Wuseless-cast` flag was used to scan for no longer needed casts and remove them. The `-Wuseless-cast` flag did not flag the cast being updated here, even though it probably should have. Later the `static_cast` was switched to a `dynamic_cast`. At this point, the `-Wuseless-cast` flag now reports the cast. Though we weren't checking with that flag at that time.

----

Related:
- Issue #307
- PR #2238 (Required update to warning flags)
- PR #769
  - Commit c03f3ae98f5b3c14e1794119a89926cc9639b0db (Initial implementation)
- PR #916
  - Commit 5e454674cd8a88adb024ca04e9f8867b26a6b01b (Switch to temlated `structure` method)
  - Commit 78c9dccab8d487416b2e57c65f72164e114252c4 (Remove casts flagged by `-Wuseless-cast`)
- PR #1727
  - Commit becfa4561336eb3d7a23be754d3b436f7435d89e (Switch from `static_cast` to `dynamic_cast`)
