### PR TITLE
Update Docker builds - Consolidate Linux builds into one job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,9 +188,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - build-env-nas2d-clang:1.7
-        - build-env-nas2d-gcc:1.8
-        - build-env-nas2d-mingw:1.18
+        - build-env-nas2d-clang:2026-08-09
+        - build-env-nas2d-gcc:2026-08-09
+        - build-env-nas2d-mingw:2026-08-09
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/lairworks/${{ matrix.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,10 +211,11 @@ jobs:
 
   linux-arm:
     runs-on: ubuntu-24.04-arm
+    container:
+      image: ghcr.io/lairworks/build-env-nas2d-gcc:2026-08-09
+      options: --user=1001:1001
 
     steps:
-    - run: sudo apt-get update && sudo apt-get --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libgtest-dev libgmock-dev
-
     - uses: actions/checkout@v6
 
     - name: Checkout NAS2D

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,9 +188,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "build-env-nas2d-clang:1.7"
-        - "build-env-nas2d-gcc:1.8"
-        - "build-env-nas2d-mingw:1.18"
+        - build-env-nas2d-clang:1.7
+        - build-env-nas2d-gcc:1.8
+        - build-env-nas2d-mingw:1.18
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/lairworks/${{ matrix.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,8 @@ jobs:
         runner:
         - ubuntu-latest
         include:
+        - image: build-env-nas2d-clang:2026-08-09
+          runner: ubuntu-24.04-arm
         - image: build-env-nas2d-gcc:2026-08-09
           runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,28 +191,14 @@ jobs:
         - build-env-nas2d-clang:2026-08-09
         - build-env-nas2d-gcc:2026-08-09
         - build-env-nas2d-mingw:2026-08-09
-    runs-on: ubuntu-latest
+        runner:
+        - ubuntu-latest
+        include:
+        - image: build-env-nas2d-gcc:2026-08-09
+          runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     container:
       image: "ghcr.io/lairworks/${{ matrix.image }}"
-      options: --user=1001:1001
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Checkout NAS2D
-      run: git submodule update --init nas2d-core/
-
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" nas2d
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" ophd
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibOPHD
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" testLibControls
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkOPHD
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" checkControls
-
-  linux-arm:
-    runs-on: ubuntu-24.04-arm
-    container:
-      image: ghcr.io/lairworks/build-env-nas2d-gcc:2026-08-09
       options: --user=1001:1001
 
     steps:

--- a/makefile
+++ b/makefile
@@ -292,7 +292,7 @@ POSTCOMPILE = @mv -f $(@:.o=.Td) $(@:.o=.d) && touch $@
 
 lib%.a:
 	@mkdir -p "${@D}"
-	ar rcs $@ $^
+	$(AR) rcs $@ $^
 
 %.o:
 	@mkdir -p "${@D}"


### PR DESCRIPTION
Update NAS2D submodule to latest, and use the newer Docker images provided by NAS2D for the OPHD builds.

Use a Docker image with dependencies pre-installed for the `arm64` build rather than `apt-get install` dependencies on every run.

Use `matrix` to combine the `amd64` and `arm64` Linux builds into a single job.

Add an `arm64` build of OPHD using the Clang toolchain.

Use the `AR` variable in the `makefile` when creating static libraries (archives of object files), since the standard `ar` tool might not be installed if only cross compiling tools are installed.

Related:
- Issue https://github.com/lairworks/nas2d-core/issues/1527
- PR https://github.com/lairworks/nas2d-core/pull/1546
- PR https://github.com/lairworks/nas2d-core/pull/1549
- PR https://github.com/lairworks/nas2d-core/pull/1550
- PR https://github.com/lairworks/nas2d-core/pull/1551
- PR https://github.com/lairworks/nas2d-core/pull/1553
