### PR TITLE
Update Linux builds - Implied `Toolchain`, Fix NRVO warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
       - image: ghcr.io/lairworks/build-env-nas2d-clang:1.7
     environment:
       Toolchain: "clang"
-      WARN_EXTRA: "-Wno-nrvo"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ jobs:
   build-linux-gcc:
     docker:
       - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.8
-    environment:
-      Toolchain: "gcc"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
@@ -37,8 +35,6 @@ jobs:
   build-linux-clang:
     docker:
       - image: ghcr.io/lairworks/build-env-nas2d-clang:1.7
-    environment:
-      Toolchain: "clang"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/
@@ -46,8 +42,6 @@ jobs:
   build-linux-mingw:
     docker:
       - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.17
-    environment:
-      Toolchain: "mingw"
     steps:
       - checkout
       - run: git submodule update --init nas2d-core/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - build
   build-linux-gcc:
     docker:
-      - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.7
+      - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.8
     environment:
       Toolchain: "gcc"
     steps:
@@ -36,7 +36,7 @@ jobs:
       - build
   build-linux-clang:
     docker:
-      - image: ghcr.io/lairworks/build-env-nas2d-clang:1.6
+      - image: ghcr.io/lairworks/build-env-nas2d-clang:1.7
     environment:
       Toolchain: "clang"
       WARN_EXTRA: "-Wno-nrvo"
@@ -46,7 +46,7 @@ jobs:
       - build
   build-linux-mingw:
     docker:
-      - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.16
+      - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.17
     environment:
       Toolchain: "mingw"
     steps:

--- a/libOPHD/Technology/TechnologyCatalog.cpp
+++ b/libOPHD/Technology/TechnologyCatalog.cpp
@@ -66,8 +66,7 @@ namespace
 	template <typename UnaryOperation>
 	auto readSubElementArray(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName, UnaryOperation mapFunction)
 	{
-		using ResultType = decltype(mapFunction(std::declval<NAS2D::Xml::XmlElement&>()));
-		using ElementType = std::remove_cvref_t<ResultType>;
+		using ElementType = std::remove_cvref_t<decltype(mapFunction(std::declval<NAS2D::Xml::XmlElement&>()))>;
 
 		std::vector<ElementType> results;
 		for (auto subElement = parentElement.firstChildElement(subElementName); subElement; subElement = subElement->nextSiblingElement(subElementName))

--- a/libOPHD/Technology/TechnologyCatalog.cpp
+++ b/libOPHD/Technology/TechnologyCatalog.cpp
@@ -67,7 +67,7 @@ namespace
 	auto readSubElementArray(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName, UnaryOperation mapFunction)
 	{
 		using ResultType = decltype(mapFunction(std::declval<NAS2D::Xml::XmlElement&>()));
-		using ElementType = std::remove_cv_t<std::remove_reference_t<ResultType>>;
+		using ElementType = std::remove_cvref_t<ResultType>;
 
 		std::vector<ElementType> results;
 		for (auto subElement = parentElement.firstChildElement(subElementName); subElement; subElement = subElement->nextSiblingElement(subElementName))

--- a/libOPHD/Technology/TechnologyCatalog.cpp
+++ b/libOPHD/Technology/TechnologyCatalog.cpp
@@ -65,6 +65,7 @@ namespace
 
 	template <typename UnaryOperation>
 	auto readSubElementArray(const NAS2D::Xml::XmlElement& parentElement, const std::string& subElementName, UnaryOperation mapFunction)
+		-> std::vector<std::remove_cvref_t<decltype(mapFunction(std::declval<NAS2D::Xml::XmlElement&>()))>>
 	{
 		using ElementType = std::remove_cvref_t<decltype(mapFunction(std::declval<NAS2D::Xml::XmlElement&>()))>;
 


### PR DESCRIPTION
Update NAS2D submodule for updated Linux build environments.

New environments have `Toolchain` set within the Docker image, so it doesn't need to be set by the CI workflow.

The new Clang warning `-Wnrvo` generated by NAS2D has been fixed, so no longer needs an explicit disable (`-Wno-nrvo`).

OPHD contains a related `-Wnrvo` warning that also needed to be fixed.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1530
- PR https://github.com/lairworks/nas2d-core/pull/1531
- PR #2240
- PR #2238
