### PR TITLE
Update GitHub Actions cache cleanup

### DIFF
--- a/makefile
+++ b/makefile
@@ -401,7 +401,7 @@ cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq '.[0:-2] | .[] .id' | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq '.[0:-6] | .[] .id' | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)

--- a/makefile
+++ b/makefile
@@ -382,7 +382,9 @@ flame-charts:
 
 
 ## GitHub ##
-.PHONY: cache-list-all cache-list-main cache-list-branch cache-delete-main-stale cache-delete-branch
+.PHONY: cache-list-all cache-list-main cache-list-current cache-list-stale cache-list-branch cache-delete-main-stale cache-delete-branch
+GhMain := origin/main
+GhMainSha = $(shell git rev-parse --short=8 ${GhMain})
 GhCacheKeyIncremental := ophd-
 GhCacheLimit := 100
 GhCacheFields := id,ref,key,version,sizeInBytes,createdAt,lastAccessedAt
@@ -397,11 +399,17 @@ cache-list-all:
 cache-list-main:
 	$(GhCacheListMain)
 
+cache-list-current:
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\"))"
+
+cache-list-stale:
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\") | not)"
+
 cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq '.[0:-6] | .[] .id' | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\") | not) | .id" | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)


### PR DESCRIPTION
We have since starting doing both `Debug` and `Release` builds, and then added `ARM64` builds, so no longer have a fixed `2` caches for the most recent build.

Do the cache cleanup based on the SHA tag for the latest build, rather than keeping a fixed number of most recent caches.

Add ability to list current and stale caches.

Related:
- PR https://github.com/lairworks/nas2d-core/pull/1475
- PR https://github.com/lairworks/nas2d-core/pull/1476
