### PR TITLE
Refactor population model

### DIFF
--- a/appOPHD/States/MapViewStateTurn.cpp
+++ b/appOPHD/States/MapViewStateTurn.cpp
@@ -98,16 +98,19 @@ namespace
 
 void MapViewState::updatePopulation()
 {
-	int residences = mStructureManager.operationalCount(StructureClass::Residence);
-	int universities = mStructureManager.operationalCount(StructureClass::University);
-	int nurseries = mStructureManager.operationalCount(StructureClass::Nursery);
-	int hospitals = mStructureManager.operationalCount(StructureClass::MedicalCenter);
-
 	auto foodProducers = mStructureManager.getStructures<FoodProduction>();
 	const auto& commandCenters = mStructureManager.getStructures<CommandCenter>();
 	foodProducers.insert(foodProducers.end(), commandCenters.begin(), commandCenters.end());
 
-	int amountToConsume = mPopulationModel.update(mMorale.currentMorale(), mFood, residences, universities, nurseries, hospitals);
+	int amountToConsume = mPopulationModel.update({
+			mMorale.currentMorale(),
+			mFood,
+			mStructureManager.operationalCount(StructureClass::Residence),
+			mStructureManager.operationalCount(StructureClass::University),
+			mStructureManager.operationalCount(StructureClass::Nursery),
+			mStructureManager.operationalCount(StructureClass::MedicalCenter)
+		});
+
 	consumeFood(foodProducers, amountToConsume);
 }
 

--- a/libOPHD/Population/Morale.h
+++ b/libOPHD/Population/Morale.h
@@ -12,7 +12,7 @@ struct MoraleModifier
 {
 	int researchBonus{0};
 	int productionBonus{0};
-	int fertilityCost{0};
+	int fertilityResistance{0};
 	int mortalityResistance{0};
 };
 

--- a/libOPHD/Population/Morale.h
+++ b/libOPHD/Population/Morale.h
@@ -12,8 +12,8 @@ struct MoraleModifier
 {
 	int researchBonus{0};
 	int productionBonus{0};
-	int fertilityRate{0};
-	int mortalityRate{0};
+	int fertilityCost{0};
+	int mortalityResistance{0};
 };
 
 

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -95,7 +95,7 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 
 	const int totalAdults = mPopulation.worker + mPopulation.scientist;
 
-	const int divisorChild = MoraleModifierTable[moraleIndex(morale)].fertilityCost;
+	const int divisorChild = MoraleModifierTable[moraleIndex(morale)].fertilityResistance;
 	const int divisorStudent = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 13) * 4;
 	const int divisorAdult = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 38) * 4;
 	const int divisorRetiree = (mPopulationGrowth.retiree < MinRetireeGrowthThreshold) ?

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -17,12 +17,12 @@ namespace
 	constexpr auto AdultToRetireeBase = 2000;
 	constexpr auto MinRetireeGrowthThreshold = 1200; // Prevents retirees for approximately 150 turns
 
