### PR TITLE
Fix Mingw unit test running and error reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
         image:
         - "build-env-nas2d-clang:1.7"
         - "build-env-nas2d-gcc:1.8"
-        - "build-env-nas2d-mingw:1.17"
+        - "build-env-nas2d-mingw:1.18"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/lairworks/${{ matrix.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,14 +194,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/lairworks/${{ matrix.image }}"
+      options: --user=1001:1001
 
     steps:
     - uses: actions/checkout@v6
 
     - name: Checkout NAS2D
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        git submodule update --init nas2d-core/
+      run: git submodule update --init nas2d-core/
 
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" ophd

--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ WindowsSpecialPreprocessorFlags = -DGLEW_STATIC -DSDL_MAIN_HANDLED
 WindowsSpecialWarnFlags = -Wno-redundant-decls
 WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
-WindowsRunSuffixUnitTest := --gtest_color=yes | cat -
+WindowsRunSuffixUnitTest := --gtest_color=yes > >(cat)
 
 DarwinIncludeSearchFlags = -isystem$(shell brew --prefix)/include
 
@@ -175,6 +175,7 @@ testLibOphd_PROJECT_LINKFLAGS = $(LDFLAGS) $(testLibOphd_LDLIBS)
 testLibOPHD: $(testLibOphd_OUTPUT)
 
 .PHONY: checkOPHD
+checkOPHD: SHELL := bash
 checkOPHD: $(testLibOphd_OUTPUT)
 	$(RunPrefix) $(testLibOphd_OUTPUT) $(GTEST_OPTIONS) $(RunSuffixUnitTest)
 
@@ -205,6 +206,7 @@ testLibControls_PROJECT_LINKFLAGS = $(LDFLAGS) $(testLibControls_LDLIBS)
 testLibControls: $(testLibControls_OUTPUT)
 
 .PHONY: checkControls
+checkControls: SHELL := bash
 checkControls: $(testLibControls_OUTPUT)
 	$(RunPrefix) $(testLibControls_OUTPUT) $(GTEST_OPTIONS) $(RunSuffixUnitTest)
 


### PR DESCRIPTION
Fix unit test running for Mingw environment, and update to avoid having failures swallowed silently without failing the workflow.

----

Update Docker image used by Mingw build to one with the `wine` package installed, rather than only `wine64`. This gives access to the `wine` shell script that can dispatch to either `wine64` or theoretically `wine32`. Fixes error:
> /bin/sh: 1: wine: not found

----

Run Docker container with option `--user 1001:1001` to match uid of host runner. Fixes error:
> wine: '/github/home' is not owned by you, refusing to create a configuration directory there

The `--user` option also means we can remove the `safe.directory` setting for the NAS2D submodule checkout.

----

Use `bash` feature for process substitution rather than a pipe. This prevents swallowing errors for the unit test steps, so that errors running that unit tests get reported as workflow failures.

----

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/1533
- PR https://github.com/lairworks/nas2d-core/pull/1534
- PR https://github.com/lairworks/nas2d-core/pull/1535
- PR #2242
- PR #2238
