### PR TITLE
Simplify Linux warning flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-clang:1.6
     environment:
       Toolchain: "clang"
-      WARN_EXTRA: "-Wno-weak-vtables -Wno-switch-enum -Wno-switch-default -Wno-missing-variable-declarations -Wno-float-equal -Wno-comma -Wno-nrvo"
+      WARN_EXTRA: "-Wno-nrvo"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.7
     environment:
       Toolchain: "gcc"
-      WARN_EXTRA: "-Wno-useless-cast -Wno-effc++"
+      WARN_EXTRA: "-Wno-effc++"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
@@ -50,7 +50,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.16
     environment:
       Toolchain: "mingw"
-      WARN_EXTRA: "-Wno-useless-cast -Wno-effc++"
+      WARN_EXTRA: "-Wno-effc++"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.7
     environment:
       Toolchain: "gcc"
-      WARN_EXTRA: ""
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
@@ -50,7 +49,6 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.16
     environment:
       Toolchain: "mingw"
-      WARN_EXTRA: ""
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.7
     environment:
       Toolchain: "gcc"
-      WARN_EXTRA: "-Wno-effc++"
+      WARN_EXTRA: ""
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
@@ -50,7 +50,7 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.16
     environment:
       Toolchain: "mingw"
-      WARN_EXTRA: "-Wno-effc++"
+      WARN_EXTRA: ""
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ PkgConfig := pkg-config
 WarnFlags := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wfloat-conversion -Wsign-conversion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wunknown-pragmas -Wmissing-format-attribute -Wredundant-decls -Wformat=2
 
 gccCXX := g++
-gccWarnFlags := $(WarnFlags) -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Weffc++
+gccWarnFlags := $(WarnFlags) -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast
 gccPkgConfig := $(PkgConfig)
 gccTARGET_OS := $(TARGET_OS)
 


### PR DESCRIPTION
Remove duplicate, outdated, and contrary warning flags.

Related:
- Issue #307
- PR #2239
- PR #2238