-	const std::array moraleModifierTable{
-		MoraleModifier{50, 50, 30, 110},  // Excellent
-		MoraleModifier{25, 25, 40, 90},   // Good
-		MoraleModifier{0, 0, 50, 70},     // Fair
-		MoraleModifier{-25, -25, 70, 50}, // Poor
-		MoraleModifier{-50, -50, 90, 30}  // Terrible
+	const std::array moraleModifierTable {
+		MoraleModifier{0, 0, 30, 110},	// Excellent
+		MoraleModifier{0, 0, 40, 90},	// Good
+		MoraleModifier{0, 0, 50, 70},	// Fair
+		MoraleModifier{0, 0, 70, 50},	// Poor
+		MoraleModifier{0, 0, 90, 30}	// Terrible
 	};
 
 

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -47,7 +47,7 @@ namespace
 
 	void retireAdults(int toRetire, PopulationTable& population)
 	{
-		for (toRetire; toRetire > 0;)
+		while (toRetire > 0)
 		{
 			/** Workers retire earlier than scientists. */
 			auto& retireRole = (randomNumber.generate(0, 100) <= 45) ? population.scientist : population.worker;

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -66,7 +66,7 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 
 	int totalAdults = mPopulation.worker + mPopulation.scientist;
 
-	int divisorChild = moraleModifierTable[moraleIndex(morale)].fertilityRate;
+	int divisorChild = moraleModifierTable[moraleIndex(morale)].fertilityCost;
 	int divisorStudent = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 13) * 4;
 	int divisorAdult = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 38) * 4;
 	int divisorRetiree = ((std::max(totalAdults, AdultToRetireeBase) / 40) * 3 + 40) * 4;
@@ -137,7 +137,7 @@ void PopulationModel::killRoles(const PopulationTable& divisor)
 
 void PopulationModel::killPopulation(int morale, int nurseries, int hospitals)
 {
-	const auto mortalityRate = moraleModifierTable[moraleIndex(morale)].mortalityRate;
+	const auto mortalityRate = moraleModifierTable[moraleIndex(morale)].mortalityResistance;
 
 	int divisorChild = mortalityRate + (nurseries * 10);
 	int divisorStudent = mortalityRate + (hospitals * 65);

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -17,7 +17,7 @@ namespace
 	constexpr auto AdultToRetireeBase = 2000;
 	constexpr auto MinRetireeGrowthThreshold = 1200; // Prevents retirees for approximately 150 turns
 
-	const std::array moraleModifierTable {
+	const std::array MoraleModifierTable {
 		MoraleModifier{0, 0, 30, 110},	// Excellent
 		MoraleModifier{0, 0, 40, 90},	// Good
 		MoraleModifier{0, 0, 50, 70},	// Fair
@@ -66,7 +66,7 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 
 	int totalAdults = mPopulation.worker + mPopulation.scientist;
 
-	int divisorChild = moraleModifierTable[moraleIndex(morale)].fertilityCost;
+	int divisorChild = MoraleModifierTable[moraleIndex(morale)].fertilityCost;
 	int divisorStudent = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 13) * 4;
 	int divisorAdult = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 38) * 4;
 	int divisorRetiree = ((std::max(totalAdults, AdultToRetireeBase) / 40) * 3 + 40) * 4;
@@ -137,7 +137,7 @@ void PopulationModel::killRoles(const PopulationTable& divisor)
 
 void PopulationModel::killPopulation(int morale, int nurseries, int hospitals)
 {
-	const auto mortalityRate = moraleModifierTable[moraleIndex(morale)].mortalityResistance;
+	const auto mortalityRate = MoraleModifierTable[moraleIndex(morale)].mortalityResistance;
 
 	int divisorChild = mortalityRate + (nurseries * 10);
 	int divisorStudent = mortalityRate + (hospitals * 65);

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -36,7 +36,7 @@ namespace
 	}
 
 
-	void assertNoOverritirement(int retirees, int employable)
+	void assertNoOverretirement(int retirees, int employable)
 	{
 		if (retirees > employable)
 		{
@@ -110,7 +110,7 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 	mPopulation.child -= newRoles.student;
 	mPopulation.student -= (newRoles.worker + newRoles.scientist);
 
-	assertNoOverritirement(newRoles.retiree, mPopulation.employable());
+	assertNoOverretirement(newRoles.retiree, mPopulation.employable());
 	retireAdults(newRoles.retiree, mPopulation);
 }
 

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -14,6 +15,7 @@ namespace
 	constexpr auto StudentToScientistRate = 35;
 	constexpr auto StudentToAdultBase = 190;
 	constexpr auto AdultToRetireeBase = 2000;
+	constexpr auto MinRetireeGrowthThreshold = 1200; // Prevents retirees for approximately 150 turns
 
 	const std::array moraleModifierTable{
 		MoraleModifier{50, 50, 30, 110},  // Excellent
@@ -68,6 +70,11 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 	int divisorStudent = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 13) * 4;
 	int divisorAdult = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 38) * 4;
 	int divisorRetiree = ((std::max(totalAdults, AdultToRetireeBase) / 40) * 3 + 40) * 4;
+
+	if (mPopulationGrowth.retiree < MinRetireeGrowthThreshold)
+	{
+		divisorRetiree = std::numeric_limits<int>::max();
+	}
 
 	const auto newRoles = spawnRoles(
 		{growthChild, mPopulation.child, growthWorker, growthScientist, totalAdults / 10},

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -43,6 +43,22 @@ namespace
 			throw std::runtime_error("Retiring more people than employable population: Retiring: " + std::to_string(retirees));
 		}
 	}
+
+
+	void retireAdults(int toRetire, PopulationTable& population)
+	{
+		for (toRetire; toRetire > 0;)
+		{
+			/** Workers retire earlier than scientists. */
+			auto& retireRole = (randomNumber.generate(0, 100) <= 45) ? population.scientist : population.worker;
+
+			if (retireRole > 0)
+			{
+				--retireRole;
+				--toRetire;
+			}
+		}
+	}
 }
 
 
@@ -95,18 +111,7 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 	mPopulation.student -= (newRoles.worker + newRoles.scientist);
 
 	assertNoOverritirement(newRoles.retiree, mPopulation.employable());
-
-	for (int toRetire = newRoles.retiree; toRetire > 0;)
-	{
-		/** Workers retire earlier than scientists. */
-		auto& retireRole = randomNumber.generate(0, 100) <= 45 ?
-			mPopulation.scientist : mPopulation.worker;
-		if (retireRole > 0)
-		{
-			--retireRole;
-			--toRetire;
-		}
-	}
+	retireAdults(newRoles.retiree, mPopulation);
 }
 
 

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -59,6 +59,12 @@ namespace
 			}
 		}
 	}
+
+
+	int childGrowth(int residences, int nurseries, PopulationTable& population)
+	{
+		return (residences > 0 || nurseries > 0) ? population.scientist / 4 + population.worker / 2 : 0;
+	}
 }
 
 
@@ -81,10 +87,8 @@ void PopulationModel::removePopulation(const PopulationTable& population)
 
 void PopulationModel::spawnPopulation(int morale, int residences, int nurseries, int universities)
 {
-	const int growthChild = (residences > 0 || nurseries > 0) ?
-		mPopulation.scientist / 4 + mPopulation.worker / 2 : 0;
+	const auto growthChild = childGrowth(residences, nurseries, mPopulation);
 
-	// Account for universities
 	const int convertRate = (universities > 0) ? StudentToScientistRate : 0;
 	const int growthWorker = mPopulation.student * (100 - convertRate) / 100;
 	const int growthScientist = mPopulation.student * convertRate / 100;
@@ -102,8 +106,8 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 	}
 
 	const auto newRoles = spawnRoles(
-		{growthChild, mPopulation.child, growthWorker, growthScientist, totalAdults / 10},
-		{divisorChild, divisorStudent, divisorAdult, divisorAdult, divisorRetiree}
+		{ growthChild, mPopulation.child, growthWorker, growthScientist, totalAdults / 10 },
+		{ divisorChild, divisorStudent, divisorAdult, divisorAdult, divisorRetiree }
 	);
 
 	mBirthCount = newRoles.child;

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -150,9 +150,9 @@ void PopulationModel::killPopulation(int morale, int nurseries, int hospitals)
 {
 	const auto mortalityRate = MoraleModifierTable[moraleIndex(morale)].mortalityResistance;
 
-	int divisorChild = mortalityRate + (nurseries * 10);
-	int divisorStudent = mortalityRate + (hospitals * 65);
-	int divisorAdult = mortalityRate + 250 + (hospitals * 60);
+	const int divisorChild = mortalityRate + (nurseries * 10);
+	const int divisorStudent = mortalityRate + (hospitals * 65);
+	const int divisorAdult = mortalityRate + 250 + (hospitals * 60);
 
 	killRoles({divisorChild, divisorStudent, divisorAdult * 2 - 50, divisorAdult * 2 + 50, divisorAdult});
 
@@ -199,13 +199,13 @@ int PopulationModel::consumeFood(int food)
 /**
  * \return	Actual amount of food consumed.
  */
-int PopulationModel::update(int morale, int food, int residences, int universities, int nurseries, int hospitals)
+int PopulationModel::update(const UpdateParameters& paremters)
 {
 	mBirthCount = 0;
 	mDeathCount = 0;
 
-	spawnPopulation(morale, residences, nurseries, universities);
-	killPopulation(morale, nurseries, hospitals);
+	spawnPopulation(paremters.morale, paremters.residences, paremters.nurseries, paremters.universities);
+	killPopulation(paremters.morale, paremters.nurseries, paremters.hospitals);
 
-	return consumeFood(food);
+	return consumeFood(paremters.food);
 }

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -34,6 +34,15 @@ namespace
 	{
 		return static_cast<std::size_t>(4 - (std::clamp(morale, 0, 999) / 200));
 	}
+
+
+	void assertNoOverritirement(int retirees, int employable)
+	{
+		if (retirees > employable)
+		{
+			throw std::runtime_error("Retiring more people than employable population: Retiring: " + std::to_string(retirees));
+		}
+	}
 }
 
 
@@ -85,10 +94,7 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 	mPopulation.child -= newRoles.student;
 	mPopulation.student -= (newRoles.worker + newRoles.scientist);
 
-	if (newRoles.retiree > mPopulation.employable())
-	{
-		throw std::runtime_error("Retiring more people than employable population: Retiring: " + std::to_string(newRoles.retiree));
-	}
+	assertNoOverritirement(newRoles.retiree, mPopulation.employable());
 
 	for (int toRetire = newRoles.retiree; toRetire > 0;)
 	{

--- a/libOPHD/Population/PopulationModel.cpp
+++ b/libOPHD/Population/PopulationModel.cpp
@@ -93,17 +93,13 @@ void PopulationModel::spawnPopulation(int morale, int residences, int nurseries,
 	const int growthWorker = mPopulation.student * (100 - convertRate) / 100;
 	const int growthScientist = mPopulation.student * convertRate / 100;
 
-	int totalAdults = mPopulation.worker + mPopulation.scientist;
+	const int totalAdults = mPopulation.worker + mPopulation.scientist;
 
-	int divisorChild = MoraleModifierTable[moraleIndex(morale)].fertilityCost;
-	int divisorStudent = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 13) * 4;
-	int divisorAdult = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 38) * 4;
-	int divisorRetiree = ((std::max(totalAdults, AdultToRetireeBase) / 40) * 3 + 40) * 4;
-
-	if (mPopulationGrowth.retiree < MinRetireeGrowthThreshold)
-	{
-		divisorRetiree = std::numeric_limits<int>::max();
-	}
+	const int divisorChild = MoraleModifierTable[moraleIndex(morale)].fertilityCost;
+	const int divisorStudent = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 13) * 4;
+	const int divisorAdult = ((std::max(mPopulation.adults(), StudentToAdultBase) / 40) * 3 + 38) * 4;
+	const int divisorRetiree = (mPopulationGrowth.retiree < MinRetireeGrowthThreshold) ?
+		std::numeric_limits<int>::max() : ((std::max(totalAdults, AdultToRetireeBase) / 40) * 3 + 40) * 4;
 
 	const auto newRoles = spawnRoles(
 		{ growthChild, mPopulation.child, growthWorker, growthScientist, totalAdults / 10 },

--- a/libOPHD/Population/PopulationModel.h
+++ b/libOPHD/Population/PopulationModel.h
@@ -6,6 +6,17 @@
 class PopulationModel
 {
 public:
+	struct UpdateParameters
+	{
+		int morale{0};
+		int food{0};
+		int residences{0};
+		int universities{0};
+		int nurseries{0};
+		int hospitals{0};
+	};
+
+public:
 	int birthCount() const { return mBirthCount; }
 	int deathCount() const { return mDeathCount; }
 
@@ -14,7 +25,7 @@ public:
 	void addPopulation(const PopulationTable& population);
 	void removePopulation(const PopulationTable& population);
 
-	int update(int morale, int food, int residences, int universities, int nurseries, int hospitals);
+	int update(const UpdateParameters& params);
 
 	void starveRate(float rate) { mStarveRate = rate; }
 


### PR DESCRIPTION
Some basic/minor refactoring.

Changes `PopulationModel::update()` to use a parameter object instead of a long list of parameters. This will aid in future updates where I intend to inject transient modifiers into the update loop that are tracked outside of the population model (e.g., first landing fertility bonus and mortality resistance).